### PR TITLE
Support encryption tests from S3Tests

### DIFF
--- a/suites/pacific/rgw/tier_2_rgw_ssl_s3tests.yaml
+++ b/suites/pacific/rgw/tier_2_rgw_ssl_s3tests.yaml
@@ -1,0 +1,108 @@
+# Tier - 2: Execute S3Tests using self-signed certificate
+#
+# Depends on: https://github.com/ceph/s3-tests/pull/405
+#
+# Requires the following keys in cephci.yaml
+#
+#   vault:
+#        url: http://<vault-server>/
+#        agent:
+#          auth: agent
+#          engine: transit
+#          role-id: <role-id>
+#          secret-id: <secret-id>
+#          prefix: /v1/<path>
+#
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgw.ssl
+                  placement:
+                    nodes:
+                      - node5
+                  spec:
+                    ssl: true
+                    rgw_frontend_ssl_certificate: create-cert
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        install:
+          - agent
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+
+  - test:
+      abort-on-fail: false
+      config:
+        branch: ceph-pacific
+        kms_keyid: testKey01
+      desc: S3tests
+      destroy-cluster: false
+      module: test_s3.py
+      name: execute s3tests

--- a/tests/misc_env/install_vault.py
+++ b/tests/misc_env/install_vault.py
@@ -1,0 +1,311 @@
+"""
+This module installs and configures HashiCorp's Vault on the given node.
+
+Support for configuring vault-agent is also supported in this module. The configuration
+is done based on the inputs provided in .cephci.yaml file.
+
+In case of vault-agent configuration, the following information is required in
+.cephci.yaml
+
+Example:
+
+    vault:
+        url: http://<vault-server>/
+        agent:
+          auth: agent
+          engine: transit
+          role-id: <role-id>
+          secret-id: <secret-id>
+          prefix: /v1/<path>
+
+ToDo:
+  - configure server
+  - support TLS
+  - support token auth method
+"""
+from json import loads
+from logging import getLogger
+from typing import Dict
+
+from jinja2 import Template
+
+from ceph.ceph import Ceph, CephNode
+from utility.utils import get_cephci_config
+
+LOG = getLogger(__name__)
+AGENT_HCL = """pid_file = "/run/vault-agent-pid"
+
+auto_auth {
+  method "AppRole" {
+    mount_path = "auth/approle"
+    config = {
+      role_id_file_path = "/usr/local/etc/vault/.app-role-id"
+      secret_id_file_path = "/usr/local/etc/vault/.app-secret-id"
+      remove_secret_id_file_after_reading = "false"
+    }
+  }
+}
+{%- if data.auth == "token" %}
+sink "file" {
+  config = {
+    path = {{ data.token.file }}
+  }
+}
+{%- endif %}
+
+{%- if data.auth == "agent" %}
+cache {
+  use_auto_auth_token = true
+}
+
+listener "tcp" {
+  address = "127.0.0.1:8100"
+  tls_disable = true
+}
+{%- endif %}
+
+vault {
+  address = "{{ data.url }}"
+}
+"""
+
+AGENT_SYSTEMD = """[Unit]
+Description=HashiCorp Vault agent
+
+[Service]
+ExecStart=/usr/bin/vault-agent
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+
+"""
+
+AGENT_LAUNCHER = """#!/bin/sh
+/bin/vault agent -config /usr/local/etc/vault/agent.hcl
+
+"""
+
+
+def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
+    """
+    Entry point for module execution.
+
+    Args:
+        ceph_cluster    The cluster participating in the test.
+        config          Configuration passed to the test
+        kwargs          Additional configurations passed to the test.
+
+    Returns:
+        0 on Success else 1
+
+    Raises:
+        CommandFailure
+
+    Example:
+
+        - test:
+            abort-on-fail: false
+            config:
+              install:
+                - agent
+            desc: Install and configure vault agent
+            module: install_vault.py
+            name: install vault agent
+    """
+    if "agent" in config["install"]:
+        vault_cfg = get_cephci_config().get("vault")
+        _install_agent(ceph_cluster, vault_cfg)
+
+        client = ceph_cluster.get_nodes(role="client")[0]
+        _configure_rgw_daemons(client, vault_cfg)
+
+    return 0
+
+
+# Private methods
+
+
+def _write_remote_file(node: CephNode, file_name: str, content: str) -> None:
+    """
+    Copies the provide content to the specified file on the given node.
+
+    Args:
+        node        The target system
+        file_name   The name of the remote file to which the content needs to be written
+        content     The content of the file to be written
+
+    Returns:
+          None
+
+    Raises:
+          CommandFailed
+    """
+    LOG.debug(f"Writing to remote file {file_name}")
+    file_handle = node.remote_file(sudo=True, file_mode="w", file_name=file_name)
+    file_handle.write(data=content)
+    file_handle.flush()
+    file_handle.close()
+
+
+def _install_agent(cluster: Ceph, config: Dict) -> None:
+    """
+    Installs and configures the vault-agent on all RGW nodes
+
+    Args:
+        cluster     Ceph cluster participating in the test
+        config      key/value pairs useful for customization
+
+    Returns:
+        None
+
+    Raises:
+        CommandFailed
+    """
+    rgw_nodes = cluster.get_nodes(role="rgw")
+    for node in rgw_nodes:
+        LOG.debug(f"Vault install and configuration on {node.shortname}")
+        _install_vault_packages(node)
+        _create_agent_config(node, config)
+        _create_agent_systemd(node)
+
+
+def _install_vault_packages(node: CephNode) -> None:
+    """
+    Installs the required packages for vault
+
+    Args:
+        node    The system on which the package needs to be installed
+
+    Returns:
+        None
+
+    Raises:
+        CommandFailed
+    """
+    vault_repo = "https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo"
+    commands = [f"yum-config-manager --add-repo {vault_repo}", "yum install -y vault"]
+    for command in commands:
+        node.exec_command(sudo=True, cmd=command, check_ec=False)
+
+
+def _create_agent_config(node: CephNode, config: Dict) -> None:
+    """
+    Writes the required configuration file to the provided node.
+
+    The following files are created .app-role-id, .app-secret-id and agent.hcl
+
+    Args:
+        node    The system on which files have to be copied
+        config  Dictionary holding the tokens
+
+    Returns:
+        None
+
+    Raises:
+        CommandFailed
+    """
+    node.exec_command(sudo=True, cmd="mkdir -p /usr/local/etc/vault/")
+
+    _write_remote_file(
+        node=node,
+        file_name="/usr/local/etc/vault/.app-role-id",
+        content=config["agent"]["role-id"],
+    )
+    _write_remote_file(
+        node=node,
+        file_name="/usr/local/etc/vault/.app-secret-id",
+        content=config["agent"]["secret-id"],
+    )
+    # hcl file
+    agent_conf = {"url": config["url"], "auth": config["agent"]["auth"]}
+    tmpl = Template(AGENT_HCL)
+    data = tmpl.render(data=agent_conf)
+    _write_remote_file(
+        node=node,
+        file_name="/usr/local/etc/vault/agent.hcl",
+        content=data,
+    )
+
+
+def _create_agent_systemd(node: CephNode) -> None:
+    """
+    Configures and runs the vault-agent as a system daemon.
+
+    This method creates two files i.e. a launcher file and a system service unit. It
+    also enables the service to start.
+
+    Args:
+        node    The node for which the vault agent needs to be set.
+
+    Returns:
+        None
+
+    Raises:
+        CommandFailed
+    """
+    _write_remote_file(
+        node=node,
+        file_name="/usr/bin/vault-agent",
+        content=AGENT_LAUNCHER,
+    )
+    _write_remote_file(
+        node=node,
+        file_name="/usr/lib/systemd/system/vault-agent.service",
+        content=AGENT_SYSTEMD,
+    )
+
+    commands = [
+        "chmod +x /usr/bin/vault-agent",
+        "systemctl start vault-agent.service",
+        "systemctl enable vault-agent.service",
+    ]
+    for command in commands:
+        node.exec_command(sudo=True, cmd=command)
+
+
+def _configure_rgw_daemons(node: CephNode, config: Dict) -> None:
+    """
+    Updates the RGW daemons with the provided configuration.
+
+    Args:
+         node       Server that has privilege to perform ceph config set commands.
+         config     Key/value pairs to be used for configuration
+    Returns:
+        None
+    Raises:
+        CommandFailed
+    """
+    out, err = node.exec_command(
+        sudo=True, cmd="ceph orch ps --daemon_type rgw --format json"
+    )
+    rgw_daemons = [f"client.rgw.{x['daemon_id']}" for x in loads(out.read().decode())]
+
+    out, err = node.exec_command(
+        sudo=True, cmd="ceph orch ls --service_type rgw --format json"
+    )
+    rgw_services = [x["service_name"] for x in loads(out.read().decode())]
+
+    configs = [
+        ("rgw_crypt_s3_kms_backend", "vault"),
+        ("rgw_crypt_vault_secret_engine", config["agent"]["engine"]),
+        ("rgw_crypt_vault_auth", config["agent"]["auth"]),
+    ]
+
+    if config["agent"]["auth"] == "token":
+        configs += [
+            ("rgw_crypt_vault_token_file", config["agent"]["token_file"]),
+            ("rgw_crypt_vault_addr", config["url"]),
+        ]
+    else:
+        configs += [
+            ("rgw_crypt_vault_prefix", config["agent"]["prefix"]),
+            ("rgw_crypt_vault_addr", "http://127.0.0.1:8100"),
+        ]
+
+    for daemon in rgw_daemons:
+        for key, value in configs:
+            node.exec_command(sudo=True, cmd=f"ceph config set {daemon} {key} {value}")
+
+    for service in rgw_services:
+        node.exec_command(sudo=True, cmd=f"ceph orch restart {service}")

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -8,14 +8,14 @@ https://github.com/ceph/s3-tests. Over here, we have three stages
     - Execute Tests
     - Test Teardown
 
