### PR TITLE
Added testcase for testing large object download with gc

### DIFF
--- a/suites/pacific/rgw/sanity_rgw_s3cmd.yaml
+++ b/suites/pacific/rgw/sanity_rgw_s3cmd.yaml
@@ -107,3 +107,14 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
         timeout: 300
+
+  - test:
+      name: S3CMD tests
+      desc: S3CMD large object download with GC
+      polarion-id: CEPH-83574416
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_large_object_gc.py
+        config-file-name: ../../s3cmd/configs/test_large_object_gc.py
+        timeout: 300
+


### PR DESCRIPTION
Operation:
Create an user
Create a bucket with user credentials
Upload large file to bucket
Set rgw_gc_obj_min_wait as 5
Download uploaded object
Verify download is succeeded
Delete uploaded object
Delete bucket

Polarion ticket: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574416

ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/146

Passed run log: http://pastebin.test.redhat.com/977570