### PR TITLE
cephadm/bootstrap: enables registry-json support

### DIFF
--- a/suites/pacific/cephadm/cephadm.yaml
+++ b/suites/pacific/cephadm/cephadm.yaml
@@ -14,6 +14,7 @@ tests:
         base_cmd_args:
           verbose: true
         args:
+          registry-json: registry.redhat.io
           custom_image: true
           mon-ip: "node1"
           orphan-initial-daemons: true

--- a/suites/pacific/cephadm/cephadm_deploy.yaml
+++ b/suites/pacific/cephadm/cephadm_deploy.yaml
@@ -19,6 +19,7 @@ tests:
               base_cmd_args:
                 verbose: true
               args:
+                registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Enables `registry-json` bootstrap option
- Provision to choose `registry-json` or `registry-url` options at bootstrap.

**Test results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1613752254624/Cephadm_Bootstrap_0.log