### PR TITLE
Block: RHCS 5.0 tier 0 test suites

### DIFF
--- a/conf/pacific/rbd/tier_0_rbd.yaml
+++ b/conf/pacific/rbd/tier_0_rbd.yaml
@@ -1,0 +1,34 @@
+# System Under Test environment configuration for RBD tier 0 test suites.
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 3
+        disk-size: 20
+      node5:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 3
+        disk-size: 20
+      node6:
+        role:
+          - client

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -33,6 +33,20 @@ def testStages = ['cephadm': {
                             }
                         }
                     }
+                 }, 'block': {
+                    stage('Block suite') {
+                        sleep(360)
+                        script {
+                            withEnv([
+                                "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
+                                "sutConf=conf/${cephVersion}/rbd/tier_0_rbd.yaml",
+                                "testSuite=suites/${cephVersion}/rbd/tier_0_rbd.yaml",
+                                "addnArgs=--post-results --log-level debug"
+                            ]) {
+                                sharedLib.runTestSuite()
+                            }
+                        }
+                    }
                  }]
 
 // Pipeline script entry point
@@ -75,4 +89,3 @@ node(nodeName) {
     }
 
 }
-

--- a/suites/pacific/rbd/tier_0_rbd.yaml
+++ b/suites/pacific/rbd/tier_0_rbd.yaml
@@ -1,0 +1,139 @@
+# Tier0: RBD build evaluation
+#
+# This test suite evaluates the build to determine the execution of identified
+# regression test suites. This suite is executed against all new builds released by the
+# development team.
+#
+# The following testing is carried out
+#   - verification of image related CLI
+#   - verification of block related CLI
+#   - verification of Snapshot and Clone CLI
+#   - verification of other block CLI
+#   - verification of IO operations.
+tests:
+
+  # Setup the cluster
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:                             # arguments to ceph orch
+                - "ceph fs volume create cephfs"
+          - config:
+              command: shell
+              args:
+                - "ceph osd pool create cephfs_data"
+          - config:
+              command: shell
+              args:
+                - "ceph osd pool create cephfs_metadata"
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:                    # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs                        # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node4
+                    - node5
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  # Test cases to be executed
+
+  - test:
+      config:
+        test_name: cli/rbd_cli_image.py
+        branch: master
+      desc: Verify image related CLI commands
+      module: rbd_system.py
+      name: test_83572722_image_cli
+      polarion-id: CEPH-83572722
+  - test:
+      config:
+        test_name: cli/rbd_cli_import_export_diff.py
+        branch: master
+      desc: Verify block related CLI commands
+      module: rbd_system.py
+      name: test_83572723_block_clis
+      polarion-id: CEPH-83572723
+  - test:
+      config:
+        test_name: cli/rbd_cli_snap_clone.py
+        branch: master
+      desc: Verify Snapshot and Clone CLI commands
+      module: rbd_system.py
+      name: test_83572725_snap_clone_clis
+      polarion-id: CEPH-83572725
+  - test:
+      config:
+        test_name: cli/rbd_cli_misc.py
+        branch: master
+      desc: CLI validation for miscellaneous rbd commands
+      module: rbd_system.py
+      name: test_83572724_misc_clis
+      polarion-id: CEPH-83572724
+  - test:
+      config:
+        io-total: 100M
+      desc: Verify export during read/write, resizing, flattening, lock operations
+      module: rbd_faster_exports.py
+      name: test_9876_to_9880_export_operations
+      polarion-id: CEPH-9876,CEPH-9877,CEPH-9878,CEPH-9879,CEPH-9880


### PR DESCRIPTION
# Description

In this PR, the support for RBD tier 0 test suite is being added and included in the QE tier 0 pipeline stage.

In addition to the support, this PR optimizes the test module to install the prerequisites only once on the client node.

**Logs** [1]
__Depends on__ [2]

[1] http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/block_tier0/run1/result.html
[2] https://github.com/red-hat-storage/ceph-qe-scripts/pull/106