### PR TITLE
Add grafana to 4x upgrade conf to avoid failure

### DIFF
--- a/conf/nautilus/upgrades/upgrades.yaml
+++ b/conf/nautilus/upgrades/upgrades.yaml
@@ -22,7 +22,9 @@ globals:
      node7:
        role: mgr
      node8:
-       role: installer
+       role: 
+         - installer
+         - grafana
      node9:
        role: rgw
      node10:


### PR DESCRIPTION
suites/nautilus/upgrades/upgrade_containerized_4.x_cdn_to_4.x_latest.yaml used to fail as there were no grafana nodes
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620708005129/ceph_ansible_install_containerized_rhcs_4.x_from_cdn_0.log
Added grafana node to conf file so that the suite doesn't file.
This would not induce any regression on suites with `dashboard_enabled` set to `false`
Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
