### PR TITLE
rados nautilus fix

### DIFF
--- a/suites/nautilus/rados/sanity_rados.yaml
+++ b/suites/nautilus/rados/sanity_rados.yaml
@@ -1,0 +1,91 @@
+tests:
+   - test:
+       name: install ceph pre-requisites
+       module: install_prereq.py
+       abort-on-fail: true
+
+   - test:
+       name: ceph ansible
+       polarion-id: CEPH-83571467
+       module: test_ansible.py
+       config:
+         is_mixed_lvm_configs: True
+         ansi_config:
+           ceph_test: True
+           ceph_origin: distro
+           ceph_stable_release: luminous
+           ceph_repository: rhcs
+           osd_scenario: lvm
+           journal_size: 1024
+           ceph_stable: True
+           ceph_stable_rh_storage: True
+           fetch_directory: ~/fetch
+           copy_admin_key: true
+           dashboard_enabled: False
+           ceph_conf_overrides:
+             global:
+               osd_pool_default_pg_num: 64
+               osd_default_pool_size: 2
+               osd_pool_default_pgp_num: 64
+               mon_max_pg_per_osd: 1024
+             mon:
+               mon_allow_pool_delete: true
+             client:
+               rgw crypt require ssl: false
+               rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                 testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+           cephfs_pools:
+             - name: "cephfs_data"
+               pgs: "8"
+             - name: "cephfs_metadata"
+               pgs: "8"
+       desc: osd with lvm scenario
+       destroy-cluster: False
+       abort-on-fail: true
+
+   - test:
+      name: LRCec pool io test_9281
+      module: test_9281.py
+      polarion-id: CEPH-9281
+      desc: LRCec pool with IO and osd failures
+
+   - test:
+      name: corrupt snaps test_9928
+      module: test_9928.py
+      polarion-id: CEPH-9928
+      desc: corrupt snapset of an object and list-inconsistent-snapset
+   - test:
+      name: corrupt object in ec pool test_9929
+      module: test_9929.py
+      polarion-id: CEPH-9929
+      desc: corrupt an object in ec pool and list-inconsistent-obj
+   - test:
+      name: Delete snapset of an object test_9939
+      module: test_9939.py
+      polarion-id: CEPH-9939
+      desc: Delete snapset of an object followed by list-inconsistent-obj
+   - test:
+      name: Corrupt snapset of an object on non-primary test_83571452
+      module: test_83571452.py
+      polarion-id: CEPH-83571452
+      desc: Corrupt snapset of an object on non-primary followed by list-inconsistent-
+   - test:
+      name: Corrupt snapset on primary osd in ec pool test_83571453
+      module: test_83571453.py
+      polarion_id: CEPH-83571453
+      desc: Corrupt snapset on a primary osd in ec pool
+   - test:
+      name: LRCec pool local recovery test_9311
+      module: test_9311.py
+      polarion_id: CEPH-9311
+      desc: Trigger recovery from local codes in LRCpool
+   - test:
+      name: remove omap key on a replica
+      module: test_9925.py
+      polarion_id: CEPH-9925
+      desc: remove a known omap item of a replica and list-inconsistent-obj
+   - test:
+      name: corrupt omap on a replica
+      module: test_9924.py
+      polarion_id: CEPH-9924
+      desc: rewrite a known omap item of a replica and check list-inconsistent-obj

--- a/tests/rados/test_83571453.py
+++ b/tests/rados/test_83571453.py
@@ -30,6 +30,7 @@ def run(ceph_cluster, **kw):
 
     ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
+    build = config.get('build', config.get('rhbuild'))
     mons = []
     role = 'client'
     for mnode in ceph_nodes:
@@ -46,12 +47,12 @@ def run(ceph_cluster, **kw):
     pname = "eccorrupt_{rand}_{k}_{m}".format(
         rand=random.randint(0, 10000), k=k, m=m)
     profile = pname
