### PR TITLE
Add support for get_node_by_id to new naming structure

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -73,7 +73,7 @@ class ApplyMixin:
         placement = args.pop("placement", {})
 
         if placement:
-            placement_str = "--placement="
+            placement_str = "--placement "
             verify_service = True
 
             if "label" in placement:

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -750,7 +750,15 @@ def get_node_by_id(cluster, node_name):
         node instance (CephVMNode)
     """
     for node in cluster.get_nodes():
-        if node_name == node.shortname or f"{node_name}-" in node.shortname:
+        if node_name == node.shortname:
+            return node
+
+        # Only installer node has the role attached so adding a check
+        if "installer" in node.shortname and f"{node_name}-" in node.shortname:
+            return node
+
+        found_node_name = node.shortname.split("-")[-1]
+        if node_name == found_node_name:
             return node
 
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

#633 modified the names of the instance causing `get_node_by_id` to fail. This PR adds support for the new naming convention in this method. It also address a warning message seen with the latest runs
