### PR TITLE
cephadm: orphan-initial-daemons and skip-monitoring-stack validations

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -1,0 +1,36 @@
+"""
+Contains helper functions that can used across the module.
+"""
+import logging
+
+LOG = logging.getLogger()
+
+
+def get_cluster_state(cls, commands=[]):
+    """
+    fetch cluster state using commands provided along
+    with the default set of commands
+
+    - ceph status
+    - ceph orch ls -f json-pretty
+    - ceph orch ps -f json-pretty
+    - ceph health detail -f yaml
+
+    Args:
+        cls: ceph.ceph_admin instance with shell access
+        commands: list of commands
+
+    """
+    __CLUSTER_STATE_COMMANDS = [
+        "ceph status",
+        "ceph orch ls -f yaml",
+        "ceph orch ps -f json-pretty",
+        "ceph health detail -f yaml",
+    ]
+
+    __CLUSTER_STATE_COMMANDS.extend(commands)
+
+    for cmd in __CLUSTER_STATE_COMMANDS:
+        out, err = cls.shell(args=[cmd])
+        LOG.info("STDOUT:\n %s" % out)
+        LOG.error("STDERR:\n %s" % err)

--- a/ceph/ceph_admin/rgw.py
+++ b/ceph/ceph_admin/rgw.py
@@ -26,9 +26,10 @@ class RGW(ApplyMixin, Orch):
                     verbose: true
                     input_file: <name of spec>
                 pos_args:                   # positional arguments
-                    - india                 # realm
-                    - south                 # zone
+                    - my_rgw                # service id
                 args:
+                    rgw-realm: realm        # realm name in case of multi-site
+                    rgw-zone: zone          # zone name in case of multi-site
                     port: int               # port number
                     ssl: true               # certification
                     placement:

--- a/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
+++ b/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
@@ -1,0 +1,39 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - installer
+          - mon
+          - mgr
+          - osd
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+        no-of-volumes: 4
+        disk-size: 15
+      node2:
+        role:
+          - osd
+          - mon
+          - mds
+          - node-exporter
+          - alertmanager
+          - crash
+          - rgw
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - mon
+          - osd
+          - node-exporter
+          - crash
+          - rgw
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - client

--- a/suites/pacific/cephadm/cephadm.yaml
+++ b/suites/pacific/cephadm/cephadm.yaml
@@ -524,8 +524,7 @@ tests:
         base_cmd_args:          # arguments to ceph orch
           verbose: true
         pos_args:               # positional arguments
-          - india             # realm
-          - south             # zone
+          - foo                 # service id
         args:
           placement:
             nodes:              # A list of strings that would looked up
@@ -631,7 +630,7 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-            service_name: rgw.india.south
+            service_name: rgw.foo
             verify: true
       destroy-cluster: false
       abort-on-fail: true

--- a/suites/pacific/cephadm/cephadm.yaml
+++ b/suites/pacific/cephadm/cephadm.yaml
@@ -22,11 +22,6 @@ tests:
           initial-dashboard-user: admin123
           initial-dashboard-password: admin123
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
-        get_cluster_details:           # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls -f yaml"
-          - "ceph orch ps -f yaml"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -39,10 +34,6 @@ tests:
         command: add
         args:                     # arguments to ceph orch
           node: node2
-        get_cluster_details:                    # to view ceph status only
-          - "ceph status"
-          - "ceph orch host ls -f yaml"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -153,10 +144,6 @@ tests:
           verbose: true
         args:
           node: node1
-        get_cluster_details:                     # to view ceph status only
-          - "ceph status"
-          - "ceph orch host ls -f yaml"
-          - "ceph health detail"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -201,10 +188,6 @@ tests:
             - node8
           attach_ip_address: false
           labels: apply-all-labels
-        get_cluster_details:                        # to view ceph status only
-          - "ceph status"
-          - "ceph orch host ls -f yaml"
-          - "ceph health detail"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -219,10 +202,6 @@ tests:
           nodes:
             - node5
             - node6
