### PR TITLE
Jenkin changes to support tier-1 4.x cephfs

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-1-cephfs.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-cephfs.groovy
@@ -1,5 +1,5 @@
 /*
-    Pipeline script for executing Tier 1 object test suites for RH Ceph 4.x
+    Pipeline script for executing Tier 1 Cephfs test suites for RH Ceph 4.x
 */
 // Global variables section
 
@@ -12,7 +12,7 @@ def sharedLib
 node(nodeName) {
 
     timeout(unit: "MINUTES", time: 30) {
-        stage('Install prereq') {
+        stage('Install Prereq') {
             checkout([
                 $class: 'GitSCM',
                 branches: [[name: '*/master']],
@@ -30,21 +30,19 @@ node(nodeName) {
                     url: 'https://github.com/red-hat-storage/cephci.git'
                 ]]
             ])
-
             sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
             sharedLib.prepareNode()
         }
     }
 
-    stage('Single-site') {
+    stage('Cephfs Extended MAT Suite') {
         withEnv([
-            "sutVMConf=conf/inventory/rhel-7.9-server-x86_64.yaml",
-            "sutConf=conf/${cephVersion}/rgw/tier_1_rgw.yaml",
-            "testSuite=suites/${cephVersion}/rgw/tier_1_object.yaml",
-            "addnArgs=--post-results --log-level DEBUG"
+            "sutVMConf=conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml",
+            "sutConf=conf/${cephVersion}/cephfs/tier_1_fs.yaml",
+            "testSuite=suites/${cephVersion}/cephfs/tier_1_fs.yaml",
+            "addnArgs=--post-results --log-level info"
         ]) {
             sharedLib.runTestSuite()
         }
     }
-
 }

--- a/pipeline/4/Jenkinsfile-tier-1-rbd.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-rbd.groovy
@@ -35,18 +35,14 @@ node(nodeName) {
         }
     }
 
-    timeout(unit: "HOURS", time: 2) {
-        stage('Extended RBD Tier1') {
-            script {
-                withEnv([
-                    "sutVMConf=conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml",
-                    "sutConf=conf/${cephVersion}/rbd/tier_0_rbd.yaml",
-                    "testSuite=suites/${cephVersion}/rbd/tier_1_rbd.yaml",
-                    "addnArgs=--post-results --log-level DEBUG"
-                ]) {
-                    sharedLib.runTestSuite()
-                }
-            }
+    stage('Extended RBD Tier1') {
+        withEnv([
+            "sutVMConf=conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml",
+            "sutConf=conf/${cephVersion}/rbd/tier_0_rbd.yaml",
+            "testSuite=suites/${cephVersion}/rbd/tier_1_rbd.yaml",
+            "addnArgs=--post-results --log-level DEBUG"
+        ]) {
+            sharedLib.runTestSuite()
         }
     }
 

--- a/pipeline/4/Jenkinsfile-tier-1-wrapper.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-wrapper.groovy
@@ -10,7 +10,8 @@ def test_results = [:]
 def composeInfo = ""
 def tier1Jobs = [
                     "rhceph-4-tier-1-object",
-                    "rhceph-4-tier-1-rbd"
+                    "rhceph-4-tier-1-rbd",
+                    "rhceph-4-tier-1-cephfs"
                 ]
 
 // Pipeline script entry point


### PR DESCRIPTION
# Description
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

Jenkin changes to support tier-1 4 cephfs
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-1-cephfs/

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
