### PR TITLE
Added swift object expire TC in RGW T1 suite

### DIFF
--- a/suites/pacific/rgw/tier_1_object.yaml
+++ b/suites/pacific/rgw/tier_1_object.yaml
@@ -106,3 +106,13 @@ tests:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_version_copy_op.yaml
         timeout: 500
+  - test:
+      name: swift object expire tests
+      desc: object expire in swift
+      polarion-id: CEPH-9718
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_object_expire_op.yaml
+        timeout: 500
+        


### PR DESCRIPTION
Signed-off-by: udaysk23 <ukurundw@redhat.com>
Added swift object expire TC in RGW T1 suite

Following is the passed jenkins log link

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/CEPH-RGW/49/console

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
