### PR TITLE
switches from non-containerized to containerized ceph daemons (Bz 1843500)

### DIFF
--- a/suites/luminous/ansible/switch_rpm_to_container.yaml
+++ b/suites/luminous/ansible/switch_rpm_to_container.yaml
@@ -1,0 +1,45 @@
+tests:
+   - test:
+      name: install ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+   - test:
+      name: ceph ansible
+      polarion-id: CEPH-83571467
+      module: test_ansible.py
+      config:
+        ansi_config:
+            ceph_test: True
+            ceph_origin: distro
+            ceph_stable_release: luminous
+            ceph_repository: rhcs
+            osd_scenario: collocated
+            osd_auto_discovery: False
+            journal_size: 1024
+            ceph_stable: True
+            ceph_stable_rh_storage: True
+            fetch_directory: ~/fetch
+            copy_admin_key: true
+            ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+                mon:
+                  mon_allow_pool_delete: true
+            cephfs_pools:
+              - name: "cephfs_data"
+                pgs: "8"
+              - name: "cephfs_metadata"
+                pgs: "8"
+      desc: osd with collocated journal
+      destroy-cluster: False
+      abort-on-fail: true
+
+   - test:
+      name: switch-from-non-containerized-to-containerized-ceph-daemons
+      polarion-id: CEPH-83573510
+      module: switch_rpm_to_container.py
+      abort-on-fail: true

--- a/suites/nautilus/ansible/switch_rpm_to_container.yaml
+++ b/suites/nautilus/ansible/switch_rpm_to_container.yaml
@@ -1,0 +1,50 @@
+tests:
+   - test:
+      name: install ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+   - test:
+      name: ceph ansible
+      polarion-id: CEPH-83571467
+      module: test_ansible.py
+      config:
+        is_mixed_lvm_configs: True
+        ansi_config:
+            ceph_test: True
+            ceph_origin: distro
+            ceph_stable_release: nautilus
+            ceph_repository: rhcs
+            osd_scenario: lvm
+            journal_size: 1024
+            ceph_stable: True
+            ceph_stable_rh_storage: True
+            fetch_directory: ~/fetch
+            copy_admin_key: true
+            dashboard_enabled: False
+            ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+                mon:
+                  mon_allow_pool_delete: true
+                client:
+                  rgw crypt require ssl: false
+                  rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                    testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+            cephfs_pools:
+              - name: "cephfs_data"
+                pgs: "8"
+              - name: "cephfs_metadata"
+                pgs: "8"
+      desc: osd with 6 osd scenarios with lvm
+      destroy-cluster: False
+      abort-on-fail: true
+
+   - test:
+      name: switch-from-non-containerized-to-containerized-ceph-daemons
+      polarion-id: CEPH-83573510
+      module: switch_rpm_to_container.py
+      abort-on-fail: true

--- a/tests/switch_rpm_to_container.py
+++ b/tests/switch_rpm_to_container.py
@@ -1,0 +1,40 @@
+'''switches non-containerized ceph daemon to containerized ceph daemon'''
+
+import logging
+logger = logging.getLogger(__name__)
+log = logger
+
+
+def run(**kw):
+
+    log.info("Running exec test")
+    ceph_nodes = kw.get('ceph_nodes')
+    config = kw.get('config')
+    build = config.get('rhbuild')
+    installer_node = None
+    ansible_dir = '/usr/share/ceph-ansible'
+    playbook = 'switch-from-non-containerized-to-containerized-ceph-daemons.yml'
+    for cnode in ceph_nodes:
+        if cnode.role == 'installer':
+            installer_node = cnode
+    if not build.startswith('4'):
+        installer_node.exec_command(sudo=True,
+                                    cmd='cd {ansible_dir}; cp {ansible_dir}/infrastructure-playbooks/{playbook} .'
+                                    .format(ansible_dir=ansible_dir, playbook=playbook))
+        out, err = installer_node.exec_command(cmd='cd {ansible_dir};ansible-playbook {playbook}'
+                                               ' -e ireallymeanit=yes -i hosts'
+                                               .format(ansible_dir=ansible_dir, playbook=playbook),
+                                               long_running=True)
+
+    else:
+        out, err = installer_node.exec_command(cmd='cd {ansible_dir};ansible-playbook'
+                                               ' infrastructure-playbooks/{playbook} -e ireallymeanit=yes -i hosts'
+                                               .format(ansible_dir=ansible_dir, playbook=playbook),
+                                               long_running=True)
+
+    if err == 0:
+        log.info("ansible-playbook switch-from-non-containerized-to-containerized-ceph-daemons.yml successful")
+        return 0
+
+    log.info("ansible-playbook switch-from-non-containerized-to-containerized-ceph-daemons.yml failed")
+    return 1


### PR DESCRIPTION
Switches from non-containerized to containerized ceph daemons

Bz: https://bugzilla.redhat.com/show_bug.cgi?id=1843500

Cli: python run.py --rhbuild 4.1-rhel-7 --global-conf conf/nautilus/ansible/sanity-ceph-ansible.yaml --osp-cred osp/osp-cred.yaml --inventory conf/inventory/rhel-7.8-server-x86_64.yaml --suite suites/nautilus/ansible/switch-from-non-containerized-to-containerized-ceph-daemons.yaml --log-level info --store --ignore-latest-container

python run.py --rhbuild 3 --global-conf conf/luminous/ansible/sanity-ansible.yaml --osp-cred osp/osp-cred.yaml --inventory conf/inventory/rhel-7.8-server-x86_64.yaml --suite suites/luminous/ansible/switch-from-non-containerized-to-containerized-ceph-daemons.yaml.bkp --log-level info --store --ignore-latest-container

Logs 
4.1Z1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1593512927051/
3 latest : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1593577788233/
