### PR TITLE
Adding tests for bucket lifecycle, object expiration feature.

### DIFF
--- a/suites/luminous/rgw/sanity_containerized_rgw_lvm.yaml
+++ b/suites/luminous/rgw/sanity_containerized_rgw_lvm.yaml
@@ -255,6 +255,52 @@ tests:
            timeout: 300
    # Bucket Lifecycle Tests
    - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for versioned buckets with filter 'Prefix', test multiple rules.
+       polarion-id: CEPH-11177, CEPH-11182, CEPH-11188, CEPH-11187
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for Prefix and tag based filter and for more than one days
+       polarion-id: CEPH-11179, CEPH-11180
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_and_tag.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration with expiration set to Date
+       polarion-id: CEPH-11185
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_date.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for delete marker set
+       polarion-id: CEPH-11189
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_delete_marker.yaml
+           timeout: 300 
+   - test: 
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for non current version expiration
+       polarion-id: CEPH-11190
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_non_current_days.yaml
+           timeout: 300
+
+   - test:
        name: Bucket Lifecycle Configuration Tests
        desc: Read lifecycle configuration on a given bucket
        polarion-id: CEPH-11181

--- a/suites/luminous/rgw/sanity_rgw.yaml
+++ b/suites/luminous/rgw/sanity_rgw.yaml
@@ -251,6 +251,52 @@ tests:
            timeout: 300
    # Bucket Lifecycle Tests
    - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for versioned buckets with filter 'Prefix', test multiple rules.
+       polarion-id: CEPH-11177, CEPH-11182, CEPH-11188, CEPH-11187
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for Prefix and tag based filter and for more than one days
+       polarion-id: CEPH-11179, CEPH-11180
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_and_tag.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration with expiration set to Date
+       polarion-id: CEPH-11185
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_date.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for delete marker set
+       polarion-id: CEPH-11189
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_delete_marker.yaml
+           timeout: 300 
+   - test: 
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for non current version expiration
+       polarion-id: CEPH-11190
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_non_current_days.yaml
+           timeout: 300
+
+   - test:
        name: Bucket Lifecycle Configuration Tests
        desc: Read lifecycle configuration on a given bucket
        polarion-id: CEPH-11181

--- a/suites/nautilus/rgw/sanity_containerized_rgw.yaml
+++ b/suites/nautilus/rgw/sanity_containerized_rgw.yaml
@@ -255,6 +255,52 @@ tests:
            timeout: 300
    # Bucket Lifecycle Tests
    - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for versioned buckets with filter 'Prefix', test multiple rules.
+       polarion-id: CEPH-11177, CEPH-11182, CEPH-11188, CEPH-11187
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for Prefix and tag based filter and for more than one days
+       polarion-id: CEPH-11179, CEPH-11180
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_and_tag.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration with expiration set to Date
+       polarion-id: CEPH-11185
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_date.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for delete marker set
+       polarion-id: CEPH-11189
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_delete_marker.yaml
+           timeout: 300 
+   - test: 
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for non current version expiration
+       polarion-id: CEPH-11190
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_non_current_days.yaml
+           timeout: 300
+
+   - test:
        name: Bucket Lifecycle Configuration Tests
        desc: Read lifecycle configuration on a given bucket
        polarion-id: CEPH-11181

--- a/suites/nautilus/rgw/sanity_rgw.yaml
+++ b/suites/nautilus/rgw/sanity_rgw.yaml
@@ -251,6 +251,51 @@ tests:
            timeout: 300
    # Bucket Lifecycle Tests
    - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for versioned buckets with filter 'Prefix', test multiple rules.
+       polarion-id: CEPH-11177, CEPH-11182, CEPH-11188, CEPH-11187
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for Prefix and tag based filter and for more than one days
+       polarion-id: CEPH-11179, CEPH-11180
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_and_tag.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration with expiration set to Date
+       polarion-id: CEPH-11185
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_date.yaml
+           timeout: 300
+   - test:
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for delete marker set
+       polarion-id: CEPH-11189
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_delete_marker.yaml
+           timeout: 300 
+   - test: 
+       name: Bucket Lifecycle Object_expiration_tests
+       desc: Test object expiration for non current version expiration
+       polarion-id: CEPH-11190
+       module: sanity_rgw.py
+       config:
+           script-name: test_bucket_lifecycle_object_expiration.py
+           config-file-name: test_lc_rule_prefix_non_current_days.yaml
+           timeout: 300
+   - test:
        name: Bucket Lifecycle Configuration Tests
        desc: Read lifecycle configuration on a given bucket
        polarion-id: CEPH-11181


### PR DESCRIPTION
a) Adding tests for Bucket lifecycle object expiration feature.
b) This PR covers below high/critical tests in Polarian :11177, 11179,11180, 11182, 11185, 11187, 11188, 11189, 11190 
Signed-off-by: viduship <vimishra@redhat.com>

 http://pastebin.test.redhat.com/875564