### PR TITLE
[Interop] Fixing rados_utils.py: Fix for osd wait method

### DIFF
--- a/ceph/rados_utils.py
+++ b/ceph/rados_utils.py
@@ -208,22 +208,26 @@ class RadosHelper:
             if osd_id == osd["osd"]:
                 return osd["up"]
 
-    def check_osd_up(self, osd_id):
+    def wait_until_osd_state(self, osd_id, down=False) -> bool:
         """
-        Checks if the given osd is up and if the osd is down waits for 120 seconds for the same to come up
+        Checks the state of given osd and waits for 120 seconds for the same state to be achieved
         Args:
             osd_id: ID of the osd to be checked
+            down: If True, Specifies that the OSD should be down
 
-        Returns: 1 if up, 0 if down
+        Returns: True -> Pass, False -> Fail
 
         """
         end_time = datetime.datetime.now() + datetime.timedelta(seconds=120)
         while end_time > datetime.datetime.now():
-            status = self.is_up(osd_id)
-            if status:
-                return 1
             time.sleep(5)
-        return 0
+            osd_is_up = self.is_up(osd_id)
+            if osd_is_up and not down:
+                return True
+            if down and not osd_is_up:
+                return True
+        print("Desired OSD state not achieved after 120 seconds")
+        return False
 
     def revive_osd(self, osd_node, osd_service):
         """

--- a/tests/rados/test_9281.py
+++ b/tests/rados/test_9281.py
@@ -212,7 +212,7 @@ def run(ceph_cluster, **kw):
     except Exception:
         log.error("killing osd failed")
         log.error(traceback.format_exc())
-    if helper.check_osd_up(pri_osd_id):
+    if not helper.wait_until_osd_state(osd_id=pri_osd_id, down=True):
         log.error("unexpected! osd is still up")
         return 1
     time.sleep(5)
@@ -226,11 +226,10 @@ def run(ceph_cluster, **kw):
         log.error("revive failed")
         log.error(traceback.format_exc())
         return 1
-    if helper.check_osd_up(pri_osd_id):
-        log.info("osd is UP")
-    else:
+    if not helper.wait_until_osd_state(pri_osd_id):
         log.error("osd is DOWN")
         return 1
+    log.info(f"Revival of Primary OSD : {pri_osd_id} is complete\n Killing random OSD")
 
     time.sleep(10)
     try:
@@ -250,7 +249,7 @@ def run(ceph_cluster, **kw):
     except Exception:
         log.error("killing osd failed")
         log.error(traceback.format_exc())
-    if helper.check_osd_up(rand_osd_id):
+    if not helper.wait_until_osd_state(osd_id=rand_osd_id, down=True):
         log.error("unexpected! osd is still up")
         return 1
     time.sleep(5)
@@ -263,10 +262,8 @@ def run(ceph_cluster, **kw):
         log.error("revive failed")
         log.error(traceback.format_exc())
         return 1
-    if helper.check_osd_up(pri_osd_id):
-        log.info("osd is UP")
-    else:
+    if not helper.wait_until_osd_state(rand_osd_id):
         log.error("osd is DOWN")
         return 1
-
+    log.info(f"Revival of Random OSD : {rand_osd_id} is complete")
     return 0


### PR DESCRIPTION
Corrected the method that waits for 120 seconds for the OSD to go down.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

