### PR TITLE
Fix issue with "returnStatus" which suppress exception

### DIFF
--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -92,7 +92,7 @@ def executeTest(def cmd, def instanceName) {
     def rc = 0
     catchError (message: 'STAGE_FAILED', buildResult: 'FAILURE', stageResult: 'FAILURE') {
         try {
-            sh(script: "PYTHONUNBUFFERED=1 ${cmd}", returnStatus: true)
+            sh(script: "PYTHONUNBUFFERED=1 ${cmd}")
         } catch(Exception ex) {
             rc = 1
             echo err.getMessage()


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

**Issue**:
` sh(script: "PYTHONUNBUFFERED=1 ${cmd}", returnStatus: true)` 
`returnStatus` suppresses the exception occured which was not getting caught in `catchError`.

**Fix**:
remove ` returnStatus`

**Test results:**
**Groovy script:** https://github.com/sunilkumarn417/cephci/commit/124fd4a5cf9ce8e4d9411a962346692b644a2e8c

``` 
Started by user Sunil Kumar
Obtained pipeline/5/Jenkinsfile.groovy from git https://github.com/sunilkumarn417/cephci.git
Running in Durability level: MAX_SURVIVABILITY
[Pipeline] Start of Pipeline
[Pipeline] node
Running on Jenkins in /var/jenkins_home/workspace/test-catcherror
[Pipeline] {
[Pipeline] stage
[Pipeline] { (test-try-catch-error)
[Pipeline] script
[Pipeline] {
[Pipeline] catchError
[Pipeline] {
[Pipeline] sh
+ exit 1
[Pipeline] echo
script returned exit code 1
[Pipeline] error
[Pipeline] echo
deleting.....
[Pipeline] }
ERROR: something wrong
[Pipeline] // catchError
[Pipeline] echo
1
[Pipeline] }
[Pipeline] // script
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Publish Results)
[Pipeline] script
[Pipeline] {
[Pipeline] echo
Hi Hello
[Pipeline] echo
0
[Pipeline] }
[Pipeline] // script
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: FAILURE 
```

![Screenshot from 2021-06-07 12-49-00](https://user-images.githubusercontent.com/31158377/120975395-ce93ac80-c78e-11eb-893c-44edb0041fed.png)

![image](https://user-images.githubusercontent.com/31158377/120975507-ed923e80-c78e-11eb-8eb6-00709f6d1506.png)

