### PR TITLE
switch from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  tox:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version:
+        - 3.6
+        - 3.7
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python:
-  - "3.6"
-  - "3.7"
-install:
-  - pip install tox-travis
-script:
-  - tox

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/red-hat-storage/cephci.svg?branch=master)](https://travis-ci.com/red-hat-storage/cephci)
+[![Build Status](https://github.com/red-hat-storage/cephci/workflows/tests/badge.svg)](https://github.com/red-hat-storage/cephci/actions)
 # Ceph-CI
 CEPH-CI is a framework tightly coupled with CentralCI and Red Hat Builds for
 testing Ceph downstream builds with CentralCI and Jenkins.

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,7 @@ commands =
 max-line-length = 120
 ignore = E402, E741, W503, F522
 
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37


### PR DESCRIPTION
The Travis CI administrators now [limit](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing) the amount of resources that open-source projects can use.

Run the tox tests as GitHub Actions instead.