### PR TITLE
exec_command(): improve SSH error handling

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1372,7 +1372,9 @@ class CephNode(object):
             stdin, stdout, stderr = ssh().exec_command(kw["cmd"], timeout=timeout)
         except SSHException as e:
             logger.error("SSHException during cmd: %s", str(e))
-        exit_status = stdout.channel.recv_exit_status()
+        exit_status = None
+        if stdout is not None:
+            exit_status = stdout.channel.recv_exit_status()
         self.exit_status = exit_status
         if kw.get("check_ec", True):
             if exit_status == 0:

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1378,7 +1378,7 @@ class CephNode(object):
             if exit_status == 0:
                 logger.info("Command completed successfully")
             else:
-                logger.error("Error during cmd %s, timeout %d", exit_status, timeout)
+                logger.error("Error %s during cmd, timeout %d", exit_status, timeout)
                 raise CommandFailed(
                     kw["cmd"]
                     + " Error:  "

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1371,7 +1371,7 @@ class CephNode(object):
         try:
             stdin, stdout, stderr = ssh().exec_command(kw["cmd"], timeout=timeout)
         except SSHException as e:
-            logger.error("Exception during cmd %s", str(e))
+            logger.error("SSHException during cmd: %s", str(e))
             if "Timeout openning channel" in str(e):
                 logger.error("channel reset error")
         exit_status = stdout.channel.recv_exit_status()

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1372,8 +1372,6 @@ class CephNode(object):
             stdin, stdout, stderr = ssh().exec_command(kw["cmd"], timeout=timeout)
         except SSHException as e:
             logger.error("SSHException during cmd: %s", str(e))
-            if "Timeout openning channel" in str(e):
-                logger.error("channel reset error")
         exit_status = stdout.channel.recv_exit_status()
         self.exit_status = exit_status
         if kw.get("check_ec", True):


### PR DESCRIPTION
Improve error log messages, clean up unreachable code, and handle the case where Paramiko's `stdout` is `None`.