### PR TITLE
Fixed 'yum update metadata' issue w.r.t rhel-8 platform

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1847,7 +1847,9 @@ class CephInstaller(CephObject):
                 raise CommandFailed(err)
 
         if kw.get('upgrade'):
-            self.exec_command(sudo=True, cmd='yum update metadata')
+            self.exec_command(sudo=True,
+                              cmd='yum update meta',
+                              check_ec=False)
             self.exec_command(sudo=True, cmd='yum update -y ansible ceph-ansible')
         else:
             self.exec_command(sudo=True, cmd='yum install -y ceph-ansible')

--- a/tests/ceph_installer/test_ceph_deploy.py
+++ b/tests/ceph_installer/test_ceph_deploy.py
@@ -74,7 +74,7 @@ def run(**kw):
             log.info("Using the cdn repo for the test")
         log.info("Updating metadata")
         if ceph.pkg_type == 'rpm':
-            ceph.exec_command(cmd='sudo yum update metadata')
+            ceph.exec_command(cmd='sudo yum update metadata', check_ec=False)
 
     ceph1.exec_command(cmd='mkdir cd')
     ceph1.exec_command(sudo=True, cmd='cd cd; yum install -y ceph-deploy')

--- a/tests/iscsi/update-kernel-iscsi.py
+++ b/tests/iscsi/update-kernel-iscsi.py
@@ -65,7 +65,7 @@ enabled=1
     kernel_repo.flush()
     o, e = client.exec_command(cmd='uname -a')
     log.info(o.read().decode())
-    client.exec_command(cmd='sudo yum update metadata')
+    client.exec_command(cmd='sudo yum update metadata', check_ec=False)
     o, e = client.exec_command(cmd='sudo yum update -y kernel')
     client.exec_command(cmd='sudo reboot', check_ec=False)
     time.sleep(300)

--- a/tests/misc_env/update-kernel.py
+++ b/tests/misc_env/update-kernel.py
@@ -47,7 +47,7 @@ enabled=1
     o, e = client.exec_command(cmd='uname -a')
     log.info(o.read().decode())
     client.exec_command(cmd='sudo subscription-manager repos --disable=*', long_running=True)
-    client.exec_command(cmd='sudo yum update metadata')
+    client.exec_command(cmd='sudo yum update metadata', check_ec=False)
     o, e = client.exec_command(cmd='sudo yum update -y kernel')
     client.exec_command(cmd='sudo reboot', check_ec=False)
     time.sleep(300)


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

In RHEL-8 this command fails due to below command, and as a fix disabled status verification.
However On RHEL-7, its doesn't throw error.

```
[cephuser@ceph-mgowri2-1598286215085-node8-installer ~]$ sudo yum update meta ; echo "exit status : $?"
Updating Subscription Management repositories.
Last metadata expiration check: 1:25:50 ago on Mon 24 Aug 2020 12:55:24 PM EDT.
No match for argument: meta
Error: No packages marked for upgrade.
exit status : 1
```
