### PR TITLE
interop_pre_req.py: update shell script path to Gitlab

### DIFF
--- a/tests/misc_env/interop_pre_req.py
+++ b/tests/misc_env/interop_pre_req.py
@@ -38,6 +38,7 @@ def add_recent_rhel8_product_cert(ceph):
     )
     ceph.exec_command(
         sudo=True,
-        cmd="curl http://magna002.ceph.redhat.com/cephci-jenkins/rhceph-qe-team-files/rhpc_8_2.sh -O",
+        cmd="curl -k https://gitlab.cee.redhat.com/ceph/teuthology-configs/-"
+        "/raw/master/cephci/interop/update_certs.sh -O",
     )
-    ceph.exec_command(sudo=True, cmd="bash rhpc_8_2.sh", long_running=True)
+    ceph.exec_command(sudo=True, cmd="bash update_certs.sh")


### PR DESCRIPTION
Since Interop runs on unreleased versions of RHEL, the certificates need to be updated with the released products.
Updating the path of the shell script to point to Gitlab repo
Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
