### PR TITLE
Upgrade from 4.x to 5.x on rhel8

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -683,6 +683,7 @@ class Ceph(object):
                 cmd += f" --cluster {cluster_name}"
             if pacific:
                 cmd = f"cephadm shell -- {cmd}"
+
             out, err = client.exec_command(cmd=cmd, sudo=True)
             lines = out.read().decode()
 

--- a/conf/pacific/upgrades/upgrade_from4x_tier0.yml
+++ b/conf/pacific/upgrades/upgrade_from4x_tier0.yml
@@ -1,0 +1,42 @@
+globals:
+  - ceph-cluster:
+     name: ceph
+     node1:
+       role:
+         - mon
+         - mgr
+         - osd
+       no-of-volumes: 1
+       disk-size: 40  
+     node2:
+       role:
+         - mon
+         - mgr
+         - osd
+         - grafana
+       no-of-volumes: 1
+       disk-size: 40
+     node3:
+       role:
+         - mon
+         - mgr
+         - osd
+         - mds
+       no-of-volumes: 1
+       disk-size: 40
+     node4:
+       role:
+         - rgw
+         - iscsi-gw
+
+     node5:
+       role:
+         - rgw
+         - iscsi-gw
+         - client
+
+     node6:
+       role:
+         - nfs
+         - installer
+

--- a/conf/pacific/upgrades/upgrade_from4x_tier1.yml
+++ b/conf/pacific/upgrades/upgrade_from4x_tier1.yml
@@ -1,0 +1,44 @@
+globals:
+  - ceph-cluster:
+     name: ceph
+     node1:
+       role:
+         - mon
+         - mgr
+     node2:
+       role:
+         - mon
+         - mgr
+     node3:
+       role:
+         - mon
+         - mgr
+     node4:
+       role:
+         - osd
+         - mds
+       no-of-volumes: 3
+       disk-size: 20
+     node5:
+       role:
+         - osd
+         - rgw
+         - iscsi-gw
+       no-of-volumes: 3
+       disk-size: 20
+     node6:
+       role:
+         - osd
+         - rgw
+         - nfs
+       no-of-volumes: 3
+       disk-size: 20
+     node7:
+       role: installer
+     node8:
+       role: iscsi-gw
+     node9:
+       role: client
+     node10:
+       role: grafana
+ 

--- a/suites/pacific/upgrades/upgrade_4x_to_5_x_baremetal.yaml
+++ b/suites/pacific/upgrades/upgrade_4x_to_5_x_baremetal.yaml
@@ -1,0 +1,170 @@
+tests:
+- test:
+    name: install ceph pre-requisites
+    module: install_prereq.py
+    abort-on-fail: True
+
+- test:
+    name: ceph ansible install rhcs 4.x from cdn
+    polarion-id: CEPH-83573588
+    module: test_ansible.py
+    config:
+      use_cdn: True
+      build: '4.x'
+      ansi_config:
+        ceph_origin: repository
+        ceph_repository: rhcs
+        ceph_repository_type: cdn
+        ceph_rhcs_version: 4
+        ceph_stable_release: nautilus
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable_rh_storage: True
+        ceph_docker_image: "rhceph/rhceph-4-rhel8"
+        ceph_docker_image_tag: "latest"
+        ceph_docker_registry: "registry.redhat.io"
+        copy_admin_key: true
+        radosgw_num_instances: 2
+        dashboard_enabled: False
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+        ceph_conf_overrides:
+            global:
+              osd_pool_default_pg_num: 64
+              osd_default_pool_size: 2
+              osd_pool_default_pgp_num: 64
+              mon_max_pg_per_osd: 1024
+            mon:
+              mon_allow_pool_delete: true
+            client:
+              rgw crypt require ssl: false
+              rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        cephfs_pools:
+          - name: "cephfs_data"
+            pgs: "8"
+          - name: "cephfs_metadata"
+            pgs: "8"
+    desc: deploy ceph containerized 4.x cdn setup using ceph-ansible
+    destroy-cluster: False
+    abort-on-fail: true
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+      name: switch-from-non-containerized-to-containerized-ceph-daemons
+      polarion-id: CEPH-83573510
+      module: switch_rpm_to_container.py
+      abort-on-fail: true
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+
+- test:
+    name: Upgrade containerized ceph to 5.x latest
+    polarion-id: CEPH-83573588
+    module: test_ansible_upgrade.py
+    config:
+      ansi_config:
+        ceph_origin: distro
+        ceph_stable_release: nautilus
+        ceph_repository: rhcs
+        ceph_rhcs_version: 5
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable: True
+        ceph_stable_rh_storage: True
+        fetch_directory: ~/fetch
+        radosgw_num_instances: 2
+        copy_admin_key: true
+        containerized_deployment: true
+        upgrade_ceph_packages: True
+        dashboard_enabled: False
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-17
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+        ceph_conf_overrides:
+            global:
+              osd_pool_default_pg_num: 64
+              osd_default_pool_size: 2
+              osd_pool_default_pgp_num: 64
+              mon_max_pg_per_osd: 1024
+            mon:
+              mon_allow_pool_delete: true
+            client:
+              rgw crypt require ssl: false
+              rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+    desc: Test Ceph-Ansible rolling update 5.x cdn -> 5.x latest
+    abort-on-fail: True
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: rbd-io
+    module: rbd_faster_exports.py
+    config:
+        io-total: 100M
+    desc: Perform export during read/write,resizing,flattening,lock operations
+
+- test:
+    name: rgw sanity tests
+    module: sanity_rgw.py
+    config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+    desc: Perform rgw tests

