### PR TITLE
Adding Tier_1 RBD mirroring Test case

### DIFF
--- a/ceph/ceph_admin/rbd_mirror.py
+++ b/ceph/ceph_admin/rbd_mirror.py
@@ -1,0 +1,36 @@
+"""Manage the RBD Mirror service via the cephadm CLI."""
+from typing import Dict
+
+from .apply import ApplyMixin
+from .orch import Orch
+
+
+class RbdMirror(ApplyMixin, Orch):
+    """Interface to ceph orch <action> rbd-mirror."""
+
+    SERVICE_NAME = "rbd-mirror"
+
+    def apply(self, config: Dict) -> None:
+        """
+        Deploy the rbd-mirror service using the provided configuration.
+
+        Args:
+            config: Key/value pairs provided by the test case to create the service.
+
+        Example
+            config:
+                command: apply
+                service: rbd-mirror
+                base_cmd_args:          # arguments to ceph orch
+                    concise: true
+                    verbose: true
+                    input_file: <name of spec>
+                args:
+                    placement:
+                        label: rbd-mirror    # either label or node.
+                        nodes:
+                            - node1
+                        sep: " "    # separator to be used for placements
+
+        """
+        super().apply(config=config)

--- a/conf/pacific/rbd/tier_1_rbd_mirror.yml
+++ b/conf/pacific/rbd/tier_1_rbd_mirror.yml
@@ -1,0 +1,56 @@
+globals:
+  - ceph-cluster:
+     name: ceph-rbd1
+     node1:
+       role:
+          - mon
+          - mgr
+          - installer
+     node2:
+       role: client
+     node3:
+       role: osd
+       no-of-volumes: 4
+       disk-size: 15
+     node4:
+       role:
+          - osd
+          - mds
+       no-of-volumes: 4
+       disk-size: 15
+     node5:
+       role:
+          - osd
+          - mds
+       no-of-volumes: 4
+       disk-size: 15
+     node6:
+       role: rbd-mirror
+
+  - ceph-cluster:
+      name: ceph-rbd2
+      node1:
+        role:
+          - mon
+          - mgr
+          - installer
+      node2:
+        role: client
+      node3:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: rbd-mirror

--- a/suites/pacific/rbd/tier_1_rbd_mirror.yaml
+++ b/suites/pacific/rbd/tier_1_rbd_mirror.yaml
@@ -1,0 +1,203 @@
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: tier_1_rbd_mirror.yaml
+# Test-Case: Configure RBD Mirror setup and run IOs
+# Polarion ID : CEPH-83573329 - RBD HA MirroringDraft
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier_1_rbd_mirror.yml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    6-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MDS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD,MDS
+#     Node5 - OSD,MDS
+#     Node6 - RBD Mirror
+
+
+# The following evaluations are carried out
+#   (1) Configures RBD Mirroring on cephadm
+#   (2) Creates Pool Image and enables Mirroring
+#   (3) Runs IO using rbd bench
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args: # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args: # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:                             # arguments to ceph orch
+                    - "ceph fs volume create cephfs"
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:                    # arguments to ceph orch
+                    verbose: true
+                  pos_args:
+                    - cephfs                        # name of the filesystem
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the Cephfs client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+  - test:
+      name: test_rbd_mirror
+      module: test_rbd_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-83573329
+      desc: Create RBD mirrored image and run IOs

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -23,6 +23,7 @@ from ceph.ceph_admin.node_exporter import NodeExporter
 from ceph.ceph_admin.orch import Orch
 from ceph.ceph_admin.osd import OSD
 from ceph.ceph_admin.prometheus import Prometheus
+from ceph.ceph_admin.rbd_mirror import RbdMirror
 from ceph.ceph_admin.rgw import RGW
 
 LOG = logging.getLogger()
@@ -43,6 +44,7 @@ SERVICE_MAP = dict(
         "prometheus": Prometheus,
         "rgw": RGW,
         "orch": Orch,
+        "rbd-mirror": RbdMirror,
     }
 )
 

--- a/tests/rbd_mirror/test_rbd_mirror.py
+++ b/tests/rbd_mirror/test_rbd_mirror.py
@@ -1,0 +1,49 @@
+import logging
+
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+
+log = logging.getLogger(__name__)
+
+
+def run(**kw):
+    """
+    --> Configures RBD Mirroring on cephadm
+    --> Creates Pool Image and enables Mirroring
+    --> Runs IO using rbd bench
+    Args:
+        **kw:
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+    """
+    try:
+        log.info("Starting RBD mirroring test case")
+        config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
+        poolname = mirror1.random_string() + "_tier_1_rbd_mirror_pool"
+        imagename = mirror1.random_string() + "_tier_1_rbd_mirror_image"
+        imagespec = poolname + "/" + imagename
+
+        mirror1.create_pool(poolname=poolname)
+        mirror2.create_pool(poolname=poolname)
+        mirror1.create_image(imagespec=imagespec, size=config.get("imagesize"))
+        mirror1.config_mirror(mirror2, poolname=poolname, mode="pool")
+        mirror2.wait_for_status(poolname=poolname, images_pattern=1)
+        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+        mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
+        mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
+        mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        return 0
+
+    except ValueError as ve:
+        log.error(
+            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
+        )
+        log.exception(ve)
+    except Exception as e:
+        log.exception(e)
+        return 1


### PR DESCRIPTION
Added Tier_1 RBD MIrroring test case

1. Configures RBD Mirroring on cephadm
2. Creates Pool Image and enables Mirroring
3. Runs IO using rbd bench

Please find the [Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1623038793989/)

Signed-off-by: AmarnatReddy <amk@redhat.com>


