### PR TITLE
Switching to RHEL8.4 for Cephfs Tier 0

### DIFF
--- a/conf/inventory/rhel-8.4-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.4-server-x86_64.yaml
@@ -2,7 +2,7 @@ version_id: 8.4
 id: rhel
 instance:
   create:
-    image-name: rhel-8.4-server-x86_64-released
+    image-name: rhel-8.4.0-x86_64-released
     vm-size: m1.medium
 
   setup: |

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -56,7 +56,7 @@ def testStages = ['cephadm': {
                         sleep(480)
                         script {
                             withEnv([
-                                "sutVMConf=conf/inventory/rhel-8.3-server-x86_64-medlarge.yaml",
+                                "sutVMConf=conf/inventory/rhel-8.4-server-x86_64.yaml",
                                 "sutConf=conf/${cephVersion}/cephfs/tier_0_fs.yaml",
                                 "testSuite=suites/${cephVersion}/cephfs/tier_0_fs.yaml",
                                 "addnArgs=--post-results --log-level debug"


### PR DESCRIPTION
Migrating the cephfs tier 0 test suite to RHEL 8.4 released version

Log file : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1621953075916

Signed-off-by: Amarnath K <amk@redhat.com>

