### PR TITLE
Fix synatx error in pipeline script

### DIFF
--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -102,11 +102,10 @@ node(nodeName) {
     stage('Publish Results') {
         script {
                sharedLib.sendEMail("Tier-0",test_results)
-               if (!(1 in test_results.values())){
+               if ( ! (1 in test_results.values()) ){
                    sharedLib.postLatestCompose()
                    sharedLib.sendUMBMessage()
                }
-            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

QE Pipeline 5 Tier 0 is broken due to an syntax error.