### PR TITLE
setup.py: revert gevent package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     install_requires=[
         'apache-libcloud',
         'docopt==0.6.2',
-        'gevent==20.9.0',
+        'gevent==1.4.0',
+        'greenlet==0.4.16',
         'reportportal-client==3.2.0',
         'requests==2.21.0',
         'paramiko==2.4.2',


### PR DESCRIPTION
We're reverting the gevent package version from 20.9.0 to 1.4.0. The installation of requirements with the latest package gives errors, which requires latest pip version. Reverting gevent version to remove the pip  upgrade dependency.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
