### PR TITLE
Fix the compose url passed to RHEL-7 T0 suites

### DIFF
--- a/pipeline/RC/Jenkinsfile-RC-container.groovy
+++ b/pipeline/RC/Jenkinsfile-RC-container.groovy
@@ -1,5 +1,6 @@
 /*
-    Pipeline script for storing the RC container information and triggering tier-0 suites for RC.
+    Pipeline script for storing the RC container information and triggering tier-0
+    suites for RC.
 */
 // Global variables section
 def nodeName = "centos-7"
@@ -40,11 +41,16 @@ node(nodeName) {
         }
     }
 
-    stage("Trigger Tier0 Job"){
+    stage("Execute Tier-0 suite") {
         def composeMap = readJSON text: "${jsonContent}"
         def rhcephMajorVersion = composeMap.compose_id.substring(7,8)
         def jobName = "rhceph-${rhcephMajorVersion}-tier-0"
-        build wait: false, job: jobName, parameters: [string(name: 'CI_MESSAGE', value: jsonContent)]
+
+        build ([
+            wait: false,
+            job: jobName,
+            parameters: [string(name: 'CI_MESSAGE', value: jsonContent)]
+        ])
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

The compose url passed to RHEL-7 was incorrect as it pointed to the development scratch build. This PR corrects the check done for the supported platform.

Fixes the issue seen in this stage
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/blue/organizations/jenkins/rhceph-4-tier-0/detail/rhceph-4-tier-0/167/pipeline/31