### PR TITLE
test py36 with tox and travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.6"
   - "3.7"
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.7"
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
We run cephci on RHEL 7's Python 3.6 with Jenkins/OpenStack, so we should test this Python environment with Travis CI.

This pull request updates the tox tests and Travis CI configuration to run the unit tests on py36 as well as py37.