-        get_cluster_details:                    # to view ceph status only
-          - "ceph status"
-          - "ceph orch host ls -f yaml"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -235,10 +214,6 @@ tests:
         command: remove_hosts
         args:
           nodes: []
-        get_cluster_details:                    # to view ceph status only
-          - "ceph status"
-          - "ceph orch host ls -f yaml"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -253,10 +228,6 @@ tests:
           nodes: []
           attach_ip_address: true
           labels: apply-all-labels
-        get_cluster_details:                      # to view ceph status only
-          - "ceph status"
-          - "ceph orch host ls -f yaml"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -277,11 +248,6 @@ tests:
                 - node6
             limit: 3    # no of daemons
             sep: " "    # separator to be used for placements
-        get_cluster_details:                        # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls mon -f json-pretty"
-          - "ceph orch ps '' mon -f json-pretty"
-          - "ceph health detail -f yaml"
   - test:
       name: Apply Monitor with placement
       desc: Apply monitor with placement only
@@ -299,11 +265,6 @@ tests:
                 - node2
                 - node6
             sep: ";"
-        get_cluster_details:                          # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls mon -f json-pretty"
-          - "ceph orch ps '' mon -f json-pretty"
-          - "ceph health detail -f yaml"
   - test:
       name: Apply Monitor using label
       desc: Apply monitor using label mon
@@ -317,11 +278,6 @@ tests:
         args:
           placement:
             label: mon
-        get_cluster_details:                          # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls mon -f json-pretty"
-          - "ceph orch ps '' mon -f json-pretty"
-          - "ceph health detail -f yaml"
   - test:
       name: Apply Manager service
       desc: Apply manager service with placement option
@@ -337,11 +293,6 @@ tests:
             nodes:
               - node1
             sep: " "
-        get_cluster_details:                        # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls mgr -f json-pretty"
-          - "ceph orch ps '' mgr -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -356,13 +307,6 @@ tests:
           verbose: true
         args:
           all-available-devices: true
-        get_cluster_details:                        # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls osd -f json-pretty"
-          - "ceph orch ps '' osd.all-available-devices -f json-pretty"
-          - "ceph osd df"
-          - "ceph osd tree"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -428,11 +372,6 @@ tests:
               - node8
             limit: 2            # no of daemons
             sep: " "            # separator to be used for placements
-        get_cluster_details:                        # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls mds -f json-pretty"
-          - "ceph orch ps '' mds.cephfs -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -488,11 +427,6 @@ tests:
         args:
           placement:
             label: iscsi          # either label or node.
-        get_cluster_details:            # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls iscsi -f json-pretty"
-          - "ceph orch ps '' iscsi.iscsi -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -513,11 +447,6 @@ tests:
           placement:
             nodes:
               - node8          # either label or node.
-        get_cluster_details:              # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls iscsi -f json-pretty"
-          - "ceph orch ps '' iscsi.iscsi -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -534,11 +463,6 @@ tests:
           placement:
             nodes:
               - node1
-        get_cluster_details:              # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls prometheus -f json-pretty"
-          - "ceph orch ps '' prometheus -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -554,11 +478,6 @@ tests:
         args:
           placement:
             nodes: "*"
-        get_cluster_details:            # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls node-exporter -f json-pretty"
-          - "ceph orch ps '' node-exporter -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -576,11 +495,6 @@ tests:
             nodes:
               - node1
               - node2
-        get_cluster_details:            # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls alertmanager -f json-pretty"
-          - "ceph orch ps '' alertmanager -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -597,11 +511,6 @@ tests:
           placement:
             nodes:
               - node1
-        get_cluster_details:            # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls grafana -f json-pretty"
-          - "ceph orch ps '' grafana -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -624,11 +533,6 @@ tests:
                 - node7
             limit: 2            # no of daemons
             sep: ";"            # separator to be used for placements
