### PR TITLE
Include CephCI API documentation on readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,11 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: "3.7"
    install:
    - requirements: docs/requirements.txt
+
+build:
+  apt_packages:
+    - libcurl4-openssl-dev
+    - libssl-dev

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -561,45 +561,49 @@ class Ceph(object):
 
     def get_osd_metadata(self, osd_id, client=None):
         """
-        Retruns metadata for osd by given id
+        Returns metadata for osd by given id
+
         Args:
-            osd_id(int): osd id
-            client(CephObject): Client with keyring and ceph-common
+            osd_id (int): osd id
+            client (CephObject): Client with keyring and ceph-common
 
         Returns:
-            dict: osd metadata like:
-                 {
-                    "id": 8,
-                    "arch": "x86_64",
-                    "back_addr": "172.16.115.29:6801/1672",
-                    "back_iface": "eth0",
-                    "backend_filestore_dev_node": "vdd",
-                    "backend_filestore_partition_path": "/dev/vdd1",
-                    "ceph_version": "ceph version 12.2.5-42.el7cp (82d52d7efa6edec70f6a0fc306f40b89265535fb) luminous
-                            (stable)",
-                    "cpu": "Intel(R) Xeon(R) CPU E5-2690 v3 @ 2.60GHz",
-                    "default_device_class": "hdd",
-                    "distro": "rhel",
-                    "distro_description": "Red Hat Enterprise Linux",
-                    "distro_version": "7.5",
-                    "filestore_backend": "xfs",
-                    "filestore_f_type": "0x58465342",
-                    "front_addr": "172.16.115.29:6800/1672",
-                    "front_iface": "eth0",
-                    "hb_back_addr": "172.16.115.29:6802/1672",
-                    "hb_front_addr": "172.16.115.29:6803/1672",
-                    "hostname": "ceph-shmohan-1537910194970-node2-osd",
-                    "journal_rotational": "1",
-                    "kernel_description": "#1 SMP Wed Mar 21 18:14:51 EDT 2018",
-                    "kernel_version": "3.10.0-862.el7.x86_64",
-                    "mem_swap_kb": "0",
-                    "mem_total_kb": "3880928",
-                    "os": "Linux",
-                    "osd_data": "/var/lib/ceph/osd/ceph-8",
-                    "osd_journal": "/var/lib/ceph/osd/ceph-8/journal",
-                    "osd_objectstore": "filestore",
-                    "rotational": "1"
-                 }
+            metadata (Dict): osd metadata
+
+        Example::
+
+             {
+                "id": 8,
+                "arch": "x86_64",
+                "back_addr": "172.16.115.29:6801/1672",
+                "back_iface": "eth0",
+                "backend_filestore_dev_node": "vdd",
+                "backend_filestore_partition_path": "/dev/vdd1",
+                "ceph_version": "ceph version 12.2.5-42.el7cp (82d52d7efa6edec70f6a0fc306f40b89265535fb) luminous
+                        (stable)",
+                "cpu": "Intel(R) Xeon(R) CPU E5-2690 v3 @ 2.60GHz",
+                "default_device_class": "hdd",
+                "distro": "rhel",
+                "distro_description": "Red Hat Enterprise Linux",
+                "distro_version": "7.5",
+                "filestore_backend": "xfs",
+                "filestore_f_type": "0x58465342",
+                "front_addr": "172.16.115.29:6800/1672",
+                "front_iface": "eth0",
+                "hb_back_addr": "172.16.115.29:6802/1672",
+                "hb_front_addr": "172.16.115.29:6803/1672",
+                "hostname": "ceph-shmohan-1537910194970-node2-osd",
+                "journal_rotational": "1",
+                "kernel_description": "#1 SMP Wed Mar 21 18:14:51 EDT 2018",
+                "kernel_version": "3.10.0-862.el7.x86_64",
+                "mem_swap_kb": "0",
+                "mem_total_kb": "3880928",
+                "os": "Linux",
+                "osd_data": "/var/lib/ceph/osd/ceph-8",
+                "osd_journal": "/var/lib/ceph/osd/ceph-8/journal",
+                "osd_objectstore": "filestore",
+                "rotational": "1"
+             }
 
         """
         metadata_list = self.get_metadata_list("osd", client)
@@ -1328,12 +1332,19 @@ class CephNode(object):
     def exec_command(self, **kw):
         """
         execute a command on the vm
-        eg: self.exec_cmd(cmd='uptime')
+
+        Attributes:
+            kw (Dict): execute command configuration
+            check_ec: False will run the command and not wait for exit code
+
+        Example::
+
+            eg: self.exec_cmd(cmd='uptime')
             or
             self.exec_cmd(cmd='background_cmd', check_ec=False)
 
-        Attributes:
-        check_ec: False will run the command and not wait for exit code
+            kw:
+                check_ec: False will run the command and not wait for exit code
 
         """
 

--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -32,12 +32,14 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         Initialize Cephadm with ceph_cluster object
 
         Args:
-            cluster: Ceph cluster object
-            config: test data configuration
+            cluster (Ceph.Ceph): Ceph cluster object
+            config (Dict): test data configuration
 
-        config:
-            base_url: ceph compose URL
-            container_image: custom ceph container image
+        Example::
+
+            config:
+                base_url (Str): ceph compose URL
+                container_image (Str): custom ceph container image
         """
         self.cluster = cluster
         self.config = config
@@ -48,10 +50,10 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         Read cephadm generated public key.
 
         Arg:
-            ssh_key_path: custom ssh public key path
+            ssh_key_path ( Str ): custom ssh public key path
 
         Returns:
-            Public Key string
+            Public Key string (Str)
         """
         path = ssh_key_path if ssh_key_path else "/etc/ceph/ceph.pub"
         ceph_pub_key, _ = self.installer.exec_command(sudo=True, cmd=f"cat {path}")
@@ -62,8 +64,8 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         Distribute cephadm generated public key to all nodes in the list.
 
         Args:
-            ssh_key_path: custom SSH ceph public key path(default: None)
-            nodes: node list to add ceph public key(default: None)
+            ssh_key_path (Str): custom SSH ceph public key path (default: None)
+            nodes (List): node list to add ceph public key (default: None)
         """
         ceph_pub_key = self.read_cephadm_gen_pub_key(ssh_key_path)
 
@@ -87,7 +89,13 @@ class CephAdmin(BootstrapMixin, ShellMixin):
             )
 
     def set_tool_repo(self, repo=None):
-        """Add the given repo on every node part of the cluster."""
+        """
+        Add the given repo on every node part of the cluster.
+
+        Args:
+            repo (Str): repository (default: None)
+
+        """
         hotfix_repo = self.config.get("hotfix_repo")
         if hotfix_repo:
             for node in self.cluster.get_nodes():
@@ -121,12 +129,17 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         Install the cephadm package in the installer node.
 
         Args:
-          kwargs: Key/value pairs that needs to be provided to the installer
+          kwargs (Dict): Key/value pairs that needs to be provided to the installer
 
-        Supported keys:
-            Note: At present, they are prefixed with -- hence use long options
-          upgrade: boolean # to upgrade cephadm RPM package
-          gpgcheck: boolean
+
+        Example::
+
+            Supported keys:
+              upgrade: boolean # to upgrade cephadm RPM package
+              gpgcheck: boolean
+
+
+        :Note: At present, they are prefixed with -- hence use long options
 
         """
         cmd = "yum install cephadm -y"
@@ -150,6 +163,9 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         """
         Display cluster state by executing commands provided
         Just used for sanity.
+
+        Args:
+            commands (List): list of commands
         """
         for cmd in commands:
             out, err = self.shell(args=[cmd])

--- a/ceph/ceph_admin/add.py
+++ b/ceph/ceph_admin/add.py
@@ -7,20 +7,26 @@ from .typing_ import DaemonProtocol
 
 
 class AddMixin:
+    """Mixin Class for orch daemon add"""
+
     def add(self: DaemonProtocol, config: Dict):
         """
         Execute the add method using the object's service name.
+
         Args:
-            config:     Key/value pairs passed from the test suite.
-        Example:
+            config (Dict): Key/value pairs passed from the test suite.
+
+        Example::
+
             config:
-              service: osd
-              command: add
-              base_cmd_args:
-                verbose: true
-              pos_args:
-                - node1
-                - /dev/vdb
+                service: osd
+                command: add
+                base_cmd_args:
+                    verbose: true
+                pos_args:
+                    - node1
+                    - /dev/vdb
+
         """
         service = config.pop("service")
         base_cmd = ["ceph", "orch"]

