### PR TITLE
Fixing Tier 1 RBD Mirror error

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -264,7 +264,8 @@ class RbdMirror:
             if self.ceph_version >= 4:
                 out1 = out.split('entries_behind_primary":')
                 out2 = out1[1].split(",")
-                if isinstance(int(out2[0]), int):
+                log.info(f"entries_behind_primary : {out2[0]}")
+                if int(out2[0]) == 0:
                     return out2[0]
             else:
                 if int(out.split("=")[-1]) == 0:
@@ -297,24 +298,14 @@ class RbdMirror:
         peercluster.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         peercluster.wait_for_replay_complete(imagespec)
         export_path = "/home/cephuser/image.export"
-        time.sleep(
-            300
-        )  # Adding sleep as image export taking some time compare to cli execution
         self.export_image(imagespec=imagespec, path=export_path)
-        time.sleep(
-            300
-        )  # Adding sleep as image export taking some time compare to cli execution
         peercluster.export_image(imagespec=imagespec, path=export_path)
-
-        time.sleep(300)
         local_md5 = self.exec_cmd(
             ceph_args=False, output=True, cmd="md5sum {}".format(export_path)
         )
         rmt_md5 = peercluster.exec_cmd(
             ceph_args=False, output=True, cmd="md5sum {}".format(export_path)
         )
-        print(local_md5)
-        print(rmt_md5)
         log.info(local_md5)
         log.info(rmt_md5)
         if local_md5 == rmt_md5:


### PR DESCRIPTION
Fixing the data check for  mirrored image

Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1626078532645/

As part of this we have removed time.sleep and added check to wait till entries_behind_primary becomes zero

Signed-off-by: Amarnath K <amk@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
