### PR TITLE
Add support for custom grafana image for cephadm

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -136,4 +136,13 @@ class BootstrapMixin:
         logger.error("Bootstrap error: %s", err)
 
         self.distribute_cephadm_gen_pub_key(args.get("output-pub-ssh-key"))
+
+        # The provided image is used by Grafana service only when
+        # --skip-monitoring-stack is set to True during bootstrap.
+        if self.config.get("grafana_image"):
+            cmd = "cephadm shell --"
+            cmd += " ceph config set mgr mgr/cephadm/container_image_grafana"
+            cmd += f" {self.config['grafana_image']}"
+            self.installer.exec_command(sudo=True, cmd=cmd)
+
         return out, err

--- a/ceph/ceph_admin/host.py
+++ b/ceph/ceph_admin/host.py
@@ -63,15 +63,15 @@ class Host(Orch):
         node = args.pop("node")
         ceph_node = get_node_by_id(self.cluster, node_name=node)
 
+        if not ceph_node:
+            raise ResourceNotFoundError(f"No matching resource found: {node}")
+
         # Skipping client node, if only client label is attached
         if (
             len(ceph_node.role.role_list) == 1
             and ["client"] == ceph_node.role.role_list
         ):
             return
-
-        if not ceph_node:
-            raise ResourceNotFoundError(f"No matching resource found: {node}")
 
         attach_address = args.get("attach_ip_address")
         _labels = args.get("labels")

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -13,7 +13,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64.yaml",
                                 "sutConf=conf/${cephVersion}/cephadm/sanity-cephadm.yaml",
                                 "testSuite=suites/${cephVersion}/cephadm/tier_0_cephadm.yaml",
-                                "addnArgs=--post-results --log-level DEBUG"
+                                "addnArgs=--post-results --log-level DEBUG --grafana-image registry.redhat.io/rhceph-alpha/rhceph-5-dashboard-rhel8:latest"
                             ]) {
                                 sharedLib.runTestSuite()
                             }
