### PR TITLE
Fix syntax error in the sanity suite file

### DIFF
--- a/suites/pacific/rgw/sanity_rgw.yaml
+++ b/suites/pacific/rgw/sanity_rgw.yaml
@@ -649,17 +649,18 @@ tests:
         config-file-name: test_sts_using_boto.yaml
         timeout: 500
 
-   # indexless buckets
-   - test:
-       name: Indexless buckets
-       desc: Indexless (blind) buckets
-       polarion-id: CEPH-10354, CEPH-10357
-       module: sanity_rgw.py
-       config:
-         test-version: v2
-         script-name: test_indexless_buckets.py
-         config-file-name: test_indexless_buckets_s3.yaml
-         timeout: 500
+  # Index-less buckets
+
+  - test:
+      name: Indexless buckets
+      desc: Indexless (blind) buckets
+      polarion-id: CEPH-10354, CEPH-10357
+      module: sanity_rgw.py
+      config:
+        test-version: v2
+        script-name: test_indexless_buckets.py
+        config-file-name: test_indexless_buckets_s3.yaml
+        timeout: 500
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

`sanity_rgw.yaml` had a test case added with an additional space. This caused loading issue as seen https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/CEPH-RGW/31/console

This PR fixes the space

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/CEPH-RGW/32/console