### PR TITLE
Adding S3Test suite support for RHCS 5

### DIFF
--- a/conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml
+++ b/conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml
@@ -1,0 +1,38 @@
+version_id: 8.3
+id: rhel
+instance:
+  create:
+    image-name: rhel-8.3-server-x86_64-released
+    vm-size: ci.m1.medlarge
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: True
+
+    groups:
+        - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDI0tHxJQ7n+uMiLpsoR6CKAVd0xatgVQuqp/gmnGpZU0kE54a29vPNnEt7/aLitbfyhc57rrbHOT09H3ov74GZKkoVBSbMJUSsK3drbN+58wcuk+HK0htRewmwCfcfi9AkrVbyw6pbPXW/pbjxnxLep52fKmpJJnImZ5eHRV5le9OSAcLA1LHYR4y9R3IOrTp7jgpE205UxZi5OopAx7gkyTsmfydvmq4MjaSwbVOJ7aW/Fdt5FVxNJP3Zl/OrvDoo/1WovoRIDbVQH8JFpLikMSnCqtBVIHDeW6imAKl6dpn9Gf4FxD94+OcurhXo2p0pvSzC4Strg4d2Sxqh4wph jenkins-build@jenkins
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser: pass123
+      expire: False
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - sudo yum clean metadata
+      - sudo yum clean all
+      - touch /ceph-qa-ready
+
+
+    final_message: "Ready for ceph qa testing"

--- a/conf/pacific/rgw/sanity_rgw.yaml
+++ b/conf/pacific/rgw/sanity_rgw.yaml
@@ -1,0 +1,42 @@
+# System Under Test environment configuration for RGW sanity suite.
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        role:
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client

--- a/suites/pacific/rgw/sanity_rgw.yaml
+++ b/suites/pacific/rgw/sanity_rgw.yaml
@@ -1,0 +1,79 @@
+# RHCS 5.0 sanity test suite for RGW daemon.
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.all
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        branch: ceph-pacific
+      desc: Run the external S3test suites.
+      destroy-cluster: false
+      module: test_s3.py
+      name: execute s3tests

--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -38,7 +38,7 @@ def add(cls, config: Dict) -> None:
 
     # Create client
     cmd = ["ceph", "auth", "get-or-create", f"{id_}"]
-    [cmd.append(f"{k} '{v}'") for k, v in config.get("caps").items()]
+    [cmd.append(f"{k} '{v}'") for k, v in config.get("caps", {}).items()]
     cnt_key, err = cls.shell(args=cmd)
 
     # Copy the keyring to client

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -1,12 +1,37 @@
-"""Test module that executes the external S3 Tests."""
+"""
+Test module that executes the external S3 Tests.
+
+The purpose of this test module is to execute the test suites available @
+https://github.com/ceph/s3-tests. Over here, we have three stages
+
+    - Test Setup
+    - Execute Tests
+    - Test Teardown
+
+In the test setup stage, the test suite is clone and the necessary steps to execute it
+is carried out here.
+
+In the execute test stage, the test suite is executed using tags based on the RHCS
+build version.
+
+In the test teardown, the cloned repository is removed and the configurations done are
+reverted.
+
+Requirement parameters
+     ceph_nodes:    The list of node participating in the RHCS environment.
+     config:        The test configuration
+        branch      the s3test branch to be used.
+
+Entry Point:
+    def run(**args):
+"""
 
 import binascii
 import json
 import logging
 import os
-import time
 
-from ceph.ceph import CephNode, CommandFailed
+from ceph.ceph import Ceph, CephNode, CommandFailed
 from ceph.utils import open_firewall_port
 
 log = logging.getLogger(__name__)
@@ -14,82 +39,232 @@ log = logging.getLogger(__name__)
 
 def run(**kw):
     log.info("Running s3-tests")
-    ceph_nodes = kw.get("ceph_nodes")
+
+    cluster = kw["ceph_cluster"]
     config = kw.get("config")
+    build = config.get("build", config.get("rhbuild"))
+    client_node = cluster.get_nodes(role="client")[0]
 
