### PR TITLE
fix pkg naming in 4.1 repos

### DIFF
--- a/run.py
+++ b/run.py
@@ -349,7 +349,7 @@ def run(args):
             ceph_pkgs = requests.get(base_url + "/compose/Tools/x86_64/os/Packages/")
             m = re.search(r'ceph-common-(.*?).x86', ceph_pkgs.text)
             ceph_version.append(m.group(1))
-            m = re.search(r'ceph-ansible-(.*?)cp', ceph_pkgs.text)
+            m = re.search(r'ceph-ansible-(.*?).rpm', ceph_pkgs.text)
             ceph_ansible_version.append(m.group(1))
             log.info("Compose id is: " + compose_id)
         else:


### PR DESCRIPTION
Signed-off-by: XDsubhash <subhashXD@gmail.com>

* ceph-ansible pkg name format changed in rhcs4.1 repos