### PR TITLE
Fix #277: updates the gevent package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ setup(
     author='Vasu Kulkarni',
     author_email='vasu@redhat.com',
     install_requires=[
-        'apache-libcloud',
+        'apache-libcloud==3.2.0',
         'docopt==0.6.2',
-        'gevent==1.4.0',
-        'greenlet==0.4.16',
+        'gevent==20.12.0',
+        'greenlet==0.4.17',
         'reportportal-client==3.2.0',
         'requests==2.21.0',
         'paramiko==2.4.2',


### PR DESCRIPTION
# Description

This fixes the issue #277 wherein the user would not be able to install `cephci` on a Fedora 33 based system. This blocks development of the tool.

This is due to a change to `PyTypeObject` in python 3.9. Moving to the latest package of `gevent` resolves the issue at hand. 

# Testing
Was able to create VM's after applying the changes. [Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1608784385927/)