### PR TITLE
Fix get_node_by_id to get exact node.

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -8,7 +8,7 @@ This is a mixin object and can be applied to the supported service classes.
 """
 from typing import Dict
 
-from ceph.utils import get_nodes_by_id
+from ceph.utils import get_nodes_by_ids
 
 from .common import config_dict_to_string
 from .typing_ import ServiceProtocol
@@ -100,7 +100,7 @@ class ApplyMixin:
                     placement_str += '"%s"' % nodes
                     verify_service = False
                 else:
-                    nodes_ = get_nodes_by_id(self.cluster, nodes)
+                    nodes_ = get_nodes_by_ids(self.cluster, nodes)
                     node_names = [node.shortname for node in nodes_]
 
                     sep = placement.get("sep", " ")

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -705,7 +705,24 @@ def get_disk_info(node):
     return disks
 
 
-def get_nodes_by_id(cluster, node_names):
+def get_node_by_id(cluster, node_name):
+    """
+    Search cluster for the first node object that matches node_name.
+
+    If this cluster has no nodes with this shortname, return None.
+
+    Args:
+        cluster: ceph object
+        node_name: node shortname, eg., 'node1'
+    Returns:
+        node
+    """
+    for node in cluster.get_nodes():
+        if node_name in node.shortname:
+            return node
+
+
+def get_nodes_by_ids(cluster, node_names):
     """
     Get node object(s) by Node Id
 
@@ -731,20 +748,3 @@ def get_nodes_by_id(cluster, node_names):
             for name in nodes
             if name in node.shortname
         ]
-
-
-def get_node_by_id(cluster, node_name):
-    """
-    Search cluster for the first node object that matches node_name.
-
-    If this cluster has no nodes with this shortname, return None.
-
-    Args:
-        cluster: ceph object
-        node_name: node shortname, eg., 'node1'
-    Returns:
-        node
-    """
-    for node in cluster.get_nodes():
-        if node_name in node.shortname:
-            return node

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -707,15 +707,32 @@ def get_disk_info(node):
 
 def get_node_by_id(cluster, node_name):
     """
-    Search cluster for the first node object that matches node_name.
+    Fetch node using provided node substring
 
-    If this cluster has no nodes with this shortname, return None.
+    As per the naming convention used at VM creation, where each node.shortname
+    is framed with hyphen("-") separated string as below, please refer
+    ceph.utils.create_ceph_nodes definition
+        "ceph-<name>-node1-<roles>"
+
+        name: RHOS-D username or provided --instances-name
+        roles: roles attached to node in inventory file
+
+    In this method we use hyphen("-") appended to node_name string to try fetch exact node.
+    for example,
+        "node1" ----> "node1-"
+
+    Note: But however if node_name doesn't follow naming convention as mentioned in
+    inventory, the first searched node will be returned.
+    for example,
+        "node" ----> it might return any node which matched first, like node11.
+
+    return None, If this cluster has no nodes with this substring.
 
     Args:
         cluster: ceph object
-        node_name: node shortname, eg., 'node1'
+        node_name: node1        # try to use node<Id>
     Returns:
-        node
+        node instance (CephVMNode)
     """
     # Append "-" as per naming convention used at instance creation
     if not node_name.endswith("-"):
@@ -728,19 +745,18 @@ def get_node_by_id(cluster, node_name):
 
 def get_nodes_by_ids(cluster, node_names):
     """
-    Get node object(s) by Node Id
+    Fetch nodes using provided substring of nodes
 
-    Returns all nodes object list if node_names is empty,
-    else node list which matched node ID(eg., 'node1')
+    Returns node list which matched node ID(eg., 'node1')
+    else all nodes object list if node_names is empty.
 
     Args:
         cluster: ceph object
         node_names: node name list (eg., ['node1'])
 
     Returns:
-        node_list: list nodes
+        node_list: list of nodes
     """
-    # Empty list wll pick all cluster nodes
     if not node_names:
         return cluster.get_nodes()
 

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -717,6 +717,10 @@ def get_node_by_id(cluster, node_name):
     Returns:
         node
     """
+    # Append "-" as per naming convention used at instance creation
+    if not node_name.endswith("-"):
+        node_name += "-"
+
     for node in cluster.get_nodes():
         if node_name in node.shortname:
             return node
@@ -736,15 +740,13 @@ def get_nodes_by_ids(cluster, node_names):
     Returns:
         node_list: list nodes
     """
-    nodes = node_names if isinstance(node_names, list) else [node_names]
-
     # Empty list wll pick all cluster nodes
-    if not nodes:
+    if not node_names:
         return cluster.get_nodes()
-    else:
-        return [
-            node
-            for node in cluster.get_nodes()
-            for name in nodes
-            if name in node.shortname
-        ]
+
+    nodes = []
+    for name in node_names:
+        node = get_node_by_id(cluster, name)
+        if node:
+            nodes.append(node)
+    return nodes


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

Since getting exact node by using node sub-string is quite tricky, so used instance naming convention which was used at the VM instances creation.

```
(Pdb) for i in get_nodes_by_id(kw['ceph_cluster'], []): i.shortname
'ceph-sunil1adm-1617805761413-node3-mon-osd-node-exporter-crash'
'ceph-sunil1adm-1617805761413-node4-client'
'ceph-sunil1adm-1617805761413-node2-osd-mon-mgr-mds-node-exporte'
'ceph-sunil1adm-1617805761413-node1-installer-mon-mgr-osd-node-e'

(Pdb) for i in get_nodes_by_id(kw['ceph_cluster'], ["node11"]): i.shortname

(Pdb) for i in get_nodes_by_id(kw['ceph_cluster'], ["node1", "node11", "node3"]): i.shortname
'ceph-sunil1adm-1617805761413-node1-installer-mon-mgr-osd-node-e'
'ceph-sunil1adm-1617805761413-node3-mon-osd-node-exporter-crash'

(Pdb) get_node_by_id(kw['ceph_cluster'], "node1").shortname
'ceph-sunil1adm-1617805761413-node1-installer-mon-mgr-osd-node-e'

(Pdb) get_node_by_id(kw['ceph_cluster'], "node11").shortname
*** AttributeError: 'NoneType' object has no attribute 'shortname'
```
