### PR TITLE
Fix #263: Moving to safe loading of yaml files

### DIFF
--- a/unittests/utility/fixtures/.cephci.yaml
+++ b/unittests/utility/fixtures/.cephci.yaml
@@ -1,0 +1,23 @@
+report-portal:
+  endpoint: http://hostname:port
+  project: project_name
+  token: user_token
+
+polarion:
+  endpoint: some_url
+  username: some_user
+  password: some_password
+
+# Provide cdn_credentials before running suites which needs
+# access to GAed container image registry i.e 'registry.redhat.io'
+
+cdn_credentials:
+  username: some_user
+  password: some_password
+
+# Provide email address(es) in comma-seperated values
+# Example., address: email1, email2, ...... ,emailn
+# To completely disable all email, remove the "email:" and "address:" settings
+# entirely.
+email:
+  address: cephci@redhat.com

--- a/unittests/utility/test_utils.py
+++ b/unittests/utility/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from utility.utils import custom_ceph_config
+from utility.utils import custom_ceph_config, get_cephci_config
 
 suite_config = {'global': {'osd_pool_default_pg_num': 64,
                            'osd_default_pool_size': 2,
@@ -98,3 +98,24 @@ def test_custom_ceph_config_all(config_file):
                         'mon_osd_nearfull_ratio': .70}}
     result = custom_ceph_config(suite_config, cli_config, config_file)
     assert result == expected
+
+
+def test_get_cephi_config(monkeypatch, fixtures_dir):
+    """Test loading of cephci configuration."""
+    def mock_return(x):
+        return fixtures_dir
+
+    monkeypatch.setattr(os.path, "expanduser", mock_return)
+    ceph_cfg = get_cephci_config()
+
+    assert ceph_cfg.get("email", {}).get("address") == "cephci@redhat.com"
+
+
+def test_get_cephci_config_raises(monkeypatch):
+    """Test exception thrown when invalid file is provided."""
+    def mock_return(x):
+        return "./"
+
+    monkeypatch.setattr(os.path, "expanduser", mock_return)
+    with pytest.raises(IOError):
+        get_cephci_config()

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -509,7 +509,7 @@ def custom_ceph_config(suite_config, custom_config, custom_config_file):
     # retrieve custom config from file
     if custom_config_file:
         with open(custom_config_file) as f:
-            custom_config_dict = yaml.load(f)
+            custom_config_dict = yaml.safe_load(f)
             log.info("File contents: {}".format(custom_config_dict))
 
     # format cli configs into dict
@@ -633,7 +633,7 @@ def get_cephci_config():
     cfg_file = os.path.join(home_dir, ".cephci.yaml")
     try:
         with open(cfg_file, "r") as yml:
-            cfg = yaml.load(yml)
+            cfg = yaml.safe_load(yml)
     except IOError:
         log.error("Please create ~/.cephci.yaml from the cephci.yaml.template. "
                   "See README for more information.")


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@psathyan.remote.csb>

# Description

Moving to `safe_load` instead of `load`. This avoids the warning message thrown due to the usage of `load`.

[Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1609758414420)