### PR TITLE
cephadm: Crash service deployment support

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -67,6 +67,9 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         """
         ceph_pub_key = self.read_cephadm_gen_pub_key()
 
+        # Add with new line, so avoiding append to earlier entry
+        ceph_pub_key = f"\n{ceph_pub_key}"
+
         if nodes is None:
             nodes = self.cluster.get_nodes()
 

--- a/ceph/ceph_admin/crash.py
+++ b/ceph/ceph_admin/crash.py
@@ -1,0 +1,38 @@
+"""Manage the Crash service via cephadm CLI."""
+from typing import Dict
+
+from .apply import ApplyMixin
+from .orch import Orch
+
+
+class Crash(ApplyMixin, Orch):
+    """Interface to ceph orch <action> crash."""
+
+    SERVICE_NAME = "crash"
+
+    def apply(self, config: Dict) -> None:
+        """
+        Deploy the Crash service using the provided configuration.
+
+        Args:
+            config: Key/value pairs provided by the test case to create the service.
+
+        Example
+            config:
+                command: apply
+                service: crash
+                base_cmd_args:          # arguments to ceph orch
+                    concise: true
+                    verbose: true
+                    input_file: <name of spec>
+                args:
+                    placement:
+                        label: crash    # either label or node.
+                        nodes:
+                            - node1
+                        limit: 3    # no of daemons
+                        sep: " "    # separator to be used for placements
+                    dry-run: true
+                    unmanaged: true
+        """
+        super().apply(config=config)

--- a/suites/pacific/cephadm/cephadm.yaml
+++ b/suites/pacific/cephadm/cephadm.yaml
@@ -561,6 +561,21 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
   - test:
+      name: Apply Crash Service
+      desc: Apply Crash service on all nodes
+      module: test_crash.py
+      polarion-id:
+      config:
+        command: apply
+        service: crash
+        base_cmd_args:
+            verbose: true
+        args:
+          placement:
+            nodes: "*"
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
       name: Remove NFS-Ganesha Service
       desc: Remove NFS-Ganesha service using orch remove option
       module: test_nfs.py
@@ -697,5 +712,19 @@ tests:
           - rm
           - cephfs
           - "--yes-i-really-mean-it"
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Remove Crash Service
+      desc: Remove Crash service using orch remove option
+      module: test_crash.py
+      polarion-id:
+      config:
+        command: remove
+        service: crash
+        base_cmd_args:
+          verbose: true
+        args:
+          service_name: crash
       destroy-cluster: false
       abort-on-fail: true

--- a/tests/cephadm/test_crash.py
+++ b/tests/cephadm/test_crash.py
@@ -1,0 +1,31 @@
+import logging
+
+from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.crash import Crash
+
+log = logging.getLogger(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Ceph-admin module to manage Crash service
+
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): Ceph cluster object
+        kw: test data
+
+    check ceph.ceph_admin.crash for test config
+    """
+    log.info("Running Ceph-admin Crash service test")
+    config = kw.get("config")
+
+    build = config.get("build", config.get("rhbuild"))
+    ceph_cluster.rhcs_version = build
+
+    # Manage Ceph using ceph-admin orchestration
+    command = config.pop("command")
+    log.info("Executing Crash %s service" % command)
+    crash = Crash(cluster=ceph_cluster, **config)
+    method = fetch_method(crash, command)
+    method(config)
+    return 0


### PR DESCRIPTION
- Added crash service deployment support with apply option.
- Updated crash deployment and removal of service in test suite. 
- Fixed issue with ceph public key string by adding newline character to avoid appending to older entry in host.

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

**Results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1614252225129/