### PR TITLE
run.py: adding the CLI used to trigger test into the log and Email alert

### DIFF
--- a/run.py
+++ b/run.py
@@ -269,6 +269,8 @@ def run(args):
         cleanup_ceph_nodes(osp_cred, cleanup_name)
         return 0
 
+    cli_arguments = f"{sys.executable} {' '.join(sys.argv)}"
+    log.info(f"The CLI for the current run :\n{cli_arguments}\n")
     # Get ceph cluster version name
     with open("rhbuild.yaml") as fd:
         rhbuild_file = yaml.safe_load(fd)
@@ -475,6 +477,7 @@ def run(args):
         details["name"] = var.get("name")
         details["desc"] = var.get("desc")
         details["file"] = var.get("module")
+        details["cli_arguments"] = cli_arguments
         details["polarion-id"] = var.get("polarion-id")
         polarion_default_url = "https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id="
         details["polarion-id-link"] = "{}{}".format(

--- a/templates/result-email-template.html
+++ b/templates/result-email-template.html
@@ -140,5 +140,16 @@
             </tr>
         {% endfor %}
     </table>
+
+    <!-- todo: The below code part for displaying the CLI for the run can be removed at later. -->
+    <!-- Keeping this section here as it will facilitate easy copying of the CLI and rerun the same run by anyone-->
+    <h4>CLI Arguments</h4>
+    <table class="half-table">
+        <tr>
+            <td>
+                    <p><code>{{ test_results[0]['cli_arguments'] }}</code></p>
+            </td>
+        </tr>
+    </table>
 </body>
 </html>


### PR DESCRIPTION
Adding the complete CLI with all the args into the log file for easy debugging.
Fixes issue : #381

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
