### PR TITLE
ansible version match for rhcs latest

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1831,8 +1831,8 @@ class CephInstaller(CephObject):
                 "7": "rhel-7-server-ansible-2.6-rpms"
             },
             "4": {
-                "7": "rhel-7-server-ansible-2.8-rpms",
-                "8": "ansible-2.8-for-rhel-8-x86_64-rpms"
+                "7": "rhel-7-server-ansible-2.9-rpms",
+                "8": "ansible-2.9-for-rhel-8-x86_64-rpms"
             },
             "5": {
                 "8": "ansible-2.9-for-rhel-8-x86_64-rpms"
@@ -1844,6 +1844,10 @@ class CephInstaller(CephObject):
         else:
             distro_ver = self.distro_info['VERSION_ID'].split(".")[0]
             rhcs_ver = rhbuild.split(".")[0]
+            # Use ansible 2.8 for rhcs 4.1.z
+            if str(rhbuild).startswith('4.1'):
+                ansible_rpm[rhcs_ver]['7'] = "rhel-7-server-ansible-2.8-rpms"
+                ansible_rpm[rhcs_ver]['8'] = "ansible-2.8-for-rhel-8-x86_64-rpms"
 
             try:
                 rpm = ansible_rpm[rhcs_ver][distro_ver]


### PR DESCRIPTION
# Description
ansible 2.9 will be discontinued from latest release of rhcs
this patch will make ansible 2.9 as default and
ansible 2.8 to be used in previous versions of rhcs

Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
NA
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
NA
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test

4.1-rhel-8 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1600428786473
4.2-rhel-8 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1600434762847
Will update further
