### PR TITLE
add ability to generate xUnit result file for executed test suites

### DIFF
--- a/run.py
+++ b/run.py
@@ -24,6 +24,7 @@ from utility.polarion import post_to_polarion
 from utility.retry import retry
 from utility.utils import timestamp, create_run_dir, create_unique_test_name, create_report_portal_session, \
     configure_logger, close_and_remove_filehandlers, get_latest_container, email_results
+from utility.xunit import create_xunit_results
 
 doc = """
 A simple test suite wrapper that executes tests based on yaml test configuration
@@ -55,6 +56,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--skip-version-compare]
         [--custom-config <key>=<value>]...
         [--custom-config-file <file>]
+        [--xunit-results]
   run.py --cleanup=name [--osp-cred <file>]
         [--log-level <LEVEL>]
 
@@ -99,6 +101,7 @@ Options:
   --skip-version-compare            Skip verification that ceph versions change post upgrade
   -c --custom-config <name>=<value> Add a custom config key/value to ceph_conf_overrides
   --custom-config-file <file>       Add custom config yaml to ceph_conf_overrides
+  --xunit-results                   Create xUnit result file for test suite run [default: false]
 """
 log = logging.getLogger(__name__)
 root = logging.getLogger()
@@ -229,6 +232,7 @@ def run(args):
     skip_version_compare = args.get('--skip-version-compare', False)
     custom_config = args.get('--custom-config')
     custom_config_file = args.get('--custom-config-file')
+    xunit_results = args.get('--xunit-results', False)
     if console_log_level:
         ch.setLevel(logging.getLevelName(console_log_level.upper()))
 
@@ -578,6 +582,8 @@ def run(args):
     if post_to_report_portal:
         service.finish_launch(end_time=timestamp())
         service.terminate()
+    if xunit_results:
+        create_xunit_results(suite_name, tcs, run_dir)
     url_base = "http://magna002.ceph.redhat.com/cephci-jenkins"
     run_dir_name = run_dir.split('/')[-1]
     print("\nAll test logs located here: {base}/{dir}".format(base=url_base, dir=run_dir_name))

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'paramiko==2.4.2',
         'pyyaml>=4.2b1',
         'jinja2==2.10.1',
+        'junitparser==1.4.0'
     ],
     zip_safe=True,
     include_package_data=True,

--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -1,0 +1,39 @@
+"""Create xUnit result files."""
+
+import logging
+
+from junitparser import Failure, JUnitXml, TestCase, TestSuite
+
+log = logging.getLogger(__name__)
+
+
+def create_xunit_results(suite_name, test_cases, run_dir):
+    """
+    Create an xUnit result file for the test suite's executed test cases.
+
+    Args:
+        suite_name: the test suite name
+        test_cases: the test cases objects
+        run_dir: the run directory to store xUnit result files
+
+    Returns: None
+    """
+    xml_file = f"{run_dir}/{suite_name}.xml"
+
+    log.info(f"Creating xUnit result file for test suite: {suite_name}")
+
+    suite = TestSuite(suite_name)
+
+    for tc in test_cases:
+        case = TestCase(tc['name'])
+        if tc['status'] != "Pass":
+            case.result = Failure("test failed")
+        suite.add_testcase(case)
+
+    suite.update_statistics()
+
+    xml = JUnitXml()
+    xml.add_testsuite(suite)
+    xml.write(xml_file, pretty=True)
+
+    log.info(f"xUnit result file created: {xml_file}")


### PR DESCRIPTION
This commit adds a new cli option to allow users to enable creating an
xUnit result file at the end of running the test suite provided. By
default this is disabled. Uses the junitparser library to easily create
the xUnit result file.

To enable this new feature, all you would need to do is add an additional command line option to enable creating the result file:

```
python run.py --rhbuild 3.3 --global-conf conf/luminous/ansible/sanity-ansible-lvm.yaml --osp-cred osp/osp-cred-ci-2.yaml
--inventory conf/inventory/rhel-7.7-server-x86_64.yaml --suite suites/luminous/ansible/sanity_ceph_ansible_lvm.yaml
--log-level info --xunit-results
```

The xUnit result files are written to the run directory and the name of the xUnit result file is the name of the test suite provided. Below are two examples of a pass and failed run:

```xml
<?xml version="1.0" encoding="utf-8"?>  
<testsuites>
    <testsuite errors="0" failures="0" name="sanity_rbd" skipped="0" tests="7" time="0">
        <testcase name="install ceph pre-requisites"/>
        <testcase name="ceph ansible"/>
        <testcase name="test_83572722"/>
        <testcase name="test_83572723"/>
        <testcase name="test_83572725"/>
        <testcase name="test_83572724"/>
        <testcase name="test_9876-9880"/>
    </testsuite>
</testsuites>
```

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
	<testsuite errors="0" failures="2" name="sanity_ceph" skipped="0" tests="23" time="0">
		<testcase name="install ceph pre-requisites"/>
		<testcase name="ceph ansible"/>
		<testcase name="rbd cli image"/>
		<testcase name="rbd cli snap_clone"/>
		<testcase name="rbd cli misc"/>
		<testcase name="check-ceph-health"/>
		<testcase name="config roll over"/>
		<testcase name="config roll over"/>
		<testcase name="config roll over"/>
		<testcase name="shrink mon"/>
		<testcase name="shrink osd"/>
		<testcase name="s3 tests">
			<failure message="test failed"/>
		</testcase>
		<testcase name="Mbuckets"/>
		<testcase name="Mbuckets_with_Nobjects"/>
		<testcase name="Mbuckets_with_Nobjects_delete"/>
		<testcase name="cephfs-lifecycle ops"/>
		<testcase name="multi-client-rw-io"/>
		<testcase name="cephfs-basics"/>
		<testcase name="LRCec pool io test_9281"/>
		<testcase name="Different k,m,l:test_9322"/>
		<testcase name="corrupt snaps test_9928"/>
		<testcase name="corrupt object in ec pool test_9929"/>
		<testcase name="ceph ansible purge">
			<failure message="test failed"/>
		</testcase>
	</testsuite>
</testsuites>
```