### PR TITLE
Moving custom image of tier 0 cephadm to beta

### DIFF
--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -21,7 +21,7 @@ def testStages = ['cephadm': {
                     }
                  }, 'object': {
                     stage('Object suite') {
-                        sleep(180)
+                        sleep(60)
                         script {
                             withEnv([
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
@@ -35,7 +35,7 @@ def testStages = ['cephadm': {
                     }
                  }, 'block': {
                     stage('Block suite') {
-                        sleep(360)
+                        sleep(120)
                         script {
                             withEnv([
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
@@ -49,7 +49,7 @@ def testStages = ['cephadm': {
                     }
                  }, 'cephfs': {
                     stage('Cephfs Suite') {
-                        sleep(540)
+                        sleep(180)
                         script {
                             withEnv([
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -13,7 +13,7 @@ def testStages = ['cephadm': {
                                 "sutVMConf=conf/inventory/rhel-8.3-server-x86_64.yaml",
                                 "sutConf=conf/${cephVersion}/cephadm/sanity-cephadm.yaml",
                                 "testSuite=suites/${cephVersion}/cephadm/tier_0_cephadm.yaml",
-                                "addnArgs=--post-results --log-level DEBUG --grafana-image registry.redhat.io/rhceph-alpha/rhceph-5-dashboard-rhel8:latest"
+                                "addnArgs=--post-results --log-level debug --grafana-image registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest"
                             ]) {
                                 sharedLib.runTestSuite()
                             }


### PR DESCRIPTION
# Description

With the beta images available, moving the custom image option for deploy in tier 0 to use it. Along with this change, the wait time between the stages have been reduced as cephci internally throttles the VM.