### PR TITLE
Fix#475: ValueError during test execution

### DIFF
--- a/tests/ceph_ansible/bug_1834974.py
+++ b/tests/ceph_ansible/bug_1834974.py
@@ -1,22 +1,28 @@
 import logging
 import time
 
-logger = logging.getLogger(__name__)
-log = logger
+LOG = logging.getLogger(__name__)
 
 
 def run(**kw):
-    log.info("Bug 1834974")
+    LOG.info("Executing test case: Bug 1834974 verification")
     ceph_nodes = kw.get("ceph_nodes")
+
     time.sleep(180)
+
     for cnode in ceph_nodes:
         out, err = cnode.exec_command(
-            cmd="sudo df -h | grep -v shm | grep -i containers | wc -l",
-            long_running=True,
+            sudo=True,
+            cmd="df -h | grep -v shm | grep -i containers | wc -l",
         )
-        if int(out) == 0:
-            log.info("No old container directories found")
-        else:
-            log.error("Old container directories found which are consuming space")
+        out = out.read().decode()
+        err = err.read().decode()
+
+        if int(out) != 0:
+            LOG.debug(err)
+            LOG.error("Old container directories found which are consuming space")
             return 1
+
+        LOG.info("No old container directories found.")
+
     return 0


### PR DESCRIPTION
# Description

This PR fixes an issue when `exec_command` returns an empty string when the option `long_running` is enabled. Ideally, this shouldn't occur. This is a workaround and it utilizes the same command with `long_running` disabled.

Closes #475 

### Logs
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/475/

### Notes
`exec.py` was used for executing `ceph -s` command hence setting the default value of the option to False.

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>