### PR TITLE
Increase upgrade timeout to as hour duration

### DIFF
--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -73,7 +73,7 @@ class UpgradeMixin:
         LOG.info("check upgrade : %s" % out)
         return loads(out)
 
-    def monitor_upgrade_status(self, timeout=1200):
+    def monitor_upgrade_status(self, timeout=3600):
         """
         Monitor upgrade status
         """


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

Upgrade failed to complete within 20 mins(current timeout) and post radosbench executor code inclusion makes upgrade to complete longer time than usual. Increased timeout to an hour(based on the observation) to make sure upgrade would be successful within timeout duration.

```
2021-07-15 07:04:51,633 - test_cephadm_upgrade - ERROR - Upgrade did not complete or failed
Traceback (most recent call last):
  File "/home/jenkins-build/workspace/rhceph-5-tier-1-deploy/tests/cephadm/test_cephadm_upgrade.py", line 66, in run
    orch.monitor_upgrade_status()
  File "/home/jenkins-build/workspace/rhceph-5-tier-1-deploy/ceph/ceph_admin/upgrade.py", line 93, in monitor_upgrade_status
    raise UpgradeFailure("Upgrade did not complete or failed")
```
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1I73KO/Upgrade_ceph_0.log