-    client_node = None
-    rgw_node = None
+    execute_setup(cluster, config)
+    exit_status = execute_s3_tests(client_node, build)
+    execute_teardown(cluster, build)
 
-    for node in ceph_nodes:
-        if node.role == "client":
-            client_node = node
-            break
-
-    for node in ceph_nodes:
-        if node.role == "rgw":
-            rgw_node = node
-            break
-
-    if not client_node:
-        log.warning("No client node in cluster, skipping s3 tests.")
-        return 0
-
-    setup_s3_tests(client_node, rgw_node, config)
-    exit_status = execute_s3_tests(client_node)
-    cleanup(client_node)
-    teardown_rgw_conf(rgw_node)
-
-    log.info("Returning status code of {}".format(exit_status))
+    log.info("Returning status code of %s", exit_status)
     return exit_status
 
 
-def setup_s3_tests(client_node, rgw_node, config):
+def execute_setup(cluster: Ceph, config: dict) -> None:
     """
-    Performs initial setup and configuration for s3 tests on client node.
+    Execute the prerequisites required to run the tests.
+
+    It involves the following steps
+        - install the required software (radosgw for CLI execution)
+        - Clone the S3 tests repo in the client node
+        - Install S3 pre-requisites in the client node
+        - Open the firewall port on the RGW node
+        - Add 'rgw_lc_debug_interval' key to the RGW node config
+        - Restart the service
 
     Args:
-        client_node: The node configured with 'client'
-        rgw_node: The node configured with 'radosgw'
-        config: test configuration
+        cluster: Ceph cluster participating in the test.
+        config:  The key/value pairs passed by the tester.
+
+    Raises:
+        CommandFailed:  When a remote command returned non-zero value.
+    """
+    build = config.get("build", config.get("rhbuild"))
+    client_node = cluster.get_nodes(role="client")[0]
+    rgw_node = cluster.get_nodes(role="rgw")[0]
+
+    branch = config.get("branch", "ceph-luminous")
+    clone_s3_tests(node=client_node, branch=branch)
+    install_s3test_requirements(client_node, branch)
+
+    host = rgw_node.shortname
+    secure = config.get("is_secure", "no")
+    port = "443" if secure.lower() == "yes" else rgw_frontend_port(cluster, build)
+    create_s3_conf(cluster, build, host, port, secure)
+
+    if not build.startswith("5"):
+        open_firewall_port(rgw_node, port=port, protocol="tcp")
+
+    add_lc_debug(cluster, build)
+
+
+def execute_s3_tests(node: CephNode, build: str) -> int:
+    """
+    Return the result of S3 test run.
+
+    Args:
+        node: The node from which the test execution is triggered.
+        build: the RH build version
 
     Returns:
-        None
-
+        0 - Success
+        1 - Failure
     """
-    log.info("Removing existing s3-tests directory if it exists")
-    client_node.exec_command(cmd="if test -d s3-tests; then rm -r s3-tests; fi")
+    log.info("Executing s3-tests")
+    try:
+        base_cmd = "cd s3-tests; S3TEST_CONF=config.yaml virtualenv/bin/nosetests -v"
+        extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!encryption'"
+        tests = "s3tests"
 
-    log.info("Cloning s3-tests repository")
-    branch = config.get("branch", "ceph-luminous")
+        if build.startswith("5"):
+            extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!encryption"
+            extra_args += ",!test_of_sts,!lifecycle,!s3select,!user-policy"
+            extra_args += ",!webidentity_test'"
+            tests = "s3tests_boto3"
+
+        cmd = f"{base_cmd} {extra_args} {tests}"
+        out, err = node.exec_command(cmd=cmd, timeout=3600)
+        log.info(out.read().decode())
+        log.error(err.read().decode())
+    except CommandFailed as e:
+        log.warning("Received CommandFailed")
+        log.warning(e)
+        return 1
+
+    return 0
+
+
+def execute_teardown(cluster: Ceph, build: str) -> None:
+    """
+    Execute the test teardown phase.
+    """
+    command = "rm -r s3-tests"
+
+    node = cluster.get_nodes(role="client")[0]
+    node.exec_command(cmd=command)
+
+    del_lc_debug(cluster, build)
+
+
+# Internal functions
+
+
+def clone_s3_tests(node: CephNode, branch="ceph-luminous") -> None:
+    """Clone the S3 repository on the given node."""
     repo_url = "https://github.com/ceph/s3-tests.git"
