### PR TITLE
allow users to disable all email

### DIFF
--- a/cephci.yaml.template
+++ b/cephci.yaml.template
@@ -17,5 +17,7 @@ polarion:
 
 # Provide email address(es) in comma-seperated values
 # Example., address: email1, email2, ...... ,emailn
+# To completely disable all email, remove the "email:" and "address:" settings
+# entirely.
 email:
   address: cephci@redhat.com

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -539,6 +539,9 @@ def email_results(results_list, run_id, trigger_user, run_dir, suite_run_time, s
     """
     Email results of test run to QE
 
+    If the user specifies no "email" settings in ~/.cephci.yaml, this method
+    is a no-op.
+
     Args:
         results_list (list): test case results info
         run_id (str): id of the test run
@@ -551,6 +554,8 @@ def email_results(results_list, run_id, trigger_user, run_dir, suite_run_time, s
 
     """
     cfg = get_cephci_config().get('email')
+    if not cfg:
+        return
     sender = "cephci@redhat.com"
     recipients = []
     address = cfg.get('address')


### PR DESCRIPTION
cephci can generate a lot of email. Provide a way for users to turn off the email reports.