### PR TITLE
cephadm: fixed ceph compose path error

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -85,12 +85,12 @@ class CephAdmin(BootstrapMixin, ShellMixin):
 
     def set_tool_repo(self):
         """Add the given repo on every node part of the cluster."""
+        base_url = self.config.get("base_url")
+        if not base_url.endswith("/"):
+            base_url += "/"
+        cmd = f"yum-config-manager --add-repo {base_url}compose/Tools/x86_64/os/"
         for node in self.cluster.get_nodes():
-            node.exec_command(
-                sudo=True,
-                cmd="yum-config-manager --add-repo"
-                " {}compose/Tools/x86_64/os/".format(self.config.get("base_url")),
-            )
+            node.exec_command(sudo=True, cmd=cmd)
 
     def install(self, **kwargs: Dict) -> None:
         """


### PR DESCRIPTION

- Fixes ceph compose path join error, if ceph-compose did not have trailing slash at the end.

currently user has to provide compose with trailing slash character  `20210216.ci.1/`.
otherwise incorrect ceph-compose were framed as below, which would fail download to packages.
```--rhs-ceph-repo  http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.0-rhel-8/RHCEPH-5.0-RHEL-8-20210216.ci.1``` 
```http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.0-rhel-8/RHCEPH-5.0-RHEL-8-20210216.ci.1compose/Tools/x86_64/os/```

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1613998624549/Cephadm_Bootstrap_0.log

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>
