### PR TITLE
raise OrchApplyServiceFailure with service name

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -118,4 +118,4 @@ class ApplyMixin:
         if not self.check_service_exists(
             service_name=self.SERVICE_NAME, ids=node_names
         ):
-            raise OrchApplyServiceFailure
+            raise OrchApplyServiceFailure(self.SERVICE_NAME)


### PR DESCRIPTION
Raise the `OrchApplyServiceFailure` exception with the specific service name that caused the failure.

The log message will look like this (for example):
```
ceph.ceph_admin.apply.OrchApplyServiceFailure: rgw
```