### PR TITLE
fix solves container issues for RGW sanity test

### DIFF
--- a/tests/sanity_rgw.py
+++ b/tests/sanity_rgw.py
@@ -9,34 +9,6 @@ DIR = {"v1": {"script": "/ceph-qe-scripts/rgw/v1/tests/s3/",
               "config": "/ceph-qe-scripts/rgw/v2/tests/s3_swift/configs/"}}
 
 
-def container_exec(rgw_node, container_name, docker_type, test_cmd, test_folder, timeout):
-    rgw_node.exec_command(
-        cmd='sudo {docker_type} exec {container} rm -rf {test_folder}'.format(
-            container=container_name, docker_type=docker_type, test_folder=test_folder))
-    rgw_node.exec_command(
-        cmd='sudo {docker_type} exec {container} mkdir {test_folder}'.format(
-            container=container_name, docker_type=docker_type, test_folder=test_folder))
-    rgw_node.exec_command(
-        cmd='sudo {docker_type} cp {test_folder}/* {container}:/{test_folder}/'.format(
-            container=container_name, docker_type=docker_type, test_folder=test_folder))
-    rgw_node.exec_command(cmd='curl https://bootstrap.pypa.io/get-pip.py -o ~/get-pip.py')
-    rgw_node.exec_command(
-        cmd='sudo {docker_type} cp ~/get-pip.py {container}:/get-pip.py'.format(
-            container=container_name, docker_type=docker_type))
-    rgw_node.exec_command(
-        cmd='sudo {docker_type} exec {container} python3 /get-pip.py'.format(
-            container=container_name, docker_type=docker_type))
-    rgw_node.exec_command(
-        cmd='sudo {docker_type} exec {container} pip3 install -r '
-            '{test_folder}/ceph-qe-scripts/rgw/requirements.txt'.format(
-                container=container_name, docker_type=docker_type, test_folder=test_folder))
-    out, err = rgw_node.exec_command(
-        cmd='sudo {docker_type} exec {container} {test_cmd} '.format(
-            container=container_name, docker_type=docker_type, test_cmd=test_cmd, timeout=timeout))
-    log.info(out.read().decode())
-    log.error(err.read().decode())
-
-
 def run(ceph_cluster, **kw):
     """
 
@@ -45,12 +17,6 @@ def run(ceph_cluster, **kw):
     """
     log.info("Running test")
     config = kw.get('config')
-    script_name = config.get('script-name')
-    config_file_name = config.get('config-file-name')
-    test_version = config.get('test-version', 'v2')
-    script_dir = DIR[test_version]['script']
-    config_dir = DIR[test_version]['config']
-    timeout = config.get('timeout', 300)
     log.info("Running rgw tests %s" % config.get('test-version', 'v2'))
     rgw_ceph_object = ceph_cluster.get_ceph_object('rgw')
     git_url = 'https://github.com/red-hat-storage/ceph-qe-scripts.git'
@@ -67,35 +33,18 @@ def run(ceph_cluster, **kw):
     rgw_node.exec_command(cmd='sudo mkdir ' + test_folder)
     rgw_node.exec_command(cmd='cd ' + test_folder + ' ; ' + git_clone)
     if ceph_cluster.containerized:
-        test_folder_path = '/{test_folder}'.format(test_folder=test_folder)
-        test_cmd = 'python3 ' + test_folder_path + script_dir + script_name + ' -c ' \
-                   + test_folder + config_dir + config_file_name
-        build_a = ceph_cluster.rhcs_version
-        build = str(build_a)
-        distro_info = rgw_node.distro_info
-        distro_ver = distro_info['VERSION_ID']
-        if build.startswith('4'):
-            container = rgw_ceph_object.container_name + '-rgw0'
-            if distro_ver.startswith('8'):
-                docker_type = "podman"
-                container_exec(rgw_node, container, docker_type, test_cmd, test_folder, timeout)
-                return 0
-            else:
-                docker_type = "docker"
-                container_exec(rgw_node, container, docker_type, test_cmd, test_folder, timeout)
-                return 0
-        else:
-            container = rgw_ceph_object.container_name
-            docker_type = "docker"
-            container_exec(rgw_node, container, docker_type, test_cmd, test_folder, timeout)
-            return 0
-    else:
-        rgw_ceph_object.exec_command(
-            cmd='sudo pip3 install -r ' + test_folder + '/ceph-qe-scripts/rgw/requirements.txt')
-        out, err = rgw_ceph_object.exec_command(
-            cmd='sudo python3 ' + test_folder_path + script_dir + script_name + ' -c '
-                + test_folder + config_dir + config_file_name,
-            timeout=timeout)
-        log.info(out.read().decode())
-        log.error(err.read().decode())
-        return 0
+        rgw_node.exec_command(cmd='sudo yum install ceph-radosgw -y')
+    rgw_node.exec_command(
+        cmd='sudo pip3 install -r {test_folder}/ceph-qe-scripts/rgw/requirements.txt'.format(test_folder=test_folder))
+    script_name = config.get('script-name')
+    config_file_name = config.get('config-file-name')
+    test_version = config.get('test-version', 'v2')
+    script_dir = DIR[test_version]['script']
+    config_dir = DIR[test_version]['config']
+    timeout = config.get('timeout', 300)
+    out, err = rgw_node.exec_command(
+        cmd='sudo python3 ' + test_folder_path + script_dir + script_name + ' -c '
+            + test_folder + config_dir + config_file_name, timeout=timeout)
+    log.info(out.read().decode())
+    log.error(err.read().decode())
+    return 0


### PR DESCRIPTION
fix will install ceph-radosgw for running rgw commands outside of container and also fixes container issues for RGW sanity test.

Following is the log location:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1593524799454/

Signed-off-by: udaysk23 <ukurundw@redhat.com>