### PR TITLE
sanity_rgw: verify_io script is called based on config

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -4,8 +4,11 @@ import logging
 log = logging.getLogger(__name__)
 
 DIR = {"v1": {"script": "/ceph-qe-scripts/rgw/v1/tests/s3/",
+              "lib": "/ceph-qe-scripts/rgw/v1/lib/",
               "config": "/ceph-qe-scripts/rgw/v1/tests/s3/yamls/"},
+
        "v2": {"script": "/ceph-qe-scripts/rgw/v2/tests/s3_swift/",
+              "lib": "/ceph-qe-scripts/rgw/v2/lib/",
               "config": "/ceph-qe-scripts/rgw/v2/tests/s3_swift/configs/"}}
 
 
@@ -19,6 +22,7 @@ def run(ceph_cluster, **kw):
     config = kw.get('config')
     log.info("Running rgw tests %s" % config.get('test-version', 'v2'))
     rgw_ceph_object = ceph_cluster.get_ceph_object('rgw')
+    run_io_verify = config.get('run_io_verify', False)
     git_url = 'https://github.com/red-hat-storage/ceph-qe-scripts.git'
     branch = ' -b master'
     git_clone = 'sudo git clone ' + git_url + branch
@@ -41,10 +45,19 @@ def run(ceph_cluster, **kw):
     test_version = config.get('test-version', 'v2')
     script_dir = DIR[test_version]['script']
     config_dir = DIR[test_version]['config']
+    lib_dir = DIR[test_version]['lib']
     timeout = config.get('timeout', 300)
     out, err = rgw_node.exec_command(
         cmd='sudo python3 ' + test_folder_path + script_dir + script_name + ' -c '
             + test_folder + config_dir + config_file_name, timeout=timeout)
     log.info(out.read().decode())
     log.error(err.read().decode())
+
+    if run_io_verify:
+        log.info('running io verify script')
+        verify_out, err = rgw_node.exec_command(cmd='sudo python3 ' + test_folder_path + lib_dir + 'read_io_info.py',
+                                                timeout=timeout)
+        log.info(verify_out.read().decode())
+        log.error(verify_out.read().decode())
+
     return 0


### PR DESCRIPTION
`read_io_info` script is being called based on test config 

Signed-off-by: rakeshgm <rakeshgm@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
