### PR TITLE
Improvements to get_image method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Vasu Kulkarni',
     author_email='vasu@redhat.com',
     install_requires=[
-        'apache-libcloud',
+        'apache-libcloud>=3.3.0',
         'docopt==0.6.2',
         'gevent==1.4.0',
         'greenlet==0.4.16',


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

We form a list of suitable OpenStack image after retrieving the list of images from the server and then traversing it. In this PR, the identification of suitable images is modified to use the `name` param with the request to get a smaller suitable list of matched image resources.

In addition to the above change, the request call is made using `OpenStack_2_NodeDriver`. This requires us to move to `3.3.0` version of `apache-libcloud`. It is required to fix a problem with image retrieval. 

[Logs](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/openstack/image_filter.log)