### PR TITLE
added object_store change after filestore to bluestore migration

### DIFF
--- a/tests/ceph_ansible/filestore_to_bluestore.py
+++ b/tests/ceph_ansible/filestore_to_bluestore.py
@@ -11,6 +11,7 @@ def run(**kw):
     ceph_nodes = kw.get('ceph_nodes')
     ansible_dir = '/usr/share/ceph-ansible'
     playbook = 'filestore-to-bluestore.yml'
+    replace_objectstore = "sed -i 's/osd_objectstore: filestore/osd_objectstore: bluestore/g' group_vars/all.yml"
     for cnode in ceph_nodes:
         if cnode.role == 'installer':
             installer_node = cnode
@@ -20,6 +21,9 @@ def run(**kw):
                                                        ' -i hosts --limit {osd_daemon_to_migrate}'.format(
                                                            ansible_dir=ansible_dir, playbook=playbook,
                                                            osd_daemon_to_migrate=cnode.hostname), long_running=True)
+    installer_node.exec_command(sudo=True, cmd='cd {ansible_dir} ; {replace_objectstore}'.format(
+                                ansible_dir=ansible_dir, replace_objectstore=replace_objectstore))
+
     if err == 0:
         log.info("ansible-playbook filestore-to-bluestore.yml successful")
         return 0


### PR DESCRIPTION
# Description
The object_store has to be updated in group_var once the filestore to bluestore migration is done to perform other operations

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [x] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1597778664738/