### PR TITLE
Logging unexpected exceptions for easier triage

### DIFF
--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -382,12 +382,20 @@ class CephVMNode(object):
 
     def create_node(self):
         """Create the instance with the provided data."""
-        self._create_vm_node()
-        self._wait_until_vm_state_running()
-        self._wait_until_ip_is_known()
+        try:
+            self._create_vm_node()
+            self._wait_until_vm_state_running()
+            self._wait_until_ip_is_known()
 
-        if self.no_of_volumes:
-            self._create_attach_volumes()
+            if self.no_of_volumes:
+                self._create_attach_volumes()
+        except (ResourceNotFound, NodeErrorState, GetIPError, VolumeOpError):
+            raise
+        except BaseException as be:  # noqa
+            logger.error(be)
+            raise NodeErrorState(
+                f"Unknown exception occurred during creation of {self.node_name}"
+            )
 
     def destroy_node(self):
         """


### PR DESCRIPTION
# Description
Due to resurrecting of exceptions, at times the exact error messages/exceptions are lost. In this PR, the unknown exceptions are logged before raising `NodeStateError` in the `create_node` method. 

This way we may be able to pinpoint connection or driver issues occurring during environment setup.

Partially addresses the problem in #309 
- `TypeError` exception
- Better message logging.

[Logs](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/issue_309/)

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>
