### PR TITLE
../suites/pacific/rgw/rgw_multisite.yaml: Validating sync-status on s…

### DIFF
--- a/suites/pacific/rgw/rgw_multisite.yaml
+++ b/suites/pacific/rgw/rgw_multisite.yaml
@@ -183,7 +183,21 @@ tests:
       desc: Retrieve the configured environment details
       module: exec.py
       name: get shared realm info
-
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
   # Test work flow
 
   - test:


### PR DESCRIPTION
This would address the information on sync-status, a zone list, realm list, zonegroup list on the slave site once the rgw-multisite environment has been deployed.

Note: We already have this implemented for the Master site.

Signed-off-by: viduship <vimishra@redhat.com>

