### PR TITLE
cvp/sanity_rhceph_base_container.yaml: changing test params to dict

### DIFF
--- a/suites/luminous/cvp/sanity_rhceph_base_container.yaml
+++ b/suites/luminous/cvp/sanity_rhceph_base_container.yaml
@@ -191,25 +191,25 @@ tests:
 # basic cephfs tests
 
   - test:
-    name: cephfs-lifecycle ops
-    module: CEPH-11333.py
-    polarion-id: CEPH-11333
-    desc: Perfrom cephfs lifecycle ops like delete cephfs,recreate cephfs
-    abort-on-fail: false
+      name: cephfs-lifecycle ops
+      module: CEPH-11333.py
+      polarion-id: CEPH-11333
+      desc: Perfrom cephfs lifecycle ops like delete cephfs,recreate cephfs
+      abort-on-fail: false
 
   - test:
-    name: multi-client-rw-io
-    module: CEPH-10528_10529.py
-    polarion-id: CEPH-10528,CEPH-10529
-    desc: Single CephFS on multiple clients,performing IOs and checking file locking mechanism
-    abort-on-fail: false
+      name: multi-client-rw-io
+      module: CEPH-10528_10529.py
+      polarion-id: CEPH-10528,CEPH-10529
+      desc: Single CephFS on multiple clients,performing IOs and checking file locking mechanism
+      abort-on-fail: false
 
   - test:
-    name: cephfs-basics
-    module: cephfs_basic_tests.py
-    polarion-id: CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295
-    desc: cephfs basic operations
-    abort-on-fail: false
+      name: cephfs-basics
+      module: cephfs_basic_tests.py
+      polarion-id: CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295
+      desc: cephfs basic operations
+      abort-on-fail: false
 
   # - test:
   #    name: ceph ansible purge

--- a/suites/nautilus/cvp/sanity_rhceph_base_container.yaml
+++ b/suites/nautilus/cvp/sanity_rhceph_base_container.yaml
@@ -195,25 +195,25 @@ tests:
 # basic cephfs tests
 
   - test:
-    name: cephfs-lifecycle ops
-    module: CEPH-11333.py
-    polarion-id: CEPH-11333
-    desc: Perfrom cephfs lifecycle ops like delete cephfs,recreate cephfs
-    abort-on-fail: false
+      name: cephfs-lifecycle ops
+      module: CEPH-11333.py
+      polarion-id: CEPH-11333
+      desc: Perfrom cephfs lifecycle ops like delete cephfs,recreate cephfs
+      abort-on-fail: false
 
   - test:
-    name: multi-client-rw-io
-    module: CEPH-10528_10529.py
-    polarion-id: CEPH-10528,CEPH-10529
-    desc: Single CephFS on multiple clients,performing IOs and checking file locking mechanism
-    abort-on-fail: false
+      name: multi-client-rw-io
+      module: CEPH-10528_10529.py
+      polarion-id: CEPH-10528,CEPH-10529
+      desc: Single CephFS on multiple clients,performing IOs and checking file locking mechanism
+      abort-on-fail: false
 
   - test:
-    name: cephfs-basics
-    module: cephfs_basic_tests.py
-    polarion-id: CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295
-    desc: cephfs basic operations
-    abort-on-fail: false
+      name: cephfs-basics
+      module: cephfs_basic_tests.py
+      polarion-id: CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295
+      desc: cephfs basic operations
+      abort-on-fail: false
 
  #  - test:
  #     name: ceph ansible purge


### PR DESCRIPTION
The params of the tests were set as a list, which would error when tried to access as dictionary with get() method in run.py.
Making them as dictionary items.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
