### PR TITLE
Fix issue in get_node_by_id when hostname provided.

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -734,12 +734,8 @@ def get_node_by_id(cluster, node_name):
     Returns:
         node instance (CephVMNode)
     """
-    # Append "-" as per naming convention used at instance creation
-    if not node_name.endswith("-"):
-        node_name += "-"
-
     for node in cluster.get_nodes():
-        if node_name in node.shortname:
+        if node_name == node.shortname or f"{node_name}-" in node.shortname:
             return node
 
 


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

Added a fix to avoid get_node_by_id failing when full host name was provided.

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1618208257816/Add_all_hosts_to_ceph_cluster_0.log