-        get_cluster_details:          # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls rgw -f json-pretty"
-          - "ceph orch ps '' rgw.india.south -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -684,11 +588,6 @@ tests:
               - node6
             limit: 2
             sep: ";"
-        get_cluster_details:              # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls nfs -f json-pretty"
-          - "ceph orch ps '' nfs.mynfs -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -704,11 +603,6 @@ tests:
         args:
           placement:
             nodes: "*"
-        get_cluster_details:              # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls crash -f json-pretty"
-          - "ceph orch ps '' crash -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -862,10 +756,5 @@ tests:
           verbose: true
         args:
           service_name: crash
-        get_cluster_details:              # to view ceph status only
-          - "ceph status"
-          - "ceph orch ls -f json-pretty"
-          - "ceph orch ps -f json-pretty"
-          - "ceph health detail -f yaml"
       destroy-cluster: false
       abort-on-fail: true

--- a/suites/pacific/cephadm/tier1_cephadm_bootstrap.yaml
+++ b/suites/pacific/cephadm/tier1_cephadm_bootstrap.yaml
@@ -114,8 +114,7 @@ tests:
               base_cmd_args:                    # arguments to ceph orch
                 verbose: true
               pos_args:                         # positional arguments
-                - india                         # realm
-                - south                         # zone
+                - myrgw
               args:
                 placement:
                   label: rgw                    # label

--- a/suites/pacific/cephadm/tier1_cephadm_bootstrap.yaml
+++ b/suites/pacific/cephadm/tier1_cephadm_bootstrap.yaml
@@ -1,0 +1,142 @@
+#===============================================================================================
+# Cluster configuration:
+# --------------------
+# 4-Node cluster(RHEL-8.3 and above)
+# 3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#   Node1- Mon, Mgr, Installer, OSD
+#   Node2- Mon, OSD, MDS, RGW
+#   Node3- Mon, OSD, MDS, RGW
+#   Node4- Client
+#
+# TIER1:
+# -------
+# Bootstrap without skip-monitoring, orphan-initial-daemons options
+#
+# (1) Bootstrap cluster without options,
+#     - skip-monitoring stack
+#     - orphan-initial-daemons options.
+# (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+# (3) Deploy services using apply option,
+#     - 3 Mon on node1, node2, Node3
+#     - addition of OSD's using "all-available-devices" option.
+#     - RGW on node2, node3 with india.south(realm.zone) using label.
+#     - MDS on node2, node3 with host placements.
+# (4) Configure client node by adding ceph.conf and keying to node.
+# (5) Setup S3cmd tool and prepare for RGW IO on client Node.         - TO-DO
+# (6) Run IOs from S3cmd tool for 20 mins.                            - TO-DO
+# (7) Kernel Mount:                                                   - TO-DO
+#     - Create /mnt/cephfs directory and Mount cephfs on client node.
+#        sudo mount -t ceph 10.8.128.110:6789:/ /mnt/cephfs -o name=client.0,secret=<key>
+#     - using dd command create files on /mnt/cephfs directory.
+#===============================================================================================
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: Cephadm Bootstrap
+      desc: cephadm cluster bootstrap
+      module: test_bootstrap.py
+      polarion-id:
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          registry-json: registry.redhat.io
+          custom_image: true
+          mon-ip: node1
+          initial-dashboard-user: admin123
+          initial-dashboard-password: admin123
+          fsid: f64f341c-655d-11eb-8778-fa163e914bcc
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Host addition and Service(s) deployment
+      desc: HOST,MGR,MON,OSD,RGW,MDS deployment.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  nodes:
+                      - node1
+                      - node2
+                      - node3
+                  sep: ";"
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:                             # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:                    # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs                        # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node3
+          - config:
+              command: apply
+              service: rgw
+              base_cmd_args:                    # arguments to ceph orch
+                verbose: true
+              pos_args:                         # positional arguments
+                - india                         # realm
+                - south                         # zone
+              args:
+                placement:
+                  label: rgw                    # label
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Configure client
+      desc: Configure client on node4
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node4                       # client node
+        install_packages:
+          - ceph-common                   # install ceph common packages
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      destroy-cluster: false
+      abort-on-fail: true

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -12,6 +12,7 @@ from ceph.ceph_admin.alert_manager import AlertManager
 from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.crash import Crash
 from ceph.ceph_admin.grafana import Grafana
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.host import Host
 from ceph.ceph_admin.iscsi import ISCSI
 from ceph.ceph_admin.mds import MDS
