### PR TITLE
Fix ip_address type as string

### DIFF
--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -298,6 +298,8 @@ class CephVMNode(object):
             self.ip_address = self.get_private_ip()
 
             if self.ip_address is not None:
+                # Let's keep the ip_address as a string instead of bytes
+                self.ip_address = self.ip_address.decode("ascii", "ignore")
                 break
 
             if datetime.datetime.now() - start_time > timeout:


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@psathyan.remote.csb>

# Description

This PR fixes the issue #284 by decoding the return value of `get_private_ip` method.

[Log](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/pr285/log.tgz)