### PR TITLE
Adding Run Information row in the Result Email alert

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,9 @@ setup(
         'requests==2.21.0',
         'paramiko==2.4.2',
         'pyyaml>=4.2b1',
-        'jinja2==2.10.1',
-        'junitparser==1.4.0'
+        'jinja2',
+        'junitparser==1.4.0',
+        'jinja_markdown'
     ],
     zip_safe=True,
     include_package_data=True,

--- a/templates/result-email-template.html
+++ b/templates/result-email-template.html
@@ -26,10 +26,12 @@
         text-align: left;
         padding: 8px;
     }
+
+    p { margin:0 }
     </style>
 </head>
 <body>
-    <h2>General Information</h2>
+    <h2>Summary</h2>
     <table class="half-table">
         <tr>
             <th style="color: blue">Ceph Version</th>
@@ -72,13 +74,47 @@
             <td>{{ log_link }}</td>
         </tr>
         <tr>
-            <th style="color: blue">Total suite duration</th>
-            <td>{{ suite_run_time }}</td>
-        </tr>
-        </tr>
-        <tr>
             <th style="color: blue">Invoked by User</th>
             <td>{{ trigger_user }}</td>
+        </tr>
+    </table>
+    <h2>Suite Setup Details</h2>
+    <table class="half-table">
+        {% if info.status == 'Pass' %}
+            <tr>
+                <th style="color: blue">Environment SetUp</th>
+                <td><a style="color: green;" href="{{ info.link }}">PASS</a></td>
+            </tr>
+        {% else %}
+            <tr>
+                <th style="color: blue">Environment SetUp</th>
+                <td><a style="color: red;" href="{{ info.link }}">FAIL</a></td>
+            </tr>
+             <tr>
+                <th style="color: blue">Additional Information</th>
+                <td>
+                    {% markdown %}
+                        {% for line in info.trace %}
+                            <p><code>{{ line }}</code></p>
+                        {% endfor %}
+                    {% endmarkdown %}
+                </td>
+            </tr>
+        {% endif %}
+    </table>
+    <h2>Suite duration</h2>
+    <table class="half-table">
+        <tr>
+                <th style="color: blue">Start Time</th>
+                <td>{{ suite_run_time.start }}</td>
+        </tr>
+        <tr>
+                <th style="color: blue">End Time</th>
+                <td>{{ suite_run_time.end }}</td>
+        </tr>
+        <tr>
+                <th style="color: blue">Execution Duration</th>
+                <td>{{ suite_run_time.total }}</td>
         </tr>
     </table>
     <h2>Test Results</h2>
@@ -99,7 +135,7 @@
                 {% elif test.status == 'Failed' %}
                     <td><a style="color: red;" href="{{ test['log-link'] }}">{{ test.status }}</a></td>
                 {% elif test.status == 'Not Executed' %}
-                    <td>{{ test.status }}</td>
+                <td style="color: grey">{{ test.status }}</td>
                 {% endif %}
             </tr>
         {% endfor %}


### PR DESCRIPTION
<s>Suspecting that this commit is causing the tests to send Not Run status report. Will debug and fix the issue</s>.
Issue with the Openstack connection, due to which tests were failing during node creation. Added a Run Information column information row in the email, which provides information about failure during node creation if any, otherwise gives the run status.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
