### PR TITLE
tests: use "log" variable

### DIFF
--- a/tests/ceph_ansible/bug_1834974.py
+++ b/tests/ceph_ansible/bug_1834974.py
@@ -1,8 +1,7 @@
 import logging
 import time
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/ceph_ansible/filestore_to_bluestore.py
+++ b/tests/ceph_ansible/filestore_to_bluestore.py
@@ -2,8 +2,7 @@
 
 import logging
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/ceph_ansible/switch_rpm_to_container.py
+++ b/tests/ceph_ansible/switch_rpm_to_container.py
@@ -2,8 +2,7 @@
 
 import logging
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/ceph_ansible/test_ansible_roll_over.py
+++ b/tests/ceph_ansible/test_ansible_roll_over.py
@@ -5,8 +5,7 @@ import re
 
 from ceph.ceph import NodeVolume
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/ceph_ansible/test_ceph_1623580.py
+++ b/tests/ceph_ansible/test_ceph_1623580.py
@@ -2,8 +2,7 @@ import json
 import logging
 import re
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 BOOT_DISK_CMD = "findmnt -v -n -T / -o SOURCE"
 

--- a/tests/ceph_installer/test_ceph_deploy.py
+++ b/tests/ceph_installer/test_ceph_deploy.py
@@ -3,8 +3,7 @@ import time
 
 from ceph.utils import create_ceph_conf, keep_alive, setup_deb_repos, setup_repos
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/cephfs/BUG-1798719.py
+++ b/tests/cephfs/BUG-1798719.py
@@ -5,8 +5,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-10528_10529.py
+++ b/tests/cephfs/CEPH-10528_10529.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-10625_11225.py
+++ b/tests/cephfs/CEPH-10625_11225.py
@@ -8,8 +8,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11219.py
+++ b/tests/cephfs/CEPH-11219.py
@@ -7,8 +7,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11220.py
+++ b/tests/cephfs/CEPH-11220.py
@@ -5,8 +5,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11221.py
+++ b/tests/cephfs/CEPH-11221.py
@@ -7,8 +7,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11222.py
+++ b/tests/cephfs/CEPH-11222.py
@@ -9,8 +9,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11222_11223.py
+++ b/tests/cephfs/CEPH-11222_11223.py
@@ -9,8 +9,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11227.py
+++ b/tests/cephfs/CEPH-11227.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11228.py
+++ b/tests/cephfs/CEPH-11228.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11229.py
+++ b/tests/cephfs/CEPH-11229.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11230.py
+++ b/tests/cephfs/CEPH-11230.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11231.py
+++ b/tests/cephfs/CEPH-11231.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11232_11233.py
+++ b/tests/cephfs/CEPH-11232_11233.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11242.py
+++ b/tests/cephfs/CEPH-11242.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11254_fuse.py
+++ b/tests/cephfs/CEPH-11254_fuse.py
@@ -7,8 +7,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11255_11336_fuse.py
+++ b/tests/cephfs/CEPH-11255_11336_fuse.py
@@ -8,8 +8,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 # osd

--- a/tests/cephfs/CEPH-11256_fuse.py
+++ b/tests/cephfs/CEPH-11256_fuse.py
@@ -7,8 +7,7 @@ from ceph.parallel import parallel
 from ceph.utils import check_ceph_healthly
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 # mds

--- a/tests/cephfs/CEPH-11262.py
+++ b/tests/cephfs/CEPH-11262.py
@@ -7,8 +7,7 @@ from ceph.parallel import parallel
 from ceph.utils import node_power_failure
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11298.py
+++ b/tests/cephfs/CEPH-11298.py
@@ -6,8 +6,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11333.py
+++ b/tests/cephfs/CEPH-11333.py
@@ -4,8 +4,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11334.py
+++ b/tests/cephfs/CEPH-11334.py
@@ -5,8 +5,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11335.py
+++ b/tests/cephfs/CEPH-11335.py
@@ -7,8 +7,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/CEPH-11338.py
+++ b/tests/cephfs/CEPH-11338.py
@@ -5,8 +5,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/cephfs_basic_tests.py
+++ b/tests/cephfs/cephfs_basic_tests.py
@@ -7,8 +7,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/cephfs_utils.py
+++ b/tests/cephfs/cephfs_utils.py
@@ -7,8 +7,7 @@ import time
 
 from ceph.ceph import CommandFailed
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 class FsUtils(object):

--- a/tests/cephfs/nfs-ganesha_basics.py
+++ b/tests/cephfs/nfs-ganesha_basics.py
@@ -5,8 +5,7 @@ from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/cephfs/recreate-cephfs-ecpool.py
+++ b/tests/cephfs/recreate-cephfs-ecpool.py
@@ -3,8 +3,7 @@ import time
 
 from tests.cephfs.cephfs_utils import FsUtils
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(ceph_cluster, **kw):

--- a/tests/iscsi/update-kernel-iscsi.py
+++ b/tests/iscsi/update-kernel-iscsi.py
@@ -5,8 +5,7 @@ import time
 from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/mgr/test_ceph_83573397.py
+++ b/tests/mgr/test_ceph_83573397.py
@@ -2,8 +2,7 @@ import json
 import logging
 from time import time
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 __script = """
 import requests
@@ -43,7 +42,7 @@ def exec_cmd_status(ceph_installer, commands):
     for cmd in commands:
         out, err = ceph_installer.exec_command(sudo=True, cmd=cmd)
         out, err = out.read().decode().strip(), err.read().decode().strip()
-        logger.info("Command Response : {} {}".format(out, err))
+        log.info("Command Response : {} {}".format(out, err))
     return True
 
 
@@ -108,10 +107,10 @@ def run(ceph_cluster, **kw):
     out, err = out.read().decode().strip(), err.read().decode().strip()
 
     json_data = json.loads(out)
-    logger.info("Status Code : {}".format(json_data.get("status_code")))
+    log.info("Status Code : {}".format(json_data.get("status_code")))
 
     if json_data.get("status_code") == 200:
         logger.info(json_data.get("json"))
         return 0
-    logger.error(json_data.get("json"))
+    log.error(json_data.get("json"))
     return 1

--- a/tests/mgr/test_mgr_keyring.py
+++ b/tests/mgr/test_mgr_keyring.py
@@ -1,7 +1,6 @@
 import logging
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/misc_env/exec.py
+++ b/tests/misc_env/exec.py
@@ -1,7 +1,6 @@
 import logging
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/misc_env/test_workunit.py
+++ b/tests/misc_env/test_workunit.py
@@ -3,8 +3,7 @@ import time
 
 from ceph.utils import keep_alive
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/misc_env/update-kernel.py
+++ b/tests/misc_env/update-kernel.py
@@ -4,8 +4,7 @@ import time
 
 from ceph.parallel import parallel
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):

--- a/tests/rados/radosbench.py
+++ b/tests/rados/radosbench.py
@@ -1,8 +1,7 @@
 import logging
 import random
 
-logger = logging.getLogger(__name__)
-log = logger
+log = logging.getLogger(__name__)
 
 
 def run(**kw):


### PR DESCRIPTION
Many tests assigned the Python logger to a variable named `logger`, and then assigned that to another variable `log`. The test suites used `log` and ignored `logger`.

`tests/mgr/test_ceph_83573397.py` was unique in that it used the `logger` variable instead of `log`.

Standardize on the `log` variable everywhere. Directly assign the logger to `log` and remove the unused `logger` variable.

The purpose of this change is to simplify the code and make it easier to understand.