### PR TITLE
Moving orch parent to CephCLI

### DIFF
--- a/ceph/ceph_admin/ceph.py
+++ b/ceph/ceph_admin/ceph.py
@@ -1,0 +1,8 @@
+"""Interface to the base command ceph."""
+from ceph.ceph_admin import CephAdmin
+
+
+class CephCLI(CephAdmin):
+    """Interface to the ceph CLI."""
+
+    direct_calls = ["orch"]

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -10,15 +10,15 @@ from time import sleep
 from typing import List
 
 from ceph.ceph import ResourcesNotFoundError
-from ceph.ceph_admin import CephAdmin
 
 from .ls import LSMixin
 from .ps import PSMixin
+from .ceph import CephCLI
 
 LOG = logging.getLogger()
 
 
-class Orch(LSMixin, PSMixin, CephAdmin):
+class Orch(LSMixin, PSMixin, CephCLI):
     """Represent ceph orch command."""
 
     direct_calls = ["ls", "ps"]


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, `orch` object inherits from `cephcli` instead of `cephadm`. This is to allow adding of objects to `cephcli` without changes to existing implementation.