### PR TITLE
Fix 468: ERROR - 'str' object has no attribute 'read'

### DIFF
--- a/tests/misc_env/exec.py
+++ b/tests/misc_env/exec.py
@@ -4,6 +4,8 @@ import logging
 import re
 from typing import Any, Tuple
 
+from paramiko.channel import ChannelFile
+
 from ceph.utils import get_node_by_id
 
 LOG = logging.getLogger(__name__)
@@ -27,7 +29,10 @@ def exec_command(node, **kwargs: Any) -> Tuple:
         CommandFailed   when there is an execution failure
     """
     out, err = node.exec_command(**kwargs)
-    return out.read().decode(), err.read().decode()
+
+    out = out.read().decode() if isinstance(out, ChannelFile) else out
+    err = err.read().decode() if isinstance(err, ChannelFile) else err
+    return out, err
 
 
 def translate_to_hostname(cluster, string: str) -> str:


### PR DESCRIPTION
# Description

When `long_running` argument is enabled then the return type is string which has caused the breaking mentioned in #468 

This PR modifies the default behavior to check the type before decoding.

Closes #468 

### Logs:
4: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/i468/4/ 
5: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/i468/5/

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>