### PR TITLE
 Fix testrbd.py to support rhel7 cases

### DIFF
--- a/tests/rbd/test_rbd.py
+++ b/tests/rbd/test_rbd.py
@@ -29,6 +29,15 @@ def one_time_setup(node, rhbuild, branch: str) -> None:
         branch: The branch that needs to be cloned
         rhbuild: specification of rhbuild. ex: 4.3-rhel-7
     """
+    node.exec_command(
+        cmd=f"sudo rm -rf ceph && git clone --branch {branch} --single-branch --depth 1 {TEST_REPO}"
+    )
+
+    try:
+        node.exec_command(cmd="rpm -qa | grep epel-release")
+        return
+    except BaseException:  # noqa
+        pass
 
     os_ver = rhbuild.split("-")[-1]
 
@@ -37,8 +46,6 @@ def one_time_setup(node, rhbuild, branch: str) -> None:
     )
 
     commands = [
-        {"cmd": "rm -rf ceph"},
-        {"cmd": f"git clone --branch {branch} --single-branch --depth 1 {TEST_REPO}"},
         {"cmd": f"yum install -y {EPEL_RPM} --nogpgcheck", "sudo": True},
         {
             "cmd": "yum install -y xmlstarlet rbd-nbd qemu-img cryptsetup --nogpgcheck",


### PR DESCRIPTION
In case of RHEL7 scenario execution of package installation on a node throws an error if package installation is already done on that node.(in case of cloning and package install for each testcase)

so code is enhanced in such a way that if ceph folder already exist.. then just removal of ceph folder and cloning of code takes place not the package installation.

logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1626235604707/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UL2EXB/

Signed-off-by: ckulal <ckulal@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
