### PR TITLE
Changes to observe stage failure but proceed with the next stage in jenkins. Changes to parse docker parameters from ci message only for containerized builds.

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-0-rhel-7.groovy
+++ b/pipeline/4/Jenkinsfile-tier-0-rhel-7.groovy
@@ -5,6 +5,7 @@
 def nodeName = "centos-7"
 def cephVersion = "nautilus"
 def sharedLib
+def test_results = [:]
 
 // Pipeline script entry point
 node(nodeName) {
@@ -35,7 +36,6 @@ node(nodeName) {
 
     timeout(unit: "HOURS", time: 4) {
   	    stage('RPM Sanity') {
-                try { 
 		script {
 		    withEnv([
 			"osVersion=RHEL-7",
@@ -45,20 +45,16 @@ node(nodeName) {
 			"containerized=false",
 			"addnArgs=--post-results --log-level DEBUG"
 		    ]) {
-			sharedLib.runTestSuite()
+			rc = sharedLib.runTestSuite()
+			test_results['rpm_sanity'] = rc
 		    }
 		}
-                }
-                catch(Exception ex){
-                     echo 'Exception occured'
-                     echo ex.getMessage()
-                }
 	    }
     }
 
     stage('Publish Results') {
         script {
-            sharedLib.sendEMail("Tier-0")
+            sharedLib.sendEMail("Tier-0", test_results)
             sharedLib.postLatestCompose()
         }
     }

--- a/pipeline/4/Jenkinsfile-tier-0.groovy
+++ b/pipeline/4/Jenkinsfile-tier-0.groovy
@@ -5,6 +5,7 @@
 def nodeName = "centos-7"
 def cephVersion = "nautilus"
 def sharedLib
+def test_results = [:]
 
 // Pipeline script entry point
 node(nodeName) {
@@ -35,7 +36,6 @@ node(nodeName) {
 
     timeout(unit: "HOURS", time: 6) {
 	    stage('RPM Sanity') {
-                try {
 		script {
 		    withEnv([
 			"osVersion=RHEL-8",
@@ -45,17 +45,12 @@ node(nodeName) {
 			"containerized=false",
 			"addnArgs=--post-results --log-level DEBUG"
 		    ]) {
-			sharedLib.runTestSuite()
+			rc = sharedLib.runTestSuite()
+			test_results['rpm_sanity'] = rc
 		    }
 		}
-                }
-                catch(Exception ex){ 
-                     echo 'Exception occured' 
-                     echo ex.getMessage() 
-                } 
 	    }
 	    stage('Image Sanity') {
-                try {
 		script {
 		    withEnv([
 			"osVersion=RHEL-8",
@@ -64,20 +59,16 @@ node(nodeName) {
 			"testSuite=suites/${cephVersion}/ansible/sanity_containerized_ceph_ansible.yaml",
 			"addnArgs=--post-results --log-level DEBUG"
 		    ]) {
-			sharedLib.runTestSuite()
+			rc = sharedLib.runTestSuite()
+			test_results['image_sanity'] = rc
 		    }
 		}
-                }
-                catch(Exception ex){ 
-                     echo 'Exception occured' 
-                     echo ex.getMessage() 
-                } 
 	  }
     }
 
     stage('Publish Results') {
         script {
-            sharedLib.sendEMail("Tier-0")
+            sharedLib.sendEMail("Tier-0", test_results)
             sharedLib.postLatestCompose()
         }
     }

--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -21,6 +21,7 @@ def getCLIArgsFromMessage(){
 
     // Processing CI_MESSAGE parameter, it can be empty
     def ciMessage = "${params.CI_MESSAGE}" ?: ""
+    println "ciMessage : " + ciMessage
     def cmd = ""
 
     if (ciMessage?.trim()) {
@@ -30,10 +31,6 @@ def getCLIArgsFromMessage(){
 
         env.composeId = jsonCIMsg.compose_id
         def composeUrl = jsonCIMsg.compose_url
-
-        def (dockerDTR, dockerImage1, dockerImage2Tag) = (jsonCIMsg.repository).split('/')
-        def (dockerImage2, dockerTag) = dockerImage2Tag.split(':')
-        def dockerImage = "${dockerImage1}/${dockerImage2}"
 
         // get rhbuild value from RHCEPH-5.0-RHEL-8.yyyymmdd.ci.x
         env.rhcephVersion = env.composeId.substring(7,17).toLowerCase()
@@ -49,6 +46,9 @@ def getCLIArgsFromMessage(){
         }
 
         if(!env.containerized || (env.containerized && "${env.containerized}" == "true")){
+            def (dockerDTR, dockerImage1, dockerImage2Tag) = (jsonCIMsg.repository).split('/')
+            def (dockerImage2, dockerTag) = dockerImage2Tag.split(':')
+            def dockerImage = "${dockerImage1}/${dockerImage2}"
             cmd += " --docker-registry ${dockerDTR}"
             cmd += " --docker-image ${dockerImage}"
             cmd += " --docker-tag ${dockerTag}"
@@ -140,12 +140,7 @@ def runTestSuite() {
     // Forcing cleanup
     cleanUp(instanceName)
 
-    if (rc != 0) {
-        error("Test execution has failed.")
-    }
     return rc
-
-
 }
 
 def sendEMail(def subjectPrefix,def test_results) {


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Added few changes to the 4.x pipeline jobs, in order to fail the current stage in case of any failures but proceed with the next stage. Also, the changes to parse docker related parameters only if the containerized key is either unset or set to true.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
