### PR TITLE
Avoid failure rhs-ceph-repo if repo doesn't end with a /

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -882,7 +882,8 @@ class Ceph(object):
         """
         repo_file = ""
         for repo in repos:
-            repo_to_use = base_url + "compose/" + repo + "/x86_64/os/"
+            base_url = base_url.rstrip("/")
+            repo_to_use = f"{base_url}/compose/{repo}/x86_64/os"
             r = requests.get(repo_to_use, timeout=10)
             logger.info("Checking %s", repo_to_use)
             if r.status_code == 200:


### PR DESCRIPTION
With this fix, run no longer fails even if user doesn't end "--rhs-ceph-repo"'s value with a '/'
Prior -
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1616388243467/
base url was incorrectly formed with below string "RHCEPH-4.2-RHEL-8-20210316.ci.0compose" 

Now -
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1616431770187

Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
