### PR TITLE
Issue-#478: Added check to verify required number of node(s).

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -37,7 +37,7 @@ def create_ceph_nodes(
         inventory_path = os.path.abspath(ceph_cluster.get("inventory"))
         with open(inventory_path, "r") as inventory_stream:
             inventory = yaml.safe_load(inventory_stream)
-
+    node_count = 0
     params["cloud-data"] = inventory.get("instance").get("setup")
     params["username"] = os_cred["username"]
     params["password"] = os_cred["password"]
@@ -107,8 +107,15 @@ def create_ceph_nodes(
 
                 if node_dict.get("cloud-data"):
                     node_params["cloud-data"] = node_dict.get("cloud-data")
-
+                node_count += 1
                 p.spawn(setup_vm_node, node, ceph_nodes, **node_params)
+
+    if len(ceph_nodes) != node_count:
+        log.error(
+            f"Mismatch error in number of VMs spawned. "
+            f"Expected: {len(ceph_nodes)} \t Actual: {node_count}"
+        )
+        raise NodeError("Required number of nodes not created")
 
     log.info("Done creating nodes")
     return ceph_nodes


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

Fixes #478.

- Added a check required number of nodes.

```
2021-04-28 18:12:32,331 - root - INFO - Creating 4 volumes with 15GiB storage for ceph-sunil1adm-1619613182649-node1-installer-mon-mgr-osd-node-exporter-alertmanager-grafana-prometheus-crash
> /home/sunnagar/work/cephci/ceph/utils.py(114)create_ceph_nodes()
-> if len(ceph_nodes) != node_count:
(Pdb) len(ceph_nodes) != node_count
False
(Pdb) node_count
4
(Pdb) ceph_nodes
{'node2': <mita.v2.CephVMNodeV2 object at 0x7fce1472bf28>, 'node3': <mita.v2.CephVMNodeV2 object at 0x7fce157dab00>, 'node4': <mita.v2.CephVMNodeV2 object at 0x7fce14750f28>, 'node1': <mita.v2.CephVMNodeV2 object at 0x7fce1472beb8>}
(Pdb) len(ceph_nodes)
4
```

 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1619613182649
