### PR TITLE
Adds RGW multisite T1 TCs into jenkins pipeline

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-1-object.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-object.groovy
@@ -54,5 +54,17 @@ node(nodeName) {
             sharedLib.runTestSuite()
         }
     }
+    stage('Multi-site') {
+        withEnv([
+            "sutVMConf=conf/inventory/rhel-7.9-server-x86_64.yaml",
+            "sutConf=conf/${cephVersion}/rgw/tier_1_rgw_multisite.yaml",
+            "testSuite=suites/${cephVersion}/rgw/tier_1_rgw_multisite.yaml",
+            "addnArgs=--post-results --log-level DEBUG",
+            "composeUrl=${defaultRHEL7BaseUrl}",
+            "rhcephVersion=${defaultRHEL7Build}"
+        ]) {
+            sharedLib.runTestSuite()
+        }
+    }
 
 }


### PR DESCRIPTION
Adds RGW multisite T1 TCs into jenkins pipeline

Signed-off-by: udaysk23 <ukurundw@redhat.com>

# Description

Following is the log link for both single site and multi-site

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-1-object/22/console

There are some failures into multi-site suite(Not from script side)

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
