### PR TITLE
Improve get_vm_size method.

### DIFF
--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -149,23 +149,26 @@ class CephVMNode(object):
 
     def _get_vm_size(self, name: Optional[str] = None) -> NodeSize:
         """
-        Return the NodeSize instance retrieved based on the provided name or vm_size.
+        Return a NodeSize instance found using the provided name or self.vm_size.
 
         Args:
-            name: The OpenStack flavor (m1.small or m1.medium or m1.large) to be found.
+            name: (Optional), the name of the VM size to be retrieved.
+                  Example:
+                            m1.small, m1.medium or m1.large
 
         Return:
-            Reference to NodeSize
+            NodeSize instance that is referenced by the vm size name.
 
         Raises:
-            ResourceNotFound exception when none resources found.
+            ResourceNotFound - when the named vm size resource does not exist in the
+                               given OpenStack Cloud.
         """
         name = self.vm_size if name is None else name
         for flavor in self.driver_v2.list_sizes():
             if flavor.name == name:
                 return flavor
 
-        raise ResourceNotFound("No flavor matched the name %s", name)
+        raise ResourceNotFound(f"Failed to retrieve vm size with name: {name}")
 
     def _has_free_ip_address(self, network: str) -> bool:
         """


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, the `_get_vm_size` method is improved so that it returns the flavor as soon it matches the provided name or configuration set for `vm-size` in the configuration file.

Unlike image resource, we are unable to use `params` to request server side filtration due to lack of support from OpenStack. Hence, we retrieve the entire list from the server and the traverse the list to find a suitable flavor.

[Logs](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/openstack/flavor.log)