### PR TITLE
using clusters var in the test module to avoid looping of tests

### DIFF
--- a/suites/nautilus/rgw/sanity_rgw_multisite.yaml
+++ b/suites/nautilus/rgw/sanity_rgw_multisite.yaml
@@ -92,21 +92,24 @@ tests:
       name: create user
       desc: create tenanted user
       module: sanity_rgw_multisite.py
-      config:
-        set-env: true
-        test-site: ceph-rgw1
-        script-name: user_create.py
-        config-file-name: tenanted_user.yaml
-        copy-user-info-to-site: ceph-rgw2
-        timeout: 300
+      clusters:
+        ceph-rgw1:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-rgw2
+            timeout: 300
 
   - test:
       name: Buckets and Objects test
       desc: create buckets and objects test
       module: sanity_rgw_multisite.py
-      config:
-        test-site: ceph-rgw2
-        script-name: test_Mbuckets_with_Nobjects.py
-        config-file-name: test_Mbuckets_with_Nobjects.yaml
-        timeout: 300
+      clusters:
+        ceph-rgw2:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects.yaml
+            timeout: 300
+
 

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -16,6 +16,10 @@ def run(**kw):
     log.info("Running test")
     clusters = kw.get("ceph_cluster_dict")
     config = kw.get("config")
+    test_site = kw.get("ceph_cluster")
+    log.info(f"test site: {test_site.name}")
+    test_site_node = test_site.get_ceph_object("rgw").node
+
     # adding sleep for 60 seconds before another test starts, sync needs to complete
     time.sleep(60)
     verify_io_on_sites = config.get("verify-io-on-sites", [])
@@ -24,9 +28,6 @@ def run(**kw):
     secondary_cluster = clusters.get("ceph-rgw2")
     primary_rgw_node = primary_cluster.get_ceph_object("rgw").node
     secondary_rgw_node = secondary_cluster.get_ceph_object("rgw").node
-    log.info(f'test_site: {config.get("test-site")}')
-    test_site = clusters.get(config.get("test-site"))
-    test_site_node = test_site.get_ceph_object("rgw").node
 
     test_folder = "rgw-ms-tests"
     test_folder_path = f"/home/cephuser/{test_folder}"


### PR DESCRIPTION
using clusters var in the test module to avoid looping of tests 
[logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1613724400690/result.html)
Signed-off-by: rakeshgm <rakeshgm@redhat.com>