--- a/ceph/ceph_admin/alert_manager.py
+++ b/ceph/ceph_admin/alert_manager.py
@@ -15,9 +15,10 @@ class AlertManager(ApplyMixin, Orch):
         Deploy the alert manager service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: alertmanager

--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -27,12 +27,15 @@ class ApplyMixin:
         Execute the apply method using the object's service name and provided input.
 
         Args:
-            config:     Key/value pairs passed from the test suite.
-                        base_cmd_args   - key/value pairs to set for base command
-                        pos_args        - List to be added as positional params
-                        args            - Key/value pairs as optional arguments.
+            config (Dict):     Key/value pairs passed from the test suite.
 
-        Example:
+
+        Example::
+
+            base_cmd_args   - key/value pairs to set for base command
+            pos_args        - List to be added as positional params
+            args            - Key/value pairs as optional arguments.
+
             config:
                 command: apply
                 service: rgw

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -24,17 +24,19 @@ def construct_registry(cls, registry: str, json_file: bool = False):
     Construct registry credentials for bootstrapping cluster
 
     Args:
-        cls: class object
-        registry: registry name
-        json_file: registry credentials in file with JSON format
+        cls (CephAdmin): class object
+        registry (Str): registry name
+        json_file (Bool): registry credentials in JSON file (default:False)
 
-    json_file(default=false):
-    - False : Constructs registry credentials for bootstrap
-    - True  : Creates file with registry name attached with it,
-              and saved as /tmp/<registry>.json file.
+    Example::
+
+        json_file:
+            - False : Constructs registry credentials for bootstrap
+            - True  : Creates file with registry name attached with it,
+                      and saved as /tmp/<registry>.json file.
 
     Returns:
-        constructed string for registry credentials
+        constructed string of registry credentials ( Str )
     """
     # Todo: Retrieve credentials based on registry name
     cdn_cred = get_cephci_config().get("cdn_credentials")
@@ -62,19 +64,21 @@ def copy_ceph_configuration_files(cls, ceph_conf_args):
     """
     Copy ceph configuration files to ceph default "/etc/ceph" path.
 
-     we can eliminate this definition when we have support to access
-     ceph cli via custom ceph config files.
-
     Args:
-        ceph_conf_args: bootstrap arguments
-        cls: cephadm instance
+        cls (CephAdmin): cephadm instance
+        ceph_conf_args (Dict): bootstrap arguments
 
-    ceph_conf_args:
-          output-dir: "/root/ceph"
-          output-keyring : "/root/ceph/ceph.client.admin.keyring"
-          output-config : "/root/ceph/ceph.conf"
-          output-pub-ssh-key : "/root/ceph/ceph.pub"
-          ssh-public-key : "/root/ceph/ceph.pub"
+    Example::
+
+        ceph_conf_args:
+            output-dir: "/root/ceph"
+            output-keyring : "/root/ceph/ceph.client.admin.keyring"
+            output-config : "/root/ceph/ceph.conf"
+            output-pub-ssh-key : "/root/ceph/ceph.pub"
+            ssh-public-key : "/root/ceph/ceph.pub"
+
+    :Note: we can eliminate this definition when we have support to access
+            ceph cli via custom ceph config files.
     """
     ceph_dir = ceph_conf_args.get("output-dir")
     if ceph_dir:
@@ -99,10 +103,14 @@ def generate_ssl_certificate(cls, dashboard_key, dashboard_crt):
     """
     Construct dashboard key and certificate files for bootstrapping cluster
     with dashboard custom key and certificate files for ssl
+
     Args:
-        cls: class object
-        dashboard_key: path to generate ssl key
-        dashboard_crt: path to generate ssl certificate
+        cls (CephAdmin): class object
+        dashboard_key (Str): path to generate ssl key
+        dashboard_crt (Str): path to generate ssl certificate
+
+    Returns:
+         constructed string of SSL CLI option (Str)
     """
 
     # Installing openssl package needed for ssl
@@ -128,22 +136,24 @@ class BootstrapMixin:
 
     def bootstrap(self: CephAdmProtocol, config: Dict):
         """
-        Execute cephadm bootstrap with the passed kwargs on the installer node.
+        Execute cephadm bootstrap with the passed kwargs on the installer node.::
 
-        Bootstrap involves,
-          - Creates /etc/ceph directory with permissions
-          - CLI creation with bootstrap options with custom/default image
-          - Execution of bootstrap command
+            Bootstrap involves,
+              - Creates /etc/ceph directory with permissions
+              - CLI creation with bootstrap options with custom/default image
+              - Execution of bootstrap command
 
         Args:
-            config: Key/value pairs passed from the test case.
+            config (Dict): Key/value pairs passed from the test case.
 
-        Example:
+        Example::
+
             config:
                 command: bootstrap
                 base_cmd_args:
                     verbose: true
                 args:
+                    custom_repo: custom repository path
                     custom_image: <image path> or <boolean>
                     mon-ip: <node_name>
                     mgr-id: <mgr_id>
@@ -153,13 +163,15 @@ class BootstrapMixin:
                     initial-dashboard-user: <admin123>
                     initial-dashboard-password: <admin123>
 
-        custom_image:
-          image path: compose path for example alpha build,
-            ftp://partners.redhat.com/d960e6f2052ade028fa16dfc24a827f5/rhel-8/Tools/x86_64/os/
-          boolean:
-            True: use latest image from test config
-            False: do not use latest image from test config,
-                   and also indicates usage of default image from cephadm source-code.
+        custom_image::
+
+            image path: compose path for example alpha build,
+                ftp://partners.redhat.com/d960e6f2052ade028fa16dfc24a827f5/rhel-8/Tools/x86_64/os/
+
+            boolean:
+                True: use latest image from test config
+                False: do not use latest image from test config,
+                        and also indicates usage of default image from cephadm source-code.
 
         """
         self.cluster.setup_ssh_keys()

--- a/ceph/ceph_admin/common.py
+++ b/ceph/ceph_admin/common.py
@@ -7,10 +7,10 @@ def config_dict_to_string(data: Dict) -> str:
     Convert the provided data to a string of optional arguments.
 
     Args:
-        data:   Key/value pairs that are CLI optional arguments
+        data (Dict):   Key/value pairs that are CLI optional arguments
 
     Return:
-        string instead of the a data dict
+        string instead of the a data dict (Str)
     """
     rtn = ""
     for key, value in data.items():
@@ -27,12 +27,14 @@ def config_dict_to_string(data: Dict) -> str:
 
 def fetch_method(obj, method):
     """
-    fetch object attributes by name
+    Fetch object attributes by name
+
     Args:
-        obj: class object
-        method: name of the method
+        obj (CephAdmin): class object
+        method (Str): name of the method
+
     Returns:
-        function
+        function (Func)
     """
     try:
         return getattr(obj, method)

--- a/ceph/ceph_admin/crash.py
+++ b/ceph/ceph_admin/crash.py
@@ -15,9 +15,10 @@ class Crash(ApplyMixin, Orch):
         Deploy the Crash service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: crash

--- a/ceph/ceph_admin/daemon.py
+++ b/ceph/ceph_admin/daemon.py
@@ -12,20 +12,18 @@ class Daemon(AddMixin, Orch):
     def op(self, op, config):
         """
         Execute the command ceph orch daemon <start|stop|restart|reconfigure|redeploy> <service>.
-        Args:
-            config: command and service are passed from the test case.
-            op: operation parameters ex: restart|start|stop|reconfigure|redeploy
-        Example:
-            Testing ceph orch daemon restart mon
-        config:
-          command: restart
-          service: mon
-        Returns:
-          output, error   returned by the command.
 
-        example
+        Args:
+            config (Dict): command and service are passed from the test case.
+            op (Str): operation parameters
+
+        Returns:
+          output (Str), error (Str) returned by the command.
+
+        Example::
+
             config:
-                command: start
+                command: start   # (restart | start | stop | reconfigure | redeploy)
                 base_cmd_args:
                     verbose: true
                 pos_args:

--- a/ceph/ceph_admin/device.py
+++ b/ceph/ceph_admin/device.py
@@ -14,9 +14,17 @@ LOG = logging.getLogger()
 class Device(Orch):
     def zap(self, config: Dict) -> None:
         """
+        Zap particular device
+
         Args:
