### PR TITLE
Removing + Operator used twice

### DIFF
--- a/suites/luminous/cephfs/sanity_fs.yaml
+++ b/suites/luminous/cephfs/sanity_fs.yaml
@@ -214,7 +214,7 @@ tests:
        polarion-id: CEPH-11221
        desc: Mount CephFS on multiple clients and perform IO ,fill cluster upto 30%
        abort-on-fail: false
-  - test:
+   - test:
        name: kcephfs mount with long user name
        module: BUG-1798719.py
        polarion-id: BUG-1798719

--- a/tests/cephfs/CEPH-11222_11223.py
+++ b/tests/cephfs/CEPH-11222_11223.py
@@ -79,7 +79,7 @@ def run(ceph_cluster, **kw):
         )
 
         dir1 = "".join(
-            random.choice(string.ascii_lowercase + +string.digits) for _ in range(10)
+            random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
         )
         for client in client_info["clients"]:
             log.info("Creating directory:")


### PR DESCRIPTION
Removed Extra + Operator in tests/cephfs/CEPH_11222_11223.py This will fix #420 

Added Space to align the tests block. This will close #404 