-In the test setup stage, the test suite is clone and the necessary steps to execute it
-is carried out here.
+In the test setup stage, the test suite is cloned and the necessary steps to execute it
+is carried out.
 
 In the execute test stage, the test suite is executed using tags based on the RHCS
 build version.
 
-In the test teardown, the cloned repository is removed and the configurations done are
-reverted.
+In the test teardown, the cloned repository is removed and the configuration changes
+undone.
 
 Requirement parameters
      ceph_nodes:    The list of node participating in the RHCS environment.
@@ -30,11 +30,67 @@ import binascii
 import json
 import logging
 import os
+from json import loads
+from typing import Dict, Optional, Tuple
+
+from jinja2 import Template
 
 from ceph.ceph import Ceph, CephNode, CommandFailed
 from ceph.utils import open_firewall_port
 
 log = logging.getLogger(__name__)
+S3CONF = """[DEFAULT]
+host = {{ data.host }}
+port = {{ data.port }}
+is_secure = {{ data.secure }}
+ssl_verify = false
+
+[fixtures]
+bucket_prefix = cephci-{random}-
+
+[s3 main]
+api_name = default
+display_name = {{ data.main.name }}
+user_id = {{ data.main.id }}
+access_key = {{ data.main.access_key }}
+secret_key = {{ data.main.secret_key }}
+email = {{ data.main.email }}
+{%- if data.main.kms_keyid %}
+kms_keyid = {{ data.main.kms_keyid }}
+{% endif %}
+
+[s3 alt]
+display_name = {{ data.alt.name }}
+user_id = {{ data.alt.id }}
+access_key = {{ data.alt.access_key }}
+secret_key = {{ data.alt.secret_key }}
+email = {{ data.alt.email }}
+
+[s3 tenant]
+display_name = {{ data.tenant.name }}
+user_id = {{ data.tenant.id }}
+access_key = {{ data.tenant.access_key }}
+secret_key = {{ data.tenant.secret_key }}
+email = {{ data.tenant.email }}
+
+{%- if data.iam %}
+[iam]
+display_name = {{ data.iam.name }}
+user_id = {{ data.iam.id }}
+access_key = {{ data.iam.access_key }}
+secret_key = {{ data.iam.secret_key }}
+email = {{ data.iam.email }}
+{% endif %}
+
+{%- if data.webidentity %}
+[webidentity]
+token = {{ data.webidentity.token }}
+aud = {{ data.webidentity.aud }}
+thumbprint = {{ data.webidentity.thumbprint }}
+KC_REALM = {{ data.webidentity.realm }}
+{% endif %}
+
+"""
 
 
 def run(**kw):
