### PR TITLE
Adding Tier 0 Cephfs Test cases

### DIFF
--- a/conf/pacific/cephfs/tier_0_fs.yaml
+++ b/conf/pacific/cephfs/tier_0_fs.yaml
@@ -1,0 +1,49 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - mon
+          - mgr
+          - client
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - client
+      node3:
+        role:
+          - osd
+          - mon
+          - mds
+          - client
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+          - client
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - osd
+          - nfs
+        no-of-volumes: 4
+        disk-size: 15
+

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -47,7 +47,20 @@ def testStages = ['cephadm': {
                             }
                         }
                     }
-                 }]
+                 }, 'cephfs': {
+                    stage('Cephfs Suite') {
+                        sleep(540)
+                        script {
+                            withEnv([
+                                "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
+                                "sutConf=conf/${cephVersion}/rbd/tier_0_fs.yaml",
+                                "testSuite=suites/${cephVersion}/rbd/tier_0_fs.yaml",
+                                "addnArgs=--post-results --log-level debug"
+                            ]) {
+                                sharedLib.runTestSuite()
+                            }
+                        }
+                    }]
 
 // Pipeline script entry point
 

--- a/suites/pacific/cephfs/tier_0_fs.yaml
+++ b/suites/pacific/cephfs/tier_0_fs.yaml
@@ -1,0 +1,132 @@
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+        abort-on-fail: true
+        config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+                - ceph-common
+            copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2
+        node: node3
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 2
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3
+        node: node1
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 3
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.4
+        node: node5
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the Cephfs client system 4
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+        name: cephfs-basics
+        module: cephfs_basic_tests.py
+        polarion-id: CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295
+        desc: cephfs basic operations
+        abort-on-fail: false
+  - test:
+        name: nfs-ganesha_with_cephfs
+        module: nfs-ganesha_basics.py
+        desc: Mount cephfs on clients,configure nfs-ganesha on nfs server,do mount on any client and do IOs
+        abort-on-fail: false
+

--- a/tests/cephfs/cephfs_basic_tests.py
+++ b/tests/cephfs/cephfs_basic_tests.py
@@ -87,9 +87,10 @@ def run(ceph_cluster, **kw):
             )
             log.info("Execution of testcase %s started" % tc1)
             out, rc = client.exec_command(
-                cmd="sudo crefi %s%s --fop create --multi -b 1000 -d 1000 "
-                "-n 1 -T 5 --random --min=1K --max=10K"
-                % (client_info["mounting_dir"], dir1),
+                sudo=True,
+                cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 4 "
+                f"--files 1000 --files-per-dir 10 --dirs-per-dir 2 --top "
+                f"{client_info['mounting_dir']}{dir1}",
                 long_running=True,
             )
             log.info("Execution of testcase %s ended" % tc1)

--- a/tests/cephfs/cephfs_utils.py
+++ b/tests/cephfs/cephfs_utils.py
@@ -84,7 +84,7 @@ class FsUtils(object):
                 + self.mon_node_ip[-1].strip("/0")
             )
             self.mon_node_ip = self.mon_node_ip.split(" ")
-            if build.startswith("4"):
+            if build.startswith("4") or build.startswith("5"):
                 self.mon_node_ip[0] = re.search(
                     r"\W+v\w+:(\d+.\d+.\d+.\d+:\d+)/0,v\w+:(\d+.\d+.\d+.\d+:\d+)/0\W",
                     self.mon_node_ip[0],
@@ -562,7 +562,9 @@ class FsUtils(object):
     @staticmethod
     def nfs_ganesha_install(ceph_demon):
         if ceph_demon.pkg_type == "rpm":
-            ceph_demon.exec_command(sudo=True, cmd="yum install nfs-ganesha-ceph -y")
+            ceph_demon.exec_command(
+                sudo=True, cmd="yum install --nogpgcheck nfs-ganesha-ceph -y"
+            )
             ceph_demon.exec_command(sudo=True, cmd="systemctl start rpcbind")
             ceph_demon.exec_command(sudo=True, cmd="systemctl stop nfs-server.service")
             ceph_demon.exec_command(


### PR DESCRIPTION
Adding Tier 0 Cephfs test cases.

Following test cases are covered:
1. Mounting drive using Kernal 
2. Mounting drive using fuse 
3. Mounting drive using NFS
4. Running IOs on all the mounts

Please find the [LOGS](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1619683904207)