-            config:
-                command: zap
+            config (Dict): Zap configs
+
+        Returns:
+            output (Str), error (Str)  returned by the command.
+
+        Example::
+
+            command: zap
                 base_cmd_args:
                     verbose: true
                 pos_args:
@@ -24,8 +32,7 @@ class Device(Orch):
                     - "/dev/vdb"
                 args:
                     force: true
-        Returns:
-            output, error   returned by the command.
+
         """
         base_cmd = ["ceph", "orch"]
 
@@ -49,18 +56,27 @@ class Device(Orch):
 
     def ls(self, config: Optional[Dict] = None) -> Tuple:
         """
-        config:
-            command: ls
-            base_cmd_args:
-                verbose: true
+        lists out devices in cluster
 
-        Return all available devices using "orch device ls" command.
-        device_list:
-            node1: ["/dev/sda", "/dev/sdb"]
-            node2: ["/dev/sda"]
+        Args:
+            config (Dict): device list command configuration
+
+        Configuration-Example::
+
+            config:
+                command: ls
+                base_cmd_args:
+                    verbose: true
 
         Returns:
-            device_list: list of nodes with available devices
+            device_list (List): list of nodes with available devices
+
+        Example::
+
+            Return all available devices using "orch device ls" command.
+            device_list:
+                node1: ["/dev/sda", "/dev/sdb"]
+                node2: ["/dev/sda"]
         """
         cmd = ["ceph", "orch"]
 

--- a/ceph/ceph_admin/grafana.py
+++ b/ceph/ceph_admin/grafana.py
@@ -15,9 +15,10 @@ class Grafana(ApplyMixin, Orch):
         Deploy the grafana service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: grafana

--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -35,40 +35,42 @@ class GenerateServiceSpec:
         Initialize the GenerateServiceSpec
 
         Args:
-            node: ceph node where spec file to be created
-            cluster: ceph cluster (ceph-nodes)
-            specs: service specifications
+            node (CephNode): ceph node where spec file to be created
+            cluster (Ceph.Ceph): ceph cluster (ceph-nodes)
+            specs (Dict): service specifications
 
-        specs:
-          - service_type: host
-            address: true
-            labels: apply-all-labels
-            nodes:
-                - node2
-                - node3
-          - service_type: mon
-            placement:
-              nodes:
-                - node2
-                - node3
-          - service_type: mgr
-            placement:
-                count: 2
-          - service_type: alertmanager
-            placement:
-                count: 1
-          - service_type: crash
-            placement:
-                host_pattern: '*'
-          - service_type: grafana
-            placement:
-                count: 1
-          - service_type: node-exporter
-            placement:
-                host_pattern: '*'
-          - service_type: prometheus
-            placement:
-                count: 1
+        Example::
+
+            specs:
+              - service_type: host
+                address: true
+                labels: apply-all-labels
+                nodes:
+                    - node2
+                    - node3
+              - service_type: mon
+                placement:
+                  nodes:
+                    - node2
+                    - node3
+              - service_type: mgr
+                placement:
+                    count: 2
+              - service_type: alertmanager
+                placement:
+                    count: 1
+              - service_type: crash
+                placement:
+                    host_pattern: '*'
+              - service_type: grafana
+                placement:
+                    count: 1
+              - service_type: node-exporter
+                placement:
+                    host_pattern: '*'
+              - service_type: prometheus
+                placement:
+                    count: 1
         """
         self.cluster = cluster
         self.node = node
@@ -77,24 +79,52 @@ class GenerateServiceSpec:
 
     @staticmethod
     def get_hostname(node):
+        """
+        Returns Host Name of node
+
+        Args:
+            node (CephNode): node object
+
+        Returns:
+            hostname (Str)
+        """
         return node.shortname
 
     @staticmethod
     def get_addr(node):
+        """
+        Returns IP Address of node
+
+        Args:
+            node (CephNode): node object
+
+        Returns:
+            IP Address (Str)
+        """
         return node.ip_address
 
     @staticmethod
     def get_labels(node):
+        """
+        Returns role list of node
+
+        Args:
+            node (CephNode): node object
+
+        Returns:
+            node role list (List)
+        """
         return node.role.role_list
 
     def get_hostnames(self, node_names):
         """
         Return list of hostnames
+
         Args:
-            node_names: node names
+            node_names (List): node names
 
         Returns:
-            list of hostanmes
+            list of hostanmes (List)
         """
         nodes = get_nodes_by_ids(self.cluster, node_names)
         return [node.shortname for node in nodes]
@@ -102,8 +132,10 @@ class GenerateServiceSpec:
     def _get_template(self, service_type):
         """
         Return Jinja template based on the service_type
+
         Args:
-            service_type: service name (ex., "host")
+            service_type (Str): service name (ex., "host")
+
         Returns:
             template
         """
@@ -115,18 +147,22 @@ class GenerateServiceSpec:
     def generate_host_spec(self, spec):
         """
         Return hosts spec content based on host config
-        args:
-            spec: hosts specification
 
-        spec:
-          - service_type: host
-            address: true
-            labels: apply-all-labels
-            nodes:
-                - node2
-                - node3
+        Args:
+            spec (Dict): hosts specification
+
         Returns:
-            hosts_spec
+            hosts_spec (Str)
+
+        Example::
+
+            spec:
+              - service_type: host
+                address: true
+                labels: apply-all-labels
+                nodes:
+                    - node2
+                    - node3
         """
         template = self._get_template("host")
         hosts = []
@@ -147,30 +183,34 @@ class GenerateServiceSpec:
     def generate_generic_spec(self, spec):
         """
         Return spec content for common services
-        which is mentioned in COMMON_SERVICES
-         - mon
-         - mgr
-         - alertmanager
-         - crash
-         - grafana
-         - node-exporter
-         - prometheus
+        which is mentioned in COMMON_SERVICES::
+
+             - mon
+             - mgr
+             - alertmanager
+             - crash
+             - grafana
+             - node-exporter
+             - prometheus
 
         Args:
-            spec: common service spec config
+            spec (Dict): common service spec config
 
-        spec:
-          - service_type: mon
-            unmanaged: boolean    # true or false
-            placement:
-              count: 2
-              label: "mon"
-              host_pattern: "*"   # either hosts or host_pattern
-              nodes:
-                - node2
-                - node3
         Returns:
             service_spec
+
+        Example::
+
+            spec:
+              - service_type: mon
+                unmanaged: boolean    # true or false
+                placement:
+                  count: 2
+                  label: "mon"
+                  host_pattern: "*"   # either hosts or host_pattern
+                  nodes:
+                    - node2
+                    - node3
         """
         template = self._get_template("common_svc_template")
         node_names = spec["placement"].pop("nodes", None)
@@ -184,21 +224,25 @@ class GenerateServiceSpec:
         Return spec content for osd service
 
         Args:
-            spec: osd service spec config
+            spec (Dict): osd service spec config
 
-        spec:
-          - service_type: osd
-            unmanaged: boolean    # true or false
-            placement:
-              host_pattern: "*"   # either hosts or host_pattern
-              nodes:
-                - node2
-                - node3
-            data_devices:
-                all: boolean      # true or false
-            encrypted: boolean    # true or false
         Returns:
-            service_spec
+            service_spec (Str)
+
+        Example::
+
+            spec:
+              - service_type: osd
+                unmanaged: boolean    # true or false
+                placement:
+                  host_pattern: "*"   # either hosts or host_pattern
+                  nodes:
+                    - node2
+                    - node3
+                data_devices:
+                    all: boolean      # true or false
+                encrypted: boolean    # true or false
+
         """
         template = self._get_template("osd")
         node_names = spec["placement"].pop("nodes", None)
@@ -211,23 +255,27 @@ class GenerateServiceSpec:
         """
         Return spec content for mds service
 
-        Note: make sure volume is already created.
-
         Args:
-            spec: mds service spec config
+            spec (Dict): mds service spec config
 
-        spec:
-          - service_type: mds
-            service_id: cephfs
-            unmanaged: boolean    # true or false
-            placement:
-              host_pattern: "*"   # either hosts or host_pattern
-              nodes:
-                - node2
-                - node3
-              label: mds
         Returns:
-            service_spec
+            service_spec (Str)
+
+        Example::
+
+            spec:
+              - service_type: mds
+                service_id: cephfs
+                unmanaged: boolean    # true or false
+                placement:
+                  host_pattern: "*"   # either hosts or host_pattern
+                  nodes:
+                    - node2
+                    - node3
+                  label: mds
+
+        :Note: make sure volume is already created.
+
         """
         template = self._get_template("mds")
         node_names = spec["placement"].pop("nodes", None)
@@ -240,26 +288,29 @@ class GenerateServiceSpec:
         """
         Return spec content for nfs service
 
