### PR TITLE
added provision to set custom LVM scenario

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -281,8 +281,9 @@ class Ceph(object):
                             check_lvm=False if device_to_add else True,
                         )
                     else:
+                        osd_scenario = node.vm_node.osd_scenario or counter
                         lvm_vols = node.multiple_lvm_scenarios(
-                            devices, lvm_utils.osd_scenario_list[counter]
+                            devices, lvm_utils.osd_scenario_list[osd_scenario]
                         )
                         counter += 1
                         logger.info(lvm_vols)

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -92,6 +92,9 @@ def create_ceph_nodes(
                 if node_dict.get("no-of-volumes"):
                     node_params["no-of-volumes"] = node_dict.get("no-of-volumes")
                     node_params["size-of-disks"] = node_dict.get("disk-size")
+                    # osd-scenario option is not mandatory and,
+                    # can be used only for specific OSD_SCENARIO
+                    node_params["osd-scenario"] = node_dict.get("osd-scenario")
 
                 if node_dict.get("image-name"):
                     node_params["image-name"] = node_dict.get("image-name")
@@ -146,6 +149,7 @@ def setup_vm_node(node, ceph_nodes, **params):
         vm.role = params["role"]
         vm.root_login = params["root-login"]
         vm.keypair = params["keypair"]
+        vm.osd_scenario = params.get("osd-scenario", False)
         ceph_nodes[node] = vm
     except RETRY_EXCEPTIONS as retry_except:
         log.warning(retry_except, exc_info=True)

--- a/conf/nautilus/ansible/3node-custom-osd-scenario.yaml
+++ b/conf/nautilus/ansible/3node-custom-osd-scenario.yaml
@@ -1,0 +1,88 @@
+# Temporary cluster configuration file and
+# will be removed once nautilus pipeline is in place
+# OSD_SCENARIO(osd-scenario) works with
+#    ansi_config['osd_scenario'] = lvm and
+#    "mixed_lvm_config" option set
+#
+# OSD_SCENARIO 0 - osd_scenario1
+#--------------------------------
+#lvm_volumes="[
+#  {'data':'data-lv1','data_vg':'vg1'},
+#  {'data':'data-lv2','data_vg':'vg1','db':'db-lv1','db_vg':'vg1'},
+#  {'data':'data-lv3','data_vg':'vg1','wal':'wal-lv1','wal_vg':'vg1'},
+#  {'data':'data-lv4','data_vg':'vg1','db':'db-lv2','db_vg':'vg1','wal':'wal-lv2','wal_vg':'vg1'}]"
+#
+# OSD_SCENARIO 1 - osd_scenario1_dmcrypt
+#---------------------------------------
+#lvm_volumes="[
+#  {'data':'data-lv1','data_vg':'vg1'},
+#  {'data':'data-lv2','data_vg':'vg1','db':'db-lv1','db_vg':'vg1'},
+#  {'data':'data-lv3','data_vg':'vg1','wal':'wal-lv1','wal_vg':'vg1'},
+#  {'data':'data-lv4','data_vg':'vg1','db':'db-lv2','db_vg':'vg1','wal':'wal-lv2','wal_vg':'vg1'}]" dmcrypt='True'
+#
+# OSD_SCENARIO 2 - osd_scenario2
+#-------------------------------
+# lvm_volumes="[
+#  {'data':'/dev/vdc1','db':'/dev/vdc2','wal':'/dev/vdc3'},
+#  {'data':'/dev/vdd','db':'/dev/vdc4','wal':'/dev/vdc5'},
+#  {'data':'/dev/vde'}]"
+#
+# OSD_SCENARIO 3 - osd_scenario2_dmcrypt
+#----------------------------------------
+# lvm_volumes="[
+#  {'data':'/dev/vdc1','db':'/dev/vdc2','wal':'/dev/vdc3'},
+#  {'data':'/dev/vdd','db':'/dev/vdc4','wal':'/dev/vdc5'},
+#  {'data':'/dev/vde'}]" dmcrypt='True'
+#
+# OSD_SCENARIO 4 - osd_scenario3_dmcrypt
+#----------------------------------------
+# lvm_volumes="[
+#  {'data':'/dev/vdc','db':'db-lv1','db_vg':'vg1','wal':'wal-lv1','wal_vg':'vg1'},
+#  {'data':'data-lv1','data_vg':'vg1','db':'/dev/vde2','wal':'/dev/vde3'},
+#  {'data':'/dev/vde1'}]" dmcrypt='True'
+#
+# OSD_SCENARIO 5 - osd_scenario3_dmcrypt
+#----------------------------------------
+# lvm_volumes="[
+#  {'data':'/dev/vdc','db':'db-lv1','db_vg':'vg1','wal':'wal-lv1','wal_vg':'vg1'},
+#  {'data':'data-lv1','data_vg':'vg1','db':'/dev/vde2','wal':'/dev/vde3'},
+#  {'data':'/dev/vde1'}]" dmcrypt='True'
+#
+# OSD_SCENARIO 6 - osd_scenario4
+#----------------------------------
+# devices="['/dev/vdb', '/dev/vdc', '/dev/vdd', '/dev/vde']"
+#
+# OSD_SCENARIO 7 - osd_scenario4_dmcyrpt
+#----------------------------------------
+# devices="['/dev/vdb', '/dev/vdc', '/dev/vdd', '/dev/vde']" dmcrypt='True'
+#
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - mon
+          - mgr
+          - installer
+          - osd
+        osd-scenario: 1                  # pick osd scenario[0-8], OSD_SCENARIO 1
+        no-of-volumes: 4
+        disk-size: 15
+      node2:
+        role:
+          - mon
+          - client
+          - osd
+        osd-scenario: 5                  # OSD_SCENARIO 5
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - mon
+          - osd
+        osd-scenario: 3                  # OSD_SCENARIO 3
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - grafana

--- a/mita/v2.py
+++ b/mita/v2.py
@@ -138,6 +138,7 @@ class CephVMNodeV2:
 
         # Fixme: determine if we can pick this information for OpenStack.
         self.root_login: str
+        self.osd_scenario: int
         self.keypair: Optional[str] = None
 
         if node_name:


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Support option to set custom LVM OSD_SCENARIO using `osd-scenario` Id from cluster config file.

`osd_scenario` option will be considered when `osd_scenario=lvm` in all.yaml global ceph ansible configuration file along with `is_mixed_lvm_config` set in test case config. 


**Test results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0NIXRF/ 