### PR TITLE
Removing the Tier_1 operations test case

### DIFF
--- a/suites/nautilus/cephfs/tier_1_fs.yaml
+++ b/suites/nautilus/cephfs/tier_1_fs.yaml
@@ -47,12 +47,6 @@ tests:
       module: recreate-cephfs-ecpool.py
       abort-on-fail: false
   - test:
-      name: cephfs_tier1_ops
-      module: cephfs_tier1_ops.py
-      polarion-id: CEPH-83573447
-      desc: cephfs tier1 operations
-      abort-on-fail: false
-  - test:
       name: cephfs-lifecycle ops
       module: CEPH-11333.py
       polarion-id: CEPH-11333


### PR DESCRIPTION
Removing the cephfs tier 1 test case

We have a problem with the user capabilities from the previous tests to this.
For now i have removed the test case will fix the cap issue and add this test case back to the tier 1

Signed-off-by: Amarnath K <amk@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
