### PR TITLE
osp: remove old osp-cred-depricated.yaml file

### DIFF
--- a/osp/osp-cred-depricated.yaml
+++ b/osp/osp-cred-depricated.yaml
@@ -1,8 +1,0 @@
-globals:
-    openstack-credentials:
-        username: 'vakulkar'
-        password: 'XX'
-        auth-url: 'http://10.8.188.11:5000'
-        auth-version: '2.0_password'
-        tenant-name: 'ceph-jenkins'
-        service-region: 'regionOne'


### PR DESCRIPTION
Nothing uses this file, so we can delete it.

This helps new users understand what file(s) they should modify when getting started.