### PR TITLE
RHCEPHQE-36: Task 1 publish the test run information to report portal

### DIFF
--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -13,7 +13,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64.yaml",
                                 "sutConf=conf/${cephVersion}/cephadm/sanity-cephadm.yaml",
                                 "testSuite=suites/${cephVersion}/cephadm/tier_0_cephadm.yaml",
-                                "addnArgs=--post-results --log-level DEBUG --grafana-image registry.redhat.io/rhceph-alpha/rhceph-5-dashboard-rhel8:latest"
+                                "addnArgs=--post-results --log-level DEBUG --grafana-image registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest"
                             ]) {
                                 sharedLib.runTestSuite()
                             }

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -13,7 +13,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64.yaml",
                                 "sutConf=conf/${cephVersion}/cephadm/sanity-cephadm.yaml",
                                 "testSuite=suites/${cephVersion}/cephadm/tier_0_cephadm.yaml",
-                                "addnArgs=--post-results --log-level DEBUG --grafana-image registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest"
+                                "addnArgs=--post-results --log-level debug --grafana-image registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest --report-portal"
                             ]) {
                                 sharedLib.runTestSuite()
                             }
@@ -27,7 +27,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
                                 "sutConf=conf/${cephVersion}/rgw/sanity_rgw.yaml",
                                 "testSuite=suites/${cephVersion}/rgw/tier_0_rgw.yaml",
-                                "addnArgs=--post-results --log-level debug"
+                                "addnArgs=--post-results --log-level debug --report-portal"
                             ]) {
                                 sharedLib.runTestSuite()
                             }
@@ -41,7 +41,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
                                 "sutConf=conf/${cephVersion}/rbd/tier_0_rbd.yaml",
                                 "testSuite=suites/${cephVersion}/rbd/tier_0_rbd.yaml",
-                                "addnArgs=--post-results --log-level debug"
+                                "addnArgs=--post-results --log-level debug --report-portal"
                             ]) {
                                 sharedLib.runTestSuite()
                             }
@@ -55,7 +55,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
                                 "sutConf=conf/${cephVersion}/cephfs/tier_0_fs.yaml",
                                 "testSuite=suites/${cephVersion}/cephfs/tier_0_fs.yaml",
-                                "addnArgs=--post-results --log-level debug"
+                                "addnArgs=--post-results --log-level debug --report-portal"
                             ]) {
                                 sharedLib.runTestSuite()
                             }


### PR DESCRIPTION
# Description

This PR is a completer for the user story RHCEPHQE-36 wherein the results of the run would need to be captured in the Report Portal. Here we add the CLI option `--report-portal` to be passed to the executor.

In addition to this change, we are moving to use grafana's beta image.