### PR TITLE
Add support for RGW SSL spec file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "reportportal-client==3.2.0",
         "requests==2.21.0",
         "paramiko==2.4.2",
+        "pyOpenSSL==20.0.1",
         "pyyaml>=4.2b1",
         "jinja2",
         "junitparser==1.4.0",

--- a/suites/pacific/rgw/tier_1_object.yaml
+++ b/suites/pacific/rgw/tier_1_object.yaml
@@ -41,13 +41,17 @@ tests:
               args:
                 all-available-devices: true
           - config:
-              command: apply
-              service: rgw
-              pos_args:
-                - rgw.all
-              args:
-                placement:
-                  label: rgw
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgw.ssl
+                  placement:
+                    nodes:
+                      - node5
+                  spec:
+                    ssl: true
+                    rgw_frontend_ssl_certificate: create-cert
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py
@@ -133,4 +137,3 @@ tests:
         script-name: test_object_lock.py
         config-file-name: test_object_lock.yaml
         timeout: 500
-     

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py36, py37
 deps =
     -rrequirements.txt
     flake8
+    pyOpenSSL
     pytest
     isort
     black


### PR DESCRIPTION
# Description

In this PR, we add the following support

- creating a self-signed SSL certificate
- support `rgw_frontent_ssl_certificate` in the spec file

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_ssl/
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_ssl/deploy_cluster_0.log

depends on: 
https://github.com/red-hat-storage/ceph-qe-scripts/pull/159

Closes:
[RHCEPHQE-327](https://projects.engineering.redhat.com/browse/RHCEPHQE-327) 

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>