### PR TITLE
Creating Tier 1 json file irrespective of test status

### DIFF
--- a/pipeline/5/Jenkinsfile-tier-1-wrapper.groovy
+++ b/pipeline/5/Jenkinsfile-tier-1-wrapper.groovy
@@ -62,8 +62,8 @@ node(nodeName) {
 					def jobResult = build propagate: false, \
 							job: jobName, \
 							parameters: [[
-								$class: 'StringParameterValue', 
-								name: 'CI_MESSAGE', 
+								$class: 'StringParameterValue',
+								name: 'CI_MESSAGE',
 								value: composeInfo
 							]]
 					println "The job ${jobName} completed with status ${jobResult.result}"
@@ -89,9 +89,9 @@ node(nodeName) {
 				sharedLib.sendEMail("Tier-1", test_results, false)
 				def result_set = test_results.values().toSet()
 				if ( result_set.size() == 1 && ("SUCCESS" in test_results.values()) ){
-					sharedLib.postTier1Compose(test_results, composeInfo)
 					sharedLib.sendUMBMessage("Tier1TestingDone")
 				}
+				sharedLib.postTier1Compose(test_results, composeInfo)
 			}
 		}
 	}


### PR DESCRIPTION
Creating Tier 1 json file irrespective of test status
Moving the postTier1Compose function out of the if condition.
Made few changes to tier-1-deploy for testing convenience 

Tested with rc = 0 and 1 in Jenkinsfile-tier-1-deploy.groovy.
Able to see RHCEPH-5.0-rhel-8-tier1.json in /ceph/cephci-jenkins/latest-rhceph-container-info

Tested using below jobs :
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%205%20QE/job/rhceph-5-tier-1-wrapper-Amar/5/console   -> rc =1
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%205%20QE/job/rhceph-5-tier-1-wrapper-Amar/6/console --> rc = 0

Signed-off-by: Amarnath K <amk@redhat.com>

