### PR TITLE
Adding pipeline script for tier-0 job

### DIFF
--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -1,0 +1,70 @@
+/*
+    Pipeline script for executing Tier 0 test suites for RH Ceph 5.0.
+*/
+// Global variables section
+
+def nodeName = "centos-7"
+def cephVersion = "pacific"
+def sharedLib
+def testStages = ['deploy': {
+                    stage('Deployment suite') {
+                        script {
+                            withEnv([
+                                "sutVMConf=conf/inventory/rhel-8.3-server-x86_64.yaml",
+                                "sutConf=conf/${cephVersion}/cephadm/sanity-cephadm.yaml",
+                                "testSuite=suites/${cephVersion}/cephadm/cephadm_deploy.yaml",
+                                "addnArgs=--post-results --log-level DEBUG"
+                            ]) {
+                                sharedLib.runTestSuite()
+                            }
+                        }
+                    }
+                 }, 'upgrade': {
+
+                    stage('Upgrade suite') {
+                        println "Work in progress"
+                    }
+
+                 }]
+
+// Pipeline script entry point
+
+node(nodeName) {
+
+    timeout(unit: "MINUTES", time: 30) {
+        stage('Install prereq') {
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'SubmoduleOption',
+                    disableSubmodules: false,
+                    parentCredentials: false,
+                    recursiveSubmodules: true,
+                    reference: '',
+                    trackingSubmodules: false
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
+            ])
+            script {
+                sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
+                sharedLib.prepareNode()
+            }
+        }
+    }
+
+    timeout(unit: "MINUTES", time: 60) {
+        parallel testStages
+    }
+
+    stage('Publish Results') {
+        script {
+            sharedLib.sendEMail("Tier-0")
+            sharedLib.postLatestCompose()
+        }
+    }
+
+}
+

