### PR TITLE
Inconsistent failure when pulling realm information in secondary cluster

### DIFF
--- a/suites/pacific/rgw/rgw_multisite.yaml
+++ b/suites/pacific/rgw/rgw_multisite.yaml
@@ -156,6 +156,7 @@ tests:
           config:
             cephadm: true
             commands:
+              - "sleep 120"
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
               - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"


### PR DESCRIPTION
# Description

In some environments, we are seeing failures on pulling realm information in the secondary data center. Adding a sleep for some time allows us to have consistent success. In this PR, we are adding a 2 minute sleep before pulling the realm information in the secondary cluster.

### Logs
[1] http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_ms/e2e_4/

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>