### PR TITLE
cephadm: remove ceph.setup_packages from install_prereq and setup hotfix_repo in set_tool_repo

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -88,7 +88,23 @@ class CephAdmin(BootstrapMixin, ShellMixin):
 
     def set_tool_repo(self):
         """Add the given repo on every node part of the cluster."""
-        if not self.config.get("hotfix_repo"):
+        hotfix_repo = self.config.get("hotfix_repo")
+        if hotfix_repo:
+            for node in self.cluster.get_nodes():
+                logger.info(
+                    "Adding hotfix repo {repo} to {sn}".format(
+                        repo=hotfix_repo,
+                        sn=node.shortname,
+                    )
+                )
+                node.exec_command(
+                    sudo=True,
+                    cmd="curl -o /etc/yum.repos.d/rh_hotfix_repo.repo {repo}".format(
+                        repo=hotfix_repo,
+                    ),
+                )
+                node.exec_command(sudo=True, cmd="yum update metadata", check_ec=False)
+        else:
             base_url = self.config["base_url"]
             if not base_url.endswith("/"):
                 base_url += "/"

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -36,34 +36,17 @@ def run(**kw):
     ceph_nodes = kw.get("ceph_nodes")
     # skip subscription manager if testing beta RHEL
     config = kw.get("config")
-    ceph_cluster = kw.get("ceph_cluster")
     skip_subscription = config.get("skip_subscription", False)
     enable_eus = config.get("enable_eus", False)
     repo = config.get("add-repo", False)
-    hotfix_repo = config.get("hotfix_repo", False)
     rhbuild = config.get("rhbuild")
-    ubuntu_repo = config.get("ubuntu_repo", None)
-    base_url = config.get("base_url", None)
-    installer_url = config.get("installer_url", None)
 
     with parallel() as p:
         for ceph in ceph_nodes:
             p.spawn(
-                install_prereq,
-                ceph,
-                1800,
-                skip_subscription,
-                repo,
-                rhbuild,
-                enable_eus,
+                install_prereq, ceph, 1800, skip_subscription, repo, rhbuild, enable_eus
             )
             time.sleep(20)
-
-    ceph_cluster.ansible_config = dict(dedicated_devices=[])
-    ceph_cluster.setup_packages(
-        base_url, hotfix_repo, installer_url, ubuntu_repo, rhbuild
-    )
-
     return 0
 
 


### PR DESCRIPTION
Fixes #406 

This removes the initial fix for #369, which introduced #406, and provides an alternative fix for #369.