### PR TITLE
inventory: update RHEL 7.7 image name

### DIFF
--- a/conf/inventory/rhel-7.7-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.7-server-x86_64.yaml
@@ -1,6 +1,6 @@
 instance:
   create:
-    image-name: RHEL-7.7-20190723.1-Server-x86_64
+    image-name: rhel-7.7-server-x86_64-released
     vm-size: m1.medium
 
   setup: |


### PR DESCRIPTION
PSI OpenStack no longer hosts the `RHEL-7.7-20190723.1-Server-x86_64` image. Use the latest RHEL 7.7 released image name instead.