### PR TITLE
'TypeError' fix in utility/polarion.py

### DIFF
--- a/utility/polarion.py
+++ b/utility/polarion.py
@@ -52,7 +52,7 @@ def post_to_polarion(tc):
             f = NamedTemporaryFile(delete=False)
             test_results = j2_env.get_template('importer-template.xml').render(tc=tc)
             log.info("updating results for %s " % id)
-            f.write(test_results)
+            f.write(test_results.encode())
             f.close()
             url = polarion_cred.get('url')
             user = polarion_cred.get('username')


### PR DESCRIPTION
Encode string into 'a bytes-like object' which was failing with 'TypeError' while writing into a file

