### PR TITLE
run.py: CLI argument to skip enabling rpms from subscription

### DIFF
--- a/run.py
+++ b/run.py
@@ -71,6 +71,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--custom-config-file <file>]
         [--xunit-results]
         [--enable-eus]
+        [--skip-enabling-rhel-rpms]
   run.py --cleanup=name [--osp-cred <file>]
         [--log-level <LEVEL>]
 
@@ -115,6 +116,7 @@ Options:
   --custom-config-file <file>       Add custom config yaml to ceph_conf_overrides
   --xunit-results                   Create xUnit result file for test suite run [default: false]
   --enable-eus                      Enables EUS rpms on EUS suppored distro [default: false]
+  --skip-enabling-rhel-rpms         skip adding rpms from subscription if using beta rhel images for Interop runs
 """
 log = logging.getLogger(__name__)
 root = logging.getLogger()
@@ -255,6 +257,7 @@ def run(args):
     custom_config_file = args.get("--custom-config-file")
     xunit_results = args.get("--xunit-results", False)
     enable_eus = args.get("--enable-eus", False)
+    skip_enabling_rhel_rpms = args.get("--skip-enabling-rhel-rpms", False)
 
     # Set log directory and get absolute path
     run_id = timestamp()
@@ -617,6 +620,7 @@ def run(args):
                 if repo.startswith("http"):
                     config["add-repo"] = repo
             config["enable_eus"] = enable_eus
+            config["skip_enabling_rhel_rpms"] = skip_enabling_rhel_rpms
             config["docker-insecure-registry"] = docker_insecure_registry
             config["skip_version_compare"] = skip_version_compare
             config["container_image"] = None


### PR DESCRIPTION
Adding cli argument to skip the addition of rpms provided by the subscription for interop runs.
When specifying the skip argument, the repos specified via a repo file with --add-repo option will be added.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>