### PR TITLE
Checks for old container directories( BZ 1834974)

### DIFF
--- a/suites/nautilus/ansible/sanity_containerized_ceph_ansible.yaml
+++ b/suites/nautilus/ansible/sanity_containerized_ceph_ansible.yaml
@@ -253,12 +253,17 @@ tests:
       desc: remove containerized osd
 
 
-  #  - test:
-  #     name: ceph ansible purge
-  #     polarion-id: CEPH-83571493
-  #     module: purge_cluster.py
-  #     config:
-  #           ansible-dir: /usr/share/ceph-ansible
-  #           playbook-command: purge-docker-cluster.yml -e ireallymeanit=yes -e remove_packages=yes
-  #     desc: Purge ceph cluster
-  #     destroy-cluster: True
+   - test:
+      name: ceph ansible purge
+      polarion-id: CEPH-83571493
+      module: purge_cluster.py
+      config:
+           ansible-dir: /usr/share/ceph-ansible
+           playbook-command: purge-docker-cluster.yml -e ireallymeanit=yes -e remove_packages=yes
+      desc: Purge ceph cluster
+
+   - test:
+      name: Check for old container directories
+      module: bug_1834974.py
+      desc: Check for old container directories
+      destroy-cluster: True

--- a/tests/bug_1834974.py
+++ b/tests/bug_1834974.py
@@ -1,0 +1,18 @@
+import logging
+import time
+logger = logging.getLogger(__name__)
+log = logger
+
+
+def run(**kw):
+    log.info("Bug 1834974")
+    ceph_nodes = kw.get('ceph_nodes')
+    time.sleep(180)
+    for cnode in ceph_nodes:
+        out, err = cnode.exec_command(cmd='sudo df -h | grep -v shm | grep -i containers | wc -l', long_running=True)
+        if int(out) == 0:
+            log.info("No old container directories found")
+        else:
+            log.error("Old container directories found which are consuming space")
+            return 1
+    return 0


### PR DESCRIPTION
Checks if old container directories are removed after the purge playbook.

Ref bug: https://bugzilla.redhat.com/show_bug.cgi?id=1834974

CLI: python run.py --rhbuild 4.1-rhel-8 --global-conf conf/nautilus/ansible/sanity-ceph-ansible.yaml --osp-cred osp/osp-cred.yaml --inventory conf/inventory/rhel-8.2-server-x86_64.yaml --suite suites/nautilus/ansible/sanity_containerized_ceph_ansible.yaml --log-level info --insecure-registry --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag ceph-4.1-rhel-8-containers-candidate-79904-20200623031941 --store

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1592955649938