--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -1,0 +1,132 @@
+#!/usr/bin/env groovy
+/*
+    Common groovy methods that can be reused by the pipeline jobs.
+*/
+
+import groovy.json.JsonSlurper
+
+def prepareNode() {
+    /*
+        Installs the required packages needed by the Jenkins node to
+        run and execute the cephci test suites.
+    */
+    sh(script: "bash ${env.WORKSPACE}/pipeline/vars/node_bootstrap.bash")
+}
+
+def runTestSuite() {
+    /*
+        Execute the test suite by processing CI_MESSAGE for container
+        information along with the environment variables. The required
+        variables are
+            - sutVMConf
+            - sutConf
+            - testSuite
+            - addnArgs
+    */
+    println "Begin Test Suite execution"
+
+    // generate random instance name
+    def sec = sh(script: "echo \$(date +%s)", returnStdout: true).trim()
+    def instanceName = "psi${sec}"
+
+    env.rhcephVersion = "5.0-rhel-8"
+
+    // Build the CLI options
+    def cmd = "${env.WORKSPACE}/.venv/bin/python run.py"
+    cmd += " --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
+    cmd += " --instances-name ${instanceName}"
+
+    // Append test suite specific
+    cmd += " --inventory ${env.sutVMConf}"
+    cmd += " --global-conf ${env.sutConf}"
+    cmd += " --suite ${env.testSuite}"
+
+    // Processing CI_MESSAGE parameter, it can be empty
+    def ciMessage = "${params.CI_MESSAGE}" ?: ""
+    if (ciMessage?.trim()) {
+        // Process the CI Message
+        def jsonParser = new JsonSlurper()
+        def jsonCIMsg = jsonParser.parseText("${params.CI_MESSAGE}")
+
+        env.composeId = jsonCIMsg.compose_id
+        def composeUrl = jsonCIMsg.compose_url
+
+        def (dockerDTR, dockerImage1, dockerImage2Tag) = (jsonCIMsg.repository).split('/')
+        def (dockerImage2, dockerTag) = dockerImage2Tag.split(':')
+        def dockerImage = "${dockerImage1}/${dockerImage2}"
+
+        // get rhbuild value from RHCEPH-5.0-RHEL-8.yyyymmdd.ci.x
+        env.rhcephVersion = env.composeId.substring(7,17).toLowerCase()
+
+        cmd += " --docker-registry ${dockerDTR}"
+        cmd += " --docker-image ${dockerImage}"
+        cmd += " --docker-tag ${dockerTag}"
+
+        cmd += " --rhbuild ${env.rhcephVersion}"
+        cmd += " --rhs-ceph-repo ${composeUrl}"
+        cmd += " --insecure-registry"
+        cmd += " --ignore-latest-container"
+
+    } else {
+        cmd += " --rhbuild ${env.rhcephVersion}"
+    }
+
+    // Check for additional arguments
+    def addnArgFlag = "${env.addnArgs}" ?: ""
+    if (addnArgFlag?.trim()) {
+        cmd += " ${env.addnArgs}"
+    }
+
+    // test suite execution
+    def rc = 0
+    try {
+        rc = sh(script: "PYTHONUNBUFFERED=1 ${cmd}", returnStatus: true)
+    } catch(Exception ex) {
+        rc = 1
+        echo "Encountered an error"
+    }
+
+    // Forcing cleanup
+    try {
+        cleanup_cmd = "PYTHONUNBUFFERED=1 ${env.WORKSPACE}/.venv/bin/python"
+        cleanup_cmd += " run.py --cleanup ${instanceName}"
+        cleanup_cmd += " --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
+        cleanup_cmd += " --log-level debug"
+
+        sh(script: "${cleanup_cmd}")
+    } catch(Exception ex) {
+        echo "WARNING: Encountered an error during cleanup."
+        echo "Please manually verify the test artifacts are removed."
+    }
+
+    if (rc != 0) {
+        error("Test execution has failed.")
+    }
+
+}
+
+def sendEMail(def subjectPrefix) {
+    /*
+        Send an email notification.
+    */
+    emailext(
+        subject: "${subjectPrefix} test suite execution summary of ${env.composeId}",
+        body: "Console logs are available at ${env.BUILD_URL}/console",
+        from: "cephci@redhat.com",
+        to: "cephci@redhat.com"
+    )
+}
+
+def postLatestCompose() {
+    /*
+        Store the latest compose in ressi for QE usage.
+    */
+    def msgPath = "/ceph/cephci-jenkins/latest-rhceph-container-info/latest-RHCEPH-${env.rhcephVersion}.json"
+    def ciMsgFlag = "${params.CI_MESSAGE}" ?: ""
+    if (ciMsgFlag?.trim()) {
+        sh(script: "echo ${params.CI_MESSAGE} > ${msgPath}")
+    }
+}
+
+return this;
+

--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# As we are dynamically creating the Jenkins node using the OpenStack plugin,
+# we require additional configurations to enable us to use the system for
+# executing the cephci test suites. This script performs the required changes.
+
+echo "Initialize Node"
+sudo yum install -y wget git-core python3
+
+# Workaround: Disable IPv6 to have quicker downloads
+sudo sysctl -w net.ipv6.conf.eth0.disable_ipv6=1
+
+# Mount reesi for storing logs
+if [ ! -d "/ceph" ]; then
+    echo "Mounting ressi004"
+    sudo mkdir -p /ceph
+    sudo mount -t nfs -o sec=sys,nfsvers=4.1 reesi004.ceph.redhat.com:/ /ceph
+fi
+
+# Copy the auth files from internal server to the Jenkins user home directory
+wget http://magna002.ceph.redhat.com/cephci-jenkins/.osp-cred-ci-2.yaml -O ${HOME}/osp-cred-ci-2.yaml
+wget http://magna002.ceph.redhat.com/cephci-jenkins/.cephci.yaml -O ${HOME}/.cephci.yaml
+
+# Install cephci pre-requisistes
+rm -rf .venv
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+deactivate
+
+echo "Done bootstraping the Jenkins node."
+


### PR DESCRIPTION
# Description

A new approach of executing the test suites based on their classifications from our central Jenkins server. In this approach, the job configurations are defined in our internal repo. In this PR,

- the required CLI arguments are derived from the CI_MESSAGE
- the test suites are executed in parallel
- the environment is cleaned

[RHCS Job View](https://storage-jenkins-csb-ceph.cloud.paas.psi.redhat.com/view/RHCS%205%20QE/)

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>