### PR TITLE
Fix #416: s3tests requirements installation failure

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -81,20 +81,17 @@ def setup_s3_tests(client_node, rgw_node, config, build):
             "libxslt-devel",
             "zlib-devel",
         ]
-        client_node.exec_command(cmd="cd s3-tests")
         client_node.exec_command(
             cmd="sudo yum install -y {pkgs}".format(pkgs=" ".join(pkgs)), check_ec=False
         )
-        client_node.exec_command(
-            cmd="virtualenv -p python2 --no-site-packages --distribute virtualenv"
-        )
-        client_node.exec_command(cmd="~/virtualenv/bin/pip install setuptools==32.3.1")
-        client_node.exec_command(
-            cmd="~/virtualenv/bin/pip install -r s3-tests/requirements.txt"
-        )
-        client_node.exec_command(
-            cmd="~/virtualenv/bin/python s3-tests/setup.py develop"
-        )
+        commands = [
+            "virtualenv -p python2 --no-site-packages --distribute virtualenv",
+            "~/virtualenv/bin/pip install --upgrade pip setuptools",
+            "~/virtualenv/bin/pip install -r s3-tests/requirements.txt",
+            "~/virtualenv/bin/python s3-tests/setup.py develop",
+        ]
+        for cmd in commands:
+            client_node.exec_command(cmd=cmd)
     else:
         log.info("Running bootstrap")
         client_node.exec_command(


### PR DESCRIPTION
# Description

The python package requirements did not install on VMs running RHEL 7.9 as the pip version was lower. In this PR, the pip version is first upgraded before proceeding with the installation of the test requirements.

Closes #416 

[Logs](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3_tests/fix79/)

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>