-    prof_cmd = "osd erasure-code-profile set {profile}\
-                k={k}\
-                m={m}\
-                ruleset-failure-domain=osd\
-                crush-failure-domain=osd".format(profile=profile,
-                                                 k=k, m=m)
+    if build.startswith('4'):
+        prof_cmd = "osd erasure-code-profile set {profile} k={k} m={m} \
+            crush-failure-domain=osd".format(profile=profile, k=k, m=m)
+    else:
+        prof_cmd = "osd erasure-code-profile set {profile} k={k} m={m} \
+            ruleset-failure-domain=osd crush-failure-domain=osd".format(profile=profile, k=k, m=m)
     try:
         (out, err) = helper.raw_cluster_cmd(prof_cmd)
         outbuf = out.read().decode()

--- a/tests/rados/test_9281.py
+++ b/tests/rados/test_9281.py
@@ -140,6 +140,7 @@ def run(ceph_cluster, **kw):
     log.info("Running test CEPH-9281")
     ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
+    build = config.get('build', config.get('rhbuild'))
 
     mons = []
     role = 'client'
@@ -156,11 +157,12 @@ def run(ceph_cluster, **kw):
     ''' create LRC profile '''
     sufix = random.randint(0, 10000)
     prof_name = "LRCprofile{suf}".format(suf=sufix)
-    profile = "osd erasure-code-profile set {LRCprofile} \
-        plugin=lrc\
-        k=4 m=2 l=3 \
-        ruleset-failure-domain=osd \
-        crush-failure-domain=osd".format(LRCprofile=prof_name)
+    if build.startswith('4'):
+        profile = "osd erasure-code-profile set {LRCprofile} plugin=lrc k=4 m=2 l=3 \
+            crush-failure-domain=osd".format(LRCprofile=prof_name)
+    else:
+        profile = "osd erasure-code-profile set {LRCprofile}plugin=lrc k=4 m=2 l=3 \
+            ruleset-failure-domain=osd crush-failure-domain=osd".format(LRCprofile=prof_name)
     try:
         (out, err) = helper.raw_cluster_cmd(profile)
         outbuf = out.read().decode()

--- a/tests/rados/test_9311.py
+++ b/tests/rados/test_9311.py
@@ -44,6 +44,7 @@ def run(ceph_cluster, **kw):
     log.info("Running test ceph-9311")
     ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
+    build = config.get('build', config.get('rhbuild'))
 
     mons = []
     role = 'client'
@@ -60,11 +61,12 @@ def run(ceph_cluster, **kw):
     '''Create an LRC profile'''
     sufix = random.randint(0, 10000)
     prof_name = "LRCprofile{suf}".format(suf=sufix)
-    profile = "osd erasure-code-profile set {LRCprofile} \
-            plugin=lrc\
-            k=4 m=2 l=3 \
-            ruleset-failure-domain=osd \
+    if build.startswith('4'):
+        profile = "osd erasure-code-profile set {LRCprofile} plugin=lrc k=4 m=2 l=3 \
             crush-failure-domain=osd".format(LRCprofile=prof_name)
+    else:
+        profile = "osd erasure-code-profile set {LRCprofile}plugin=lrc k=4 m=2 l=3 \
+            ruleset-failure-domain=osd crush-failure-domain=osd".format(LRCprofile=prof_name)
     try:
         (out, err) = helper.raw_cluster_cmd(profile)
         outbuf = out.read().decode()

--- a/tests/rados/test_9322.py
+++ b/tests/rados/test_9322.py
@@ -28,6 +28,7 @@ def run(**kw):
 
     ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
+    build = config.get('build', config.get('rhbuild'))
 
     mons = []
     osds = []
@@ -54,12 +55,12 @@ def run(**kw):
         (k, m, l) = conf
         suffix = "{k}_{m}_{l}".format(k=k, m=m, l=l)
         prof_name = "LRCprofile{suf}".format(suf=suffix)
