### PR TITLE
Dashboard enable and validate dashboard login Tests

### DIFF
--- a/ceph/ceph_admin/dashboard.py
+++ b/ceph/ceph_admin/dashboard.py
@@ -1,0 +1,113 @@
+"""Manage the Ceph Dashboard service via ceph CLI."""
+import json
+import logging
+import tempfile
+from time import sleep
+
+import requests
+
+LOG = logging.getLogger(__name__)
+
+
+def enable_dashboard(cls, config):
+    """Method to enable the dashboard module.
+
+    if user bootstrap with skip-dashboard option
+    then enabling the dashboard module.
+
+    Args:
+        cls (CephAdmin object) : cephadm instance object.
+        config (Dict): Key/value pairs passed from the test suite.
+
+        Example::
+
+            args:
+                username: admin123
+                password: admin@123
+    """
+    user = config.get("username")
+    pwd = config.get("password")
+
+    # To create password text file
+    temp_file = tempfile.NamedTemporaryFile(suffix=".txt")
+    passwd_file = cls.installer.node.remote_file(
+        sudo=True, file_name=temp_file.name, file_mode="w"
+    )
+    passwd_file.write(pwd)
+    passwd_file.flush()
+
+    # To enable dashboard module
+    DASHBOARD_ENABLE_COMMANDS = [
+        "ceph mgr module enable dashboard",
+        "ceph dashboard create-self-signed-cert",
+    ]
+
+    for cmd in DASHBOARD_ENABLE_COMMANDS:
+        out, err = cls.shell(args=[cmd])
+        LOG.info("STDOUT:\n %s" % out)
+        LOG.error("STDERR:\n %s" % err)
+
+    # command to create username and password to access dashboard as administrator
+    cmd = [
+        "ceph",
+        "dashboard",
+        "ac-user-create",
+        user,
+        "-i",
+        temp_file.name,
+        "administrator",
+    ]
+
+    out, err = cls.shell(
+        args=cmd,
+        base_cmd_args={"mount": "/tmp:/tmp"},
+    )
+    LOG.info("STDOUT:\n %s" % out)
+    LOG.error("STDERR:\n %s" % err)
+
+    validate_enable_dashboard(cls, user, pwd)
+
+
+def validate_enable_dashboard(cls, username, password):
+    """Method to validate dashboard login.
+
+    After enabling the dashboard module validating by API login.
+
+    Args:
+        cls (CephAdmin object): cephadm instance.
+        username (str) : configured user name to login.
+        password (str) : configured password to login.
+    """
+    LOG.info("wait for some seconds for mgr to setup dashboard")
+    sleep(100)
+    out, _ = cls.shell(args=["ceph", "mgr", "services"])
+    formatted = json.loads(out)
+    # validating dashboard URL
+    url = formatted.get("dashboard")
+    if not url:
+        raise KeyError("Dashboard URL not found")
+    LOG.info(f"Dashboard URL to login : {url}")
+    LOG.info(
+        f"Configured credentials to login username:{username} and password:{password}"
+    )
+
+    # Performing dasboard API login test
+    data = json.dumps({"username": username, "password": password})
+    url_ = f"{url}/api/auth" if not url.endswith("/") else f"{url}api/auth"
+
+    session = requests.Session()
+    session.headers = {
+        "accept": "application/vnd.ceph.api.v1.0+json",
+        "content-type": "application/json",
+    }
+
+    resp = session.post(url_, data=data, verify=False)
+    if not resp.ok:
+        LOG.error(
+            f"Dashboard API login is not successful, Status code: \
+            {resp.status_code}\nResponse: {resp.text}"
+        )
+    else:
+        LOG.info(
+            "Dashboard API login is successful, status code : %s" % resp.status_code
+        )

--- a/suites/pacific/cephadm/tier1_skip_dashboard.yaml
+++ b/suites/pacific/cephadm/tier1_skip_dashboard.yaml
@@ -3,7 +3,7 @@
 #  Test-Suite: tier1_skip_dashboard.yaml
 #  Test-Case:
 #      Bootstrap cluster with skip-dashboard, output configuration directories/files,
-#      initial-dashboard credentials options.
+#      then enabling the dashboard with provided credentials and validate login
 #
 #  Cluster Configuration:
 #    cephci/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
@@ -67,8 +67,6 @@ tests:
           registry-json: registry.redhat.io
           custom_image: true
           mon-ip: node1
-          initial-dashboard-user: admin123
-          initial-dashboard-password: admin@123
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
           skip-dashboard: true
           output-dir: "/root/ceph"
@@ -211,5 +209,15 @@ tests:
           mgr: "allow *"
       destroy-cluster: false
       abort-on-fail: true
-
-
+  - test:
+      name: Enable the dashboard
+      desc: After skip-dashboard enable the dashboard and validate login
+      module: test_dashboard.py
+      polarion-id: CEPH-83573717
+      config:
+        command: enable_dashboard
+        args:
+          username: admin123
+          password: admin@123
+      destroy-cluster: false
+      abort-on-fail: true

--- a/tests/cephadm/test_dashboard.py
+++ b/tests/cephadm/test_dashboard.py
@@ -1,0 +1,41 @@
+"""Manage the ceph dashboard service via cephadm CLI."""
+import logging
+
+from ceph.ceph_admin import CephAdmin, dashboard
+from ceph.ceph_admin.common import fetch_method
+from ceph.ceph_admin.helper import get_cluster_state
+
+log = logging.getLogger(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Ceph-admin module to manage ceph-dashboard service.
+
+    check ceph.ceph_admin.dashboard for test config.
+
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): Ceph cluster object.
+        kw: keyword arguments from test data.
+
+    Returns:
+        value 0 on success.
+
+    """
+    log.info("Running Ceph-admin Dashboard test")
+    config = kw.get("config")
+
+    build = config.get("build", config.get("rhbuild"))
+    ceph_cluster.rhcs_version = build
+
+    # Manage Ceph using ceph-admin orchestration
+    command = config.pop("command")
+    log.info("Executing dashboard %s operation" % command)
+    instance = CephAdmin(cluster=ceph_cluster, **config)
+
+    try:
+        method = fetch_method(dashboard, command)
+        method(instance, config.get("args"))
+    finally:
+        # Get cluster state
+        get_cluster_state(instance)
+    return 0


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Jira ticket: https://projects.engineering.redhat.com/browse/RHCEPHQE-183

In bootstrap with **skip-dashboard** deploys ceph with dashboard module disabled.
So added test case to enable the dashboard and validate dashboard login with provided credentials

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [x] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