@@ -46,7 +102,8 @@ def run(**kw):
     client_node = cluster.get_nodes(role="client")[0]
 
     execute_setup(cluster, config)
-    exit_status = execute_s3_tests(client_node, build)
+    _, secure, _ = get_rgw_frontend(cluster)
+    exit_status = execute_s3_tests(client_node, build, secure)
     execute_teardown(cluster, build)
 
     log.info("Returning status code of %s", exit_status)
@@ -81,9 +138,9 @@ def execute_setup(cluster: Ceph, config: dict) -> None:
     install_s3test_requirements(client_node, branch)
 
     host = rgw_node.shortname
-    secure = config.get("is_secure", "no")
-    port = "443" if secure.lower() == "yes" else rgw_frontend_port(cluster, build)
-    create_s3_conf(cluster, build, host, port, secure)
+    lib, secure, port = get_rgw_frontend(cluster)
+    kms_keyid = config.get("kms_keyid")
+    create_s3_conf(cluster, build, host, port, secure, kms_keyid)
 
     if not build.startswith("5"):
         open_firewall_port(rgw_node, port=port, protocol="tcp")
@@ -91,14 +148,14 @@ def execute_setup(cluster: Ceph, config: dict) -> None:
     add_lc_debug(cluster, build)
 
 
-def execute_s3_tests(node: CephNode, build: str) -> int:
+def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> int:
     """
     Return the result of S3 test run.
 
     Args:
-        node: The node from which the test execution is triggered.
-        build: the RH build version
-
+        node        The node from which the test execution is triggered.
+        build       The RH build version
+        encryption  include encryption test or not
     Returns:
         0 - Success
         1 - Failure
@@ -110,9 +167,12 @@ def execute_s3_tests(node: CephNode, build: str) -> int:
         tests = "s3tests"
 
         if build.startswith("5"):
-            extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!encryption"
-            extra_args += ",!test_of_sts,!lifecycle,!s3select,!user-policy"
-            extra_args += ",!webidentity_test'"
+            extra_args = "-a '!fails_on_aws,!fails_on_rgw,!fails_strict_rfc2616"
+
+            if not encryption:
+                extra_args += ",!encryption"
+
+            extra_args += ",!test_of_sts,!s3select,!user-policy,!webidentity_test'"
             tests = "s3tests_boto3"
 
         cmd = f"{base_cmd} {extra_args} {tests}"
@@ -145,7 +205,7 @@ def execute_teardown(cluster: Ceph, build: str) -> None:
 def clone_s3_tests(node: CephNode, branch="ceph-luminous") -> None:
     """Clone the S3 repository on the given node."""
     repo_url = "https://github.com/ceph/s3-tests.git"
-    node.exec_command(sudo=True, cmd="if test -d s3-tests; then rm -r s3-tests; fi")
+    node.exec_command(cmd="if test -d s3-tests; then sudo rm -r s3-tests; fi")
     node.exec_command(cmd=f"git clone -b {branch} {repo_url}")
 
 
@@ -174,44 +234,78 @@ def install_s3test_requirements(node: CephNode, branch: str) -> None:
     _s3tests_req_bootstrap(node)
 
 
-def rgw_frontend_port(cluster: Ceph, build: str) -> str:
+def get_rgw_frontend(cluster: Ceph) -> Tuple:
     """