-        profile = "osd erasure-code-profile set {LRC} \
-                plugin=lrc\
-                k={k} m={m} l={l}\
-                ruleset-failure-domain=osd\
-                crush-failure-domain=osd".format(LRC=prof_name,
-                                                 k=k, m=m, l=l)
+        if build.startswith('4'):
+            profile = "osd erasure-code-profile set {LRC} plugin=lrc k={k} m={m} l={l} \
+                crush-failure-domain=osd".format(LRC=prof_name, k=k, m=m, l=l)
+        else:
+            profile = "osd erasure-code-profile set {LRC} plugin=lrc k={k} m={m} l={l} \
+                ruleset-failure-domain=osd crush-failure-domain=osd".format(LRC=prof_name, k=k, m=m, l=l)
         try:
             (out, err) = helper.raw_cluster_cmd(profile)
             outbuf = out.read().decode()

--- a/tests/rados/test_9929.py
+++ b/tests/rados/test_9929.py
@@ -30,6 +30,7 @@ def run(ceph_cluster, **kw):
 
     ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
+    build = config.get('build', config.get('rhbuild'))
     mons = []
     role = 'client'
     for mnode in ceph_nodes:
@@ -46,12 +47,12 @@ def run(ceph_cluster, **kw):
     pname = "eccorrupt_{rand}_{k}_{m}".format(
         rand=random.randint(0, 10000), k=k, m=m)
     profile = pname
-    prof_cmd = "osd erasure-code-profile set {profile}\
-                k={k}\
-                m={m}\
-                ruleset-failure-domain=osd\
-                crush-failure-domain=osd".format(profile=profile,
-                                                 k=k, m=m)
+    if build.startswith('4'):
+        prof_cmd = "osd erasure-code-profile set {profile} k={k} m={m} \
+            crush-failure-domain=osd".format(profile=profile, k=k, m=m)
+    else:
+        prof_cmd = "osd erasure-code-profile set {profile} k={k} m={m} \
+            ruleset-failure-domain=osd crush-failure-domain=osd".format(profile=profile, k=k, m=m)
     try:
         (out, err) = helper.raw_cluster_cmd(prof_cmd)
         outbuf = out.read().decode()

--- a/tests/rados/test_9939.py
+++ b/tests/rados/test_9939.py
@@ -30,6 +30,7 @@ def run(ceph_cluster, **kw):
 
     ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
+    build = config.get('build', config.get('rhbuild'))
     mons = []
     osds = []
     role = 'client'
@@ -51,12 +52,12 @@ def run(ceph_cluster, **kw):
     pname = "ecsnapdelete_{rand}_{k}_{m}".format(
         rand=random.randint(0, 1000), k=k, m=m)
     profile = pname
-    prof_cmd = "osd erasure-code-profile set {profile}\
-                k={k}\
-                m={m}\
-                ruleset-failure-domain=osd\
-                crush-failure-domain=osd".format(profile=profile,
-                                                 k=k, m=m)
+    if build.startswith('4'):
+        prof_cmd = "osd erasure-code-profile set {profile} k={k} m={m} \
+            crush-failure-domain=osd".format(profile=profile, k=k, m=m)
+    else:
+        prof_cmd = "osd erasure-code-profile set {profile} k={k} m={m} \
+            ruleset-failure-domain=osd crush-failure-domain=osd".format(profile=profile, k=k, m=m)
     try:
         (out, err) = helper.raw_cluster_cmd(prof_cmd)
         outbuf = out.read().decode()


### PR DESCRIPTION
* ruleset failure domain option in ec pool creation has been renamed in rhcs4
https://github.com/ceph/ceph/pull/16027/commits/dc7a2aaf7a34b1e6af0c7b79dc44a69974c1da23
* removed one tc from rados suite of nautilus CEPH-11538: To Check for default messenger i.e. async messenger and switch,as we moved from simple to async messenger from luminous