### PR TITLE
Hostname with a + sign is invalid hence moving to use - sign

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -67,7 +67,7 @@ def create_ceph_nodes(cluster_conf, inventory, osp_cred, run_id, instances_name=
                         instances_name,
                         run_id,
                         node,
-                        "+".join(role),
+                        "-".join(role),
                     )
                 else:
                     node_params["node-name"] = "{}-{}-{}-{}-{}".format(
@@ -75,7 +75,7 @@ def create_ceph_nodes(cluster_conf, inventory, osp_cred, run_id, instances_name=
                         user,
                         run_id,
                         node,
-                        "+".join(role),
+                        "-".join(role),
                     )
                 if node_dict.get("no-of-volumes"):
                     node_params["no-of-volumes"] = node_dict.get("no-of-volumes")


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
The host and vm names are different when we have '+' sign in their values. This is because '+' is not a valid character for host names. In this PR, using '-' sign which is a valid character.

At present, we create the 
```
vm_name = "ceph-prag01-1612368034194-node1-mon+mgr+installer+osd"
host_name = "ceph-prag01-1612368034194-node1-monmgrinstallerosd"

# echo $(hostname)
ceph-prag01-1612368034194-node1-monmgrinstallerosd
```
notice the stripping of `+` sign

With this change,
```
vm_name = "ceph-prag01-1612368034194-node1-mon-mgr-installer-osd"
host_name =  "ceph-prag01-1612368034194-node1-mon-mgr-installer-osd"
```