### PR TITLE
Clean_volumes - update size of available VMs

### DIFF
--- a/suites/nautilus/rgw/sanity_rgw_multisite.yaml
+++ b/suites/nautilus/rgw/sanity_rgw_multisite.yaml
@@ -66,7 +66,7 @@ tests:
               rgw_realm: USA
               rgw_zonemaster: false
               rgw_zonesecondary: true
-              rgw_zonegroupmaster: true
+              rgw_zonegroupmaster: false
               rgw_zone_user: synchronization-user
               rgw_zone_user_display_name: "Synchronization User"
               system_access_key: 86nBoQOGpQgKxh4BLMyq


### PR DESCRIPTION
update clean_ceph_vols.py to display count and capacity consumed by volumes in state "available"
python clean_ceph_vols.py 
102 Volumes in available state using storage capacity 1710 GB

Also added check to delete volumes whose name start with "ceph-" to exclude deletion of non-ci volumes.
