### PR TITLE
cephci.yaml.template: explain cephadm requires cdn_credentials

### DIFF
--- a/cephci.yaml.template
+++ b/cephci.yaml.template
@@ -12,8 +12,10 @@
 #  username: <polarion_user_name>
 #  password: <polarion_password>
 
-# Provide cdn_credentials before running suites which needs
-# access to GAed container image registry i.e 'registry.redhat.io'
+# Some test suites require a CDN login in order to pull GA'd images from
+# registry.redhat.io. For example, cephadm requires the prometheus images from
+# registry.redhat.io, so you must fill out the cdn_credentials section to run
+# the cephadm suites:
 
 # cdn_credentials:
 #  username: <user_name>


### PR DESCRIPTION
Explain that the user must fill out `cdn_credentials` in order to run any cephadm tests.