### PR TITLE
README: reformat install instructions and add pip upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Please use a Python virtual environment to install the necessary dependencies an
 1. Setup a Python virtualenv (CEPH-CI requires Python 3.6 or newer).
     * `python3 -m venv <path/to/venv>`
     * `source <path/to/venv>/bin/activate`
-2. Install cephci's dependencies:
+2. Install the latest version of Pip into your virtualenv:
+    * `pip install --upgrade pip`
+3. Install cephci's dependencies:
     * `pip install -r requirements.txt`
 
 #### Initial Setup

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Please use a Python virtual environment to install the necessary dependencies an
 1. Setup a Python virtualenv (CEPH-CI requires Python 3.6 or newer).
     * `python3 -m venv <path/to/venv>`
     * `source <path/to/venv>/bin/activate`
-2. Install requirements with `pip install -r requirements.txt`
+2. Install cephci's dependencies:
+    * `pip install -r requirements.txt`
 
 #### Initial Setup
 Configure your cephci.yaml file:


### PR DESCRIPTION
This pull request moves the `pip install -r requirements.txt` preformatted text to a separate line in the readme. The purpose of this change is to make it easier for users to copy and paste this line.

This pull request also adds a new instruction for cephci users to upgrade `pip`. The latest versions of the cryptography library on PyPI require a version of Pip that is newer than what is bundled into RHEL 8's standard py36 virtualenv.