### PR TITLE
install_prereq: pool id changed

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -121,8 +121,7 @@ def setup_subscription_manager(ceph, timeout=1800):
             )
 
             ceph.exec_command(
-                cmd="sudo subscription-manager attach "
-                "--pool $(sudo subscription-manager list --all --available --pool-only | head -1)",
+                cmd="sudo subscription-manager attach --pool 8a99f9a471e63f73017212730c2c4fb6",
                 timeout=720,
             )
             break


### PR DESCRIPTION
pool id was being using head -1 form pool list
this will cause problems when we add more SKUs
using this pool id 8a99f9a471e63f73017212730c2c4fb6
for enabling rhel_7 rpms and extra options rpms

Signed-off-by: rakeshgm <rakeshgm@redhat.com>