--- a/suites/pacific/upgrades/upgrade_4x_to_5_x_containerized.yaml
+++ b/suites/pacific/upgrades/upgrade_4x_to_5_x_containerized.yaml
@@ -1,0 +1,146 @@
+tests:
+- test:
+    name: install ceph pre-requisites
+    module: install_prereq.py
+    abort-on-fail: True
+
+- test:
+    name: ceph ansible install containerized rhcs 4.x from cdn
+    polarion-id: CEPH-83573588
+    module: test_ansible.py
+    config:
+      use_cdn: True
+      build: '4.x'
+      ansi_config:
+        ceph_origin: repository
+        ceph_repository: rhcs
+        ceph_repository_type: cdn
+        ceph_rhcs_version: 4
+        ceph_stable_release: nautilus
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable_rh_storage: True
+        containerized_deployment: true
+        ceph_docker_image: "rhceph/rhceph-4-rhel8"
+        ceph_docker_image_tag: "latest"
+        ceph_docker_registry: "registry.redhat.io"
+        copy_admin_key: true
+        dashboard_enabled: True
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+        ceph_conf_overrides:
+            global:
+              osd_pool_default_pg_num: 64
+              osd_default_pool_size: 2
+              osd_pool_default_pgp_num: 64
+              mon_max_pg_per_osd: 1024
+            mon:
+              mon_allow_pool_delete: true
+            client:
+              rgw crypt require ssl: false
+              rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        cephfs_pools:
+          - name: "cephfs_data"
+            pgs: "8"
+          - name: "cephfs_metadata"
+            pgs: "8"
+    desc: deploy ceph containerized 4.x cdn setup using ceph-ansible
+    destroy-cluster: False
+    abort-on-fail: true
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: Upgrade containerized ceph to 5.x latest
+    polarion-id: CEPH-83573588
+    module: test_ansible_upgrade.py
+    config:
+      ansi_config:
+        ceph_origin: distro
+        ceph_stable_release: nautilus
+        ceph_repository: rhcs
+        ceph_rhcs_version: 5
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable: True
+        ceph_stable_rh_storage: True
+        fetch_directory: ~/fetch
+        copy_admin_key: true
+        containerized_deployment: true
+        upgrade_ceph_packages: True
+        dashboard_enabled: True
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-17
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+        ceph_conf_overrides:
+            global:
+              osd_pool_default_pg_num: 64
+              osd_default_pool_size: 2
+              osd_pool_default_pgp_num: 64
+              mon_max_pg_per_osd: 1024
+            mon:
+              mon_allow_pool_delete: true
+            client:
+              rgw crypt require ssl: false
+              rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+    desc: Test Ceph-Ansible rolling update 5.x cdn -> 5.x latest
+    abort-on-fail: True
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: rbd-io
+    module: rbd_faster_exports.py
+    config:
+        io-total: 100M
+    desc: Perform export during read/write,resizing,flattening,lock operations
+
+- test:
+    name: rgw sanity tests
+    module: sanity_rgw.py
+    config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+    desc: Perform rgw tests

--- a/tests/ceph_ansible/switch_rpm_to_container.py
+++ b/tests/ceph_ansible/switch_rpm_to_container.py
@@ -18,7 +18,7 @@ def run(**kw):
     for cnode in ceph_nodes:
         if cnode.role == "installer":
             installer_node = cnode
-    if not build.startswith("4"):
+    if build.startswith("3"):
         installer_node.exec_command(
             sudo=True,
             cmd="cd {ansible_dir}; cp {ansible_dir}/infrastructure-playbooks/{playbook} .".format(


### PR DESCRIPTION
Adding -
two suites to cover two paths
one conf
modified ansible_upgrade file to call cephadm-adopt.yaml post rolling_update

Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Testing of these additions are blocked because of BZ1935554
The latest logs are -
After commenting out part of additions made in PR cephci/pull/399 - http://magna002.ceph.redhat.com/ceph-qe-logs/vasishta/to_test_1935554/
- [x] Have not tried suite bare metal to containerized conversion involves,
- [ ] plan on having lite-suite for t0
- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
