### PR TITLE
None not a valid variable for groovy

### DIFF
--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -425,7 +425,7 @@ def getRHBuild(def osVersion) {
     return build
 }
 
-def getPlatformComposeMap(def osVersion, def tier=None) {
+def getPlatformComposeMap(def osVersion, def tier=null) {
     /*
         Return the Map of the given platform's latest json content.
     */
@@ -448,7 +448,7 @@ def getPlatformComposeMap(def osVersion, def tier=None) {
     return composeInfo
 }
 
-def getBaseUrl(def osVersion, def tier=None) {
+def getBaseUrl(def osVersion, def tier=null) {
     /*
         Return the compose url for the current RHCS build. The osVersion determines the
         platform for which the URL needs to be retrieved.


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

```
groovy.lang.MissingPropertyException: No such property: None for class: groovy.lang.Binding
	at groovy.lang.Binding.getVariable(Binding.java:63)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:271)
	at org.kohsuke.groovy.sandbox.impl.Checker$7.call(Checker.java:353)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:357)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:29)
	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
	at Script1.getBaseUrl(Script1.groovy:451)
	at WorkflowScript.run(WorkflowScript:155)
```

This PR fixes the above issue seen in the pipeline.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-0/182/console