### PR TITLE
sanity_rgw_multisite.yaml: set rgw_zonegroupmaster to false

### DIFF
--- a/suites/nautilus/rgw/sanity_rgw_multisite.yaml
+++ b/suites/nautilus/rgw/sanity_rgw_multisite.yaml
@@ -66,7 +66,7 @@ tests:
               rgw_realm: USA
               rgw_zonemaster: false
               rgw_zonesecondary: true
-              rgw_zonegroupmaster: true
+              rgw_zonegroupmaster: false
               rgw_zone_user: synchronization-user
               rgw_zone_user_display_name: "Synchronization User"
               system_access_key: 86nBoQOGpQgKxh4BLMyq


### PR DESCRIPTION
rgw_zonegroupmaster cannot be set to true
on a secondary site. this will fail the installation 

[Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1613390970512/ceph_ansible_0.log)

