### PR TITLE
reverting the greenlet package to n-1 and gevent package to earlier v…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     install_requires=[
         'apache-libcloud',
         'docopt==0.6.2',
-        'gevent==20.9.0',
+        'gevent==1.4.0',
+        'greenlet==0.4.16',
         'reportportal-client==3.2.0',
         'requests==2.21.0',
         'paramiko==2.4.2',


### PR DESCRIPTION
…ersion

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test

Reverting as the installation of the requirements without pup upgrade gave errors : 
    File "/usr/lib64/python3.6/subprocess.py", line 311, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '(cd  "/tmp/pip-build-gs2jqfym/gevent/deps/libev"  && sh ./configure -C > configure-output.txt )' returned non-zero exit status 1.

    ----------------------------------------
Command "/home/pdhiran/ceph/cephci/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-gs2jqfym/gevent/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-lx9t6pi4-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/pdhiran/ceph/cephci/include/site/python3.6/gevent" failed with error code 1 in /tmp/pip-build-gs2jqfym/gevent/

reverting the package versions so that requirements will be installed successfully without requiring to upgrade the pip versions. 