### PR TITLE
interop: fixing general interop issues

### DIFF
--- a/ceph/rados_utils.py
+++ b/ceph/rados_utils.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import random
@@ -206,6 +207,23 @@ class RadosHelper:
         for osd in jbuf["osds"]:
             if osd_id == osd["osd"]:
                 return osd["up"]
+
+    def check_osd_up(self, osd_id):
+        """
+        Checks if the given osd is up and if the osd is down waits for 120 seconds for the same to come up
+        Args:
+            osd_id: ID of the osd to be checked
+
+        Returns: 1 if up, 0 if down
+
+        """
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=120)
+        while end_time > datetime.datetime.now():
+            status = self.is_up(osd_id)
+            if status:
+                return 1
+            time.sleep(5)
+        return 0
 
     def revive_osd(self, osd_node, osd_service):
         """

--- a/suites/nautilus/interop/sanity_ceph.yaml
+++ b/suites/nautilus/interop/sanity_ceph.yaml
@@ -128,7 +128,7 @@ tests:
           add:
               - node:
                   node-name: .*node10.*
-                  demon:
+                  daemon:
                       - mon
       desc: add mon
 
@@ -169,7 +169,7 @@ tests:
           add:
               - node:
                   node-name: .*node11.*
-                  demon:
+                  daemon:
                       - osd
       desc: add new osd node with lvm scenario
 
@@ -211,7 +211,7 @@ tests:
           add:
               - node:
                   node-name: .*node11.*
-                  demon:
+                  daemon:
                       - osd
       desc: add osd to existing node with lvm scenario
 

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -77,7 +77,7 @@ def install_prereq(
             setup_addition_repo(ceph, repo)
         # TODO enable only python3 rpms on both rhel7 &rhel8 once all component suites(rhcs3,4) are comptatible
         if distro_ver.startswith("8"):
-            rpm_all_packages = rpm_packages.get("py3")
+            rpm_all_packages = rpm_packages.get("py3") + ["net-tools"]
             if str(rhbuild).startswith("5"):
                 rpm_all_packages = rpm_packages.get("py3") + ["lvm2", "podman"]
             rpm_all_packages = " ".join(rpm_all_packages)

--- a/tests/rados/test_9281.py
+++ b/tests/rados/test_9281.py
@@ -212,8 +212,7 @@ def run(ceph_cluster, **kw):
     except Exception:
         log.error("killing osd failed")
         log.error(traceback.format_exc())
-    time.sleep(10)
-    if helper.is_up(pri_osd_id):
+    if helper.check_osd_up(pri_osd_id):
         log.error("unexpected! osd is still up")
         return 1
     time.sleep(5)
@@ -227,8 +226,7 @@ def run(ceph_cluster, **kw):
         log.error("revive failed")
         log.error(traceback.format_exc())
         return 1
-    time.sleep(10)
-    if helper.is_up(pri_osd_id):
+    if helper.check_osd_up(pri_osd_id):
         log.info("osd is UP")
     else:
         log.error("osd is DOWN")
@@ -252,8 +250,7 @@ def run(ceph_cluster, **kw):
     except Exception:
         log.error("killing osd failed")
         log.error(traceback.format_exc())
-    time.sleep(10)
-    if helper.is_up(rand_osd_id):
+    if helper.check_osd_up(rand_osd_id):
         log.error("unexpected! osd is still up")
         return 1
     time.sleep(5)
@@ -266,8 +263,7 @@ def run(ceph_cluster, **kw):
         log.error("revive failed")
         log.error(traceback.format_exc())
         return 1
-    time.sleep(30)
-    if helper.is_up(pri_osd_id):
+    if helper.check_osd_up(pri_osd_id):
         log.info("osd is UP")
     else:
         log.error("osd is DOWN")


### PR DESCRIPTION
Fixed the following:
1. Added net-tools as part of the rpm's to be installed on rhel 8.x. fixes netstat not found on 8.4
2. Corrected the typo in interop/sanity.yaml. Fixes fetching None value
3. Added a method to check OSD status instead of blind sleep

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
