### PR TITLE
Setting 2 Active MDS on cephfs

### DIFF
--- a/suites/pacific/cephfs/tier_0_fs.yaml
+++ b/suites/pacific/cephfs/tier_0_fs.yaml
@@ -66,6 +66,22 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
   - test:
+      name: Add Active Active configuration of MDS
+      desc: Add Active Active configuration of MDS for cephfs
+      module: test_bootstrap.py
+      polarion-id: CEPH-11344
+      config:
+        command: shell
+        args: # arguments to ceph orch
+          - ceph
+          - fs
+          - set
+          - cephfs
+          - max_mds
+          - "2"
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
         abort-on-fail: true
         config:
             command: add


### PR DESCRIPTION
Adding test case to set Active-Active configuration on the cephfs 

Please find the[ Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620923019012)

Polarion ID : [CEPH-11344](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11344)

