### PR TITLE
Fix to retrieve exact service name in apply method

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -6,6 +6,7 @@ Module to deploy ceph role service(s) using orchestration command
 
 This is a mixin object and can be applied to the supported service classes.
 """
+import re
 from typing import Dict
 
 from ceph.utils import get_nodes_by_ids
@@ -128,7 +129,7 @@ class ApplyMixin:
             raise OrchApplyServiceFailure(self.SERVICE_NAME)
 
         # out value is "Scheduled <service_name> update..."
-        service_name = out.split()[1]
+        service_name = re.search(r"Scheduled\s(.*)\supdate", out).group(1)
 
         if not verify_service:
             return


### PR DESCRIPTION
- Fix service name search in apply method.

**Failure**: In case of verbose data, expression fails to get service name.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1618995752172/cluster_deployment_0.log

**test results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1619001891058/cluster_deployment_0.log

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

