### PR TITLE
issue#405 - Fix errors when installing RH IT CA

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -70,7 +70,13 @@ def install_prereq(
     log.info("Waiting for cloud config to complete on " + ceph.hostname)
     ceph.exec_command(cmd="while [ ! -f /ceph-qa-ready ]; do sleep 15; done")
     log.info("cloud config to completed on " + ceph.hostname)
-    update_ca_cert(ceph, "https://password.corp.redhat.com/RH-IT-Root-CA.crt")
+
+    # Update certs
+    update_ca_cert(
+        node=ceph,
+        cert_url="https://password.corp.redhat.com/RH-IT-Root-CA.crt",
+        out_file="RH-IT-Root-CA.crt",
+    )
     distro_info = ceph.distro_info
     distro_ver = distro_info["VERSION_ID"]
     log.info("distro name: {name}".format(name=distro_info["NAME"]))


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- simplify curl command to this single operation(downloading certs using curl).
- Fixes https://github.com/red-hat-storage/cephci/issues/405 , bail on errors when installing RH IT CA
```
2021-05-01 00:36:07,563 - ceph.ceph - INFO - Running command curl https://password.corp.redhat.com/RH-IT-Root-CA.crt -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt on 10.0.209.204
2021-05-01 00:36:07,588 - ceph.ceph - INFO - Command completed successfully
```

**Downloading certs:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1619808669799/Install_ceph_pre-requisites_0.log

**Bootstrap cluster after downloading certs from install prerequisites task.**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1619809852336/Cephadm_Bootstrap_0.log