### PR TITLE
fixes apache-licloud version to 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Vasu Kulkarni',
     author_email='vasu@redhat.com',
     install_requires=[
-        'apache-libcloud',
+        'apache-libcloud==2.6.0',
         'docopt==0.6.2',
         'gevent==1.4.0',
         'reportportal-client==3.2.0',


### PR DESCRIPTION
fixes apache-licloud version to 2.6
logs: http://pastebin.test.redhat.com/835689