### PR TITLE
Add krbd testcase to t1 rbd test suite

### DIFF
--- a/suites/nautilus/rbd/tier_1_rbd.yaml
+++ b/suites/nautilus/rbd/tier_1_rbd.yaml
@@ -79,3 +79,11 @@ tests:
       desc: Executig upstream RBD Kernal scenarios
       module: test_rbd.py
       name: 5_rbd_kernel
+   - test:
+       config:
+         branch: master
+         script_path: qa/workunits/rbd
+         script: krbd_exclusive_option.sh
+       desc: Executig upstream RBD kernel exclusive scenarios
+       module: test_rbd.py
+       name: 6_rbd_krbd_exclusive

--- a/tests/rbd/test_rbd.py
+++ b/tests/rbd/test_rbd.py
@@ -34,12 +34,20 @@ def one_time_setup(node, rhbuild, branch: str) -> None:
         cmd=f"sudo rm -rf ceph && git clone --branch {branch} --single-branch --depth 1 {TEST_REPO}"
     )
     os_ver = rhbuild.split("-")[-1]
+    ceph_ver = rhbuild.split("-")[0]
 
     if os_ver == "7":
         node.exec_command(
             cmd="sed -i '49 a rbd feature disable testimg1 object-map fast-diff deep-flatten' "
             "ceph/qa/workunits/rbd/kernel.sh"
         )
+
+    if "4." in ceph_ver:
+        node.exec_command(
+            cmd="sed -i 's/blocklist/blacklist/g' "
+            "ceph/qa/workunits/rbd/krbd_exclusive_option.sh"
+        )
+
     try:
         node.exec_command(cmd="rpm -qa | grep epel-release")
         return


### PR DESCRIPTION
Add krbd testcase to 4x t1 rbd test suite

log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XFB2C0/

Signed-off-by: ckulal ckulal@redhat.com

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
