### PR TITLE
Improvements to CephVMNode

### DIFF
--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -121,7 +121,7 @@ class CephVMNode(object):
             if flavor.name == self.vm_size:
                 return flavor
 
-        raise ResourceNotFound(f"No matching {self.vm_size}flavor found.")
+        raise ResourceNotFound(f"No matching {self.vm_size} flavor found.")
 
     def _get_network_by_name(self, name: str) -> OpenStackNetwork:
         """
@@ -152,7 +152,7 @@ class CephVMNode(object):
         Return True if the given network has an IPv4 Address to lease.
 
         Arguments:
-            net: String, The network UUID
+            net: Reference to OpenStackNetwork object
 
         Returns:
             bool - True on success else False
@@ -174,8 +174,6 @@ class CephVMNode(object):
                 if _free_ips > 3:
                     self.subnet = subnet.get("cidr")
                     return True
-
-            return False
         except BaseException as be:  # noqa
             logger.warning(be)
 
@@ -306,7 +304,7 @@ class CephVMNode(object):
             logger.info("Successfully attached %s to %s", _vol.name, self.node_name)
 
     def _wait_until_volume_available(self, volume) -> bool:
-        """Wait until a StorageVolume's is in available state."""
+        """Wait until the state of the StorageVolume is available."""
         tries = 0
         while True:
             sleep(3)

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -2,7 +2,6 @@
 import datetime
 import logging
 import socket
-from ssl import SSLError
 from time import sleep
 from typing import Optional
 
@@ -47,10 +46,6 @@ class GetIPError(Exception):
 
 
 class ResourceNotFound(Exception):
-    pass
-
-
-class OpenStackDriverError(Exception):
     pass
 
 

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -220,7 +220,7 @@ class CephVMNode(object):
                 logger.debug(be)
                 continue
 
-        raise ResourceNotFound(f"No suitable network resource found.")
+        raise ResourceNotFound("No suitable network resource found.")
 
     def _create_vm_node(self) -> None:
         """Create the instance using the provided data."""

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -229,29 +229,18 @@ class CephVMNode(object):
 
     def _create_vm_node(self) -> None:
         """Create the instance using the provided data."""
-        try:
-            logger.info("Instantiating VM with name %s", self.node_name)
-            self.node = self.driver.create_node(
-                name=self.node_name,
-                image=self._get_image_by_name(),
-                size=self._get_flavor_by_name(),
-                ex_userdata=self.cloud_data,
-                networks=[self._get_network(self.vm_network)],
-            )
+        logger.info("Begin %s VM instantiation process.", self.node_name)
 
-            if self.node is None:
-                raise NodeErrorState(
-                    "Unable to create the instance {}".format(self.node_name)
-                )
+        self.node = self.driver.create_node(
+            name=self.node_name,
+            image=self._get_image_by_name(),
+            size=self._get_flavor_by_name(),
+            ex_userdata=self.cloud_data,
+            networks=[self._get_network(self.vm_network)],
+        )
 
-            logger.info("%s is created", self.node.name)
-            return
-        except SSLError:
-            logger.error("Connection failed, probably a timeout was reached")
-        except BaseException as be:  # noqa
-            logger.error(be)
-
-        raise NodeErrorState("Failed to create the instance {}".format(self.node_name))
+        if self.node is None:
+            raise NodeErrorState(f"Failed to create {self.node_name}.")
 
     def _wait_until_vm_state_running(self):
         """Wait till the VM moves to running state."""

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Vasu Kulkarni',
     author_email='vasu@redhat.com',
     install_requires=[
-        'apache-libcloud',
+        'apache-libcloud==3.3.0',
         'docopt==0.6.2',
         'gevent==1.4.0',
         'greenlet==0.4.16',


### PR DESCRIPTION
# Description

This PR improves the `CephVMNode` object by the changing the below

- Moves to api_version `2.2` hence using `OpenStack_2_NodeDriver` i.e. #289 
- Server side filtering of the resource instead of client side.
- Removes unused Exceptions
- Method to collect `CIDR` is modified and no longer uses subnets
- Network select process is now modified

VM and ansible run [logs](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/issue_289/)