-    Return the configured port number of RadosGW.
+    Returns the RGW frontend information.
 
-    For prior versions of RHCS 5.0, the port number is determined using the ceph.conf
-    and for the higher versions, the value is retrieved from cephadm.
-
-    Note: In case of RHCS 5.0, we assume that the installer node is provided.
+    The frontend information is found by
+        - getting the config dump (or)
+        - reading the config file
 
     Args:
-        cluster:    The cluster participating in the test.
-        build:      RHCS version string.
+         cluster     The cluster participating in the test
 
     Returns:
-        port_number:    The configured port number
+         Tuple(str, bool, int)
+            lib         beast or civetweb
+            secure      True if secure else False
+            port        the configured port
     """
-    node = cluster.get_nodes(role="rgw")[0]
+    frontend_value = None
 
-    if build.startswith("5"):
+    try:
         node = cluster.get_nodes(role="client")[0]
-        # Allow realm & zone variability hence using config dump instead of config-key
-        cmd1 = "ceph config dump | grep client.rgw | grep port | head -n 1"
-        cmd2 = "cut -d '=' -f 2 | cut -d ' ' -f 1"
-        command = f"{cmd1} | {cmd2}"
-    else:
-        # To determine the configured port, the line must start with rgw frontends
-        # in ceph.conf. An example is given below,
-        #
+        out, err = node.exec_command(sudo=True, cmd="ceph config dump --format json")
+        configs = loads(out.read().decode())
+
+        for config in configs:
+            if config.get("name").lower() != "rgw_frontends":
+                continue
+
+            frontend_value = config.get("value").split()
+
+        # the command would work but may not have the required values
+        if not frontend_value:
+            raise AttributeError("Config has no frontend information. Trying conf file")
+
+    except BaseException as e:
+        log.debug(e)
+
+        # Process via config
+        node = cluster.get_nodes(role="rgw")[0]
+
         # rgw frontends = civetweb port=192.168.122.199:8080 num_threads=100
-        cmd1 = "grep -e '^rgw frontends' /etc/ceph/ceph.conf"
-        cmd2 = "cut -d ':' -f 2 | cut -d ' ' -f 1"
-        command = f"{cmd1} | {cmd2}"
+        command = "grep -e '^rgw frontends' /etc/ceph/ceph.conf"
+        out, err = node.exec_command(sudo=True, cmd=command)
+        out = out.read().decode()
+        key, sep, value = out.partition("=")
+        frontend_value = value.lstrip().split()
 
-    out, _ = node.exec_command(sudo=True, cmd=command)
-    return out.read().decode().strip()
+        if not frontend_value:
+            raise AttributeError("RGW frontend details not found in conf.")
+
+    lib = "beast" if "beast" in frontend_value else "civetweb"
+    secure = False
+    port = 80
+
+    # Double check the port number
+    for value in frontend_value:
+        if "port" in value:
+            port = value.split("=")[-1]
+            continue
+
+        if not secure and "ssl" in value.lower():
+            secure = True
+            continue
+
+        # support 4.x wherein conf has endpoint=x.x.x.x:port
+        if "endpoint" in value:
+            port = value.split(":")[-1]
+
+    return lib, secure, port
 
 
-def create_s3_user(node, display_name, email=False):
+def create_s3_user(node: CephNode, user_prefix: str, data: Dict) -> None:
     """
     Create a S3 user with the given display_name.
 
