### PR TITLE
ceph/ceph: rename write_file() to remote_file()

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -102,7 +102,7 @@ class CephAdmin(
 
         for each_node in nodes:
             each_node.exec_command(sudo=True, cmd="install -d -m 0700 /root/.ssh")
-            keys_file = each_node.write_file(
+            keys_file = each_node.remote_file(
                 sudo=True, file_name="/root/.ssh/authorized_keys", file_mode="a"
             )
             keys_file.write(ceph_pub_key)
@@ -678,7 +678,7 @@ class CephAdmin(
                 client.exec_command(sudo=True, cmd="mkdir -p /etc/ceph")
                 client.exec_command(sudo=True, cmd="chmod 777 /etc/ceph")
 
-                keyring_file = client.write_file(
+                keyring_file = client.remote_file(
                     sudo=True,
                     file_name=client_keyring,
                     file_mode="w",

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -195,7 +195,7 @@ def keep_alive(ceph_nodes):
 def setup_repos(ceph, base_url, installer_url=None):
     repos = ["MON", "OSD", "Tools", "Calamari", "Installer"]
     base_repo = generate_repo_file(base_url, repos)
-    base_file = ceph.write_file(
+    base_file = ceph.remote_file(
         sudo=True, file_name="/etc/yum.repos.d/rh_ceph.repo", file_mode="w"
     )
     base_file.write(base_repo)
@@ -204,7 +204,7 @@ def setup_repos(ceph, base_url, installer_url=None):
         installer_repos = ["Agent", "Main", "Installer"]
         inst_repo = generate_repo_file(installer_url, installer_repos)
         log.info("Setting up repo on %s", ceph.hostname)
-        inst_file = ceph.write_file(
+        inst_file = ceph.remote_file(
             sudo=True, file_name="/etc/yum.repos.d/rh_ceph_inst.repo", file_mode="w"
         )
         inst_file.write(inst_repo)

--- a/tests/ceph_ansible/shrink_mon.py
+++ b/tests/ceph_ansible/shrink_mon.py
@@ -94,7 +94,7 @@ def run(ceph_cluster, **kw):
     modified_inventory = "\n".join(inventory)
     log.info("\nInventory after shrink-mon playbook\n")
     log.info(modified_inventory)
-    hosts_file = ceph_installer.write_file(
+    hosts_file = ceph_installer.remote_file(
         sudo=True, file_name="{}/hosts".format(ansible_dir), file_mode="w"
     )
     hosts_file.write(modified_inventory)

--- a/tests/ceph_ansible/test_ansible_upgrade.py
+++ b/tests/ceph_ansible/test_ansible_upgrade.py
@@ -83,7 +83,7 @@ def run(ceph_cluster, **kw):
 
     # create all.yml
     log.info("global vars {}".format(gvar))
-    gvars_file = ceph_installer.write_file(
+    gvars_file = ceph_installer.remote_file(
         sudo=True, file_name="{}/group_vars/all.yml".format(ansible_dir), file_mode="w"
     )
     gvars_file.write(gvar)
@@ -275,13 +275,13 @@ def collocate_mons_with_mgrs(ceph_cluster, ansible_dir):
     for node in mon_nodes:
         mgr_block += node.shortname + " monitor_interface=" + node.eth_interface + "\n"
 
-    host_file = ceph_installer.write_file(
+    host_file = ceph_installer.remote_file(
         sudo=True, file_name="{}/hosts".format(ansible_dir), file_mode="a"
     )
     host_file.write(mgr_block)
     host_file.flush()
 
-    host_file = ceph_installer.write_file(
+    host_file = ceph_installer.remote_file(
         sudo=True, file_name="{}/hosts".format(ansible_dir), file_mode="r"
     )
     host_contents = ""

--- a/tests/ceph_installer/test_ceph_deploy.py
+++ b/tests/ceph_installer/test_ceph_deploy.py
@@ -51,12 +51,12 @@ def run(**kw):
         )
 
     for ceph in ceph_nodes:
-        keys_file = ceph.write_file(file_name=".ssh/authorized_keys", file_mode="a")
-        hosts_file = ceph.write_file(sudo=True, file_name="/etc/hosts", file_mode="a")
+        keys_file = ceph.remote_file(file_name=".ssh/authorized_keys", file_mode="a")
+        hosts_file = ceph.remote_file(sudo=True, file_name="/etc/hosts", file_mode="a")
         ceph.exec_command(
             cmd="[ -f ~/.ssh/config ] && chmod 700 ~/.ssh/config", check_ec=False
         )
-        ssh_config = ceph.write_file(file_name=".ssh/config", file_mode="w")
+        ssh_config = ceph.remote_file(file_name=".ssh/config", file_mode="w")
         keys_file.write(keys)
         hosts_file.write(hosts)
         ssh_config.write(hostkeycheck)
@@ -83,7 +83,7 @@ def run(**kw):
     ceph1.exec_command(cmd="mkdir cd")
     ceph1.exec_command(sudo=True, cmd="cd cd; yum install -y ceph-deploy")
     ceph1.exec_command(cmd="cd cd; ceph-deploy new {mons}".format(mons=mon_names))
-    cc = ceph1.write_file(file_name="cd/ceph.conf", file_mode="w")
+    cc = ceph1.remote_file(file_name="cd/ceph.conf", file_mode="w")
     cc.write(ceph_conf)
     cc.flush()
     out, err = ceph1.exec_command(

--- a/tests/cephfs/BUG-1798719.py
+++ b/tests/cephfs/BUG-1798719.py
@@ -42,7 +42,7 @@ def run(ceph_cluster, **kw):
                 cmd="sudo ceph auth get-key client.%s" % (user_name)
             )
             secret_key = out.read().decode().rstrip("\n")
-            key_file = client.write_file(
+            key_file = client.remote_file(
                 sudo=True, file_name="/etc/ceph/%s.secret" % (user_name), file_mode="w"
             )
             key_file.write(secret_key)

--- a/tests/cephfs/cephfs_utils.py
+++ b/tests/cephfs/cephfs_utils.py
@@ -252,7 +252,7 @@ class FsUtils(object):
                     )
                     self.rc_list.append(mon.node.exit_status)
                     keyring = out.read().decode()
-                    key_file = client.write_file(
+                    key_file = client.remote_file(
                         sudo=True,
                         file_name="/etc/ceph/ceph.client.%s_%s.keyring"
                         % (client.node.hostname, self.path),
@@ -302,7 +302,7 @@ class FsUtils(object):
                     )
                     self.rc_list.append(mon.node.exit_status)
                     keyring = out.read().decode()
-                    key_file = client.write_file(
+                    key_file = client.remote_file(
                         sudo=True,
                         file_name="/etc/ceph/ceph.client.%s.keyring"
                         % (client.node.hostname),
@@ -405,7 +405,7 @@ class FsUtils(object):
                         cmd="sudo ceph auth get-key client.%s" % (new_client_hostname)
                     )
                     secret_key = out.read().decode().rstrip("\n")
-                    key_file = client.write_file(
+                    key_file = client.remote_file(
                         sudo=True,
                         file_name="/etc/ceph/%s.secret" % (new_client_hostname),
                         file_mode="w",
@@ -469,7 +469,7 @@ class FsUtils(object):
                         cmd="sudo ceph auth get-key client.%s" % (client.node.hostname)
                     )
                     secret_key = out.read().decode().rstrip("\n")
-                    key_file = client.write_file(
+                    key_file = client.remote_file(
                         sudo=True,
                         file_name="/etc/ceph/%s.secret" % (client.node.hostname),
                         file_mode="w",
@@ -564,7 +564,7 @@ class FsUtils(object):
             nfs_client_name,
             secret_key,
         )
-        conf_file = node.write_file(
+        conf_file = node.remote_file(
             sudo=True, file_name="/etc/ganesha/ganesha.conf", file_mode="w"
         )
         conf_file.write(conf)
@@ -847,7 +847,7 @@ finally:
                 mounting_dir,
                 mounting_dir,
             )
-            to_lock_code = client.write_file(
+            to_lock_code = client.remote_file(
                 sudo=True, file_name="/home/cephuser/file_lock.py", file_mode="w"
             )
             to_lock_code.write(to_lock_file)
@@ -1264,7 +1264,7 @@ ceph.conf=/etc/ceph/ceph.conf,_netdev,defaults  0 0
                             mounting_dir=mounting_dir,
                             client_hostname=client.node.hostname,
                         )
-                        fstab = client.write_file(
+                        fstab = client.remote_file(
                             sudo=True, file_name="/etc/fstab", file_mode="w"
                         )
                         fstab.write(fuse_fstab)
@@ -1298,7 +1298,7 @@ secretfile={secret_key},_netdev,noatime 00
                             client_hostname=client.node.hostname,
                             secret_key="/etc/ceph/%s.secret" % client.node.hostname,
                         )
-                        fstab = client.write_file(
+                        fstab = client.remote_file(
                             sudo=True, file_name="/etc/fstab", file_mode="w"
                         )
                         fstab.write(kernel_fstab)
@@ -1325,7 +1325,7 @@ time.sleep(20)
 os.system('sudo systemctl start  network')
 """
         node = ceph_object.node
-        nw_disconnect = node.write_file(
+        nw_disconnect = node.remote_file(
             sudo=True, file_name="/home/cephuser/nw_disconnect.py", file_mode="w"
         )
         nw_disconnect.write(script)
@@ -1447,7 +1447,7 @@ mds standby for rank = 1
                     )
                     out, rc = mds.exec_command(sudo=True, cmd="cat /etc/ceph/ceph.conf")
                     mds_conf_file = out.read().decode()
-                    key_file = mds.write_file(
+                    key_file = mds.remote_file(
                         sudo=True, file_name="/etc/ceph/ceph.conf", file_mode="w"
                     )
                     key_file.write(mds_conf_file)
@@ -1464,7 +1464,7 @@ mds standby for rank = 1
                     )
                     out, rc = mon.exec_command(sudo=True, cmd="cat /etc/ceph/ceph.conf")
                     mon_conf_file = out.read().decode()
-                    key_file = mon.write_file(
+                    key_file = mon.remote_file(
                         sudo=True, file_name="/etc/ceph/ceph.conf", file_mode="w"
                     )
                     key_file.write(mon_conf_file)

--- a/tests/iscsi/CEPH-10572_10460_10450.py
+++ b/tests/iscsi/CEPH-10572_10460_10450.py
@@ -46,7 +46,7 @@ def run(**kw):
             "\nUUID=" + uuid[i] + "\t/mnt/" + device_list[i] + "/\text4\t_netdev\t0 0"
         )
         fstab += temp
-    fstab_file = iscsi_initiators.write_file(
+    fstab_file = iscsi_initiators.remote_file(
         sudo=True, file_name="/etc/fstab", file_mode="w"
     )
     fstab_file.write(fstab)

--- a/tests/iscsi/iscsi_utils.py
+++ b/tests/iscsi/iscsi_utils.py
@@ -181,7 +181,7 @@ trusted_ip_list = {0}
             trusted_ips
         )
         for gw in gw_list:
-            conf_file = gw.write_file(
+            conf_file = gw.remote_file(
                 sudo=True, file_name="/etc/ceph/iscsi-gateway.cfg", file_mode="w"
             )
             conf_file.write(iscsi_gateway_cfg)
@@ -365,7 +365,7 @@ devices {
         iscsi_initiators.exec_command(
             sudo=True, cmd="mpathconf --enable --with_multipathd y"
         )
-        multipath_file = iscsi_initiators.write_file(
+        multipath_file = iscsi_initiators.remote_file(
             sudo=True, file_name="/etc/multipath.conf", file_mode="w"
         )
         multipath_file.write(multipath)
@@ -404,7 +404,7 @@ node.session.scan = auto
     """.format(
             username=iscsi_name
         )
-        multipath_file = iscsi_initiators.write_file(
+        multipath_file = iscsi_initiators.remote_file(
             sudo=True, file_name="/etc/iscsi/iscsid.conf", file_mode="w"
         )
         multipath_file.write(iscsid)

--- a/tests/iscsi/update-kernel-iscsi.py
+++ b/tests/iscsi/update-kernel-iscsi.py
@@ -60,7 +60,7 @@ enabled=1
         cmd="sudo wget -O /etc/yum.repos.d/rh_7_nightly.repo "
         "http://file.rdu.redhat.com/~kdreyer/repos/rhel-7-nightly.repo"
     )
-    kernel_repo = client.write_file(
+    kernel_repo = client.remote_file(
         sudo=True, file_name="/etc/yum.repos.d/rh_kernel.repo", file_mode="w"
     )
     kernel_repo.write(kernel_repo_file)

--- a/tests/mgr/test_ceph_83573397.py
+++ b/tests/mgr/test_ceph_83573397.py
@@ -96,7 +96,7 @@ def run(ceph_cluster, **kw):
         PASSWORD=cred["password"],
     )
 
-    script_file = ceph_installer.write_file(
+    script_file = ceph_installer.remote_file(
         sudo=True, file_name=file_name, file_mode="w"
     )
     script_file.write(script)

--- a/tests/misc_env/update-kernel.py
+++ b/tests/misc_env/update-kernel.py
@@ -41,7 +41,7 @@ enabled=1
 """.format(
         base_url=repo_url
     )
-    kernel_repo = client.write_file(
+    kernel_repo = client.remote_file(
         sudo=True, file_name="/etc/yum.repos.d/rh_kernel.repo", file_mode="w"
     )
     kernel_repo.write(kernel_repo_file)

--- a/tests/rados/test_9281.py
+++ b/tests/rados/test_9281.py
@@ -26,7 +26,7 @@ def prepare_sdata(mon):
 
     try:
 
-        sfd = mon.write_file(file_name=sdata, file_mode="w+")
+        sfd = mon.remote_file(file_name=sdata, file_mode="w+")
         sfd.write(dbuf)
         sfd.flush()
     except Exception:
@@ -94,7 +94,7 @@ def do_rados_get(mon, pool, niter):
             except Exception:
                 log.error("rados get failed for {obj}".format(obj=obj))
                 log.error(traceback.format_exc)
-            dfd = mon.write_file(file_name=file_name, file_mode="r")
+            dfd = mon.remote_file(file_name=file_name, file_mode="r")
             dcsum = hashlib.md5(dfd.read()).hexdigest()
             log.info("csum of obj {objname}={dcsum}".format(objname=obj, dcsum=dcsum))
             print(type(fcsum))

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -64,7 +64,7 @@ class RbdMirror:
     def copy_file(self, file_name, src, dest):
         out, err = src.exec_command(sudo=True, cmd="cat {}".format(file_name))
         contents = out.read().decode()
-        key_file = dest.write_file(sudo=True, file_name=file_name, file_mode="w")
+        key_file = dest.remote_file(sudo=True, file_name=file_name, file_mode="w")
         key_file.write(contents)
         key_file.flush()
 

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -158,7 +158,7 @@ secret_key = {tenant_secret_key}
     )
 
     log.info("s3-tests configuration: {s3_config}".format(s3_config=s3_config))
-    config_file = client_node.write_file(
+    config_file = client_node.remote_file(
         file_name="s3-tests/config.yaml", file_mode="w"
     )
     config_file.write(s3_config)

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -79,7 +79,7 @@ def auth_list(clients, mon_node):
             sudo=True, cmd="cat /etc/ceph/ceph.client.%s.keyring" % (node.hostname)
         )
         keyring = out.read().decode()
-        key_file = node.write_file(
+        key_file = node.remote_file(
             sudo=True,
             file_name="/etc/ceph/ceph.client.%s.keyring" % (node.hostname),
             file_mode="w",
@@ -217,7 +217,7 @@ finally:
     print "Unlocking file:------------------------------"
     fcntl.lockf(f,fcntl.LOCK_UN)
             """
-        to_lock_code = client.write_file(
+        to_lock_code = client.remote_file(
             sudo=True, file_name="/home/cephuser/file_lock.py", file_mode="w"
         )
         to_lock_code.write(to_lock_file)


### PR DESCRIPTION
`write_file()` function in `CephNode` actually returns `remote_file` object which can perform all file mode types. Naming the function as `write_file()` seems incorrect

[Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1613587586988/result.html)
