### PR TITLE
mita: refactor get methods

### DIFF
--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -137,15 +137,11 @@ class CephVMNode(object):
 
     def _get_image(self) -> NodeImage:
         """Return the glance image reference."""
-        try:
-            return [
-                i for i in self.driver_v2.list_images() if i.name == self.image_name
-            ][0]
-        except IndexError:
-            raise ResourceNotFound("Image {} not found".format(self.image_name))
-        except BaseException as be:  # noqa
-            logger.error(be)
-            raise OpenStackDriverError("Encountered an unknown exception.")
+        images = self.driver_v2.list_images()
+        for image in images:
+            if image.name == self.image_name:
+                return image
+        raise ResourceNotFound("Image {} not found".format(self.image_name))
 
     def _get_flavor(self) -> NodeSize:
         """Return the flavor reference."""

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -145,13 +145,11 @@ class CephVMNode(object):
 
     def _get_flavor(self) -> NodeSize:
         """Return the flavor reference."""
-        try:
-            return [f for f in self.driver_v2.list_sizes() if f.name == self.vm_size][0]
-        except IndexError:
-            raise ResourceNotFound("Flavor {} not found".format(self.vm_size))
-        except BaseException as be:  # noqa
-            logger.error(be)
-            raise OpenStackDriverError("Encountered an unknown exception.")
+        flavors = self.driver_v2.list_sizes()
+        for flavor in flavors:
+            if flavor.name == self.vm_size:
+                return flavor
+        raise ResourceNotFound("Flavor {} not found".format(self.vm_size))
 
     def _has_free_ip_address(self, network: str) -> bool:
         """

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -372,12 +372,11 @@ class CephVMNode(object):
 
     def get_volume(self, name):
         """ Return libcloud.compute.base.StorageVolume """
-        driver = self.driver
-        volumes = driver.list_volumes()
-        try:
-            return [v for v in volumes if v.name == name][0]
-        except IndexError:
-            raise RuntimeError("Unable to get volume")
+        volumes = self.driver.list_volumes()
+        for volume in volumes:
+            if volume.name == name:
+                return volume
+        raise ResourceNotFound("Volume {} not found".format(name))
 
     def create_node(self):
         """Create the instance with the provided data."""


### PR DESCRIPTION
This pull request simplifies and standardizes the code in the `get_image()`, `_get_flavor()` and `get_volume()` methods.

Loop and immediately return the very first matching resource, rather than
continuing through the entire list comprehension and then indexing the 0'th element.

Raise a simple `ResourceNotFound` if we can't find the resource, and let every other possible exception raise naturally without hiding behind a generic `OpenStackDriverError`.

Make `get_volume()` raise the exact name of the volume we were trying to find so that we provide more information to the user and match the behavior of the other methods.