@@ -219,40 +313,52 @@ def create_s3_user(node, display_name, email=False):
 
     Args:
         node: node in the cluster to create the user on
-        display_name: display name for the new user
-        email: (optional) generate fake email address for user
+        user_prefix: Prefix to be added to the new user
+        data: a reference to the payload that needs to be updated.
 
     Returns:
         user_info dict
     """
     uid = binascii.hexlify(os.urandom(32)).decode()
+    display_name = f"{user_prefix}-user"
     log.info("Creating user: {display_name}".format(display_name=display_name))
 
     cmd = f"radosgw-admin user create --uid={uid} --display_name={display_name}"
-
-    if email:
-        cmd += " --email={email}@foo.bar".format(email=uid)
+    cmd += " --email={email}@foo.bar".format(email=uid)
 
     out, err = node.exec_command(sudo=True, cmd=cmd)
     user_info = json.loads(out.read().decode())
 
-    return user_info
+    data[user_prefix] = {
+        "id": user_info["keys"][0]["user"],
+        "access_key": user_info["keys"][0]["access_key"],
+        "secret_key": user_info["keys"][0]["secret_key"],
+        "name": user_info["display_name"],
+        "email": user_info["email"],
+    }
 
 
 def create_s3_conf(
-    cluster: Ceph, build: str, host: str, port: str, secure: str
+    cluster: Ceph,
+    build: str,
+    host: str,
+    port: str,
+    secure: bool,
+    kms_keyid: Optional[str] = None,
 ) -> None:
     """
     Generate the S3TestConf for test execution.
 
     Args:
-        cluster:    The cluster participating in the test
-        build:      The RHCS version string
-        host:       The RGW hostname to be set in the conf
-        port:       The RGW port number to be used in the conf
-        secure:     If the connection is secure or unsecure.
+        cluster     The cluster participating in the test
+        build       The RHCS version string
+        host        The RGW hostname to be set in the conf
+        port        The RGW port number to be used in the conf
+        secure      If the connection is secure or unsecure.
+        kms_keyid   key to be used for encryption
     """
     log.info("Creating the S3TestConfig file")
+    data = dict({"host": host, "port": int(port), "secure": secure})
 
     rgw_node = cluster.get_nodes(role="rgw")[0]
     client_node = cluster.get_nodes(role="client")[0]
@@ -260,60 +366,15 @@ def create_s3_conf(
     if build.startswith("5"):
         rgw_node = client_node
 
-    main_user = create_s3_user(node=rgw_node, display_name="main-user", email=True)
-    alt_user = create_s3_user(node=rgw_node, display_name="alt-user", email=True)
-    tenant_user = create_s3_user(node=rgw_node, display_name="tenant", email=True)
+    create_s3_user(node=rgw_node, user_prefix="main", data=data)
+    create_s3_user(node=rgw_node, user_prefix="alt", data=data)
+    create_s3_user(node=rgw_node, user_prefix="tenant", data=data)
 
-    _config = """
-[DEFAULT]
-host = {host}
-port = {port}
-is_secure = {secure}
+    if kms_keyid:
+        data["main"]["kms_keyid"] = kms_keyid
 
