### PR TITLE
Add indexless (blind) buckets tests to nautilus and pacific suites

### DIFF
--- a/suites/nautilus/rgw/sanity_rgw.yaml
+++ b/suites/nautilus/rgw/sanity_rgw.yaml
@@ -704,3 +704,16 @@ tests:
          script-name: test_user_bucket_rename.py
          config-file-name: test_bucket_link_unlink.yaml
          timeout: 500
+
+   # indexless buckets
+   - test:
+       name: Indexless buckets
+       desc: Indexless (blind) buckets
+       polarion-id: CEPH-10354, CEPH-10357
+       module: sanity_rgw.py
+       config:
+         test-version: v2
+         script-name: test_indexless_buckets.py
+         config-file-name: test_indexless_buckets_s3.yaml
+         timeout: 500
+

--- a/suites/pacific/rgw/sanity_rgw.yaml
+++ b/suites/pacific/rgw/sanity_rgw.yaml
@@ -649,6 +649,18 @@ tests:
         config-file-name: test_sts_using_boto.yaml
         timeout: 500
 
+   # indexless buckets
+   - test:
+       name: Indexless buckets
+       desc: Indexless (blind) buckets
+       polarion-id: CEPH-10354, CEPH-10357
+       module: sanity_rgw.py
+       config:
+         test-version: v2
+         script-name: test_indexless_buckets.py
+         config-file-name: test_indexless_buckets_s3.yaml
+         timeout: 500
+
   - test:
       abort-on-fail: true
       config:


### PR DESCRIPTION
# Description

Add indexless buckets tests to nautilus and pacific suites

PFA, the logs
Nautilus/rhel8 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1621572329818/result
Nautilus/rhel7 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1621586435044/result
Pacific - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1621541084517/result

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
