### PR TITLE
README: improve versions in cluster config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Cluster configuration files are kept in a directory under `conf` for each ceph v
 | "Jewel"                | RH Ceph Storage 2       | `conf/jewel`    |
 | "Luminous              | RH Ceph Storage 3       | `conf/luminous` |
 | "Nautilus              | RH Ceph Storage 4       | `conf/nautilus` |
+| "Pacific"              | RH Ceph Storage 5       | `conf/pacific`  |
 
 The conf files describes the test bed configuration.
 The image-name inside globals: define what image is used to clone ceph-nodes(

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ your own OpenStack credentials.
 
 #### Cluster Configuration
 Cluster configuration files are kept in a directory under `conf` for each ceph version.
-For jewel, configs are under `conf/jewel`.
-For luminous, configs are under `conf/luminous`.
-For nautilus, configs are under `conf/nautilus`
+
+| Ceph upstream codename | RH Ceph Storage Release | Location        |
+| ---------------------- | ----------------------- | --------------- |
+| "Jewel"                | RH Ceph Storage 2       | `conf/jewel`    |
+| "Luminous              | RH Ceph Storage 3       | `conf/luminous` |
+| "Nautilus              | RH Ceph Storage 4       | `conf/nautilus` |
 
 The conf files describes the test bed configuration.
 The image-name inside globals: define what image is used to clone ceph-nodes(

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Cluster configuration files are kept in a directory under `conf` for each ceph v
 | "Nautilus              | RH Ceph Storage 4       | `conf/nautilus` |
 | "Pacific"              | RH Ceph Storage 5       | `conf/pacific`  |
 
-The conf files describes the test bed configuration.
 The image-name inside globals: define what image is used to clone ceph-nodes(
 mon, osd, mds etc), The role maps to ceph role that the node will take
 and osd generally attach 3 additional volumes with disk-size as specified in


### PR DESCRIPTION
Reformat the versions information in the Cluster Configuration section of the README.