### PR TITLE
use id from inventory flle to check distro type

### DIFF
--- a/run.py
+++ b/run.py
@@ -433,7 +433,7 @@ def run(args):
         id = requests.get(base_url + "/COMPOSE_ID")
         compose_id = id.text
 
-        if "rhel" in image_name.lower():
+        if "rhel" == inventory.get("id"):
             ceph_pkgs = requests.get(base_url + "/compose/Tools/x86_64/os/Packages/")
             m = re.search(r"ceph-common-(.*?).x86", ceph_pkgs.text)
             ceph_version.append(m.group(1))


### PR DESCRIPTION
use `id` from inventory file to check distro type
 
[logs](https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/CEPH-RGW/109/console)