### PR TITLE
Fix config_dict_to_string method to handle boolean argument.

### DIFF
--- a/ceph/ceph_admin/common.py
+++ b/ceph/ceph_admin/common.py
@@ -14,6 +14,9 @@ def config_dict_to_string(data: Dict) -> str:
     """
     rtn = ""
     for key, value in data.items():
+        if isinstance(value, bool) and value is False:
+            continue
+
         rtn += f" -{key}" if len(key) == 1 else f" --{key}"
 
         if not isinstance(value, bool):


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Fix config_dict_to_string method to handle boolean False argument.

**Issue:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1619501088417/Cephadm_Bootstrap_0.log

**Fix:**
```
$ cat /home/sunnagar/.config/JetBrains/PyCharmCE2020.1/scratches/test_jinja2.py

d = {
    "a": "single-hyphen-string-val",
    "abc": "double-hyphen-string-val",
    "test-true-boolean": True,
    "test-false-boolean": False,
    "t": True,
    "f": False,
}


def config_dict_to_string(data) -> str:
    """
    Convert the provided data to a string of optional arguments.

    Args:
        data:   Key/value pairs that are CLI optional arguments

    Return:
        string instead of the a data dict
    """
    rtn = ""
    for key, value in data.items():
        if isinstance(value, bool) and value is False:
            continue

        rtn += f" -{key}" if len(key) == 1 else f" --{key}"

        if not isinstance(value, bool):
            rtn += f" {value}"

    return rtn

print(config_dict_to_string(d)) 

------ execution ----------

$ python3  /home/sunnagar/.config/JetBrains/PyCharmCE2020.1/scratches/test_jinja2.py                                                                                                      ─╯
 -a single-hyphen-string-val --abc double-hyphen-string-val --test-true-boolean -t

```
