### PR TITLE
Fix syntax error in common groovy script

### DIFF
--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -31,7 +31,7 @@ def getCLIArgsFromMessage() {
         def jsonCIMsg = jsonParser.parseText("${params.CI_MESSAGE}")
 
         env.composeId = jsonCIMsg.compose_id
-        if (not env.composeUrl) {
+        if (! "${env.composeUrl}" ) {
             env.composeUrl = jsonCIMsg.compose_url
         }
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

The pipeline is broken due to a syntax error. Unit testing did not catch when the change was introduced in 4.x