### PR TITLE
code changes for rhel-8.x network time synchronization support

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -362,6 +362,23 @@ def open_firewall_port(ceph_node, port, protocol):
 
 
 def config_ntp(ceph_node):
+    distro_info = ceph_node.distro_info
+    distro_ver = distro_info['VERSION_ID']
+
+    if distro_ver.startswith('8'):
+        ceph_node.exec_command(
+            cmd="sudo sed -i '/pool*/d;/server*/d' /etc/chrony.conf",
+            long_running=True)
+        ceph_node.exec_command(
+            cmd="sudo sed -i '1i server clock.corp.redhat.com iburst'"
+                " /etc/chrony.conf",
+            long_running=True)
+        ceph_node.exec_command(
+            cmd="sudo systemctl stop chronyd.service; sudo chronyc makestep;"
+                " sudo systemctl start chronyd.service; sudo chronyc sources",
+            long_running=True,
+        )
+        return True
     ceph_node.exec_command(
         cmd="sudo sed -i '/server*/d' /etc/ntp.conf",
         long_running=True)


### PR DESCRIPTION
- Added rhel-8.x time synchronization support(chronyc)

Test result: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1608614945384/install_ceph_pre-requisites_0.log

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

