### PR TITLE
update log.warn() -> log.warning()

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -424,8 +424,8 @@ class Ceph(object):
         Update all ceph demons nodes to allow insecure registry use
         """
         if self.containerized and self.ansible_config.get('ceph_docker_registry'):
-            logger.warn('Adding insecure registry:\n{registry}'
-                        .format(registry=self.ansible_config.get('ceph_docker_registry')))
+            logger.warning('Adding insecure registry:\n{registry}'
+                           .format(registry=self.ansible_config.get('ceph_docker_registry')))
             # for node in self.get_nodes():
             #     node.exec_command(sudo=True, cmd='sudo chmod 777 /etc/containers/registries.conf;'
             #                                      'sudo sed -i "16,17d" /etc/containers/registries.conf;'
@@ -959,7 +959,7 @@ class SSHConnectionManager(object):
                                       allow_agent=False)
                 break
             except Exception as e:
-                logger.warn('Connection outage: \n{error}'.format(error=e))
+                logger.warning('Connection outage: \n{error}'.format(error=e))
                 if not self.__outage_start_time:
                     self.__outage_start_time = datetime.datetime.now()
                 if datetime.datetime.now() - self.__outage_start_time > self.outage_timeout:

--- a/tests/cephfs/CEPH-11221.py
+++ b/tests/cephfs/CEPH-11221.py
@@ -153,7 +153,7 @@ def check_health(ceph_cluster):
             print(out1)
             out2 = out1.split()
             if 'HEALTH_OK' not in out2:
-                log.warn('Ceph Health is NOT OK')
+                log.warning('Ceph Health is NOT OK')
                 return 0
             else:
                 log.info('Health IS OK')

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -139,13 +139,13 @@ def registry_login(ceph, distro_ver):
         docker for RHEL 7.x and podman for RHEL 8.x'''
     cdn_cred = get_cephci_config().get('cdn_credentials')
     if not cdn_cred:
-        log.warn('no cdn_credentials in ~/.cephci.yaml.'
-                 ' Not logging into registry.redhat.io.')
+        log.warning('no cdn_credentials in ~/.cephci.yaml.'
+                    ' Not logging into registry.redhat.io.')
         return
     user = cdn_cred.get('username')
     pwd = cdn_cred.get('password')
     if not (user and pwd):
-        log.warn('username and password not found for cdn_credentials')
+        log.warning('username and password not found for cdn_credentials')
         return
 
     container = 'docker'


### PR DESCRIPTION
As discussed in https://github.com/red-hat-storage/cephci/pull/222, `log.warn()` is deprecated in Python 3.