### PR TITLE
ceph: set allow_agent to False during initial deployment

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -946,7 +946,8 @@ class SSHConnectionManager(object):
                 self.__client.connect(self.ip_address,
                                       username=self.username,
                                       password=self.password,
-                                      look_for_keys=self.look_for_keys)
+                                      look_for_keys=self.look_for_keys,
+                                      allow_agent=False)
                 break
             except Exception as e:
                 logger.warn('Connection outage: \n{error}'.format(error=e))


### PR DESCRIPTION
Paramiko will attempt to use public key authentication as the
root user during inital setup if there is an ssh agent running.
This forces paramiko to use password authentication so the
ssh connection succeeds.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
