### PR TITLE
fs_to_bs script fix

### DIFF
--- a/tests/ceph_ansible/filestore_to_bluestore.py
+++ b/tests/ceph_ansible/filestore_to_bluestore.py
@@ -13,9 +13,8 @@ def run(**kw):
     ansible_dir = "/usr/share/ceph-ansible"
     playbook = "filestore-to-bluestore.yml"
     replace_objectstore = "sed -i 's/osd_objectstore: filestore/osd_objectstore: bluestore/g' group_vars/all.yml"
+    installer_node = kw["ceph_cluster"].get_nodes(role="installer")[0]
     for cnode in ceph_nodes:
-        if cnode.role == "installer":
-            installer_node = cnode
         if cnode.role == "osd":
             out, err = installer_node.exec_command(
                 cmd="cd {ansible_dir};ansible-playbook -vvvv"


### PR DESCRIPTION
Description:
Filestore to bluestore migration fails when osd or other daemons are evaluated before the installer with error local variable 'installer_node' referenced before assignment

Failure Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620725514928/filestore_to_bluestore_migration_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620650713914/filestore_to_bluestore_migration_0.log

PR test run logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1620752227170