### PR TITLE
Fix 4x wrapper job to support rhel7 compose fetch

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-1-object.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-object.groovy
@@ -6,6 +6,8 @@
 def nodeName = "centos-7"
 def cephVersion = "nautilus"
 def sharedLib
+def defaultRHEL7BaseUrl
+def defaultRHEL7Build
 
 // Pipeline script entry point
 
@@ -35,13 +37,19 @@ node(nodeName) {
             sharedLib.prepareNode()
         }
     }
+    stage('Set RHEL7 vars') {
+    // Gather the RHEL 7 latest compose information
+        defaultRHEL7Build = sharedLib.getRHBuild("rhel-7")
+        defaultRHEL7BaseUrl = sharedLib.getBaseUrl("rhel-7")}
 
     stage('Single-site') {
         withEnv([
             "sutVMConf=conf/inventory/rhel-7.9-server-x86_64.yaml",
             "sutConf=conf/${cephVersion}/rgw/tier_1_rgw.yaml",
             "testSuite=suites/${cephVersion}/rgw/tier_1_object.yaml",
-            "addnArgs=--post-results --log-level DEBUG"
+            "addnArgs=--post-results --log-level DEBUG",
+            "composeUrl=${defaultRHEL7BaseUrl}",
+            "rhcephVersion=${defaultRHEL7Build}"
         ]) {
             sharedLib.runTestSuite()
         }

--- a/pipeline/4/Jenkinsfile-tier-1-wrapper.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-wrapper.groovy
@@ -48,7 +48,7 @@ node(nodeName) {
 		}
 		else {
 			withEnv([
-				"rhcephVersion=4.3-rhel-7"
+				"rhcephVersion=4.3-rhel-8"
 			]) {
 				composeInfo = sharedLib.fetchTier1Compose()
 			}
@@ -89,7 +89,7 @@ node(nodeName) {
 	    def ciValues = sharedLib.fetchComposeInfo(composeInfo)
 
         withEnv([
-            "rhcephVersion=4.3-rhel-7",
+            "rhcephVersion=4.3-rhel-8",
             "composeId=${ciValues["composeId"]}",
             "composeUrl=${ciValues["composeUrl"]}",
             "repository=${ciValues["repository"]}"


### PR DESCRIPTION
Fix 4x wrapper job to support rhel7 compose fetch.
console output: 
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-1-wrapper/

Signed-off-by: ckulal <ckulal@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