-        Note: make sure pool is already created.
-
         Args:
-            spec: mds service spec config
+            spec (Dict): mds service spec config
 
-        spec:
-          - service_type: nfs
-            service_id: nfs-name
-            unmanaged: boolean    # true or false
-            placement:
-              host_pattern: "*"   # either hosts or host_pattern
-              nodes:
-                - node2
-                - node3
-              label: nfs
-            spec:
-              pool: pool-name
-              namespace: namespace-name
         Returns:
-            service_spec
+            service_spec (Str)
+
+        Example::
+
+            spec:
+              - service_type: nfs
+                service_id: nfs-name
+                unmanaged: boolean    # true or false
+                placement:
+                  host_pattern: "*"   # either hosts or host_pattern
+                  nodes:
+                    - node2
+                    - node3
+                  label: nfs
+                spec:
+                  pool: pool-name
+                  namespace: namespace-name
+
+        :Note: make sure pool is already created.
         """
         template = self._get_template("nfs")
         node_names = spec["placement"].pop("nodes", None)
@@ -272,41 +323,45 @@ class GenerateServiceSpec:
         """
         Return spec content for rgw service
 
-        Note: make sure realm, zone group and zone is already created.
-
         Args:
-            spec: rgw service spec config
+            spec (Dict): rgw service spec config
 
-        spec:
-          - service_type: rgw
-            service_id: my-rgw
-            unmanaged: boolean    # true or false
-            placement:
-              host_pattern: "*"   # either hosts or host_pattern
-              nodes:
-                - node2
-                - node3
-              label: rgw
-            spec:
-              rgw_frontend_port: 8080
-              rgw_realm: east
-              rgw_zone: india
-              rgw_frontend_ssl_certificate: create-cert | <contents of crt>
         Returns:
-            service_spec
+            service_spec (Str)
 
-        contents of rgw_spec.yaml file
+        Example::
 
-            service_type: rgw
-            service_id: rgw.india
-            placement:
-              hosts:
-                - node5
             spec:
-              ssl: true
-              rgw_frontend_ssl_certificate: |
-                -----BEGIN PRIVATE KEY------
-                ...
+              - service_type: rgw
+                service_id: my-rgw
+                unmanaged: boolean    # true or false
+                placement:
+                  host_pattern: "*"   # either hosts or host_pattern
+                  nodes:
+                    - node2
+                    - node3
+                  label: rgw
+                spec:
+                  rgw_frontend_port: 8080
+                  rgw_realm: east
+                  rgw_zone: india
+                  rgw_frontend_ssl_certificate: create-cert | <contents of crt>
+
+            contents of rgw_spec.yaml file
+
+                service_type: rgw
+                service_id: rgw.india
+                placement:
+                  hosts:
+                    - node5
+                spec:
+                  ssl: true
+                  rgw_frontend_ssl_certificate: |
+                    -----BEGIN PRIVATE KEY------
+                    ...
+
+        :Note: make sure realm, zone group and zone is already created.
+
         """
         template = self._get_template("rgw")
         node_names = spec["placement"].pop("nodes", None)
@@ -351,10 +406,12 @@ class GenerateServiceSpec:
     def _get_render_method(self, service_type):
         """
         Return render definition based on service_type
+
         Args:
-            service_type: service name
+            service_type (Str): service name
+
         Returns:
-            method
+            method (Func)
         """
         render_definitions = {
             "host": self.generate_host_spec,
@@ -373,10 +430,11 @@ class GenerateServiceSpec:
 
     def create_spec_file(self):
         """
-        start to generate spec file based on spec config
+        Create spec file based on spec config and return file name
 
         Returns:
-            temp_filename
+            temp_filename (Str)
+
         """
         spec_content = ""
         for spec in self.specs:
@@ -400,16 +458,16 @@ class GenerateServiceSpec:
 def get_cluster_state(cls, commands=[]):
     """
     fetch cluster state using commands provided along
-    with the default set of commands
+    with the default set of commands::
 
-    - ceph status
-    - ceph orch ls -f json-pretty
-    - ceph orch ps -f json-pretty
-    - ceph health detail -f yaml
+        - ceph status
+        - ceph orch ls -f json-pretty
+        - ceph orch ps -f json-pretty
+        - ceph health detail -f yaml
 
     Args:
-        cls: ceph.ceph_admin instance with shell access
-        commands: list of commands
+        cls (CephAdmin): ceph.ceph_admin instance with shell access
+        commands (List): list of commands
 
     """
     __CLUSTER_STATE_COMMANDS = [

--- a/ceph/ceph_admin/host.py
+++ b/ceph/ceph_admin/host.py
@@ -24,8 +24,10 @@ class Host(Orch):
     def list(self):
         """
         List the cluster hosts
+
         Returns:
-            json output of hosts list
+            json output of hosts list (List)
+
         """
         return self.shell(
             args=["ceph", "orch", "host", "ls", "--format=json"],
@@ -34,25 +36,28 @@ class Host(Orch):
     def add(self, config):
         """
         Add host to cluster
-        - add_label: host added with labels(roles assigned are considered)
-        - attach_address: host added with ip address(host ip address used)
 
         Args:
-            config
+            config (Dict):  host addition configuration
 
-        config:
-            service: host
-            command: add
-            base_cmd_args:                          # arguments to ceph orch
-                concise: true
-                block: true
-            args:
-                node: "node2"                         # node-name or object
-                attach_ip_address: bool               # true or false
-                labels: [mon, osd] or apply-all-labels
+        Example::
 
-        labels are considered if list of strings are provided or all roles associated
-        with node will be considered if string "apply-all-labels"
+            config:
+                service: host
+                command: add
+                base_cmd_args:                          # arguments to ceph orch
+                    concise: true
+                    block: true
+                args:
+                    node: "node2"                         # node-name or object
+                    attach_ip_address: bool               # true or false
+                    labels: [mon, osd] or apply-all-labels
+
+            add_label: host added with labels(roles assigned are considered)
+            attach_address: host added with ip address(host ip address used)
+
+            labels are considered if list of strings are provided or all roles associated
+            with node will be considered if string "apply-all-labels"
 
         """
         cmd = ["ceph", "orch"]
@@ -118,25 +123,28 @@ class Host(Orch):
 
     def add_hosts(self, config):
         """
-        Add host(s) to cluster.
+        Add host(s) to cluster
 
-        - Attach host to cluster
-        - if nodes are empty, all nodes in cluster are considered
-        - add_label: host added with labels(roles assigned are considered)
-        - attach_address: host added with ip address(host ip address used)
-        - by default add_label and attach_address are set to True
-
-        config:
-            base_cmd_args:
-                concise: true
-                block: true
-            args:
-                nodes: ["node1", "node2", ...]
-                labels: [mon, osd] or apply-all-labels
-                attach_ip_address: boolean
+          - Attach host to cluster
+          - if nodes are empty, all nodes in cluster are considered
+          - add_label: host added with labels(roles assigned are considered)
+          - attach_address: host added with ip address(host ip address used)
+          - by default add_label and attach_address are set to True
 
         Args:
-            config
+            config (Dict): hosts configuration
+
+        Example::
+
+            config:
+                base_cmd_args:
+                    concise: true
+                    block: true
+                args:
+                    nodes: ["node1", "node2", ...]
+                    labels: [mon, osd] or apply-all-labels
+                    attach_ip_address: boolean
+
         """
         args = config.get("args")
         nodes = args.pop("nodes", None)
@@ -155,15 +163,17 @@ class Host(Orch):
         Remove host from cluster
 
         Args:
-            config
+            config (Dict): Remove host configuration
 
-        config:
-            service: host
-            command: remove
-            base_cmd_args:
-              verbose: true                        # arguments to ceph orch
-            args:
-              node: "node2"                         # node-name or object
+        Example::
+
+            config:
+                service: host
+                command: remove
+                base_cmd_args:
+                  verbose: true                        # arguments to ceph orch
+                args:
+                  node: "node2"                         # node-name or object
         """
         cmd = ["ceph", "orch"]
         if config.get("base_cmd_args"):
