### PR TITLE
Publish UMB message when all the test suites have passed

### DIFF
--- a/pipeline/5/Jenkinsfile-tier-1-wrapper.groovy
+++ b/pipeline/5/Jenkinsfile-tier-1-wrapper.groovy
@@ -8,68 +8,77 @@ def cephVersion = "pacific"
 def sharedLib
 def test_results = [:]
 def composeInfo = ""
-def tier1Jobs = ["rhceph-5-tier-1-deploy", "rhceph-5-tier-1-object", "rhceph-5-tier-1-rbd"]
+def tier1Jobs = [
+                    "rhceph-5-tier-1-deploy",
+                    "rhceph-5-tier-1-object",
+                    "rhceph-5-tier-1-rbd"
+                ]
 
 // Pipeline script entry point
 node(nodeName) {
 
 	timeout(unit: "MINUTES", time: 30) {
 		stage('Install prereq') {
-			checkout([
-                                $class: 'GitSCM',
-                                branches: [[name: '*/master']],
-                                doGenerateSubmoduleConfigurations: false,
-                                extensions: [[
-                                       $class: 'SubmoduleOption',
-                                       disableSubmodules: false,
-                                       parentCredentials: false,
-                                       recursiveSubmodules: true,
-                                       reference: '',
-                                       trackingSubmodules: false
-                                ]],
-                                submoduleCfg: [],
-                                userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
-                        ])
+		    checkout([
+		        $class: 'GitSCM',
+		        branches: [[name: '*/master']],
+		        doGenerateSubmoduleConfigurations: false,
+		        extensions: [[
+		            $class: 'SubmoduleOption',
+		            disableSubmodules: false,
+		            parentCredentials: false,
+		            recursiveSubmodules: true,
+		            reference: '',
+		            trackingSubmodules: false
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
+            ])
+
 			script {
 				sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
 				sharedLib.prepareNode()
 			}
 		}
 	}
-	stage('Validate parameters'){
+	stage('Validate Argument') {
 		def ciMessage = "${params.CI_MESSAGE}" ?: ""
 		if (ciMessage?.trim()) {
 			composeInfo = "${params.CI_MESSAGE}"
 		}
-		else{
+		else {
 			withEnv([
 				"rhcephVersion=5.0-rhel-8"
-			]){
+			]) {
 				composeInfo = sharedLib.fetchTier1Compose()
 			}
 		}
-		if(!composeInfo){
+
+		if (!composeInfo) {
 			currentBuild.result = 'ABORTED'
-			error('Aborting the pipeline since the compose for tier-1 job execution does not exist')
+			error('Tier-1 jobs are not being executed as the criteria was not meet.')
 		}
+
 		println "Triggering tier-1 jobs for compose ${composeInfo}"
 	}
 
 	timeout(unit: "HOURS", time: 24) {
 		script {
-			for(jobName in tier1Jobs){
-				stage("${jobName}"){
+			for(jobName in tier1Jobs) {
+				stage("${jobName}") {
 					def jobResult = build propagate: false, \
-							job: jobName, \
-							parameters: [[
-								$class: 'StringParameterValue',
-								name: 'CI_MESSAGE',
-								value: composeInfo
-							]]
-					println "The job ${jobName} completed with status ${jobResult.result}"
+							        job: jobName, \
+							        parameters: [[
+							            $class: 'StringParameterValue',
+							            name: 'CI_MESSAGE',
+							            value: composeInfo
+							        ]]
+
 					test_results[jobName] = jobResult.result
 					catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-						if(jobResult.result != 'SUCCESS'){
+						if (jobResult.result != 'SUCCESS') {
 							sh "exit 1"
 						}
 					}
@@ -77,6 +86,7 @@ node(nodeName) {
 			}
 		}
 	}
+
 	stage('Publish Results') {
 		script {
 			def ciValues = sharedLib.fetchComposeInfo(composeInfo)
@@ -85,15 +95,16 @@ node(nodeName) {
 				"composeId=${ciValues["composeId"]}",
 				"composeUrl=${ciValues["composeUrl"]}",
 				"repository=${ciValues["repository"]}"
-			]){
+			]) {
 				sharedLib.sendEMail("Tier-1", test_results, false)
+				sharedLib.postTier1Compose(test_results, composeInfo)
+
 				def result_set = test_results.values().toSet()
-				if ( result_set.size() == 1 && ("SUCCESS" in test_results.values()) ){
+				if ( result_set.size() == 1 && ("SUCCESS" in test_results.values()) ) {
 					sharedLib.sendUMBMessage("Tier1TestingDone")
 				}
-				sharedLib.postTier1Compose(test_results, composeInfo)
 			}
 		}
 	}
-}
 
+}


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

As part of aligning 4.x with 5.x pipeline, adding sending of UMB message workflow once all the tier 0 identified test suites have passed. This is specifically for image as required by OCS.

Also fixes issues seen with the Tier-1 pipeline

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-0/91/console

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%205%20QE/job/rhceph-5-tier-1-wrapper/

Build # 12 & 13

__UMB Message__
https://datagrepper.engineering.redhat.com/id?id=ID:ceph-downstream-jenkins-csb-storage-35299-1622418151759-30341:1:1:1:1&is_raw=true&size=extra-large