### PR TITLE
suites/pacific/rgw/sanity_rgw: adding STS test case

### DIFF
--- a/suites/pacific/rgw/sanity_rgw.yaml
+++ b/suites/pacific/rgw/sanity_rgw.yaml
@@ -636,6 +636,18 @@ tests:
         config-file-name: test_bucket_link_unlink.yaml
         timeout: 500
 
+  # STS Test case
+
+  - test:
+      name: STS Tests
+      desc: Perform assume role on priciple user and perform IOs
+      polarion-id: CEPH-83572938
+      module: sanity_rgw.py
+      config:
+        test-version: v2
+        script-name: test_sts_using_boto.py
+        config-file-name: test_sts_using_boto.yaml
+        timeout: 500
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
Adding STS assume role test case

[LOGS on rhel 8.3](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1621950142616/result.html)

Signed-off-by: rakeshgm <rakeshgm@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
