### PR TITLE
CEPH-83573815: Tier 1 RGW cephadm multi realm deployment scenario

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -122,12 +122,16 @@ class ApplyMixin:
         if args:
             base_cmd.append(config_dict_to_string(args))
 
-        self.shell(args=base_cmd)
+        out, err = self.shell(args=base_cmd)
+
+        if not out:
+            raise OrchApplyServiceFailure(self.SERVICE_NAME)
+
+        # out value is "Scheduled <service_name> update..."
+        service_name = out.split()[1]
+
         if not verify_service:
             return
 
-        if not self.check_service_exists(
-            service_name=self.SERVICE_NAME,
-            ids=node_names,
-        ):
+        if not self.check_service_exists(service_name=service_name):
             raise OrchApplyServiceFailure(self.SERVICE_NAME)

--- a/ceph/ceph_admin/ls.py
+++ b/ceph/ceph_admin/ls.py
@@ -40,23 +40,8 @@ class LSMixin:
 
         cmd.append("ls")
 
-        args = None
         if config and config.get("args"):
             args = config.get("args")
-
-        if args:
-            # Export key has to be dealt differently
-            export_ = args.pop("export")
-            refresh = args.pop("refresh")
-
-            # Ideally, there is only one argument along
-            for key, value in args:
-                cmd.append(value)
-
-            if export_:
-                cmd.append("--export")
-
-            if refresh:
-                cmd.append("--refresh")
+            cmd.append(config_dict_to_string(args))
 
         return self.shell(args=cmd)

--- a/ceph/ceph_admin/ps.py
+++ b/ceph/ceph_admin/ps.py
@@ -41,19 +41,8 @@ class PSMixin:
 
         cmd.append("ps")
 
-        args = None
         if config and config.get("args"):
             args = config.get("args")
