### PR TITLE
Fix pool node issue and update "osd_scenario" as part of node attributes

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -281,7 +281,7 @@ class Ceph(object):
                             check_lvm=False if device_to_add else True,
                         )
                     else:
-                        osd_scenario = node.vm_node.osd_scenario or counter
+                        osd_scenario = node.osd_scenario or counter
                         lvm_vols = node.multiple_lvm_scenarios(
                             devices, lvm_utils.osd_scenario_list[osd_scenario]
                         )
@@ -1198,6 +1198,7 @@ class CephNode(object):
 
         if kw.get("ceph_vmnode"):
             self.vm_node = kw["ceph_vmnode"]
+            self.osd_scenario = self.vm_node.osd_scenario
         self.root_connection = SSHConnectionManager(
             self.ip_address, "root", self.root_passwd
         )

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -921,12 +921,18 @@ def generate_node_name(cluster_name, instance_name, run_id, node, role):
     which helps in identification of admin node.
 
     """
+    _role = ""
+    if "installer" in role:
+        _role = "installer"
+    elif "pool" in role:
+        _role = "pool"
+
     node_name = [
         cluster_name,
         instance_name if instance_name else "",
         run_id,
         node,
-        "installer" if "installer" in role else "",
+        _role,
     ]
     node_name = "-".join([i for i in node_name if i])
     if len(node_name) > 48:


### PR DESCRIPTION
- Update instance name to support legacy pool node for scale playbook scenarios.
https://github.com/red-hat-storage/cephci/blob/master/ceph/ceph.py#L274
- make `osd_scenario` attribute as node attribute. Currently `node.vm_node` attribute will not be available when `--reuse` option is used.
- update ntp code source to fix skew issues.
