### PR TITLE
Remove nfs+rgw from 4.x cluster to be upgraded

### DIFF
--- a/conf/pacific/upgrades/upgrade_from4x_big_cluster.yml
+++ b/conf/pacific/upgrades/upgrade_from4x_big_cluster.yml
@@ -31,7 +31,8 @@ globals:
        role:
          - osd
          - rgw
-         - nfs
+           #         - nfs
+           #         nfs upgrade is blocked till 5.1
        no-of-volumes: 3
        disk-size: 20
      node7:

--- a/conf/pacific/upgrades/upgrade_from4x_small_cluster.yml
+++ b/conf/pacific/upgrades/upgrade_from4x_small_cluster.yml
@@ -36,7 +36,7 @@ globals:
          - iscsi-gw
          - client
 
-     node6:
-       role:
-         - nfs
-
+           #     node6:
+           #       role:
+           #         - nfs
+           #     nfs upgrade is blocked till 5.1


### PR DESCRIPTION
NFS+RGW upgrade not supported (from 4.x to 5.0)
Temporarily commenting out

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
