### PR TITLE
upgrades from lvm 3.x latest to lvm 4.x latest

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -117,6 +117,7 @@ def cleanup_ceph_nodes(osp_cred, pattern=None, timeout=300):
                 log.info("Volume has no name, skipping")
             elif name in volume.name:
                 p.spawn(volume_cleanup, volume, osp_cred)
+                sleep(1)
     log.info("Done cleaning up volumes")
     with parallel() as p:
         for node in driver.list_nodes():
@@ -148,7 +149,7 @@ def volume_cleanup(volume, osp_cred):
     try:
         volobj = driver.ex_get_volume(volume.id)
         driver.detach_volume(volobj)
-        sleep(10)
+        sleep(30)
         driver.destroy_volume(volobj)
     except BaseHTTPError as e:
         log.error(e, exc_info=True)

--- a/suites/nautilus/upgrades/upgrade_3.x_lvm_to_4.x_lvm.yaml
+++ b/suites/nautilus/upgrades/upgrade_3.x_lvm_to_4.x_lvm.yaml
@@ -1,0 +1,98 @@
+tests:
+- test:
+    name: install ceph pre-requisites
+    module: install_prereq.py
+    abort-on-fail: True
+- test:
+    name: ceph ansible install rhcs 3.x cdn
+    module: test_ansible.py
+    config:
+      use_cdn: True
+      build: '3.x'
+      ansi_config:
+        ceph_test: True
+        ceph_origin: repository
+        ceph_repository: rhcs
+        ceph_repository_type: cdn
+        ceph_rhcs_version: 3
+        ceph_stable_release: luminous
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        copy_admin_key: True
+        ceph_conf_overrides:
+          global:
+            osd_pool_default_pg_num: 128
+            osd_default_pool_size: 2
+            osd_pool_default_pgp_num: 128
+            mon_max_pg_per_osd: 4096
+            mon_allow_pool_delete: True
+          client:
+            rgw crypt require ssl: false
+            rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+              testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+    desc: test cluster ceph-volume 3.x cdn setup using ceph-ansible
+    abort-on-fail: True
+- test:
+    name: Upgrade ceph ansible to 4.x
+    module: test_ansible_upgrade.py
+    config:
+      ansi_config:
+        ceph_test: True
+        ceph_origin: distro
+        ceph_stable_release: nautilus
+        ceph_repository: rhcs
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable: True
+        ceph_stable_rh_storage: True
+        fetch_directory: ~/fetch
+        copy_admin_key: true
+        dashboard_enabled: False
+        upgrade_ceph_packages: True
+        ceph_rhcs_version: 4
+        ceph_iscsi_config_dev: false
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-3-dashboard-rhel7:3
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:4.1
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1
+        ceph_conf_overrides:
+          global:
+            osd_pool_default_pg_num: 64
+            osd_default_pool_size: 2
+            osd_pool_default_pgp_num: 64
+            mon_max_pg_per_osd: 1024
+            mon_allow_pool_delete: true
+            client:
+            rgw crypt require ssl: false
+            rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+              testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+    desc: Test Ceph-Ansible rolling update - 3.x -> 4.x
+    abort-on-fail: True
+- test:
+    name: librbd workunit
+    module: test_workunit.py
+    config:
+      test_name: rbd/test_librbd_python.sh
+      branch: nautilus
+      role: mon
+    desc: Test librbd unit tests
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+- test:
+    name: ceph ansible purge
+    module: purge_cluster.py
+    desc: Purge ceph cluster
+    abort-on-fail: True
+    recreate-cluster: True


### PR DESCRIPTION
Description: upgrades from lvm 3.x latest to lvm 4.x latest

CLI used: python run.py --rhbuild 4.1-rhel-7 --global-conf conf/nautilus/upgrades/upgrade_3.x_to_4.x.yaml --osp-cred osp/osp-cred.yaml --inventory conf/inventory/rhel-7.8-server-x86_64.yaml --suite suites/nautilus/upgrades/upgrade_3.x_lvm_to_4.x_lvm.yaml --log-level info --store --ignore-latest-container

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1589360951869/