### PR TITLE
dynamically retrieve network subnet based on network supplied

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -965,8 +965,9 @@ class CephNode(object):
         Initialize a CephNode in a libcloud environment
         eg CephNode(username='cephuser', password='cephpasswd',
                     root_password='passwd', ip_address='ip_address',
-                    hostname='hostname', role='mon|osd|client',
-                    no_of_volumes=3, ceph_vmnode='ref_to_libcloudvm')
+                    subnet='subnet', hostname='hostname',
+                    role='mon|osd|client', no_of_volumes=3,
+                    ceph_vmnode='ref_to_libcloudvm')
 
         """
         self.username = kw['username']
@@ -975,6 +976,7 @@ class CephNode(object):
         self.root_login = kw['root_login']
         self.private_ip = kw['private_ip']
         self.ip_address = kw['ip_address']
+        self.subnet = kw['subnet']
         self.vmname = kw['hostname']
         vmshortname = self.vmname.split('.')
         self.vmshortname = vmshortname[0]

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -42,6 +42,7 @@ def create_ceph_nodes(cluster_conf, inventory, osp_cred, run_id, instances_name=
             params['image-name'] = inventory.get('instance').get('create').get('image-name')
         params['cluster-name'] = ceph_cluster.get('name')
         params['vm-size'] = inventory.get('instance').get('create').get('vm-size')
+        params['vm-network'] = inventory.get('instance').get('create').get('vm-network')
         if params.get('root-login') is False:
             params['root-login'] = False
         else:
@@ -502,11 +503,17 @@ def get_root_permissions(node, path):
     node.obtain_root_permissions(path)
 
 
-def get_public_network():
+def get_public_network(node):
     """
     Get the configured public network subnet for nodes in the cluster.
+    This function retrieves the public network subnet from the ceph node
+    object. The subnet is retrieved at runtime when creating nodes. See:
+    ~ mita.openstack.CephVMNode().create_node()
+
+    Args:
+        node(ceph.ceph.CephNode)
 
     Returns:
         (str) public network subnet
     """
-    return "10.0.144.0/22"  # TODO: pull from configuration file
+    return getattr(node, 'subnet')

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -48,6 +48,9 @@ class CephVMNode(object):
         self.image_name = kw['image-name']
         self.node_name = kw['node-name']
         self.vm_size = kw['vm-size']
+        self.vm_network = "provider_net_cci_4"
+        if kw.get('vm-network'):
+            self.vm_network = kw['vm-network']
         self.role = kw['role']
         self.no_of_volumes = None
         if kw.get('no-of-volumes'):
@@ -66,25 +69,56 @@ class CephVMNode(object):
         sleep(10)
 
     def get_driver(self, **kw):
-        self.driver = OpenStack(
+        driver = OpenStack(
             self.username,
             self.password,
+            api_version=kw.get("api_version", "1.1"),
             ex_force_auth_url=self.auth_url,
             ex_force_auth_version=self.auth_version,
             ex_tenant_name=self.tenant_name,
             ex_force_service_region=self.service_region,
             ex_domain_name='redhat.com'
         )
+        return driver
+
+    def get_driver_v1(self):
+        """
+        Get Apache Libcloud OpenStack driver for nova version 1.1.
+
+        https://libcloud.readthedocs.io/en/latest/compute/drivers/
+        openstack.html#compute-1-0-api-version-older-installations
+
+        Returns:
+            OpenStack driver
+        """
+        self.driver = self.get_driver(api_version="1.1")
         return self.driver
+
+    def get_driver_v2(self):
+        """
+        Get Apache Libcloud OpenStack driver for nova version 2.0.
+
+        https://libcloud.readthedocs.io/en/latest/compute/drivers/
+        openstack.html#compute-2-0-api-version-current
+
+        Returns:
+            OpenStack driver
+        """
+        return self.get_driver(api_version="2.0")
 
     def create_node(self, **kw):
         name = self.node_name
-        driver = self.get_driver()
+        driver = self.get_driver_v1()
+        driver_v2 = self.get_driver_v2()
         images = driver.list_images()
         sizes = driver.list_sizes()
-        networks = driver.ex_list_networks()
+        networks = driver_v2.ex_list_networks()
+        subnets = driver_v2.ex_list_subnets()
         available_sizes = [s for s in sizes if s.name == self.vm_size]
-        network = [n for n in networks if n.name == 'provider_net_cci_4']
+        network = [n for n in networks if n.name == self.vm_network]
+        subnet = [s.cidr for s in subnets if s.id == network[0].extra['subnets'][0]]
+        self.subnet = subnet[0]
+
         if not available_sizes:
             logger.error(
                 "provider does not have a matching 'size' for %s",

--- a/run.py
+++ b/run.py
@@ -149,6 +149,7 @@ def create_nodes(conf, inventory, osp_cred, run_id, report_portal_session=None, 
                                 role=node.role,
                                 no_of_volumes=node.no_of_volumes,
                                 ip_address=node.ip_address,
+                                subnet=node.subnet,
                                 private_ip=node.get_private_ip(),
                                 hostname=node.hostname,
                                 ceph_vmnode=node)

--- a/tests/test_ansible.py
+++ b/tests/test_ansible.py
@@ -14,6 +14,7 @@ def run(ceph_cluster, **kw):
     """
     log.info("Running test")
     log.info("Running ceph ansible test")
+    ceph_nodes = kw.get('ceph_nodes')
     config = kw.get('config')
     filestore = config.get('filestore', False)
     k_and_m = config.get('ec-pool-k-m')
@@ -25,7 +26,7 @@ def run(ceph_cluster, **kw):
     installer_url = config.get('installer_url', None)
     mixed_lvm_configs = config.get('is_mixed_lvm_configs', None)
     device_to_add = config.get('device', None)
-    config['ansi_config']['public_network'] = get_public_network()
+    config['ansi_config']['public_network'] = get_public_network(ceph_nodes[0])
 
     ceph_cluster.ansible_config = config['ansi_config']
     ceph_cluster.custom_config = test_data.get('custom-config')

--- a/tests/test_ansible_upgrade.py
+++ b/tests/test_ansible_upgrade.py
@@ -26,7 +26,7 @@ def run(ceph_cluster, **kw):
     hotfix_repo = config.get('hotfix_repo')
     base_url = config.get('base_url')
     installer_url = config.get('installer_url')
-    config['ansi_config']['public_network'] = get_public_network()
+    config['ansi_config']['public_network'] = get_public_network(ceph_nodes[0])
 
     ceph_cluster.ansible_config = config['ansi_config']
     ceph_cluster.custom_config = test_data.get('custom-config')


### PR DESCRIPTION
This change brings the following:
 1. Ability to override the default network to attach provisioned
    nodes too.

```
    Override from inventory file:
      instance:
        create:
          image-name: image-name
          vm-size: vm-size
          vm-network: vm-network
```

 2. Ability to retrieve the network subnet needed for ceph
    configuration.