### PR TITLE
Container Upgrade from 3.x cdn to 4.x latest

### DIFF
--- a/suites/nautilus/upgrades/upgrade_containerized_3.x_ceph-disk_to_4.x_lvm.yaml
+++ b/suites/nautilus/upgrades/upgrade_containerized_3.x_ceph-disk_to_4.x_lvm.yaml
@@ -1,0 +1,146 @@
+tests:
+- test:
+    name: install ceph pre-requisites
+    module: install_prereq.py
+    abort-on-fail: True
+
+- test:
+    name: ceph ansible install rhcs 3.x cdn
+    module: test_ansible.py
+    polarion-id: CEPH-83574033
+    config:
+      use_cdn: True
+      build: '3.x'
+      ansi_config:
+        ceph_origin: repository
+        ceph_repository: rhcs
+        ceph_repository_type: cdn
+        ceph_rhcs_version: 3
+        osd_scenario: collocated
+        osd_auto_discovery: False
+        copy_admin_key: True
+        containerized_deployment: true
+        ceph_docker_image: "rhceph/rhceph-3-rhel7"
+        ceph_docker_image_tag: "latest"
+        ceph_docker_registry: "registry.access.redhat.com"
+        ceph_conf_overrides:
+          global:
+            osd_pool_default_pg_num: 128
+            osd_default_pool_size: 2
+            osd_pool_default_pgp_num: 128
+            mon_max_pg_per_osd: 4096
+            mon_allow_pool_delete: True
+          client:
+            rgw crypt require ssl: false
+            rgw crypt s3 kms encryption keys: 
+              testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+              testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+    desc: test cluster ceph-disk 3.x cdn setup using ceph-ansible
+    abort-on-fail: True
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+
+- test:
+    name: Upgrade containerized ceph to 4.x latest
+    polarion-id: CEPH-83574033
+    module: test_ansible_upgrade.py
+    config:
+      ansi_config:
+        ceph_origin: distro
+        ceph_stable_release: nautilus
+        ceph_repository: rhcs
+        ceph_rhcs_version: 4
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable: True
+        ceph_stable_rh_storage: True
+        fetch_directory: ~/fetch
+        copy_admin_key: true
+        containerized_deployment: true
+        upgrade_ceph_packages: True
+        dashboard_enabled: True
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+        ceph_conf_overrides:
+            global:
+              osd_pool_default_pg_num: 64
+              osd_default_pool_size: 2
+              osd_pool_default_pgp_num: 64
+              mon_max_pg_per_osd: 1024
+            mon:
+              mon_allow_pool_delete: true
+            client:
+              rgw crypt require ssl: false
+              rgw crypt s3 kms encryption keys: 
+                testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+    desc: Ceph-Ansible container upgrade 3.x cdn to 4.x latest
+    abort-on-fail: True
+
+- test:
+    name: librbd workunit
+    module: test_workunit.py
+    config:
+      test_name: rbd/test_librbd_python.sh
+      branch: nautilus
+      role: mon
+    desc: Test librbd unit tests
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      cmd: ceph -s
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: Mbuckets_with_Nobjects
+    desc: test to create "M" no of buckets and "N" no of objects
+    polarion-id: CEPH-9789
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects.yaml
+      timeout: 300
+    
+- test:
+    name: ceph ansible purge
+    module: purge_cluster.py
+    config:
+        ansible-dir: /usr/share/ceph-ansible
+        playbook-command: purge-docker-cluster.yml -e ireallymeanit=yes -e remove_packages=yes
+    desc: Purge ceph cluster
+
+- test:
+    name: Check for old container directories
+    module: bug_1834974.py
+    desc: Check for old container directories
+    destroy-cluster: True

--- a/tests/ceph_ansible/test_ansible_upgrade.py
+++ b/tests/ceph_ansible/test_ansible_upgrade.py
@@ -181,11 +181,24 @@ def compare_ceph_versions(pre_upgrade_versions, post_upgrade_versions):
     """
     for name, version in pre_upgrade_versions.items():
         # skipping node-exporter version check as it not supported
-        if name != "node-exporter":
-            if "installer" not in name and post_upgrade_versions[name] == version:
-                log.error("Pre upgrade version matches post upgrade version")
-                log.error("{}: {} matches".format(name, version))
-                return 1
+        if name == "node-exporter":
+            continue
+
+        # for handling rgw conatiner names during 3.x 'some-rgw' but in 4.x 'some-rgw-rgw0'
+        if version.startswith("ceph version 12") and "rgw" in name:
+            for rgw_name in post_upgrade_versions.keys():
+                if "rgw" in rgw_name and rgw_name.startswith(name):
+                    if post_upgrade_versions[rgw_name] == version:
+                        log.error("Pre upgrade version matches post upgrade version")
+                        log.error("{}: {} matches".format(name, version))
+                        return 1
+                    break
+            continue
+
+        if "installer" not in name and post_upgrade_versions[name] == version:
+            log.error("Pre upgrade version matches post upgrade version")
+            log.error("{}: {} matches".format(name, version))
+            return 1
     return 0
 
 


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Added new suite for 3.x cdn to 4.x latest container upgrade
also fixed some container name issue while 3.x rgw container name `ceph-rgw-ceph-sangadi-cup7-1615198479770-node6-mon-rgw` but in 4.x container names got added with service id as `rgw0` hence handled the exception for `ceph-rgw-ceph-sangadi-cup7-1615198479770-node6-mon-rgw-rgw0`

Polarion link: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574033

Successful Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1615984458020/result.html
# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [x] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
