### PR TITLE
Added Bootstrap options for dashboard ssl key and cert

### DIFF
--- a/suites/pacific/cephadm/tier1_ssl_dashboard_port.yaml
+++ b/suites/pacific/cephadm/tier1_ssl_dashboard_port.yaml
@@ -22,6 +22,9 @@
 #       - fsid : f64f341c-655d-11eb-8778-fa163e914bcc
 #       - initial-dashboard-user: admin123
 #       - initial-dashboard-password: admin@123,
+#       - dashboard-password-noupdate: <boolean> 
+#       - dashboard-key: <path for dashboard.key>
+#       - dashboard-crt: <path for dashboard.crt>
 #       - registry-json: registry.json
 #       - ssl-dashboard-port: <port-number>.
 #       - apply-spec: <list of service specification>
@@ -68,6 +71,9 @@ tests:
           mon-ip: node1
           initial-dashboard-user: admin123
           initial-dashboard-password: admin@123
+          dashboard-password-noupdate: true
+          dashboard-key: /root/dashboard.key
+          dashboard-crt: /root/dashboard.crt
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
           skip-monitoring-stack: true
           orphan-initial-daemons: true


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Bootstrap with dashboard options
- dashboard-key
- dashboard-crt
- dashboard-password-noupdate
Success logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1625217379701
Polarion link: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574421