### PR TITLE
Cephadm/Bootstrap: initial-dashboard user/password support

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -1,8 +1,11 @@
 """Module that allows QE to interface with cephadm bootstrap CLI."""
 import json
 import logging
+import re
 import tempfile
 from typing import Dict
+
+import requests
 
 from ceph.ceph import ResourceNotFoundError
 from utility.utils import get_cephci_config
@@ -52,22 +55,125 @@ def construct_registry(cls, registry: str, json_file: bool = False):
     return config_dict_to_string(reg_args)
 
 
+def validate_fsid(cls, fsid: str, out: str) -> bool:
+    """
+    Method is used to validate fsid
+    Args:
+        cls: class object
+        fsid: <ID>
+        out: bootstrap response logs
+
+    Returns: Boolean value whether fsid is valid
+
+    """
+    out, err = cls.shell(args=["ceph", "fsid"])
+    return out == fsid
+
+
+def validate_dashboard(cls, out, user=None, password=None):
+    """
+    Method to validate dashboard login using provided user/password
+    and Also validates user/passwd in bootstrap console output
+
+    Args:
+        cls: class object
+        out: bootstrap response log
+        user: dashboard user
+        password: dashbard password
+
+    Returns:
+        boolean
+    """
+    _, _, db_log_part = out.partition("Ceph Dashboard is now available at:")
+
+    if not db_log_part:
+        logger.error("Dashboard log part not found")
+        return False
+
+    def parse(string):
+        str_ = r"%s:\s(.+)" % string
+        return re.search(str_, db_log_part).group(1)
+
+    host = parse("URL")
+    user_ = parse("User")
+    passwd_ = parse("Password")
+
+    if user:
+        assert user == user_, f"user {user} did not match"
+    if password:
+        assert password == passwd_, f"password {password} did not match"
+
+    host_ = re.search(r"https?:[/]{2}(.*):", host).group(1)
+    for node in cls.cluster.get_nodes():
+        if host_ in node.hostname:
+            host = host.replace(host_, node.ip_address)
+            break
+    else:
+        return False
+
+    data = json.dumps({"password": passwd_, "username": user_})
+    url_ = f"{host}/api/auth" if not host.endswith("/") else f"{host}api/auth"
+
+    session = requests.Session()
+    session.headers = {
+        "accept": "application/vnd.ceph.api.v1.0+json",
+        "content-type": "application/json",
+    }
+
+    resp = session.post(url_, data=data, verify=False)
+    if not resp.ok:
+        logger.info("Response: %s, Status code: %s" % (resp.text, resp.status_code))
+        return False
+    return True
+
+
+def validate_dashboard_user(cls, user: str, out: str) -> bool:
+    """
+    Method is used to validate fsid
+    Args:
+        cls: class object
+        user: dashboard user
+        out: bootstrap console response
+
+    Returns: Boolean value if user exists and able to login using username
+    """
+    return validate_dashboard(cls, out, user=user)
+
+
+def validate_dashboard_passwd(cls, password: str, out: str) -> bool:
+    """
+    Method is used to validate fsid
+    Args:
+        cls: class object
+        password: dashboard password
+        out: bootstrap console response
+
+    Returns:
+         Boolean
+    """
+    return validate_dashboard(cls, out, password=password)
+
+
+def fetch_method(key: str):
+    """
+    Fetch method using the Key
+
+    Args:
+        key: bootstrap argument
+
+    Returns:
+        Returns the method based on the Key
+    """
+    verify_map = {
+        "fsid": validate_fsid,
+        "initial-dashboard-user": validate_dashboard_user,
+        "initial-dashboard-password": validate_dashboard_passwd,
+    }
+    return verify_map.get(key)
+
+
 class BootstrapMixin:
     """Add bootstrap support to the child class."""
-
-    def get_method(self, key):
-        """
-        Fetch method using the Key
-        Args:
-            key: fsid
-
-        Returns: Returns the method based on the Key
-
-        """
-        verify_map = {
-            "fsid": self.validate_fsid,
-        }
-        return verify_map.get(key)
 
     def bootstrap(self: CephAdmProtocol, config: Dict) -> None:
         """
@@ -93,6 +199,8 @@ class BootstrapMixin:
                     fsid: <id>
                     registry-url: <registry.url.name>
                     registry-json: <registry.url.name>
+                    initial-dashboard-user: <admin123>
+                    initial-dashboard-password: <admin123>
         """
         self.cluster.setup_ssh_keys()
         self.set_tool_repo()
@@ -143,29 +251,19 @@ class BootstrapMixin:
             check_ec=True,
         )
 
-        logger.info("Bootstrap output : %s", out.read().decode())
-        logger.error("Bootstrap error: %s", err.read().decode())
+        out, err = out.read().decode(), err.read().decode()
+        logger.info("Bootstrap output : %s", out)
+        logger.error("Bootstrap error: %s", err)
 
         self.distribute_cephadm_gen_pub_key()
 
         # Verification of arguments
-
         args = self.config.get("args", {})
         for key, value in args.items():
-            func = self.get_method(key)
+            func = fetch_method(key)
             if not func:
                 continue
-            if not func(value):
+            # bootstrap response through stdout & stderr are combined here
+            # currently console response coming through stderr.
+            if not func(self, value, out + err):
                 raise AssertionError
-
-    def validate_fsid(self, fsid) -> bool:
-        """
-        Method is used to validate fsid
-        Args:
-            fsid: <ID>
-
-        Returns: Boolean value whether fsid is valid
-
-        """
-        out, err = self.shell(args=["ceph", "fsid"])
-        return out == fsid

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -25,6 +25,14 @@ class CephAdmProtocol(Protocol):
     def install(self, **kwargs: Dict) -> None:
         ...
 
+    def shell(
+        self,
+        args: List[str],
+        check_status: bool = True,
+        timeout: int = 300,
+    ):
+        ...
+
 
 class OrchProtocol(CephAdmProtocol, Protocol):
     """Orch protocol object for supporting static duck typing hints."""

--- a/suites/pacific/cephadm/cephadm.yaml
+++ b/suites/pacific/cephadm/cephadm.yaml
@@ -19,6 +19,8 @@ tests:
           mon-ip: "node1"
           orphan-initial-daemons: true
           skip-monitoring-stack: true
+          initial-dashboard-user: admin123
+          initial-dashboard-password: admin123
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
       destroy-cluster: false
       abort-on-fail: true

--- a/tests/cephadm/test_nfs.py
+++ b/tests/cephadm/test_nfs.py
@@ -16,7 +16,7 @@ def run(ceph_cluster, **kw):
 
     check ceph.ceph_admin.nfs for test config
     """
-    log.info("Running Ceph-admin Rados-GW( RGW ) test")
+    log.info("Running Ceph-admin NFS-Ganesha test")
     config = kw.get("config")
 
     build = config.get("build", config.get("rhbuild"))


### PR DESCRIPTION
- Added initial-dashboard-user, initial-dashboard-password bootstrap support options.
- Added dashboard login validations by calling API call.
- Moved out validations outside bootstrap class.

**Results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1614174384742/Cephadm_Bootstrap_0.log

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

