### PR TITLE
remove tox-gh-actions module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: pip install tox tox-gh-actions
+      run: pip install tox
     - name: Test with tox
-      run: tox
+      run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,3 @@ commands =
 [flake8]
 max-line-length = 120
 ignore = E402, E741, W503, F522
-
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37


### PR DESCRIPTION
Tox interprets `-e py` to mean "run tests with the Python version that invoked tox". That means that tox will automatically choose the right version of Python for the tests, and we do not need the separate tox-gh-actions module.