@@ -102,11 +103,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     """
     LOG.info("Starting Ceph cluster deployment.")
 
-    try:
-        config = kwargs["config"]
-        cephadm = CephAdmin(cluster=ceph_cluster, **config)
-        steps = config.get("steps", [])
+    config = kwargs["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
 
+    try:
+        steps = config.get("steps", [])
         for step in steps:
             cfg = step["config"]
 
@@ -126,4 +127,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     except BaseException as be:  # noqa
         LOG.error(be, exc_info=True)
         return 1
+    finally:
+        # Get cluster state
+        get_cluster_state(cephadm)
     return 0

--- a/tests/cephadm/test_bootstrap.py
+++ b/tests/cephadm/test_bootstrap.py
@@ -6,6 +6,7 @@ import requests
 
 from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 
 log = logging.getLogger(__name__)
 
@@ -29,20 +30,37 @@ def validate_fsid(cls, fsid: str):
         raise BootStrapValidationFailure("FSID verification failed")
 
 
-def validate_skip_monitoring_stack(cls):
+def validate_skip_monitoring_stack(cls, flag):
     """
     Method to validate monitoring service(s) has been skipped during bootstrap
         monitoring services - grafana, prometheus, alertmanager, node-exporter
+
+    if skip-monitoring-stack is,
+    used - monitoring services should not get deployed
+    not used - monitoring services should get deployed
+
     Args:
         cls: class object
+        flag: skip-monitoring-stack enabled/disabled status
     """
     out, _ = cls.shell(args=["ceph", "orch", "ls", "-f json"])
     monitoring = ["prometheus", "grafana", "alertmanager", "node-exporter"]
-    for svc in json.loads(out):
-        if svc["service_type"] in monitoring:
-            raise BootStrapValidationFailure(
-                "Monitoring service found : %s" % svc["service_type"]
-            )
+
+    svcs = [
+        svc["service_type"]
+        for svc in json.loads(out)
+        if svc["service_type"] in monitoring
+    ]
+
+    log.info("skip-monitoring-stack: %s\nMonitoring services: %s" % (flag, svcs))
+    if flag:
+        if svcs:
+            raise BootStrapValidationFailure(f"Monitoring service found : {svcs}")
+    else:
+        if sorted(svcs) != sorted(monitoring):
+            raise BootStrapValidationFailure(f"Monitoring service not found : {svcs}")
+
+    log.info("skip-monitoring-stack validation is successful")
 
 
 def validate_dashboard(cls, out, user=None, password=None):
@@ -54,7 +72,7 @@ def validate_dashboard(cls, out, user=None, password=None):
         cls: class object
         out: bootstrap response log
         user: dashboard user
-        password: dashbard password
+        password: dashboard password
     """
     _, _, db_log_part = out.partition("Ceph Dashboard is now available at:")
 
@@ -74,7 +92,7 @@ def validate_dashboard(cls, out, user=None, password=None):
         if user != user_:
             raise BootStrapValidationFailure(f"user {user} did not match")
     if password:
-        log.info("custom password: %s, configured password: %s" % (user, user_))
+        log.info("custom password: %s, configured password: %s" % (password, passwd_))
         if password != passwd_:
             raise BootStrapValidationFailure(f"password {password} did not match")
 
@@ -126,6 +144,67 @@ def validate_dashboard_passwd(cls, password: str, out: str):
     validate_dashboard(cls, out, password=password)
 
 
