### PR TITLE
INC1610944: workaround to use newly created provided networks

### DIFF
--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -226,6 +226,9 @@ class CephVMNode(object):
         """
         network_names = (
             [
+                "provider_net_cci_12",
+                "provider_net_cci_11",
+                "provider_net_cci_9",
                 "provider_net_cci_8",
                 "provider_net_cci_7",
                 "provider_net_cci_6",


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
Adding new `provider_net_cci_{9,11,12}` to workaround the issues seen __INC1610944__.