-
-        if args:
-            # Export key has to be dealt differently
-            refresh = args.pop("refresh")
-
-            # Ideally, there is only one argument along
-            for key, value in args:
-                cmd.append(value)
-
-            if refresh:
-                cmd.append("--refresh")
+            cmd.append(config_dict_to_string(args))
 
         return self.shell(args=cmd)

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -54,7 +54,7 @@ class OrchProtocol(CephAdmProtocol, Protocol):
         ...
 
     def check_service_exists(
-        self, service_name: str, ids: List[str], timeout: int = 300, interval: int = 5
+        self, service_name: str, timeout: int = 300, interval: int = 5
     ) -> bool:
         ...
 

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -66,6 +66,7 @@ def create_ceph_nodes(
 
         with parallel() as p:
             for node in range(1, 100):
+                sleep(5 * node)
                 node = "node" + str(node)
                 if not ceph_cluster.get(node):
                     break

--- a/conf/pacific/rgw/tier_1_rgw_cephadm.yaml
+++ b/conf/pacific/rgw/tier_1_rgw_cephadm.yaml
@@ -1,0 +1,46 @@
+# System Under Test environment configuration for Tier 1 RGW - CephADM test suite
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        role:
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - rgw
+
+      node7:
+        role:
+          - client

--- a/suites/pacific/rgw/tier_1_rgw_cephadm.yaml
+++ b/suites/pacific/rgw/tier_1_rgw_cephadm.yaml
@@ -1,0 +1,147 @@
+# Tier 1: CEPH-83573815 - CephADM - RGW deployment with multiple realm
+#
+# This test suite evaluates the deployment scenario wherein there exists more than one
+# RGW daemons configured with multiple realm, along with zones and zonegroups. Here,
+# the primary interface used would be CLI of CephADM.
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-dashboard: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  nodes:
+                    - node5
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.2
+              args:
+                port: 81
+                placement:
+                  nodes:
+                    - node5
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.3
+              args:
+                placement:
+                  nodes:
+                    - node6
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.4
+              args:
+                port: 81
+                placement:
+                  nodes:
+                    - node6
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node7
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "radosgw-admin realm create --rgw-realm india --default"
+          - "radosgw-admin zonegroup create --rgw-zonegroup south --rgw-realm india --master --default"
+          - "radosgw-admin zone create --rgw-zone ka --rgw-zonegroup south --rgw-realm india --endpoints http://{node:node5}:80 --master --default"
+          - "radosgw-admin zone create --rgw-zone tn --rgw-zonegroup south --rgw-realm india --endpoints http://{node:node5}:81"
+          - "radosgw-admin period update --commit --rgw-realm india"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_realm india"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_zonegroup south"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_zone ka"
+          - "ceph orch restart {service_name:rgw.1}"
+          - "ceph config set client.rgw.{daemon_id:rgw.2} rgw_realm india"
+          - "ceph config set client.rgw.{daemon_id:rgw.2} rgw_zonegroup south"
+          - "ceph config set client.rgw.{daemon_id:rgw.2} rgw_zone tn"
+          - "ceph orch restart {service_name:rgw.2}"
+          - "radosgw-admin realm create --rgw-realm us"
+          - "radosgw-admin zonegroup create --rgw-zonegroup east --rgw-realm us --master --default"
+          - "radosgw-admin zone create --rgw-zone east-1 --rgw-zonegroup east --rgw-realm us --endpoints http://{node:node6}:80 --master --default"
+          - "radosgw-admin zone create --rgw-zone east-2 --rgw-zonegroup east --rgw-realm us --endpoints http://{node:node6}:81"
+          - "radosgw-admin period update --commit --rgw-realm us"
+          - "ceph config set client.rgw.{daemon_id:rgw.3} rgw_realm us"
+          - "ceph config set client.rgw.{daemon_id:rgw.3} rgw_zonegroup east"
+          - "ceph config set client.rgw.{daemon_id:rgw.3} rgw_zone east-1"
+          - "ceph orch restart {service_name:rgw.3}"
+          - "ceph config set client.rgw.{daemon_id:rgw.4} rgw_realm us"
+          - "ceph config set client.rgw.{daemon_id:rgw.4} rgw_zonegroup east"
+          - "ceph config set client.rgw.{daemon_id:rgw.4} rgw_zone east-2"
+          - "ceph orch restart {service_name:rgw.4}"
+          - "ceph -s"
+          - "radosgw-admin realm list"
+          - "radosgw-admin zonegroup list"
+          - "radosgw-admin zone list"
+      desc: Configure the Object realms and its zones
+      module: exec.py
+      name: configure realm
+      polarion-id: CEPH-83573815

--- a/tests/misc_env/exec.py
+++ b/tests/misc_env/exec.py
@@ -1,47 +1,214 @@
+# Module to assist in executing a sequence of command.
+import json
 import logging
+import re
+from typing import Any, Tuple
 
-logger = logging.getLogger(__name__)
-log = logger
+from ceph.utils import get_node_by_id
+
+LOG = logging.getLogger(__name__)
 
 
-def run(**kw):
-    log.info("Running exec test")
-    ceph_nodes = kw.get("ceph_nodes")
-    config = kw.get("config")
+def exec_command(node, **kwargs: Any) -> Tuple:
+    """
+    Return the results of the command executed.
 
-    clients = []
-    role = "client"
-    if config.get("role"):
-        role = config.get("role")
-    for cnode in ceph_nodes:
-        if cnode.role == role:
-            clients.append(cnode)
+    Args:
+        node:   The node to be used for executing the given command.
+        kwargs: The supported keys are
+                sudo    - Default false, root privilege to be used or not
+                cmd     - The command to be executed
+                check_ec - Evaluate the error code returned.
 
-    idx = 0
-    client = clients[idx]
+    Return:
+        out, err    String values
 
-    if config.get("idx"):
-        idx = config["idx"]
-        client = clients[idx]
+    Raises:
+        CommandFailed   when there is an execution failure
+    """
+    out, err = node.exec_command(**kwargs)
+    return out.read().decode(), err.read().decode()
 
-    cmd = ""
-    if config.get("cmd"):
-        cmd = config.get("cmd")
 
-    if config.get("env"):
-        env = config.get("env")
-    else:
-        env = ""
+def translate_to_hostname(cluster, string: str) -> str:
+    """
+    Return the string with node ID replaced with shortname.
 
-    if config.get("sudo"):
-        sudo = "sudo -E"
-    else:
-        sudo = ""
+    In this method, the pattern {node:node1} would be replaced with the value of
+    node.shortname.
 
-    cmd1 = "{env} {sudo} {cmd}".format(env=env, sudo=sudo, cmd=cmd)
-    output, ec = client.exec_command(cmd=cmd1, long_running=True)
-    if ec == 0:
-        log.info("Exec completed successfully")
-    else:
-        log.info("Error during Exec of {cmd}".format(cmd=cmd1))
-    return ec
+    Args:
+        cluster:    Ceph cluster instance
+        string:    String to be searched for node ID pattern
+
+    Return:
+        String whose node ID's are replaced with shortnames
+    """
+    replaced_string = string
+    node_list = re.findall("{node:(.+?)}", string)
+
+    for node in node_list:
+        node_name = get_node_by_id(cluster, node).shortname
+        replacement_pattern = "{node:" + node + "}"
+        replaced_string = re.sub(replacement_pattern, node_name, replaced_string)
+
+    return replaced_string
+
+
+def translate_to_service_name(node, string: str) -> str:
+    """
+    Return the string after replacing the service id with it's service name.
+
+    If the given string contains {service_name:<value>} then this substring is replaced
+    with the name of the service that matches the given <value>.
+
+    The service name is determined by iterating through the output of
+
+        ceph orch ls --format json
+
+    and matching the value of the key service_id.
+
+    Args:
+        node:       System to be used to gather the service details.
+        string:     The text that needs to be searched for the given pattern.
+
+    Return:
+        String after replacing the pattern with the service name
+    """
+    replaced_string = string
+    names = re.findall("{service_name:(.+?)}", string)
+
+    out, _ = exec_command(
+        node, sudo=True, cmd="cephadm shell -- ceph orch ls --format json"
+    )
+
+    services_dict = json.loads(out)
+
+    for name in names:
+        for service_info in services_dict:
+            service_id = service_info.get("service_id")
+            if service_id and name == service_id:
+                pattern = "{service_name:" + name + "}"
+                replaced_string = re.sub(
+                    pattern, service_info["service_name"], replaced_string
+                )
+
+    return replaced_string
+
+
+def translate_to_daemon_id(node, string: str) -> str:
+    """
+    Return the given string after replacing the service id with it's daemon id.
+
+    If the given string contains {daemon_id:<value>} then this substring is replaced
+    with the Daemon Id that starts with the given <value>.
+
+    Args:
+        node:       System to be used to gather the information.
+        string:     The ID of the service that needs to be translated.
+
+    Return:
+        String after replacing the pattern with the daemon id.
+    """
+    replaced_string = string
+    ids_ = re.findall("{daemon_id:(.+?)}", string)
+
+    out, _ = exec_command(
+        node, sudo=True, cmd="cephadm shell -- ceph orch ps --format json"
+    )
+
+    daemon_details = json.loads(out)
+
+    for id_ in ids_:
+        for daemon in daemon_details:
+            if daemon["daemon_id"].startswith(id_):
+                pattern = "{daemon_id:" + id_ + "}"
+                replaced_string = re.sub(pattern, daemon["daemon_id"], replaced_string)
+
+    return replaced_string
+
+
+def run(ceph_cluster, **kwargs: Any) -> int:
+    """
+    Test module for executing a sequence of commands using the CephAdm shell interface.
+
+    The provided Ceph object is used to determine the installer node for executing the
+    provided list of commands.
+
+    Args:
+        ceph_cluster:   The participating Ceph cluster object
+        kwargs:         Supported key value pairs are
+                        cmd             | Depreciated - command to be executed
+                        idx             | Default 0, index to be used
+                        sudo            | Execute in the privileged mode
+                        cephadm         | Default False, use CephADM shell
+                        commands        | List of commands to be executed
+                        check_status    | Default True, if disabled does not raise error
+                        role            | The role of the node to be used for exec
+    Returns:
+        0 - on success
+        1 - on failure
+
+    Raises:
+        CommandError
+
+    Example:
+        - test:
+            abort-on-fail: true
+            config:
+                check_status: true
+                commands:
+                  - "radosgw-admin zone create --rgw-zone south"
+                  - "radosgw-admin realm create --rgw-realm india"
+            desc: Execute radosgw-admin commands for zone and
+            module: exec.py
+
+    Notes:
+        {node:node1} -> would be replaced with the shortname of node1
+    """
+    LOG.info("Executing command")
+    config = kwargs["config"]
+
+    command = config.get("cmd")
+    LOG.warning("Usage of cmd is deprecated instead use commands.")
+    commands = [command] if command else config["commands"]
+    cephadm = config.get("cephadm", False)
+
+    check_status = config.get("check_status", True)
+    sudo = config.get("sudo", False)
+    long_running = True
+
+    role = kwargs.get("role", "client")
+    if cephadm:
+        role = "installer"
+
+    nodes = ceph_cluster.get_nodes(role=role)
+    node = nodes[config.get("idx", 0)]
+
+    for cmd in commands:
+        # Reconstruct user values into dynamic values based on run instance
+        cmd = translate_to_hostname(ceph_cluster, cmd)
+
+        if cephadm:
+            cmd = f"cephadm shell -- {cmd}"
+            sudo = True
+            long_running = False
+
+            # Reconstruct cephadm specific lookups
+            cmd = translate_to_daemon_id(node, cmd)
+            cmd = translate_to_service_name(node, cmd)
+
+        try:
+            out, err = exec_command(
+                node,
+                sudo=sudo,
+                cmd=cmd,
+                check_ec=check_status,
+                long_running=long_running,
+            )
+            LOG.info(out)
+        except BaseException as be:
+            LOG.error(be)
+            return 1
+
+    return 0


### PR DESCRIPTION
# Description

In this PR, support for multi realm RGW deployment in a single cluster having multiple zonegroups and zones. The following changes are introduced

- Support execution of a list commands using the CephADM shell interface
- Adding test suite automating the workflow
- Adds the system configuration for evaluating the scenario

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test

# Logs
[Run 1](http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/adm_t1_rgw/): http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/adm_t1_rgw/ 