@@ -193,16 +203,19 @@ class Host(Orch):
         """
         Remove host(s) from cluster
 
-        - Removal of hosts from cluster with provided nodes
-        - if nodes are empty, all cluster nodes are considered
-        - Otherwise all node will be considered, except Installer node
-
-        config:
-            args:
-                nodes: ["node1", "node2", ...]
+          - Removal of hosts from cluster with provided nodes
+          - if nodes are empty, all cluster nodes are considered
+          - Otherwise all node will be considered, except Installer node
 
         Args:
-            config
+            config (Dict): Remove hosts configuration
+
+        Example::
+
+            config:
+                args:
+                    nodes: ["node1", "node2", ...]
+
         """
         args = config.get("args", {})
         nodes = args.pop("nodes", None)
@@ -220,22 +233,25 @@ class Host(Orch):
         """
         Add/Attach label to nodes
 
-        - Attach labels to existing nodes
-        - if nodes are empty, all cluster nodes are considered
-        - roles defined to each node used as labels( eg., [mon, mgr])
+          - Attach labels to existing nodes
+          - if nodes are empty, all cluster nodes are considered
+          - roles defined to each node used as labels( eg., [mon, mgr])
 
-        config:
-            service: host
-            command: label_add
-            base_cmd_args:
-                verbose: true
-            args:
-                node: node1
-                labels:
-                    - mon
-                    - osd
         Args:
-            config
+            config (Dict): label add configuration
+
+        Example::
+
+            config:
+                service: host
+                command: label_add
+                base_cmd_args:
+                    verbose: true
+                args:
+                    node: node1
+                    labels:
+                        - mon
+                        - osd
         """
         cmd = ["ceph", "orch"]
         if config.get("base_cmd_args"):
@@ -267,22 +283,24 @@ class Host(Orch):
         """
         Removes label from nodes
 
-        - remove labels from existing nodes
-        - if nodes are empty, all cluster nodes are considered
+          - remove labels from existing nodes
+          - if nodes are empty, all cluster nodes are considered
 
         Args:
-            config
+            config (Dict): label remove configuration
 
-        config:
-            service: host
-            command: label_remove
-            base_cmd_args:
-                verbose: true
-            args:
-                node: node1
-                labels:
-                    - mon
-                    - osd
+        Example::
+
+            config:
+                service: host
+                command: label_remove
+                base_cmd_args:
+                    verbose: true
+                args:
+                    node: node1
+                    labels:
+                        - mon
+                        - osd
         """
         cmd = ["ceph", "orch"]
         if config.get("base_cmd_args"):
@@ -317,18 +335,22 @@ class Host(Orch):
     def set_address(self, config):
         """
         Set IP address to node
-        - Attach address to existing nodes
 
-        config:
-            service: host
-            command: set_address
-            base_cmd_args:
-                verbose: true
-            args:
-                node: node1
+          - Attach address to existing nodes
 
         Args:
-            config
+            config (Dict): set address configuration
+
+        Example::
+
+            config:
+                service: host
+                command: set_address
+                base_cmd_args:
+                    verbose: true
+                args:
+                    node: node1
+
         """
         cmd = ["ceph", "orch"]
         if config.get("base_cmd_args"):
@@ -351,8 +373,9 @@ class Host(Orch):
     def fetch_labels_by_hostname(self, node_name):
         """
         Fetch labels attach to a node by hostname
+
         Returns:
-            labels: list of labels
+            labels (List): list of labels
         """
         nodes, _ = self.list()
         for node in json.loads(nodes):
@@ -363,8 +386,9 @@ class Host(Orch):
     def fetch_host_names(self):
         """
         Returns host-names attached to a cluster
+
         Returns:
-            list of host names
+            list of host names (List)
         """
         out, _ = self.list()
         return [i["hostname"] for i in json.loads(out)]
@@ -372,8 +396,9 @@ class Host(Orch):
     def get_addrs(self):
         """
         Returns IP addresses of hosts attached to a cluster
+
         Returns:
-            list of IP addresses
+            list of IP addresses (List)
         """
         out, _ = self.list()
         return [i["addr"] for i in json.loads(out)]
@@ -382,8 +407,11 @@ class Host(Orch):
         """
         Returns ip address of attached node using hostname
 
+        Args:
+            node_name (Str): node name
+
         Returns:
-            ip_address: IP address of host name
+            ip_address (Str): IP address of host name
         """
         out, _ = self.list()
         for node in json.loads(out):

--- a/ceph/ceph_admin/iscsi.py
+++ b/ceph/ceph_admin/iscsi.py
@@ -15,9 +15,10 @@ class ISCSI(ApplyMixin, Orch):
         Deploy ISCSI client daemon using the provided arguments.
 
         Args:
-            config: Key/value pairs provided from the test scenario
+            config (Dict) : Key/value pairs provided from the test scenario
 
-        Example:
+        Example::
+
             config:
                 command: apply
                 service: iscsi
@@ -39,6 +40,7 @@ class ISCSI(ApplyMixin, Orch):
                         sep: " "    # separator to be used for placements
                     dry-run: true
                     unmanaged: true
+
         """
         pos_args = config.pop("pos_args")
 

--- a/ceph/ceph_admin/ls.py
+++ b/ceph/ceph_admin/ls.py
@@ -13,9 +13,13 @@ class LSMixin:
         Execute the command ceph orch ls <args>.
 
         Args:
-            config: The key/value pairs passed from the test case.
+            config (Dict): The key/value pairs passed from the test case.
 
-        Example:
+        Returns:
+            output (Str), error (Str)   returned by the command.
+
+        Example::
+
             Testing ceph orch ls
 
             config:
@@ -30,8 +34,6 @@ class LSMixin:
                     export: true
                     refresh: true
 
-        Returns:
-            output, error   returned by the command.
         """
         cmd = ["ceph", "orch"]
 

--- a/ceph/ceph_admin/mds.py
+++ b/ceph/ceph_admin/mds.py
@@ -15,9 +15,10 @@ class MDS(ApplyMixin, Orch):
         Deploy the MDS service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: mds

--- a/ceph/ceph_admin/mgr.py
+++ b/ceph/ceph_admin/mgr.py
@@ -15,9 +15,10 @@ class Mgr(ApplyMixin, Orch):
         Deploy the Manager service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: mgr

--- a/ceph/ceph_admin/mon.py
+++ b/ceph/ceph_admin/mon.py
@@ -15,9 +15,10 @@ class Mon(ApplyMixin, Orch):
         Deploy the Monitor service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: mon

--- a/ceph/ceph_admin/nfs.py
+++ b/ceph/ceph_admin/nfs.py
@@ -15,9 +15,10 @@ class NFS(ApplyMixin, Orch):
         Deploy the NFS service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: nfs
@@ -38,5 +39,6 @@ class NFS(ApplyMixin, Orch):
                         sep: " "    # separator to be used for placements
                     dry-run: true
                     unmanaged: true
