### PR TITLE
Fix orch command output process and add abort-on-fail on required test cases 

### DIFF
--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -71,6 +71,7 @@ class Orch(LSMixin, PSMixin, RemoveMixin, UpgradeMixin, CephCLI):
 
         # Identify the failure
         out, err = self.ls(check_status_dict)
+        out = loads(out)
         LOG.error(f"{service_name} failed with \n{out[0]['events']}")
 
         return False

--- a/suites/pacific/cephadm/tier_0_cephadm.yaml
+++ b/suites/pacific/cephadm/tier_0_cephadm.yaml
@@ -235,6 +235,7 @@ tests:
       name: Apply Monitor with placement and limit
       desc: Apply monitor service with placement and limit
       module: test_mon.py
+      abort-on-fail: true
       polarion-id:
       config:
         command: apply
@@ -253,6 +254,7 @@ tests:
       name: Apply Monitor with placement
       desc: Apply monitor with placement only
       module: test_mon.py
+      abort-on-fail: true
       polarion-id:
       config:
         command: apply
@@ -269,6 +271,7 @@ tests:
   - test:
       name: Apply Monitor using label
       desc: Apply monitor using label mon
+      abort-on-fail: true
       module: test_mon.py
       polarion-id:
       config:


### PR DESCRIPTION
- Added `abort-on-fail` on required test cases in tier-0-cephadm
- Fix orch command output process.

```
>>> out = run(args=["sudo", "cephadm", "shell", "--", "ceph", "orch", "ls", "-f", "json", "--service-name", "mgr"], stdout=PIPE, stderr=DEVNULL)
>>> out.stdout
b'\n[{"placement": {"label": "mgr"}, "service_name": "mgr", "service_type": "mgr", "status": {"created": "2021-05-26T08:51:19.732667Z", "last_refresh": "2021-06-09T14:32:08.122583Z", "running": 2, "size": 2}}]\n'
>>> out = out.stdout.decode('ascii')
>>> out
'\n[{"placement": {"label": "mgr"}, "service_name": "mgr", "service_type": "mgr", "status": {"created": "2021-05-26T08:51:19.732667Z", "last_refresh": "2021-06-09T14:32:08.122583Z", "running": 2, "size": 2}}]\n'
```

**Issue:**
```
>>> print(f"{service_name} failed with \n{out[0]['status']}")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: string indices must be integers
```

**Fix:**
```
>>> print(f"{service_name} failed with \n{loads(out)[0]['status']}")
mon failed with 
{'created': '2021-05-26T08:51:19.732667Z', 'last_refresh': '2021-06-09T14:32:08.122583Z', 'running': 2, 'size': 2}
```
