### PR TITLE
SSHConnectionManager: log self.ip_address on connection failure

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1120,7 +1120,7 @@ class SSHConnectionManager(object):
                 )
                 break
             except Exception as e:
-                logger.warning(f"Connection outage: \n{e}")
+                logger.warning(f"Connection outage to {self.ip_address}: \n{e}")
                 if not self.__outage_start_time:
                     self.__outage_start_time = datetime.datetime.now()
                 if (

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1120,7 +1120,7 @@ class SSHConnectionManager(object):
                 )
                 break
             except Exception as e:
-                logger.warning("Connection outage: \n{error}".format(error=e))
+                logger.warning(f"Connection outage: \n{e}")
                 if not self.__outage_start_time:
                     self.__outage_start_time = datetime.datetime.now()
                 if (


### PR DESCRIPTION
Some Paramiko errors include the IP address, for example `[Errno None] Unable to connect to port 22 on 10.0.211.211`.

Other errors do not include the IP, like `Error reading SSH protocol banner` or `Bad authentication type`.

Always log the IP address to which cephci failed to connect, so we can get more information when troubleshooting networking problems.