### PR TITLE
Fix: reuse cli arg

### DIFF
--- a/run.py
+++ b/run.py
@@ -334,6 +334,7 @@ def run(args):
     ceph_version = []
     ceph_ansible_version = []
     distro = []
+    clients = []
     if inventory.get('instance').get('create'):
         distro.append(inventory.get('instance').get('create').get('image-name'))
     for cluster in conf.get('globals'):


### PR DESCRIPTION
Signed-off-by: vpoliset <vpoliset@redhat.com>

* Fix reuse cli arg regression caused by iscsi win client

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
