### PR TITLE
Adding support to use both '5.0' and '5.0-rhel-8' for --rhbuild

### DIFF
--- a/rhbuild.yaml
+++ b/rhbuild.yaml
@@ -45,5 +45,7 @@ ceph:
     composes:
       '5.0-rhel-8':
         base_url: 'http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.0-rhel-8/latest-RHCEPH-5-RHEL-8/'
+      '5.0':
+        base_url: 'http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.0-rhel-8/latest-RHCEPH-5-RHEL-8/'
       'latest':
         base_url: 'http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.0-rhel-8/latest-RHCEPH-5-RHEL-8/'


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description
Adding support to use both '5.0' and '5.0-rhel-8' for --rhbuild

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
