### PR TITLE
Fix to ansible issue faced in interop suite

### DIFF
--- a/conf/nautilus/interop/sanity-ceph.yaml
+++ b/conf/nautilus/interop/sanity-ceph.yaml
@@ -1,74 +1,75 @@
 globals:
-    - ceph-cluster:
-       name: ceph
-       node1:
-         role:
-            - mon
-            - mgr
-            - installer
-       node2:
-         role:
-            - mon
-            - mds
-       node3:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node4:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node5:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node6:
-         role:
-            - mon
-            - rgw
-       node7:
-         role: mds
-       node8:
-         role: rgw
-       node9:
-         role:
-           - client
-          #  - nfs https://bugzilla.redhat.com/show_bug.cgi?id=1796160
-       node10:
-         role: pool
-         no-of-volumes: 4
-         disk-size: 15
-       node11:
-         role: pool
-         no-of-volumes: 4
-         disk-size: 15
-       node12:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node13:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node14:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node15:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node16:
-         role: osd
-         no-of-volumes: 4
-         disk-size: 15
-       node17:
-         role: mds
-       node18:
-         role: mds
-       node19:
-         role: client
-       node20:
-         role: client
-       node21:
-         role: client
+  - ceph-cluster:
+     name: ceph
+     node1:
+      role: installer
+     node2:
+       role:
+          - mon
+          - mgr
+     node3:
+       role:
+          - mon
+          - mds
+     node4:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node5:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node6:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node7:
+       role:
+          - mon
+          - rgw
+     node8:
+       role: mds
+     node9:
+       role: rgw
+     node10:
+       role:
+         - client
+        #  - nfs https://bugzilla.redhat.com/show_bug.cgi?id=1796160
+     node11:
+       role: pool
+       no-of-volumes: 4
+       disk-size: 15
+     node12:
+       role: pool
+       no-of-volumes: 4
+       disk-size: 15
+     node13:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node14:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node15:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node16:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node17:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node18:
+       role: mds
+     node19:
+       role: mds
+     node20:
+       role: client
+     node21:
+       role: client
+     node22:
+       role: client


### PR DESCRIPTION
facing Ansible issue Make sure this host can be reached over ssh: unix_listener: path "/home/cephuser/.ansible/cp/ceph-interopqe-dca4-1584387520977-node1-monmgrinstaller-cephuser-22.2MQisXjxx5IHYjoz" too long for Unix domain socket
- can be mitigated with shorthost name with <=104 charc (https://github.com/ceph/ceph-ansible/pull/1512)
- removing installer collocation with other ceph daemons to avoid this, better way would be to edit in ansible.cfg