-[fixtures]
-bucket prefix = cephuser-{random}-
-
-[s3 main]
-user_id = {main_id}
-display_name = {main_name}
-access_key = {main_access_key}
-secret_key = {main_secret_key}
-email = {main_email}
-api_name = default
-
-[s3 alt]
-user_id = {alt_id}
-display_name = {alt_name}
-email = {alt_email}
-access_key = {alt_access_key}
-secret_key = {alt_secret_key}
-
-[s3 tenant]
-user_id = {tenant_id}
-display_name = {tenant_name}
-email = {tenant_email}
-access_key = {tenant_access_key}
-secret_key = {tenant_secret_key}""".format(
-        host=host,
-        port=port,
-        secure=secure,
-        random="{random}",
-        main_id=main_user["user_id"],
-        main_name=main_user["display_name"],
-        main_access_key=main_user["keys"][0]["access_key"],
-        main_secret_key=main_user["keys"][0]["secret_key"],
-        main_email=main_user["email"],
-        alt_id=alt_user["user_id"],
-        alt_name=alt_user["display_name"],
-        alt_email=alt_user["email"],
-        alt_access_key=alt_user["keys"][0]["access_key"],
-        alt_secret_key=alt_user["keys"][0]["secret_key"],
-        tenant_id=tenant_user["user_id"],
-        tenant_name=tenant_user["display_name"],
-        tenant_email=tenant_user["email"],
-        tenant_access_key=tenant_user["keys"][0]["access_key"],
-        tenant_secret_key=tenant_user["keys"][0]["secret_key"],
-    )
+    templ = Template(S3CONF)
+    _config = templ.render(data=data)
 
     conf_file = client_node.remote_file(file_name="s3-tests/config.yaml", file_mode="w")
     conf_file.write(_config)
@@ -331,22 +392,12 @@ def add_lc_debug(cluster: Ceph, build: str) -> None:
     Raises:
         CommandFailed:  Whenever a command returns a non-zero value part of the method.
     """
-    node = cluster.get_nodes(role="rgw")[0]
-    commands = [
-        "sed -i -e '$argw_lc_debug_interval = 10' /etc/ceph/ceph.conf",
-        "systemctl restart ceph-radosgw.target",
-    ]
-
+    log.debug("Setting the lifecycle interval for all RGW daemons")
     if build.startswith("5"):
-        node = cluster.get_nodes(role="client")[0]
-        rgw_service_name = _get_rgw_service_name(cluster)
-        commands = [
-            "ceph config set client.rgw.* rgw_lc_debug_interval 10",
-            f"ceph orch restart {rgw_service_name}",
-        ]
+        _rgw_lc_debug(cluster, add=True)
+        return
 
-    for cmd in commands:
-        node.exec_command(sudo=True, cmd=cmd)
+    _rgw_lc_debug_conf(cluster, add=True)
 
 
 def del_lc_debug(cluster: Ceph, build: str) -> None:
