### PR TITLE
Fix long name issue: Trim down instance name with unique ID

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -16,6 +16,7 @@ from libcloud.compute.types import Provider
 
 from mita.v2 import CephVMNodeV2, NetworkOpFailure, NodeError, VolumeOpFailure
 from utility.retry import retry
+from utility.utils import generate_node_name
 
 from .ceph import Ceph, CommandFailed, RolesContainer
 from .parallel import parallel
@@ -78,25 +79,15 @@ def create_ceph_nodes(
                 node_dict = ceph_cluster.get(node)
                 node_params = params.copy()
                 node_params["role"] = RolesContainer(node_dict.get("role"))
-                role = node_params["role"]
                 user = os.getlogin()
 
-                if instances_name:
-                    node_params["node-name"] = "{}-{}-{}-{}-{}".format(
-                        node_params.get("cluster-name", "ceph"),
-                        instances_name,
-                        run_id,
-                        node,
-                        "-".join(role),
-                    )
-                else:
-                    node_params["node-name"] = "{}-{}-{}-{}-{}".format(
-                        node_params.get("cluster-name", "ceph"),
-                        user,
-                        run_id,
-                        node,
-                        "-".join(role),
-                    )
+                node_params["node-name"] = generate_node_name(
+                    node_params.get("cluster-name", "ceph"),
+                    instances_name or user,
+                    run_id,
+                    node,
+                    node_params["role"],
+                )
 
                 if node_dict.get("no-of-volumes"):
                     node_params["no-of-volumes"] = node_dict.get("no-of-volumes")

--- a/run.py
+++ b/run.py
@@ -32,6 +32,7 @@ from utility.utils import (
     create_run_dir,
     create_unique_test_name,
     email_results,
+    generate_unique_id,
     get_latest_container,
     magna_url,
     timestamp,
@@ -292,7 +293,7 @@ def run(args):
     skip_enabling_rhel_rpms = args.get("--skip-enabling-rhel-rpms", False)
 
     # Set log directory and get absolute path
-    run_id = timestamp()
+    run_id = generate_unique_id(length=6)
     run_dir = create_run_dir(run_id, log_directory)
     startup_log = os.path.join(run_dir, "startup.log")
     print("Startup log location: {}".format(startup_log))

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -8,6 +8,7 @@ import time
 import traceback
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from string import ascii_uppercase, digits
 
 import requests
 import yaml
@@ -838,3 +839,45 @@ def setup_cluster_access(cluster, target) -> None:
         fh = target.remote_file(file_name=out_file, file_mode="w", sudo=True)
         fh.write(file_)
         fh.flush()
+
+
+def generate_unique_id(length):
+    """
+    Return unique string of N(length) characters
+    Args:
+        length: positive integer
+
+    Note:
+        make sure length > 0 for a proper value
+        length = 0, returns empty string ''
+    """
+    return "".join(random.choices(ascii_uppercase + digits, k=length))
+
+
+def generate_node_name(cluster_name, instance_name, run_id, node, role):
+    """
+    Return node name using provided parameters
+
+    Args:
+        cluster_name: cluster name from config
+        instance_name: preferred instance name
+        run_id: unique run Id
+        node: node name
+        role: all node roles
+
+    Only Installer node will get prefixed with "Installer" name,
+    which helps in identification of admin node.
+
+    """
+    node_name = [
+        cluster_name,
+        instance_name if instance_name else "",
+        run_id,
+        node,
+        "installer" if "installer" in role else "",
+    ]
+    node_name = "-".join([i for i in node_name if i])
+    if len(node_name) > 48:
+        log.warning(f"[{node_name}] WARNING!!!!, Node name too long(>48 chars)")
+
+    return node_name


### PR DESCRIPTION
- used 6 digit unique Id replacing timestamp().
- new method in utils to generate node name.
  - add installer role suffix on installer admin node.

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

```
Before:
=======
Log directory name -  
     /cephci-jenkins/cephci-run-1625823554389

Instance name  -   
     ceph-rgw1-sunilms1-1625823554389-node1-installer-mgr-mon

After:
=======
Log directory name -
      /ceph/cephci-jenkins/cephci-run-31KUOT

Instance name - 
     2021-07-12 14:37:18,234 - utility.utils - INFO - [ceph-sunnagar-31KUOT-node1-installer]......
     2021-07-12 14:37:18,234 - utility.utils - INFO - [ceph-sunnagar-31KUOT-node2]......

Warning Message if node name length exceeds 48 characters,

2021-07-12 14:54:43,101 - utility.utils - WARNING - [ceph-LengthyNodeNameGivenToNoticeWarning-PPSR8X-node1-installer] - WARNING!!!!, Node name too long(>48 chars)

```


[test results logs in attached in link](http://pastebin.test.redhat.com/978595).