### PR TITLE
Fix in decodeError with the latest nightly container information

### DIFF
--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -121,12 +121,14 @@ def postLatestCompose() {
     /*
         Store the latest compose in ressi for QE usage.
     */
-    def msgPath = "/ceph/cephci-jenkins/latest-rhceph-container-info/latest-RHCEPH-${env.rhcephVersion}.json"
+    def latestJson = "/ceph/cephci-jenkins/latest-rhceph-container-info/latest-RHCEPH-${env.rhcephVersion}.json"
     def ciMsgFlag = "${params.CI_MESSAGE}" ?: ""
+
     if (ciMsgFlag?.trim()) {
-        sh(script: "echo ${params.CI_MESSAGE} > ${msgPath}")
+        sh """
+            echo '${params.CI_MESSAGE}' > ${latestJson}
+        """
     }
 }
 
 return this;
-


### PR DESCRIPTION
# Description

This PR fixes the error that is encountered when using the latest nightly build of RHCS 5.0. 

```
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 
```
resulting in 
```
2021-03-18 19:28:47,613 - __main__ - INFO - Compose id is: RHCEPH-5.0-RHEL-8-20210315.ci.0
2021-03-18 19:28:47,613 - __main__ - INFO - Testing Ceph Version: 16.1.0-736.el8cp
2021-03-18 19:28:47,613 - __main__ - INFO - Testing Ceph Ansible Version: 6.0.1-1.el8cp.noarch
 
ERROR:No latest nightly container UMB msg at /ceph/cephci-jenkins/latest-rhceph-container-info/,specify using the cli args or use --ignore-latest-container
```

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>
