### PR TITLE
Use credentials from the Jenkins credential store

### DIFF
--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -10,7 +10,31 @@ def prepareNode() {
         Installs the required packages needed by the Jenkins node to
         run and execute the cephci test suites.
     */
-    sh(script: "bash ${env.WORKSPACE}/pipeline/vars/node_bootstrap.bash")
+    withCredentials([
+        usernamePassword(
+            credentialsId: 'psi-ceph-jenkins',
+            usernameVariable: 'OSPUSER',
+            passwordVariable: 'OSPCRED'
+        )
+    ]) {
+        def ospMap = [
+            "globals": [
+                "openstack-credentials": [
+                    "username": OSPUSER,
+                    "password": OSPCRED,
+                    "auth-url": "https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000",
+                    "auth-version": "3.x_password",
+                    "tenant-name": "ceph-jenkins",
+                    "service-region": "regionOne",
+                    "domain": "redhat.com",
+                    "tenant-domain-id": "62cf1b5ec006489db99e2b0ebfb55f57"
+                ]
+            ]
+        ]
+        writeYaml file: "${env.HOME}/osp-cred-ci-2.yaml", data: ospMap, overwrite: true
+    }
+
+    sh (script: "bash ${env.WORKSPACE}/pipeline/vars/node_bootstrap.bash")
 }
 
 def getCLIArgsFromMessage() {

--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -18,7 +18,7 @@ if [ ! -d "/ceph" ]; then
 fi
 
 # Copy the auth files from internal server to the Jenkins user home directory
-wget http://magna002.ceph.redhat.com/cephci-jenkins/.osp-cred-ci-2.yaml -O ${HOME}/osp-cred-ci-2.yaml
+# wget http://magna002.ceph.redhat.com/cephci-jenkins/.osp-cred-ci-2.yaml -O ${HOME}/osp-cred-ci-2.yaml
 wget http://magna002.ceph.redhat.com/cephci-jenkins/.cephci.yaml -O ${HOME}/.cephci.yaml
 
 # Install cephci pre-requisistes


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

With this PR, the OpenStack service account details are picked from the Credential store.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%205%20QE/job/rhceph-5-tier-0/284/console