@@ -360,22 +411,12 @@ def del_lc_debug(cluster: Ceph, build: str) -> None:
     Raises:
         CommandFailed:  Whenever a command returns a non-zero value part of the method.
     """
-    node = cluster.get_nodes(role="rgw")[0]
-    commands = [
-        "sed -i '/rgw_lc_debug_interval/d' /etc/ceph/ceph.conf",
-        "systemctl restart ceph-radosgw.target",
-    ]
-
+    log.debug("Removing the lifecycle configuration")
     if build.startswith("5"):
-        node = cluster.get_nodes(role="client")[0]
-        rgw_service_name = _get_rgw_service_name(cluster)
-        commands = [
-            "ceph config rm client.rgw.* rgw_lc_debug_interval",
-            f"ceph orch restart {rgw_service_name}",
-        ]
+        _rgw_lc_debug(cluster, add=False)
+        return
 
-    for cmd in commands:
-        node.exec_command(sudo=True, cmd=cmd)
+    _rgw_lc_debug_conf(cluster, add=False)
 
 
 # Private functions
@@ -392,6 +433,9 @@ def _s3tests_req_install(node: CephNode) -> None:
         "libxslt-devel",
         "zlib-devel",
     ]
+    node.exec_command(
+        sudo=True, cmd="yum groupinstall -y 'Development Tools'", check_ec=False
+    )
     node.exec_command(
         sudo=True, cmd=f"yum install -y --nogpgcheck {' '.join(packages)}"
     )
@@ -411,11 +455,66 @@ def _s3tests_req_bootstrap(node: CephNode) -> None:
     node.exec_command(cmd="cd s3-tests; ./bootstrap")
 
 
-def _get_rgw_service_name(cluster: Ceph) -> str:
-    """Return the RGW service name."""
-    node = cluster.get_nodes(role="client")[0]
-    cmd_ = "ceph orch ls rgw --format json"
-    out, err = node.exec_command(sudo=True, cmd=cmd_)
+def _rgw_lc_debug_conf(cluster: Ceph, add: bool = True) -> None:
+    """
+    Modifies the LC debug config entry based on add being set or unset.
 
-    json_out = json.loads(out.read().decode().strip())
-    return json_out[0]["service_name"]
+    The LC debug value is set in ceph conf file
+
+    Args:
+        cluster     The cluster participating in the tests.
+        add         If set, the config flag is added else removed
+
+    Returns:
+        None
+    """
+    if add:
+        command = "sed -i -e '$argw lc debug interval = 10' /etc/ceph/ceph.conf"
+    else:
+        command = "sed -i '/rgw lc debug interval/d' /etc/ceph/ceph.conf"
+
+    command += " && systemctl restart ceph-radosgw.target"
+
+    for node in cluster.get_nodes(role="rgw"):
+        node.exec_command(sudo=True, cmd=command)
+
+    log.debug("Lifecycle dev configuration set to 10")
+
+
+def _rgw_lc_debug(cluster: Ceph, add: bool = True) -> None:
+    """
+    Modifies the Lifecycle interval parameter used for testing.
+
+    The configurable is enable if add is set else disabled. In case of CephAdm, the
+    value has to set for every daemon.
+
+    Args:
+        cluster     The cluster participating in the test
+        add         If set adds the configurable else unsets it.
+
+    Returns:
+        None
+    """
+    node = cluster.get_nodes(role="client")[0]
+
+    out, err = node.exec_command(
+        sudo=True, cmd="ceph orch ps --daemon_type rgw --format json"
+    )
+    rgw_daemons = [f"client.rgw.{x['daemon_id']}" for x in loads(out.read().decode())]
+
+    out, err = node.exec_command(
+        sudo=True, cmd="ceph orch ls --service_type rgw --format json"
+    )
+    rgw_services = [x["service_name"] for x in loads(out.read().decode())]
+
+    # Set (or) Unset the lc_debug_interval for all daemons
+    for daemon in rgw_daemons:
+        if add:
+            command = f"ceph config set {daemon} rgw_lc_debug_interval 10"
+        else:
+            command = f"ceph config rm {daemon} rgw_lc_debug_interval"
+
+        node.exec_command(sudo=True, cmd=command)
+
+    for service in rgw_services:
+        node.exec_command(sudo=True, cmd=f"ceph orch restart {service}")


### PR DESCRIPTION
# Description

This PR adds support for encryption tests available in the external S3Tests. In order to execute the tests downstream, the following changes are implemented via this PR

- adds support for vault agent deployment using agent authentication with transit engine.
- Reads the global `cephci.yaml` for vault agent configuration
- adds a separate s3 ssl test suite due to the dependency with vault
- enhances the `test_s3` module to support added configuration by using `jinja2` template to create the test conf
- Fixes the way we use `lc_debug_interval` allowing us to add lifecycle tests
- `fails_on_aws` allows us to ignore the ACL failures seen.

__Logs__
5x-SSL - Happy path: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/t2_s3/ssl/
5x-noSSL - http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/t2_s3/5x_nossl/
4x-noSSL - http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/t2_s3/4x_nossl/

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>