+def validate_orphan_intial_daemons(cls, flag):
+    """
+    Method to validate orphan-initial-daemons
+
+    [–orphan-initial-daemons]
+     Do not create initial mon, mgr, and crash service specs
+
+    if used
+        MON, MGR service specs should not be created
+        and with unmanaged=true
+    else
+        MON, MGR, Crash specs would be deployed with unmanaged=false
+
+    Args:
+        cls: cephadm instance
+        flag: orphan-initial-daemons usage flag
+
+    """
+    out, _ = cls.shell(args=["ceph", "orch", "ls", "-f json"])
+    svcs = ["mon", "mgr", "crash"]
+
+    svcs_ = dict(
+        (svc["service_type"], svc)
+        for svc in json.loads(out)
+        if svc["service_type"] in svcs
+    )
+
+    log.info("orphan-intial-daemons: %s\n Services: %s" % (flag, svcs_))
+    if flag:
+        # verify crash service should not get deployed
+        if "crash" in svcs_:
+            raise BootStrapValidationFailure(
+                "crash service should not have deployed "
+                "with orphan-initial-daemons option"
+            )
+
+        if sorted(svcs[0:-1]) != sorted(list(svcs_.keys())):
+            raise BootStrapValidationFailure(f"MON/MGR service(s) not found: {svcs_}")
+
+        # verify unmanaged flag which should be set to true
+        for svc_name, config_ in svcs_.items():
+            if not config_.get("unmanaged"):
+                raise BootStrapValidationFailure(
+                    f"{svc_name} spec is created with unmanaged=false"
+                )
+    else:
+        if sorted(list(svcs_.keys())) != sorted(svcs):
+            raise BootStrapValidationFailure(
+                f"MGR/MON/Crash service(s) not found : {svcs_}"
+            )
+
+        # verify unmanaged flag which should be set to false
+        for svc_name, config_ in svcs_.items():
+            if config_.get("unmanaged"):
+                raise BootStrapValidationFailure(
+                    f"{svc_name} spec is created with unmanaged=true"
+                )
+
+    log.info("orphan-initial-daemons validation is successful")
+
+
 def verify_bootstrap(cls, args, response):
     """
     Verify bootstrap based on the parameter(s) provided.
@@ -140,8 +219,8 @@ def verify_bootstrap(cls, args, response):
         validate_dashboard_user(cls, args.get("initial-dashboard-user"), response)
     if args.get("initial-dashboard-password"):
         validate_dashboard_passwd(cls, args.get("initial-dashboard-password"), response)
-    if args.get("skip-monitoring-stack"):
-        validate_skip_monitoring_stack(cls)
+    validate_skip_monitoring_stack(cls, args.get("skip-monitoring-stack"))
+    validate_orphan_intial_daemons(cls, args.get("orphan-initial-daemons"))
 
 
 def run(ceph_cluster, **kw):
@@ -179,17 +258,16 @@ def run(ceph_cluster, **kw):
     if "shell" in command:
         instance.shell(args=config["args"])
         return 0
+    try:
+        method = fetch_method(instance, command)
+        out, err = method(config)
 
-    method = fetch_method(instance, command)
-    out, err = method(config)
-
-    if "get_cluster_details" in config:
-        instance.get_cluster_state(config["get_cluster_details"])
-
-    # Verification of arguments
-    # bootstrap response through stdout & stderr are combined here
-    # currently console response coming through stderr.
-    args = config.get("args", {})
-    verify_bootstrap(instance, args, out + err)
-
+        # Verification of arguments
+        # bootstrap response through stdout & stderr are combined here
+        # currently console response coming through stderr.
+        args = config.get("args", {})
+        verify_bootstrap(instance, args, out + err)
+    finally:
+        # Get cluster state
+        get_cluster_state(instance)
     return 0

--- a/tests/cephadm/test_crash.py
+++ b/tests/cephadm/test_crash.py
@@ -2,6 +2,7 @@ import logging
 
 from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.crash import Crash
+from ceph.ceph_admin.helper import get_cluster_state
 
 log = logging.getLogger(__name__)
 
@@ -26,10 +27,10 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing Crash %s service" % command)
     crash = Crash(cluster=ceph_cluster, **config)
-    method = fetch_method(crash, command)
-    method(config)
-
-    if "get_cluster_details" in config:
-        crash.get_cluster_state(config["get_cluster_details"])
-
+    try:
+        method = fetch_method(crash, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(crash)
     return 0

--- a/tests/cephadm/test_host.py
+++ b/tests/cephadm/test_host.py
@@ -1,9 +1,13 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.host import Host
 
 log = logging.getLogger(__name__)
+
+
+CLUSTER_STATE = ["ceph orch host ls -f yaml"]
 
 
 def run(ceph_cluster, **kw):
@@ -55,10 +59,11 @@ def run(ceph_cluster, **kw):
     log.info("Executing %s %s" % (service, command))
 
     host = Host(cluster=ceph_cluster, **config)
-    method = fetch_method(host, command)
-    method(config)
-
-    if "get_cluster_details" in config:
-        host.get_cluster_state(config["get_cluster_details"])
+    try:
+        method = fetch_method(host, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(host, CLUSTER_STATE)
 
     return 0

--- a/tests/cephadm/test_iscsi.py
+++ b/tests/cephadm/test_iscsi.py
@@ -1,6 +1,7 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.iscsi import ISCSI
 
 log = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ def run(ceph_cluster, **kw):
 
     check ceph.ceph_admin.iscsi for test config
     """
