### PR TITLE
Fixes upgrade suite

### DIFF
--- a/suites/nautilus/upgrades/upgrade_3.x_ceph-disk_to_4.x_lvm.yaml
+++ b/suites/nautilus/upgrades/upgrade_3.x_ceph-disk_to_4.x_lvm.yaml
@@ -11,7 +11,6 @@ tests:
       use_cdn: True
       build: '3.x'
       ansi_config:
-        ceph_test: True
         ceph_origin: repository
         ceph_repository: rhcs
         ceph_repository_type: cdn
@@ -39,7 +38,6 @@ tests:
     module: test_ansible_upgrade.py
     config:
       ansi_config:
-        ceph_test: True
         ceph_origin: distro
         ceph_stable_release: nautilus
         ceph_repository: rhcs

--- a/suites/nautilus/upgrades/upgrade_3.x_lvm_to_4.x_lvm.yaml
+++ b/suites/nautilus/upgrades/upgrade_3.x_lvm_to_4.x_lvm.yaml
@@ -11,7 +11,6 @@ tests:
       use_cdn: True
       build: '3.x'
       ansi_config:
-        ceph_test: True
         ceph_origin: repository
         ceph_repository: rhcs
         ceph_repository_type: cdn
@@ -39,7 +38,6 @@ tests:
     module: test_ansible_upgrade.py
     config:
       ansi_config:
-        ceph_test: True
         ceph_origin: distro
         ceph_stable_release: nautilus
         ceph_repository: rhcs


### PR DESCRIPTION
Upgrade suite failure is seen due to redundant ceph_test: true
Error logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1592492507135/ceph_ansible_install_rhcs_3.x_cdn_0.log