### PR TITLE
Defaulting to config drive for VM customization

### DIFF
--- a/mita/v2.py
+++ b/mita/v2.py
@@ -176,6 +176,7 @@ class CephVMNodeV2:
                 image=image,
                 size=vm_size,
                 ex_userdata=cloud_data,
+                ex_config_drive=True,
                 networks=vm_network,
             )
 


### PR DESCRIPTION
# Description

Due to ongoing RHOS-D issues, this PR changes the default behavior of VM create to use the config drive feature of OS for customization.

### Logs
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/config/startup.log

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>