### PR TITLE
jenkins: change jenkins slave platform to rhel-8-medium

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-0.groovy
+++ b/pipeline/4/Jenkinsfile-tier-0.groovy
@@ -2,7 +2,7 @@
     Pipeline script for executing Tier 0 test suites for RH Ceph 4.x.
 */
 // Global variables section
-def nodeName = "centos-7"
+def nodeName = "rhel-8-medium"
 def cephVersion = "nautilus"
 def sharedLib
 def testStages = ['sanity_rpm': {

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -3,7 +3,7 @@
 */
 // Global variables section
 
-def nodeName = "centos-7"
+def nodeName = "rhel-8-medium"
 def cephVersion = "pacific"
 def sharedLib
 def testStages = ['cephadm': {


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- replace jenkins slave platform from `centos-7` to `rhel-8-medium`