+
     log.info("Running Ceph-admin MDS test")
     config = kw.get("config")
 
@@ -26,10 +28,11 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing ISCSI %s service" % command)
     iscsi = ISCSI(cluster=ceph_cluster, **config)
-    method = fetch_method(iscsi, command)
-    method(config)
 
-    if "get_cluster_details" in config:
-        iscsi.get_cluster_state(config["get_cluster_details"])
-
+    try:
+        method = fetch_method(iscsi, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(iscsi)
     return 0

--- a/tests/cephadm/test_mds.py
+++ b/tests/cephadm/test_mds.py
@@ -1,6 +1,7 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.mds import MDS
 
 log = logging.getLogger(__name__)
@@ -26,10 +27,10 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing MDS %s service" % command)
     mds = MDS(cluster=ceph_cluster, **config)
-    method = fetch_method(mds, command)
-    method(config)
-
-    if "get_cluster_details" in config:
-        mds.get_cluster_state(config["get_cluster_details"])
-
+    try:
+        method = fetch_method(mds, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(mds)
     return 0

--- a/tests/cephadm/test_mgr.py
+++ b/tests/cephadm/test_mgr.py
@@ -1,6 +1,7 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.mgr import Mgr
 
 log = logging.getLogger(__name__)
@@ -26,8 +27,11 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing MGR %s service" % command)
     manager = Mgr(cluster=ceph_cluster, **config)
-    method = fetch_method(manager, command)
-    method(config)
-    if "get_cluster_details" in config:
-        manager.get_cluster_state(config["get_cluster_details"])
+
+    try:
+        method = fetch_method(manager, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(manager)
     return 0

--- a/tests/cephadm/test_mon.py
+++ b/tests/cephadm/test_mon.py
@@ -1,9 +1,17 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.mon import Mon
 
 log = logging.getLogger(__name__)
+
+CLUSTER_STATE = [
+    "ceph status",
+    "ceph orch ls mon -f json-pretty",
+    "ceph orch ps '' mon -f json-pretty",
+    "ceph health detail -f yaml",
+]
 
 
 def run(ceph_cluster, **kw):
@@ -26,8 +34,10 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing MON %s service" % command)
     monitor = Mon(cluster=ceph_cluster, **config)
-    method = fetch_method(monitor, command)
-    method(config)
-    if "get_cluster_details" in config:
-        monitor.get_cluster_state(config["get_cluster_details"])
+    try:
+        method = fetch_method(monitor, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(monitor, CLUSTER_STATE)
     return 0

--- a/tests/cephadm/test_monitoring.py
+++ b/tests/cephadm/test_monitoring.py
@@ -3,6 +3,7 @@ import logging
 from ceph.ceph_admin.alert_manager import AlertManager
 from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.grafana import Grafana
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.node_exporter import NodeExporter
 from ceph.ceph_admin.prometheus import Prometheus
 
@@ -38,8 +39,10 @@ def run(ceph_cluster, **kw):
     _monitoring = MONITORING[service]
     log.info("Executing %s %s service" % (service, command))
     monitoring = _monitoring(cluster=ceph_cluster, **config)
-    method = fetch_method(monitoring, command)
-    method(config)
-    if "get_cluster_details" in config:
-        monitoring.get_cluster_state(config["get_cluster_details"])
+    try:
+        method = fetch_method(monitoring, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(monitoring)
     return 0

--- a/tests/cephadm/test_nfs.py
+++ b/tests/cephadm/test_nfs.py
@@ -1,6 +1,7 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.nfs import NFS
 
 log = logging.getLogger(__name__)
@@ -27,8 +28,10 @@ def run(ceph_cluster, **kw):
 
     log.info("Executing NFS-Ganesha %s service" % command)
     nfs = NFS(cluster=ceph_cluster, **config)
-    method = fetch_method(nfs, command)
-    method(config)
-    if "get_cluster_details" in config:
-        nfs.get_cluster_state(config["get_cluster_details"])
+    try:
+        method = fetch_method(nfs, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(nfs)
     return 0

--- a/tests/cephadm/test_osd.py
+++ b/tests/cephadm/test_osd.py
@@ -1,9 +1,16 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.osd import OSD
 
 log = logging.getLogger(__name__)
+
+
+CLUSTER_STATE = [
+    "ceph osd df",
+    "ceph osd tree",
+]
 
 
 def run(ceph_cluster, **kw):
@@ -26,8 +33,10 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing OSD %s service" % command)
     osd = OSD(cluster=ceph_cluster, **config)
-    method = fetch_method(osd, command)
-    method(config)
-    if "get_cluster_details" in config:
-        osd.get_cluster_state(config["get_cluster_details"])
+    try:
+        method = fetch_method(osd, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(osd, CLUSTER_STATE)
     return 0

--- a/tests/cephadm/test_rgw.py
+++ b/tests/cephadm/test_rgw.py
@@ -1,6 +1,7 @@
 import logging
 
 from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
 from ceph.ceph_admin.rgw import RGW
 
 log = logging.getLogger(__name__)
@@ -26,8 +27,10 @@ def run(ceph_cluster, **kw):
     command = config.pop("command")
     log.info("Executing RGW %s service" % command)
     rgw = RGW(cluster=ceph_cluster, **config)
-    method = fetch_method(rgw, command)
-    method(config)
-    if "get_cluster_details" in config:
-        rgw.get_cluster_state(config["get_cluster_details"])
+    try:
+        method = fetch_method(rgw, command)
+        method(config)
+    finally:
+        # Get cluster state
+        get_cluster_state(rgw)
     return 0


### PR DESCRIPTION
- Validations for bootstrap orphan-initial-daemons and skip-monitoring-stack option(s).
- added tier1 test-suite for cephadm bootstrap without orphan-initial-daemons and skip-monitoring-stack options.

**Results**
Bootstrap without stack-monitoring-stack and orphan-initial-daemons 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1616044972568/Cephadm_Bootstrap_0.log

Bootstrap with stack-monitoring-stack and orphan-initial-daemons
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1616046948430/Cephadm_Bootstrap_0.log

Updated RGW service deployment with new changes.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1616495691399

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>