+
         """
         super().apply(config=config)

--- a/ceph/ceph_admin/node_exporter.py
+++ b/ceph/ceph_admin/node_exporter.py
@@ -15,9 +15,10 @@ class NodeExporter(ApplyMixin, Orch):
         Deploy the node-exporter service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: node-exporter
@@ -34,5 +35,6 @@ class NodeExporter(ApplyMixin, Orch):
                         sep: " "    # separator to be used for placements
                     dry-run: true
                     unmanaged: true
+
         """
         super().apply(config=config)

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -46,10 +46,12 @@ class Orch(
     def get_hosts_by_label(self, label: str):
         """
         Fetch host object by label attached to it.
+
         Args:
-            label: name of the label
+            label (Str): name of the label
+
         Returns:
-            hosts
+            hosts (List)
         """
         out, _ = self.shell(args=["ceph", "orch", "host", "ls", "--format=json"])
         return [node for node in loads(out) if label in node.get("labels")]
@@ -61,12 +63,13 @@ class Orch(
         Verify the provided service is running for the given list of ids.
 
         Args:
-            service_name:   The name of the service to be checked.
-            timeout:        In seconds, the maximum allowed time. By default 5 minutes
-            interval:      In seconds, the polling interval time.
+            service_name (Str): The name of the service to be checked.
+            timeout (Int):  In seconds, the maximum allowed time (default=300)
+            interval (int): In seconds, the polling interval time (default=5)
 
         Returns:
-            True if the service and the list of daemons are running else False.
+            Boolean: True if the service and the list of daemons are running else False.
+
         """
         end_time = datetime.now() + timedelta(seconds=timeout)
         check_status_dict = {
@@ -98,10 +101,10 @@ class Orch(
         Get service info by name.
 
         Args:
-            service_name: service name
+            service_name (Str): service name
 
         Returns:
-            service
+            service (Dict)
 
         Raises:
             ResourceNotFound: when no resource with the provided is matched.
@@ -118,18 +121,17 @@ class Orch(
         self, service_name: str, timeout: int = 300, interval: int = 5, exist=True
     ) -> bool:
         """
-        check service existence based on the exist parameter
-
-        if exist is set, then validate its presence.
-        otherwise, for its removal.
+        check service existence based on the exist parameter.
+        if exist is set, then validate its presence. otherwise, for its removal.
 
         Args:
-            service_name: service name
-            timeout: timeout in seconds
-            interval: interval in seconds
-            exist: boolean
+            service_name (Str): service name
+            timeout (Int): timeout in seconds
+            interval (Int): interval in seconds
+            exist (Bool): exists or not
+
         Returns:
-            service
+            Boolean
 
         """
         end_time = datetime.now() + timedelta(seconds=timeout)
@@ -153,11 +155,10 @@ class Orch(
         Execute the apply_spec method using the object's service name and provided input.
 
         Args:
-            config:     Key/value pairs passed from the test suite.
-                        base_cmd_args   - key/value pairs to set for base command
-                        specs           - service specifications.
+            config (Dict):     Key/value pairs passed from the test suite.
 
-        Example:
+        Example::
+
             config:
                 command: apply_spec
                 service: orch
@@ -171,6 +172,10 @@ class Orch(
                    nodes:
                      - node2
                      - node3
+
+            base_cmd_args   - key/value pairs to set for base command
+            specs           - service specifications.
+
         """
         base_cmd = ["ceph", "orch"]
 
@@ -197,18 +202,24 @@ class Orch(
     def op(self, op, config):
         """
         Execute the command ceph orch <start|stop|restart|reconfigure|redeploy> <service>.
-        Args:
-            config: command and service are passed from the test case.
-            op: operation parameters ex: restart|start|stop|reconfigure|redeploy
-        Example:
-            Testing ceph orch restart mon
-        config:
-          command: restart
-          service: mon
-        Returns:
-          output, error   returned by the command.
 
-        example
+        Args:
+            config (Dict): command and service are passed from the test case.
+            op (Str): operation parameters.
+
+        Returns:
+          output (Str), error (Str)  returned by the command.
+
+        Example::
+
+            Testing ceph orch restart mon
+            op: restart|start|stop|reconfigure|redeploy
+
+            config:
+              command: restart
+              service: mon
+            ...
+
             config:
                 command: start
                 base_cmd_args:

--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -29,9 +29,10 @@ class OSD(ApplyMixin, Orch):
         Deploy the ODS service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: osd
@@ -42,6 +43,7 @@ class OSD(ApplyMixin, Orch):
                     all-available-devices: true
                     dry-run: true
                     unmanaged: true
+
         """
         cmd = ["ceph orch device ls -f json"]
         self.shell(args=["ceph orch device ls --refresh"])

--- a/ceph/ceph_admin/prometheus.py
+++ b/ceph/ceph_admin/prometheus.py
@@ -13,9 +13,10 @@ class Prometheus(ApplyMixin, Orch):
         Deploy the Prometheus service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: prometheus
@@ -32,5 +33,6 @@ class Prometheus(ApplyMixin, Orch):
                         sep: " "    # separator to be used for placements
                     dry-run: true
                     unmanaged: true
+
         """
         super().apply(config=config)

--- a/ceph/ceph_admin/ps.py
+++ b/ceph/ceph_admin/ps.py
@@ -13,9 +13,13 @@ class PSMixin:
         Execute the command ceph orch ps <args>.
 
         Args:
-            config: The key/value pairs passed from the test case.
+            config (Dict): The key/value pairs passed from the test case.
 
-        Example:
+        Returns:
+            output, error   returned by the command.
+
+        Example::
+
             Testing ceph orch ps
 
             config:
@@ -30,8 +34,6 @@ class PSMixin:
                     daemon_id: <id of the daemon>
                     refresh: true
 
-        Returns:
-            output, error   returned by the command.
         """
         cmd = ["ceph", "orch"]
 

--- a/ceph/ceph_admin/rbd_mirror.py
+++ b/ceph/ceph_admin/rbd_mirror.py
@@ -15,9 +15,10 @@ class RbdMirror(ApplyMixin, Orch):
         Deploy the rbd-mirror service using the provided configuration.
 
         Args:
-            config: Key/value pairs provided by the test case to create the service.
+            config (Dict): Key/value pairs provided by the test case to create the service.
 
-        Example
+        Example::
+
             config:
                 command: apply
                 service: rbd-mirror

--- a/ceph/ceph_admin/reconfig.py
+++ b/ceph/ceph_admin/reconfig.py
@@ -7,11 +7,14 @@ class ReconfigMixin:
     def reconfig(self: Union[OrchProtocol, DaemonProtocol], config: Dict):
         """
         Execute the reconfigure method using the object's service name.
-        Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
 
-        Example:
+        Args:
+            config (Dict):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args        - List to be added as positional params
+
             config:
               service: mon
               command: reconfig

--- a/ceph/ceph_admin/redeploy.py
+++ b/ceph/ceph_admin/redeploy.py
@@ -7,15 +7,19 @@ class RedeployMixin:
     def redeploy(self: Union[OrchProtocol, DaemonProtocol], config: Dict):
         """
         Execute the add method using the object's service name.
-        Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
 
-        Example:
+        Args:
+            config (Dict):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args        - List to be added as positional params
+
             config:
               service: mon
               command: reconfig
               base_cmd_args:
                 verbose: true
+
         """
         return self.op("redeploy", config)

--- a/ceph/ceph_admin/remove.py
+++ b/ceph/ceph_admin/remove.py
@@ -16,10 +16,14 @@ class RemoveMixin:
     def remove(self: ServiceProtocol, config: Dict) -> None:
         """
         Execute the remove method using the object's service name.
+
         Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
-        Example:
+            config (Dict):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args - List to be added as positional params
+
             config:
                 command: remove
                 service: rgw
@@ -28,6 +32,7 @@ class RemoveMixin:
                 args:
                     service_name: rgw.realm.zone
                     verify: true
+
         """
         cmd = ["ceph", "orch"]
         if config.get("base_cmd_args"):

--- a/ceph/ceph_admin/restart.py
+++ b/ceph/ceph_admin/restart.py
@@ -7,15 +7,19 @@ class RestartMixin:
     def restart(self: Union[OrchProtocol, DaemonProtocol], config: Dict):
         """
         Execute the restart method using the object's service name.
-        Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
 
-        Example:
+        Args:
+            config (Dict):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args - List to be added as positional params
+
             config:
               service: mon
               command: restart
               base_cmd_args:
                 verbose: true
+
         """
         return self.op("restart", config)

--- a/ceph/ceph_admin/rgw.py
+++ b/ceph/ceph_admin/rgw.py
@@ -13,10 +13,11 @@ class RGW(ApplyMixin, Orch):
         Deploy the RGW service using the provided data.
 
         Args:
-            config: test arguments
+            config (Dict): test arguments
 
-        Example:
-            <adm_shell> ceph orch apply rgw realm zone --placement="label:rgw"
+        Example::
+
+            <cephadm_shell> ceph orch apply rgw realm zone --placement="label:rgw"
 
             config:
                 command: apply
@@ -40,5 +41,6 @@ class RGW(ApplyMixin, Orch):
                         sep: " "            # separator to be used for placements
                     dry-run: true
                     unmanaged: true
+
         """
         super().apply(config)

--- a/ceph/ceph_admin/rm.py
+++ b/ceph/ceph_admin/rm.py
@@ -7,15 +7,19 @@ class RmMixin:
     def remove(self: Union[OrchProtocol, DaemonProtocol], config: Dict):
         """
         Execute the remove method using the object's service name.
-        Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
 
-        Example:
+        Args:
+            config (Dict):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args - List to be added as positional params
+
             config:
               service: mon
               command: rm
               base_cmd_args:
                 verbose: true
+
         """
         return self.op("rm", config)

--- a/ceph/ceph_admin/shell.py
+++ b/ceph/ceph_admin/shell.py
@@ -24,14 +24,14 @@ class ShellMixin:
         Ceph orchestrator shell interface to run ceph commands.
 
         Args:
-            args: list arguments
-            base_cmd_args: cephadm base command options
-            check_status: check command status
-            timeout: Maximum time allowed for execution.
+            args (List): list arguments
+            base_cmd_args (Dict)): cephadm base command options
+            check_status (Bool): check command status
+            timeout (Int): Maximum time allowed for execution.
 
         Returns:
-            out: stdout
-            err: stderr
+            out (Str), err (Str) stdout and stderr response
+
         """
         cmd = deepcopy(BASE_CMD)
 

--- a/ceph/ceph_admin/start.py
+++ b/ceph/ceph_admin/start.py
@@ -7,15 +7,19 @@ class StartMixin:
     def start(self: OrchProtocol, config: Dict):
         """
         Execute the start method using the object's service name.
-        Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
 
-        Example:
+        Args:
+            config (Dict):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args        - List to be added as positional params
+
             config:
               service: mon
               command: start
               base_cmd_args:
                 verbose: true
+
         """
         return self.op("start", config)

--- a/ceph/ceph_admin/stop.py
+++ b/ceph/ceph_admin/stop.py
@@ -7,15 +7,19 @@ class StopMixin:
     def stop(self: OrchProtocol, config: Dict):
         """
         Execute the stop method using the object's service name.
-        Args:
-            config:     Key/value pairs passed from the test suite.
-                        pos_args        - List to be added as positional params
 
-        Example:
+        Args:
+            config (Args):     Key/value pairs passed from the test suite.
+
+        Example::
+
+            pos_args        - List to be added as positional params
+
             config:
               service: mon
               command: stop
               base_cmd_args:
                 verbose: true
+
         """
         return self.op("stop", config)

--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -23,9 +23,10 @@ class UpgradeMixin:
         Execute the command ceph orch start <args>.
 
         Args:
-            config: The key/value pairs passed from the test case.
+            config (Dict): The key/value pairs passed from the test case.
 
-        Example:
+        Example::
+
             Testing ceph orch upgrade
 
             config:
@@ -37,6 +38,7 @@ class UpgradeMixin:
                 args:
                     image: "latest"         # pick latest image from config
                     version: 16.0.0         # Not supported
+
         """
         cmd = ["ceph", "orch"]
 
@@ -55,6 +57,10 @@ class UpgradeMixin:
     def upgrade_status(self: OrchProtocol):
         """
         Execute the command ceph orch status.
+
+        Returns:
+            upgrade Status (Dict)
+
         """
         out, _ = self.shell(args=["ceph", "orch", "upgrade", "status"])
         return loads(out)
@@ -62,10 +68,12 @@ class UpgradeMixin:
     def upgrade_check(self: OrchProtocol, image):
         """
         Check the service versions available against targeted version
+
         Args:
-            image: image name
+            image (Str): image name
+
         Returns:
-            status
+            status (Dict)
         """
         out, _ = self.shell(
             args=["ceph", "orch", "upgrade", "check", f"--image {image}"]
@@ -76,6 +84,10 @@ class UpgradeMixin:
     def monitor_upgrade_status(self, timeout=3600):
         """
         Monitor upgrade status
+
+        Args:
+            timeout (int):  Timeout in seconds (default:3600)
+
         """
         interval = 5
         end_time = datetime.now() + timedelta(seconds=timeout)

--- a/ceph/rados/rados_bench.py
+++ b/ceph/rados/rados_bench.py
@@ -1,5 +1,4 @@
 """
-Rados Bench module to execute benchmark tests
 
 RADOS bench testing uses the rados binary that comes with the ceph-common package.
 It contains a benchmarking facility that exercises the cluster by way of librados,
@@ -34,6 +33,12 @@ class RadosBenchExecutionFailure(Exception):
 def create_id(prefix=""):
     """
     Return unique name with prefix
+
+    Args:
+        prefix (Str): required prefix
+
+    Returns:
+        Unique Id (Str)
     """
     return f"{prefix or 'test_run'}-{int(time())}"
 
@@ -43,12 +48,12 @@ def create_osd_pool(node, pool_name=None, pg_num=16):
     Create OSD pool
 
     Args:
-        node: node with Ceph CLI accessibility
-        pool_name: pool name # preferred pool name else self.create_id()
-        pg_num: placement group number
+        node (CephNode): node with Ceph CLI accessibility
+        pool_name (Str): pool name # preferred pool name else self.create_id()
+        pg_num (Int): placement group number
 
     Returns:
-        pool_name
+        pool name (Str)
     """
     name = pool_name if pool_name else create_id("pool")
     node.exec_command(cmd=f"ceph osd pool create {name} {pg_num} {pg_num}", sudo=True)
@@ -61,12 +66,12 @@ def create_pools(node, num_pools, pg_num=16):
     Return list of OSD pools
 
     Args:
-        node: node with Ceph CLI accessibility
-        num_pools: required number of pool
-        pg_num: placement group number
+        node (CephNode): node with Ceph CLI accessibility
+        num_pools (Int): required number of pool
+        pg_num (Int): placement group number
 
     Returns:
-        pool_name
+        pool names (List)
     """
     return [create_osd_pool(node=node, pg_num=pg_num) for _ in range(num_pools)]
 
@@ -74,9 +79,10 @@ def create_pools(node, num_pools, pg_num=16):
 def delete_osd_pool(node, pool_name):
     """
     Delete OSD pool
+
     Args:
-        node: node with Ceph CLI accessibility
-        pool_name: pool name
+        node (CephNode): node with Ceph CLI accessibility
+        pool_name (Str): pool name
     """
     node.exec_command(
         cmd="ceph config set global mon_allow_pool_delete true", sudo=True
@@ -88,13 +94,16 @@ def delete_osd_pool(node, pool_name):
 
 
 class RadosBench:
+    """Rados Bench class to execute benchmark tests"""
+
     def __init__(self, mon_node, clients=[]):
         """
         Initialize Rados Benchmark
 
         Args:
-            mon_node: monitor node
-            clients: list of clients
+            mon_node (CephNode): monitor node
+            clients (List): list of clients
+
         """
         self.SIGStop = False
         self.mon = mon_node
@@ -106,9 +115,11 @@ class RadosBench:
         Returns node if node name provided else self.clients[0]
 
         Args:
-            node: node name
+            node (Str): node name
+
         Returns:
-            node
+            node (CephNode)
+
         """
         if not node:
             return self.clients[0]
@@ -122,23 +133,26 @@ class RadosBench:
         """
         Rados bench write test for provided time duration
 
-        ex., rados bench 10 write -p test_bench  --no-cleanup --run-name test2
-
         Args:
-            client: client node
-            pool_name: osd pool name
-            config: write ops command arguments
-
-        config:
-            seconds: duration of write ops (Default:10)
-            run-name: benchmark run-name created based on (Boolean value : Optional)
-            no-cleanup: no clean-up option (Boolean value, Default: false(clean-up))
-            no-hints:  no-hint option (Boolean value, Default: false(hints))
-            concurrent-ios: integer (String value)
-            reuse-bench: bench name (String value)
+            client (CephVMNode): client node
+            pool_name (Str): osd pool name
+            config (Dict): write ops command arguments
 
         Returns:
-            run_name
+            run_name (Str)
+
+        Example::
+
+            rados bench 10 write -p test_bench  --no-cleanup --run-name test2
+
+            config:
+                seconds (Int) : duration of write ops (Default:10)
+                run-name (Str) : benchmark run-name created based on (Optional)
+                no-cleanup (Bool) : no clean-up option (Default: false (clean-up))
+                no-hints (Bool) :  no-hint option (Default: false(hints))
+                concurrent-ios (Str) : integer (String value)
+                reuse-bench (Str) : bench name (String value)
+
         """
         base_cmd = ["rados", "bench"]
 
@@ -161,25 +175,29 @@ class RadosBench:
     def sequential_read(client, pool_name, **config):
         """
         Rados bench sequential read test for provided time duration
-            Note: there should be a write operation pre-executed.
-
-        ex., rados bench 10 seq -p test_bench 10 seq --run-name test2
 
         Args:
-            config: sequential read ops command arguments
-            client: client node (CephVMNode)
-            pool_name: osd pool name
-
-        config:
-            seconds: duration of write ops (Default:10)
-            run-name: benchmark run-name created based on (Boolean value : Optional)
-            no-cleanup: no clean-up option (Boolean value, Default: false(clean-up))
-            no-hints:  no-hint option (Boolean value, Default: false(hints))
-            concurrent-ios: integer (String value)
-            reuse-bench: bench name (String value)
+            config (dict) : sequential read ops command arguments
+            client (CephVMNode) : client node
+            pool_name (str): osd pool name
 
         Returns:
-            run_name
+            run_name (str)
+
+        Example::
+
+            rados bench 10 seq -p test_bench 10 seq --run-name test2
+
+            config:
+                seconds: duration of write ops (Default:10)
+                run-name: benchmark run-name created based on (Boolean value : Optional)
+                no-cleanup: no clean-up option (Boolean value, Default: false(clean-up))
+                no-hints:  no-hint option (Boolean value, Default: false(hints))
+                concurrent-ios: integer (String value)
+                reuse-bench: bench name (String value)
+
+        :warning: there should be a write operation pre-executed.
+
         """
         base_cmd = ["rados", "bench"]
 
@@ -200,12 +218,15 @@ class RadosBench:
         """
         clean up benchmark operation
 
-        ex., rados cleanup -p test_bench --run-name test1
-
         Args:
-            client: client node to execute rados bench
-            pool_name: osd pool name
-            run_name: Rados benchmark run-name(Optional)
+            client (CephNode): client node to execute rados bench
+            pool_name (Str): osd pool name
+            run_name (Str): Rados benchmark run-name(Optional)
+
+        Example::
+
+            rados cleanup -p test_bench --run-name test1
+
         """
         cmd = f"rados cleanup -p {pool_name}"
         cmd += "" if not run_name else f" --run-name {run_name}"
@@ -221,13 +242,15 @@ class RadosBench:
     def continuous_run(self, client, pool_name, duration):
         """
         run indefinite loop of rados bench IOs with data provided
-            - write
-            - sequential read
-            - cleanup
+          - write
+          - sequential read
+          - cleanup
+
         Args:
-            client: client node to execute rados benchmark commands
-            pool_name: ceph OSD pool name
-            duration: duration of benchmark run in seconds
+            client (CephNode): client node to execute rados benchmark commands
+            pool_name (Str): ceph OSD pool name
+            duration (Int): duration of benchmark run in seconds
+
         """
         try:
             LOG.info(
@@ -274,21 +297,23 @@ class RadosBench:
 
     def run(self, config):
         """
-        Execute benchmark,
+
+        Execute benchmark
+
            - Create necessary pools
            - Initiate executor
            - Submit thread
            - return
 
         Args:
-            config: benchmark execution config
+            config (dict): benchmark execution config
 
-        config:
-            duration: benchmark duration
-            pg_num: placement group number
-            pool_per_client: boolean
-                # True - pool per client
-                # False - one pool used by all clients
+        Example::
+
+            config:
+                duration (int): benchmark duration
+                pg_num (int): placement group number
+                pool_per_client (bool): True - pool per client, False - one pool used by all clients
         """
         LOG.info("RadosBench Execution Started ......")
         duration = config.get("duration")

--- a/ceph/rados_utils.py
+++ b/ceph/rados_utils.py
@@ -66,11 +66,14 @@ class RadosHelper:
     ):
         """
         Create a pool named from the pool_name parameter.
-        :param pool_name: name of the pool being created.
-        :param pg_num: initial number of pgs.
-        :param erasure_code_profile_name: if set and !None create an
-            erasure coded pool using the profile
-        :param erasure_code_use_overwrites: if true, allow overwrites
+
+        Args:
+            pool_name (Str): name of the pool being created.
+            pg_num (Int): initial number of pgs.
+            erasure_code_profile_name (Str): if set and
+                !None create an erasure coded pool using the profile
+            erasure_code_use_overwrites (Bool): if true, allow overwrites
+
         """
         assert isinstance(pool_name, str)
         assert isinstance(pg_num, int)
@@ -211,11 +214,13 @@ class RadosHelper:
     def wait_until_osd_state(self, osd_id, down=False) -> bool:
         """
         Checks the state of given osd and waits for 120 seconds for the same state to be achieved
+
         Args:
             osd_id: ID of the osd to be checked
             down: If True, Specifies that the OSD should be down
 
-        Returns: True -> Pass, False -> Fail
+        Returns:
+            Boolean True -> Pass, False -> Fail
 
         """
         end_time = datetime.datetime.now() + datetime.timedelta(seconds=120)

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -291,8 +291,8 @@ def check_ceph_healthly(
        build: rhcs build version
        mon_container: monitor container name if monitor is placed in the container
        timeout: 300 seconds(default) max time to check
-         if cluster is not healthy within timeout period
-                return 1
+
+    :note:  if cluster is not healthy within timeout period return 1
 
     Returns:
        return 0 when ceph is in healthy state, else 1
@@ -733,26 +733,26 @@ def get_disk_info(node):
 
 def get_node_by_id(cluster, node_name):
     """
-    Fetch node using provided node substring
+    Fetch node using provided node substring::
 
-    As per the naming convention used at VM creation, where each node.shortname
-    is framed with hyphen("-") separated string as below, please refer
-    ceph.utils.create_ceph_nodes definition
-        "ceph-<name>-node1-<roles>"
+        As per the naming convention used at VM creation, where each node.shortname
+        is framed with hyphen("-") separated string as below, please refer
+        ceph.utils.create_ceph_nodes definition
+            "ceph-<name>-node1-<roles>"
 
-        name: RHOS-D username or provided --instances-name
-        roles: roles attached to node in inventory file
+            name: RHOS-D username or provided --instances-name
+            roles: roles attached to node in inventory file
 
-    In this method we use hyphen("-") appended to node_name string to try fetch exact node.
-    for example,
-        "node1" ----> "node1-"
+        In this method we use hyphen("-") appended to node_name string to try fetch exact node.
+        for example,
+            "node1" ----> "node1-"
 
-    Note: But however if node_name doesn't follow naming convention as mentioned in
-    inventory, the first searched node will be returned.
-    for example,
-        "node" ----> it might return any node which matched first, like node11.
+        Note: But however if node_name doesn't follow naming convention as mentioned in
+        inventory, the first searched node will be returned.
+        for example,
+            "node" ----> it might return any node which matched first, like node11.
 
-    return None, If this cluster has no nodes with this substring.
+        return None, If this cluster has no nodes with this substring.
 
     Args:
         cluster: ceph object

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,9 @@ isort:skip_file
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(".."))
+from sphinx.ext import apidoc
 
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 
@@ -34,12 +35,13 @@ author = "RHCS-QE"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
-    "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
 ]
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -68,3 +70,14 @@ source_parsers = {
     ".md": "recommonmark.parser.CommonMarkParser",
 }
 source_suffix = [".rst", ".md"]
+
+
+def run_apidoc(_):
+    """Generate API Documentation"""
+    ignore_paths = []
+    argv = ["-f", "-e", "-o", "apidoc", "../ceph"] + ignore_paths
+    apidoc.main(argv)
+
+
+def setup(app):
+    app.connect("builder-inited", run_apidoc)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,19 @@
+Welcome to CEPH-CI documentation!
+===================================
+Ceph-CI is a framework for testing Red Hat Ceph Storage product builds. It
+dynamically creates virtual machines and storage volumes within Red Hat's
+CentralCI OpenStack environment, installs and tests Ceph, and then de-allocates
+the resources when complete.
+
 .. toctree::
    :maxdepth: 2
+   :caption: Package documentations:
 
-   source/welcome.md
+   CEPH-CI modules <apidoc/modules.rst>
 
 .. toctree::
    :maxdepth: 2
+   :caption: Contents:
 
    source/Introduction.rst
    source/development_guidelines.rst

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 sphinx==2.4.4
 sphinx-autopackagesummary==1.3
 sphinx_rtd_theme==0.5.0
+recommonmark==0.6.0
+-r ../requirements.txt

--- a/docs/source/welcome.md
+++ b/docs/source/welcome.md
@@ -1,6 +1,0 @@
-Welcome to CEPH-CI documentation!
-===================================
-Ceph-CI is a framework for testing Red Hat Ceph Storage product builds. It
-dynamically creates virtual machines and storage volumes within Red Hat's
-CentralCI OpenStack environment, installs and tests Ceph, and then de-allocates
-the resources when complete.


### PR DESCRIPTION
- Updated docstring of ceph packages and modules
- Removed welcome documentation file, Moved welcome content to Index.rst file.
- support apidoc generation on ceph packages

[apidoc-ceph-ci-readthedocs-io-en-latest.pdf](https://github.com/red-hat-storage/cephci/files/6944864/apidoc-ceph-ci-readthedocs-io-en-latest.pdf)


   http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2BL4U2
   http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VLMRDP