-    client_node.exec_command(
-        cmd="git clone -b {branch} {repo_url}".format(branch=branch, repo_url=repo_url)
-    )
+    node.exec_command(cmd="if test -d s3-tests; then rm -r s3-tests; fi")
+    node.exec_command(cmd=f"git clone -b {branch} {repo_url}")
 
-    out, err = client_node.exec_command(
-        cmd="grep -i 'release 8' /etc/redhat-release",
-        check_ec=False,
+
+def install_s3test_requirements(node: CephNode, branch: str) -> None:
+    """
+    Install the required packages required by S3tests.
+
+    The S3test requirements are installed via bootstrap however for RHCS it is a
+    simulation of the manual steps.
+
+    Args:
+        node:   The node that is consider for running S3Tests.
+        branch: The branch to be installed
+
+    Raises:
+        CommandFailed:  Whenever a command returns a non-zero value part of the method.
+    """
+    rhel8, err = node.exec_command(
+        cmd="grep -i 'release 8' /etc/redhat-release", check_ec=False
     )
-    out = out.read().decode()
-    if branch == "ceph-nautilus" and out:
-        _install_s3test_prereq(client_node)
+    rhel8 = rhel8.read().decode()
+
+    if branch == "ceph-nautilus" and rhel8:
+        return _s3tests_req_install(node)
+
+    _s3tests_req_bootstrap(node)
+
+
+def rgw_frontend_port(cluster: Ceph, build: str) -> str:
+    """
+    Return the configured port number of RadosGW.
+
+    For prior versions of RHCS 5.0, the port number is determined using the ceph.conf
+    and for the higher versions, the value is retrieved from cephadm.
+
+    Note: In case of RHCS 5.0, we assume that the installer node is provided.
+
+    Args:
+        cluster:    The cluster participating in the test.
+        build:      RHCS version string.
+
+    Returns:
+        port_number:    The configured port number
+    """
+    node = cluster.get_nodes(role="rgw")[0]
+
+    if build.startswith("5"):
+        node = cluster.get_nodes(role="client")[0]
+        # Allow realm & zone variability hence using config dump instead of config-key
+        cmd1 = "ceph config dump | grep client.rgw | grep port | head -n 1"
+        cmd2 = "cut -d '=' -f 2 | cut -d ' ' -f 1"
+        command = f"{cmd1} | {cmd2}"
     else:
-        log.info("Running bootstrap")
-        client_node.exec_command(cmd="cd s3-tests; ./bootstrap")
+        cmd1 = "grep -e '^rgw frontends' /etc/ceph/ceph.conf"
+        cmd2 = "cut -d ':' -f 2"
+        command = f"{cmd1} | {cmd2}"
 
-    setup_rgw_conf(rgw_node)
+    out, _ = node.exec_command(sudo=True, cmd=command)
+    return out.read().decode().strip()
 
-    main_info = create_s3_user(client_node, "main-user")
-    alt_info = create_s3_user(client_node, "alt-user", email=True)
-    tenant_info = create_s3_user(client_node, "tenant", email=True)
 
-    log.info("Creating configuration file")
-    port = "8080"
-    s3_config = """
+def create_s3_user(node, display_name, email=False):
+    """
+    Create a S3 user with the given display_name.
+
+    The other required information for creating an user is auto generated.
+
+    Args:
+        node: node in the cluster to create the user on
+        display_name: display name for the new user
+        email: (optional) generate fake email address for user
+
+    Returns:
+        user_info dict
+    """
+    uid = binascii.hexlify(os.urandom(32)).decode()
+    log.info("Creating user: {display_name}".format(display_name=display_name))
+
+    cmd = f"radosgw-admin user create --uid={uid} --display_name={display_name}"
+
+    if email:
+        cmd += " --email={email}@foo.bar".format(email=uid)
+
+    out, err = node.exec_command(sudo=True, cmd=cmd)
+    user_info = json.loads(out.read().decode())
+
+    return user_info
+
+
+def create_s3_conf(
+    cluster: Ceph, build: str, host: str, port: str, secure: str
+) -> None:
+    """
+    Generate the S3TestConf for test execution.
+
+    Args:
+        cluster:    The cluster participating in the test
+        build:      The RHCS version string
+        host:       The RGW hostname to be set in the conf
+        port:       The RGW port number to be used in the conf
+        secure:     If the connection is secure or unsecure.
+    """
+    log.info("Creating the S3TestConfig file")
+
+    rgw_node = cluster.get_nodes(role="rgw")[0]
+    client_node = cluster.get_nodes(role="client")[0]
+
+    if build.startswith("5"):
+        rgw_node = client_node
+
+    main_user = create_s3_user(node=rgw_node, display_name="main-user", email=True)
+    alt_user = create_s3_user(node=rgw_node, display_name="alt-user", email=True)
+    tenant_user = create_s3_user(node=rgw_node, display_name="tenant", email=True)
+
+    _config = """
 [DEFAULT]
 host = {host}
 port = {port}
-is_secure = no
+is_secure = {secure}
 
 [fixtures]
 bucket prefix = cephuser-{random}-
@@ -99,6 +274,7 @@ user_id = {main_id}
 display_name = {main_name}
 access_key = {main_access_key}
 secret_key = {main_secret_key}
+email = {main_email}
 api_name = default
 
 [s3 alt]
@@ -113,172 +289,97 @@ user_id = {tenant_id}
 display_name = {tenant_name}
 email = {tenant_email}
 access_key = {tenant_access_key}
-secret_key = {tenant_secret_key}
-    """.format(
-        host=rgw_node.shortname,
+secret_key = {tenant_secret_key}""".format(
+        host=host,
         port=port,
+        secure=secure,
         random="{random}",
-        main_id=main_info["user_id"],
-        main_name=main_info["display_name"],
-        main_access_key=main_info["keys"][0]["access_key"],
-        main_secret_key=main_info["keys"][0]["secret_key"],
-        alt_id=alt_info["user_id"],
-        alt_name=alt_info["display_name"],
-        alt_email=alt_info["email"],
-        alt_access_key=alt_info["keys"][0]["access_key"],
-        alt_secret_key=alt_info["keys"][0]["secret_key"],
-        tenant_id=tenant_info["user_id"],
-        tenant_name=tenant_info["display_name"],
-        tenant_email=tenant_info["email"],
-        tenant_access_key=tenant_info["keys"][0]["access_key"],
-        tenant_secret_key=tenant_info["keys"][0]["secret_key"],
+        main_id=main_user["user_id"],
+        main_name=main_user["display_name"],
+        main_access_key=main_user["keys"][0]["access_key"],
+        main_secret_key=main_user["keys"][0]["secret_key"],
+        main_email=main_user["email"],
+        alt_id=alt_user["user_id"],
+        alt_name=alt_user["display_name"],
+        alt_email=alt_user["email"],
+        alt_access_key=alt_user["keys"][0]["access_key"],
+        alt_secret_key=alt_user["keys"][0]["secret_key"],
+        tenant_id=tenant_user["user_id"],
+        tenant_name=tenant_user["display_name"],
+        tenant_email=tenant_user["email"],
+        tenant_access_key=tenant_user["keys"][0]["access_key"],
+        tenant_secret_key=tenant_user["keys"][0]["secret_key"],
     )
 
-    log.info("s3-tests configuration: {s3_config}".format(s3_config=s3_config))
-    config_file = client_node.remote_file(
-        file_name="s3-tests/config.yaml", file_mode="w"
-    )
-    config_file.write(s3_config)
-    config_file.flush()
-
-    log.info("Opening port on rgw node")
-    open_firewall_port(rgw_node, port=port, protocol="tcp")
+    conf_file = client_node.remote_file(file_name="s3-tests/config.yaml", file_mode="w")
+    conf_file.write(_config)
+    conf_file.flush()
 
 
-def create_s3_user(client_node, display_name, email=False):
+def add_lc_debug(cluster: Ceph, build: str) -> None:
     """
-    Create an s3 user with the given display_name. The uid will be generated.
+    Modifies the RGW conf files to support lifecycle actions.
 
     Args:
-        client_node: node in the cluster to create the user on
-        display_name: display name for the new user
-        email: (optional) generate fake email address for user
-
-    Returns:
-        user_info dict
-
-    """
-    uid = binascii.hexlify(os.urandom(32)).decode()
-    log.info("Creating user: {display_name}".format(display_name=display_name))
-    cmd = "radosgw-admin user create --uid={uid} --display_name={display_name}".format(
-        uid=uid, display_name=display_name
-    )
-    if email:
-        cmd += " --email={email}@foo.bar".format(email=uid)
-
-    out, err = client_node.exec_command(sudo=True, cmd=cmd)
-    user_info = json.loads(out.read().decode())
-
-    return user_info
-
-
-def execute_s3_tests(client_node):
-    """
-    Return the result of S3 test run.
-
-    Args:
-        client_node: node to execute tests from
-
-    Returns:
-        0 - Success
-        1 - Failure
-    """
-    log.info("Executing s3-tests")
-    try:
-        base_cmd = "cd s3-tests; S3TEST_CONF=config.yaml virtualenv/bin/nosetests -v"
-        extra_args = " -a '!fails_on_rgw,!fails_strict_rfc2616,!encryption'"
-        cmd = base_cmd + extra_args
-
-        out, err = client_node.exec_command(cmd=cmd, timeout=3600)
-        log.info(out.read().decode())
-        log.error(err.read().decode())
-    except CommandFailed as e:
-        log.warning("Received CommandFailed")
-        log.warning(e)
-        time.sleep(30)
-        return 1
-
-    return 0
-
-
-def setup_rgw_conf(node: CephNode) -> None:
-    """
-    Execute the pre-setup workflow on the provided node.
-
-    Below are the steps executed
-        - Stop the RadosGW service
-        - Add `rgw_lc_debug_interval` with interval as 10 seconds
-        - Start the RadosGW service
-
-    Args:
-        node:   The node object has the rgw role
-
-    Returns:
-        None
+        cluster:    The cluster participating in the test.
+        build:      The RHCS build version
 
     Raises:
-        CommandFailed: when any remote command execution has returned a non-zero
+        CommandFailed:  Whenever a command returns a non-zero value part of the method.
     """
+    node = cluster.get_nodes(role="rgw")[0]
     commands = [
-        "sudo systemctl stop ceph-radosgw.target",
-        "sudo sed -i -e '$argw_lc_debug_interval = 10' /etc/ceph/ceph.conf",
-        "sudo systemctl start ceph-radosgw.target",
+        "sed -i -e '$argw_lc_debug_interval = 10' /etc/ceph/ceph.conf",
+        "systemctl restart ceph-radosgw.target",
     ]
 
+    if build.startswith("5"):
+        node = cluster.get_nodes(role="client")[0]
+        rgw_service_name = _get_rgw_service_name(cluster)
+        commands = [
+            "ceph config set client.rgw.* rgw_lc_debug_interval 10",
+            f"ceph orch restart {rgw_service_name}",
+        ]
+
     for cmd in commands:
-        node.exec_command(cmd=cmd)
+        node.exec_command(sudo=True, cmd=cmd)
 
 
-def teardown_rgw_conf(node: CephNode) -> None:
+def del_lc_debug(cluster: Ceph, build: str) -> None:
     """
-    Execute the pre-setup cleanup workflow on the given node.
-
-    Below are the steps executed as part of the cleanup activity
-        - Stop the RadosGW service
-        - Remove the conf changes
-        - Start the RadosGW service
+    Modifies the RGW conf files to support lifecycle actions.
 
     Args:
-        node: The node that has the rgw role
-
-    Returns:
-        None
+        cluster:    The cluster participating in the tests.
+        build:      The RHCS build version
 
     Raises:
-        CommandFailed: when any of the
+        CommandFailed:  Whenever a command returns a non-zero value part of the method.
     """
+    node = cluster.get_nodes(role="rgw")[0]
     commands = [
-        "sudo systemctl stop ceph-radosgw.target",
-        "sudo sed -i '/rgw_lc_debug_interval/d' /etc/ceph/ceph.conf",
-        "sudo systemctl start ceph-radosgw.target",
+        "sed -i -e '$argw_lc_debug_interval = 10' /etc/ceph/ceph.conf",
+        "systemctl restart ceph-radosgw.target",
     ]
 
+    if build.startswith("5"):
+        node = cluster.get_nodes(role="client")[0]
+        rgw_service_name = _get_rgw_service_name(cluster)
+        commands = [
+            "ceph config rm client.rgw.* rgw_lc_debug_interval",
+            f"ceph orch restart {rgw_service_name}",
+        ]
+
     for cmd in commands:
-        node.exec_command(cmd=cmd)
+        node.exec_command(sudo=True, cmd=cmd)
 
 
-def cleanup(client_node):
-    """
-    Cleanup the test artifacts.
-
-    Args:
-        client_node: The node
-
-    Returns:
-        None
-    """
-    log.info("Removing s3-tests directory")
-    client_node.exec_command(cmd="rm -r s3-tests")
+# Private functions
 
 
-def _install_s3test_prereq(client_node):
-    """
-    Install S3test pre-requisites.
-
-    Due to package mismatch on ceph-nautilus branch, we cannot use bootstrap. Hence,
-    installing all the required packages manually and virtualenv creation.
-    """
-    pkgs = [
+def _s3tests_req_install(node: CephNode) -> None:
+    """Install S3 prerequisites via pip."""
+    packages = [
         "python2-virtualenv",
         "python2-devel",
         "libevent-devel",
@@ -287,15 +388,30 @@ def _install_s3test_prereq(client_node):
         "libxslt-devel",
         "zlib-devel",
     ]
-    client_node.exec_command(
-        sudo=True, cmd=f"yum install -y --nogpgcheck {' '.join(pkgs)}"
+    node.exec_command(
+        sudo=True, cmd=f"yum install -y --nogpgcheck {' '.join(packages)}"
     )
+
     commands = [
         "virtualenv -p python2 --no-site-packages --distribute s3-tests/virtualenv",
         "s3-tests/virtualenv/bin/pip install --upgrade pip setuptools",
         "s3-tests/virtualenv/bin/pip install -r s3-tests/requirements.txt",
         "s3-tests/virtualenv/bin/python s3-tests/setup.py develop",
     ]
-
     for cmd in commands:
-        client_node.exec_command(cmd=cmd)
+        node.exec_command(cmd=cmd)
+
+
+def _s3tests_req_bootstrap(node: CephNode) -> None:
+    """Install the S3tests using bootstrap script."""
+    node.exec_command(cmd="cd s3-tests; ./bootstrap")
+
+
+def _get_rgw_service_name(cluster: Ceph) -> str:
+    """Return the RGW service name."""
+    node = cluster.get_nodes(role="client")[0]
+    cmd_ = "ceph orch ls rgw --format json"
+    out, err = node.exec_command(sudo=True, cmd=cmd_)
+
+    json_out = json.loads(out.read().decode().strip())
+    return json_out[0]["service_name"]


### PR DESCRIPTION
# Description

In this PR, support for s3test execution in a RHCS 5 environment is being added. Due to `cephadm`, the following changes are done

- the way conf file is modified
- service/daemon restart
- Node selection changed due to the interface.

Additional changes
- Introducing new SUT for reducing VM footprint.

**Logs**
[RHCS 5](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3_tests/5/)
[RHCS 4.x](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3_tests/4/)