### PR TITLE
Adding Test case to stop Rbd mirror Service

### DIFF
--- a/tests/rbd_mirror/test_rbd_mirror_image.py
+++ b/tests/rbd_mirror/test_rbd_mirror_image.py
@@ -28,6 +28,7 @@ def run(**kw):
     try:
         log.info("Starting RBD mirroring test case")
         config = kw.get("config")
+        build = config.get("build", config.get("rhbuild"))
         mirror1, mirror2 = [
             rbdmirror.RbdMirror(cluster, config)
             for cluster in kw.get("ceph_cluster_dict").values()
@@ -46,6 +47,18 @@ def run(**kw):
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
+
+        # Stop the rdb-mirror service and cehck the status
+        if build.startswith("5"):
+            service_name = mirror2.get_rbd_service_name("rbd-mirror")
+            mirror2.change_service_state(service_name=service_name, operation="stop")
+            mirror2.wait_for_status(imagespec=imagespec, state_pattern="down+stopped")
+            mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+            mirror2.change_service_state(service_name=service_name, operation="start")
+            mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
+            mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
+            mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
+
         mirror1.delete_image(imagespec)
         # Add check of the image in secondary cluster
 


### PR DESCRIPTION
Adding Test case to stop the rbd mirror service and checking the status of rbd sync

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UVHWIB/

Signed-off-by: Amarnath K <amk@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
