### PR TITLE
Updating the tmp log directory location in log link

### DIFF
--- a/run.py
+++ b/run.py
@@ -789,24 +789,19 @@ def run(args):
                 enable_eus=enable_eus,
             )
         tcs.append(tc)
-    url_base = magna_url if "/ceph/cephci-jenkins" in run_dir else run_dir
-    run_dir_name = run_dir.split("/")[-1]
-    log.info(
-        "\nAll test logs located here: {base}/{dir}".format(
-            base=url_base, dir=run_dir_name
-        )
+    url_base = (
+        magna_url + run_dir.split("/")[-1]
+        if "/ceph/cephci-jenkins" in run_dir
+        else run_dir
     )
+    log.info("\nAll test logs located here: {base}".format(base=url_base))
     close_and_remove_filehandlers()
     if post_to_report_portal:
         service.finish_launch(end_time=timestamp())
         service.terminate()
     if xunit_results:
         create_xunit_results(suite_name, tcs, run_dir)
-    print(
-        "\nAll test logs located here: {base}/{dir}".format(
-            base=url_base, dir=run_dir_name
-        )
-    )
+    print("\nAll test logs located here: {base}".format(base=url_base))
     print_results(tcs)
     send_to_cephci = post_results or post_to_report_portal
     run_end_time = datetime.datetime.now()

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -32,7 +32,7 @@ active_mdss = []
 RC = []
 failure = {}
 output = []
-magna_url = "http://magna002.ceph.redhat.com/cephci-jenkins"
+magna_url = "http://magna002.ceph.redhat.com/cephci-jenkins/"
 
 
 # function for getting the clients
@@ -383,11 +383,12 @@ def configure_logger(test_name, run_dir, level=logging.INFO):
     )
     _handler.setFormatter(formatter)
     _root.addHandler(_handler)
-    url_base = magna_url if "/ceph/cephci-jenkins" in run_dir else run_dir
-    run_dir_name = run_dir.split("/")[-1]
-    log_url = "{url_base}/{run_dir}/{log_name}".format(
-        url_base=url_base, run_dir=run_dir_name, log_name=full_log_name
+    url_base = (
+        magna_url + run_dir.split("/")[-1]
+        if "/ceph/cephci-jenkins" in run_dir
+        else run_dir
     )
+    log_url = "{url_base}/{log_name}".format(url_base=url_base, log_name=full_log_name)
 
     log.info("Completed log configuration")
     return log_url
@@ -705,7 +706,7 @@ def create_html_file(test_result) -> str:
 
     # we are checking for /ceph/cephci-jenkins to see if the magna is already mounted on system we are executing
     log_link = (
-        f"{magna_url}/{run_name}/" if "/ceph/cephci-jenkins" in run_dir else run_dir
+        f"{magna_url}{run_name}" if "/ceph/cephci-jenkins" in run_dir else run_dir
     )
     info["link"] = f"{log_link}/startup.log"
     project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
This is to update the /tmp log location.
currently, it is appending the run_dir_name twice so updated it to add only once

Log Files:
with magna
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1615791421606
With default log dir:
[cephci-run-1615793374185.zip](https://github.com/red-hat-storage/cephci/files/6139784/cephci-run-1615793374185.zip)


With --log-dir:
[cephci-run-1615792874148.zip](https://github.com/red-hat-storage/cephci/files/6139770/cephci-run-1615792874148.zip)