@@ -21,7 +21,7 @@ def testStages = ['cephadm': {
                     }
                  }, 'object': {
                     stage('Object suite') {
-                        sleep(10)
+                        sleep(180)
                         script {
                             withEnv([
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
@@ -63,7 +63,7 @@ node(nodeName) {
         }
     }
 
-    timeout(unit: "MINUTES", time: 60) {
+    timeout(unit: "MINUTES", time: 120) {
         parallel testStages
     }
 

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -6,13 +6,13 @@
 def nodeName = "centos-7"
 def cephVersion = "pacific"
 def sharedLib
-def testStages = ['deploy': {
+def testStages = ['cephadm': {
                     stage('Deployment suite') {
                         script {
                             withEnv([
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64.yaml",
                                 "sutConf=conf/${cephVersion}/cephadm/sanity-cephadm.yaml",
-                                "testSuite=suites/${cephVersion}/cephadm/cephadm_deploy.yaml",
+                                "testSuite=suites/${cephVersion}/cephadm/tier_0_cephadm.yaml",
                                 "addnArgs=--post-results --log-level DEBUG"
                             ]) {
                                 sharedLib.runTestSuite()

--- a/run.py
+++ b/run.py
@@ -72,6 +72,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--xunit-results]
         [--enable-eus]
         [--skip-enabling-rhel-rpms]
+        [--grafana-image <image-name>]
   run.py --cleanup=name [--osp-cred <file>]
         [--log-level <LEVEL>]
 
@@ -96,27 +97,39 @@ Options:
   --reuse <file>                    use the stored vm state for rerun
   --skip-cluster                    skip cluster creation from ansible/ceph-deploy
   --skip-subscription               skip subscription manager if using beta rhel images
-  --docker-registry <registry>      Docker registry, default value is taken from ansible config
-  --docker-image <image>            Docker image, default value is taken from ansible config
+  --docker-registry <registry>      Docker registry, default value is taken from ansible
+                                    config
+  --docker-image <image>            Docker image, default value is taken from ansible
+                                    config
   --docker-tag <tag>                Docker tag, default value is 'latest'
   --insecure-registry               Disable security check for docker registry
   --post-results                    Post results to polarion, needs Polarion IDs
-                                    in test suite yamls. Requires config file, see README.
-  --report-portal                   Post results to report portal. Requires config file, see README.
+                                    in test suite yamls. Requires config file, see
+                                    README.
+  --report-portal                   Post results to report portal. Requires config file,
+                                    see README.
   --log-level <LEVEL>               Set logging level
   --log-dir <LEVEL>                 Set log directory [default: /tmp]
   --instances-name <name>           Name that will be used for instances creation
-  --osp-image <image>               Image for osp instances, default value is taken from conf file
+  --osp-image <image>               Image for osp instances, default value is taken from
+                                    conf file
   --filestore                       To specify filestore as osd object store
   --use-ec-pool <k,m>               To use ec pools instead of replicated pools
   --hotfix-repo <repo>              To run sanity on hotfix build
   --ignore-latest-container         Skip getting latest nightly container
-  --skip-version-compare            Skip verification that ceph versions change post upgrade
+  --skip-version-compare            Skip verification that ceph versions change post
+                                    upgrade
   -c --custom-config <name>=<value> Add a custom config key/value to ceph_conf_overrides
   --custom-config-file <file>       Add custom config yaml to ceph_conf_overrides
-  --xunit-results                   Create xUnit result file for test suite run [default: false]
-  --enable-eus                      Enables EUS rpms on EUS suppored distro [default: false]
-  --skip-enabling-rhel-rpms         skip adding rpms from subscription if using beta rhel images for Interop runs
+  --xunit-results                   Create xUnit result file for test suite run
+                                    [default: false]
+  --enable-eus                      Enables EUS rpms on EUS suppored distro
+                                    [default: false]
+  --skip-enabling-rhel-rpms         skip adding rpms from subscription if using beta
+                                    rhel images for Interop runs
+  --grafana-image <image_name>      Development purpose - provide custom grafana image
+                                    in conjunction with --skip-monitoring-stack during
+                                    cluster bootstrap via CephADM
 """
 log = logging.getLogger(__name__)
 root = logging.getLogger()
@@ -253,6 +266,7 @@ def run(args):
     docker_image = args.get("--docker-image", None)
     docker_tag = args.get("--docker-tag", None)
     docker_insecure_registry = args.get("--insecure-registry", False)
+    custom_grafana_image = args.get("--grafana-image", None)
 
     post_results = args.get("--post-results")
     skip_setup = args.get("--skip-cluster", False)
@@ -762,6 +776,9 @@ def run(args):
 
             if osp_cred:
                 config["osp_cred"] = osp_cred
+
+            if custom_grafana_image:
+                config["grafana_image"] = custom_grafana_image
 
             # if Kernel Repo is defined in ENV then set the value in config
             if os.environ.get("KERNEL-REPO-URL") is not None:

--- a/suites/pacific/cephadm/tier_0_cephadm.yaml
+++ b/suites/pacific/cephadm/tier_0_cephadm.yaml
@@ -33,6 +33,7 @@ tests:
         service: host
         command: add
         args:                     # arguments to ceph orch
+          attach_ip_address: true
           node: node2
       destroy-cluster: false
       abort-on-fail: true
@@ -186,7 +187,7 @@ tests:
             - node6
             - node7
             - node8
-          attach_ip_address: false
+          attach_ip_address: true
           labels: apply-all-labels
       destroy-cluster: false
       abort-on-fail: true


### PR DESCRIPTION
# Description

The following changes are carried out in this PR

- Added support for custom grafana image test
- Workaround _Add host_ failure due to infra gaps with FQDN resolve error
- Fixed an issue with host add, the change is to check if the Object is none type before comparing the node list
- Modified the tier-0 test suite for deployment.

**Logs**
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/fix_adm/result.html