### PR TITLE
Support ssh-public-key and ssh-private-key bootstrap options

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -160,7 +160,12 @@ class BootstrapMixin:
         logger.info("Bootstrap output : %s", out)
         logger.error("Bootstrap error: %s", err)
 
-        self.distribute_cephadm_gen_pub_key(args.get("output-pub-ssh-key"))
+        # The path to ssh public key mentioned in either output-pub-ssh-key or ssh-public-key options
+        # will be considered for distributing the ssh public key, if these are not specified,
+        # then the default ssh key path /etc/ceph/ceph.pub will be considered.
+        self.distribute_cephadm_gen_pub_key(
+            args.get("output-pub-ssh-key") or args.get("ssh-public-key")
+        )
 
         # The provided image is used by Grafana service only when
         # --skip-monitoring-stack is set to True during bootstrap.

--- a/suites/pacific/cephadm/tier1_ssl_dashboard_port.yaml
+++ b/suites/pacific/cephadm/tier1_ssl_dashboard_port.yaml
@@ -2,7 +2,7 @@
 # Tier-level: 1
 # Test-Suite: tier1_ssl_dashboard_port.yaml
 # Test-Case:
-#      Bootstrap cluster with custom ssl-dashboard-port, ssh-user
+#      Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key
 #       and apply-spec options.
 #
 # Cluster Configuration:
@@ -26,8 +26,10 @@
 #       - ssl-dashboard-port: <port-number>.
 #       - apply-spec: <list of service specification>
 #       - ssh-user: <ssh user name>
+#       - ssh-public-key: <path to the custom ssh public key file>
+#       - ssh-private-key: <path to the custom ssh private key file>
 #       - mon-ip: <monitor IP address: Required>
-#   (2) Copy SSH keys to nodes ad Add it to cluster with address and role labels attached to it.
+#   (2) Copy the provided SSH keys to nodes and Add it to cluster with address and role labels attached to it.
 #   (3) Deploy services using apply option,
 #       - 3 Mon on node1, node2, node3 using placement "label:mon"
 #       - deploy MGR on node1, node2 using host placement.
@@ -52,8 +54,8 @@ tests:
       module: install_prereq.py
       abort-on-fail: true
   - test:
-      name: Cephadm Bootstrap with ssl-dashboard-port
-      desc: bootstrap with ssl-dashboard-port and apply-spec option.
+      name: Cephadm Bootstrap with ssl-dashboard-port, ssh options
+      desc: bootstrap with ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec option.
       module: test_bootstrap.py
       polarion-id:
       config:
@@ -71,6 +73,8 @@ tests:
           orphan-initial-daemons: true
           ssl-dashboard-port: "8445"
           ssh-user: cephuser
+          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide
+          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
           apply-spec:
             - service_type: host
               address: true


### PR DESCRIPTION
Adding --ssh-public-key and --ssh-private-key options while bootstrapping the cluster.
Validation of ssh public key and private key files and the values used in the cluster is also done.

Logs for successful run : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1624545282997/Cephadm_Bootstrap_with_ssl-dashboard-port_0.log

Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
