### PR TITLE
call cluster clean up before gathering information about ceph build

### DIFF
--- a/run.py
+++ b/run.py
@@ -238,6 +238,17 @@ def run(args):
     handler.setFormatter(formatter)
     root.addHandler(handler)
 
+    if console_log_level:
+        ch.setLevel(logging.getLevelName(console_log_level.upper()))
+
+    if osp_cred_file:
+        with open(osp_cred_file, 'r') as osp_cred_stream:
+            osp_cred = yaml.safe_load(osp_cred_stream)
+
+    if cleanup_name is not None:
+        cleanup_ceph_nodes(osp_cred, cleanup_name)
+        return 0
+
     # Get ceph cluster version name
     with open("rhbuild.yaml") as fd:
         rhbuild_file = yaml.safe_load(fd)
@@ -268,9 +279,6 @@ def run(args):
         else:
             ubuntu_repo = composes['latest']['ubuntu_repo']
 
-    if console_log_level:
-        ch.setLevel(logging.getLevelName(console_log_level.upper()))
-
     if glb_file:
         conf_path = os.path.abspath(glb_file)
         with open(conf_path, 'r') as conf_stream:
@@ -285,13 +293,6 @@ def run(args):
         suites_path = os.path.abspath(suite_file)
         with open(suites_path, 'r') as suite_stream:
             suite = yaml.safe_load(suite_stream)
-    if osp_cred_file:
-        with open(osp_cred_file, 'r') as osp_cred_stream:
-            osp_cred = yaml.safe_load(osp_cred_stream)
-
-    if cleanup_name is not None:
-        cleanup_ceph_nodes(osp_cred, cleanup_name)
-        return 0
 
     if osp_image and inventory.get('instance').get('create'):
         inventory.get('instance').get('create').update({'image-name': osp_image})


### PR DESCRIPTION
This commit helps to unblock cleaning up a cluster that was created
previously. Recently when manually cleaning up a cluster, an
exception is raised when trying to split a variable with none value
(rhbuild). Since rhbuild is not needed for cleanup, this change moves
the clean up code block to above the block where it access information
about the ceph build.

Attempting to clean up a cluster (latest code in master branch). Unable to split rhbuild when its value is none.

```
(cephci) [rywillia@rywillia-laptop cephci]$ python run.py --cleanup=7a281cc7 --log-level info --osp-cred ./osp-cred.yaml 

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
Startup log location: /tmp/cephci-run-1575302549939/startup.log
Traceback (most recent call last):
  File "run.py", line 608, in <module>
    rc = run(args)
  File "run.py", line 251, in run
    [(ceph[x]['name'], x) for x in ceph if x == rhbuild.split(".")[0]]))
  File "run.py", line 251, in <listcomp>
    [(ceph[x]['name'], x) for x in ceph if x == rhbuild.split(".")[0]]))
AttributeError: 'NoneType' object has no attribute 'split'
```
Attempting to clean up a cluster with moving the clean up conditional code block:

```
(cephci) [rywillia@rywillia-laptop cephci]$ python run.py --cleanup=7a281cc7 --log-level info --osp-cred ./osp-cred.yaml 

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
Startup log location: /tmp/cephci-run-1575304455345/startup.log
2019-12-02 11:34:17,684 - __main__ - INFO - final rc of test run 0
```
