### PR TITLE
prereq: improve log message for missing cdn_credentials

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -139,7 +139,8 @@ def registry_login(ceph, distro_ver):
         docker for RHEL 7.x and podman for RHEL 8.x'''
     cdn_cred = get_cephci_config().get('cdn_credentials')
     if not cdn_cred:
-        log.warn('cdn_credentials not found')
+        log.warn('no cdn_credentials in ~/.cephci.yaml.'
+                 ' Not logging into registry.redhat.io.')
         return
     user = cdn_cred.get('username')
     pwd = cdn_cred.get('password')


### PR DESCRIPTION
Log the exact file where a user should configure `cdn_credentials`.

Log the impact of lacking the credentials (we will not log into the `registry.redhat.io` registry).