### PR TITLE
Added RGW multi-site upgrade test suite

### DIFF
--- a/conf/nautilus/rgw/tier_1_rgw_multisite.yaml
+++ b/conf/nautilus/rgw/tier_1_rgw_multisite.yaml
@@ -15,6 +15,7 @@ globals:
         role:
           - mgr
           - osd
+          - grafana
 
       node3:
         disk-size: 20
@@ -53,6 +54,7 @@ globals:
         role:
           - mgr
           - osd
+          - grafana
 
       node3:
         disk-size: 20

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5x_multisite.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5x_multisite.yaml
@@ -1,0 +1,218 @@
+tests:
+  - test:
+      name: pre-req
+      module: install_prereq.py
+      abort-on-fail: true
+      desc: install ceph pre requisites
+
+  - test:
+      name: ceph-ansible deployment
+      desc: multi-site 4.x CDN ceph cluster deployment
+      module: test_ansible.py
+      clusters:
+        ceph-rgw1:
+          config:
+            use_cdn: True
+            build: '4.x'
+            ansi_config:
+              ceph_docker_image: "rhceph/rhceph-4-rhel8"
+              ceph_docker_image_tag: "latest"
+              ceph_docker_registry: "registry.redhat.io"
+              ceph_rhcs_version: 4
+              ceph_origin: repository
+              ceph_repository: rhcs
+              ceph_repository_type: cdn
+              ceph_stable_release: nautilus
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              rgw_multisite: true
+              rgw_zone: US_EAST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: true
+              rgw_zonesecondary: false
+              rgw_zonegroupmaster: true
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              rgw_multisite_proto: "http"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+              ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+        ceph-rgw2:
+          config:
+            use_cdn: True
+            build: '4.x'
+            ansi_config:
+              ceph_docker_image: "rhceph/rhceph-4-rhel8"
+              ceph_docker_image_tag: "latest"
+              ceph_docker_registry: "registry.redhat.io"
+              ceph_rhcs_version: 4
+              ceph_origin: repository
+              ceph_repository: rhcs
+              ceph_repository_type: cdn
+              ceph_stable_release: nautilus
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              rgw_multisite: true
+              rgw_zone: US_WEST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: false
+              rgw_zonesecondary: true
+              rgw_zonegroupmaster: false
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              rgw_multisite_proto: "http"
+              rgw_pull_proto: http
+              rgw_pull_port: 8080
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+              ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+      abort-on-fail: true
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        cmd: ceph -s
+        sudo: True
+      desc: Check for ceph health debug info
+
+  - test:
+      name: rados_bench_test
+      module: radosbench.py
+      config:
+        pg_num: '128'
+        pool_type: 'normal'
+      desc: run rados bench for 360 - normal profile
+
+  - test:
+        name: Switch-from-non-containerized-to-containerized-ceph-daemons
+        desc: 4x Convert RPM based daemons to container based daemons
+        polarion-id: CEPH-83573510
+        module: switch_rpm_to_container.py
+        abort-on-fail: true
+
+  - test:
+      name: Upgrade 4.x containerized ceph to 5.x latest
+      desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest
+      polarion-id: CEPH-83573680
+      module: test_ansible_upgrade.py
+      clusters:
+        ceph-rgw1:
+          config:
+            ansi_config:
+              ceph_origin: distro
+              ceph_repository: rhcs
+              ceph_rhcs_version: 5
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              containerized_deployment: true
+              upgrade_ceph_packages: True
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+              ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+                mon:
+                  mon_allow_pool_delete: true
+                client:
+                  rgw crypt require ssl: false
+                  rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                    testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        ceph-rgw2:
+          config:
+            ansi_config:
+              ceph_origin: distro
+              ceph_repository: rhcs
+              ceph_rhcs_version: 5
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              containerized_deployment: true
+              upgrade_ceph_packages: True
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+              ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+                mon:
+                  mon_allow_pool_delete: true
+                client:
+                  rgw crypt require ssl: false
+                  rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
+                    testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+      abort-on-fail: True
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        cmd: ceph -s
+        sudo: True
+      desc: Check for ceph health debug info


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Added RGW multi-site upgrade test suite from 4x CDN to 5x Latest build.

Test results: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1625823554389

```
TEST NAME                        TEST DESCRIPTION                                               DURATION                                  STATUS
pre-req                          install ceph pre requisites                                    0:11:09.977100                              Pass
ceph-ansible deployment          multi-site 4.x CDN ceph cluster deployment                     0:49:50.528428                              Pass
check-ceph-health                Check for ceph health debug info                               0:00:02.201327                              Pass
rados_bench_test                 run rados bench for 360 - normal profile                       0:03:35.354578                              Pass
Switch-from-non-containerized-   4x Convert RPM based daemons to container based daemons        0:23:17.380599                              Pass
Upgrade 4.x containerized ceph   Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest         0:57:02.595313                              Pass
check-ceph-health                Check for ceph health debug info                               0:00:02.421008                              Pass
```