### PR TITLE
Adding image details to 4.x RHEL7 latest json

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-0.groovy
+++ b/pipeline/4/Jenkinsfile-tier-0.groovy
@@ -7,21 +7,22 @@ def nodeName = "centos-7"
 def cephVersion = "nautilus"
 def sharedLib
 def test_results = [:]
+def defaultRHEL7BaseUrl
+def defaultRHEL7Build
 def rpmStages = ['deployRpmRhel7': {
                     stage('RHEL7 RPM') {
-                        script {
-                            withEnv([
-                                "osVersion=RHEL-7",
-                                "sutVMConf=conf/inventory/rhel-7.9-server-x86_64.yaml",
-                                "sutConf=conf/${cephVersion}/ansible/tier_0_deploy.yaml",
-                                "testSuite=suites/${cephVersion}/ansible/tier_0_deploy_rpm_ceph.yaml",
-                                "containerized=false",
-                                "addnArgs=--post-results --log-level DEBUG",
-                                "composeUrl=http://download.eng.bos.redhat.com/rhel-7/composes/auto/ceph-4.3-rhel-7/latest-RHCEPH-4-RHEL-7/"
-                            ]) {
-                                rc = sharedLib.runTestSuite()
-                                test_results["deployRpmRhel7"] = rc
-                            }
+                        withEnv([
+                            "osVersion=RHEL-7",
+                            "sutVMConf=conf/inventory/rhel-7.9-server-x86_64.yaml",
+                            "sutConf=conf/${cephVersion}/ansible/tier_0_deploy.yaml",
+                            "testSuite=suites/${cephVersion}/ansible/tier_0_deploy_rpm_ceph.yaml",
+                            "containerized=false",
+                            "addnArgs=--post-results --log-level DEBUG",
+                            "composeUrl=${defaultRHEL7BaseUrl}",
+                            "rhcephVersion=${defaultRHEL7Build}"
+                        ]) {
+                            rc = sharedLib.runTestSuite()
+                            test_results["deployRpmRhel7"] = rc
                         }
                     }
                  },
@@ -53,7 +54,8 @@ def containerStages = ['deployContainerRhel7': {
                                     "sutConf=conf/${cephVersion}/ansible/tier_0_deploy.yaml",
                                     "testSuite=suites/${cephVersion}/ansible/tier_0_deploy_containerized_ceph.yaml",
                                     "addnArgs=--post-results --log-level DEBUG",
-                                    "composeUrl=http://download.eng.bos.redhat.com/rhel-7/composes/auto/ceph-4.3-rhel-7/latest-RHCEPH-4-RHEL-7/"
+                                    "composeUrl=${defaultRHEL7BaseUrl}",
+                                    "rhcephVersion=${defaultRHEL7Build}"
                                 ]) {
                                     rc = sharedLib.runTestSuite()
                                     test_results["deployContainerRhel7"] = rc
@@ -123,7 +125,8 @@ def functionalityStages = [ 'object': {
                                         "testSuite=suites/${cephVersion}/cephfs/tier_0_fs.yaml",
                                         "containerized=false",
                                         "addnArgs=--post-results --log-level debug",
-                                        "composeUrl=http://download.eng.bos.redhat.com/rhel-7/composes/auto/ceph-4.3-rhel-7/latest-RHCEPH-4-RHEL-7/"
+                                        "composeUrl=${defaultRHEL7BaseUrl}",
+                                        "rhcephVersion=${defaultRHEL7Build}"
                                     ]) {
                                         rc = sharedLib.runTestSuite()
                                         test_results["cephfs"] = rc
@@ -151,7 +154,9 @@ node(nodeName) {
                     trackingSubmodules: false
                 ]],
                 submoduleCfg: [],
-                userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
             ])
             script {
                 sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
@@ -160,15 +165,21 @@ node(nodeName) {
         }
     }
 
-    timeout(unit: "MINUTES", time: 70) {
+    stage('Set RHEL7 vars') {
+        // Gather the RHEL 7 latest compose information
+        defaultRHEL7Build = sharedLib.getRHBuild("rhel-7")
+        defaultRHEL7BaseUrl = sharedLib.getBaseUrl("rhel-7")
+    }
+
+    timeout(unit: "HOURS", time: 2) {
         parallel rpmStages
     }
 
-    timeout(unit: "MINUTES", time: 70) {
+    timeout(unit: "HOURS", time: 2) {
         parallel containerStages
     }
 
-    timeout(unit: "MINUTES", time: 100) {
+    timeout(unit: "HOURS", time: 2) {
         parallel functionalityStages
     }
 
@@ -178,6 +189,20 @@ node(nodeName) {
                if ( ! (1 in test_results.values()) ){
                    sharedLib.postLatestCompose()
                    sharedLib.sendUMBMessage("Tier0TestingDone")
+
+                   // RHEL7 Tier-0
+                   def build = sharedLib.getRHBuild("rhel-7")
+                   def rh7Tier0Json = "RHCEPH-${build}-tier0.json"
+
+                   def rh7Compose = sharedLib.getPlatformComposeMap("rhel-7")
+                   def composeInfo = [
+                       "compose_id" : rh7Compose.compose_id,
+                       "compose_url" : rh7Compose.compose_url,
+                       "repository" : sharedLib.getRepository()
+                   ]
+                   def payload = writeJSON returnText: true, json: composeInfo
+
+                   sharedLib.postCompose(payload, rh7Tier0Json)
                }
         }
     }

--- a/pipeline/5/Jenkinsfile-tier-0.groovy
+++ b/pipeline/5/Jenkinsfile-tier-0.groovy
@@ -86,7 +86,9 @@ node(nodeName) {
                     trackingSubmodules: false
                 ]],
                 submoduleCfg: [],
-                userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
             ])
             script {
                 sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

The following changes are being done in this PR to support including image information into the latest compose file.

- allowing the major release jobs to be flexible so that they work for all minor versions
- Publishing RHEL7 to latest.json so that it can be picked up during the main Tier-0 job
- Publishing RHEL7 tier-0 json file.

__Logs__
RHCS 4 Tier 0: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-0/155/
RHCS 4 Tier 0 RHEL 7: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-0-rhel-7/38/console