### PR TITLE
Fix 4x tier1 rgw Multisite pipeline

### DIFF
--- a/pipeline/4/Jenkinsfile-tier-1-object.groovy
+++ b/pipeline/4/Jenkinsfile-tier-1-object.groovy
@@ -71,9 +71,7 @@ node(nodeName) {
             "sutVMConf=conf/inventory/rhel-8.4-server-x86_64.yaml",
             "sutConf=conf/${cephVersion}/rgw/tier_1_rgw_multisite.yaml",
             "testSuite=suites/${cephVersion}/rgw/tier_1_rgw_multisite_secondary_to_primary.yaml",
-            "addnArgs=--post-results --log-level DEBUG",
-            "composeUrl=${defaultRHEL7BaseUrl}",
-            "rhcephVersion=${defaultRHEL7Build}"
+            "addnArgs=--post-results --log-level DEBUG"
         ]) {
             sharedLib.runTestSuite()
         }


### PR DESCRIPTION
In this case not suppose to pass below variable to stage:
"composeUrl=${defaultRHEL7BaseUrl}",
"rhcephVersion=${defaultRHEL7Build}"

since inventory used was "rhel8"

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%204%20QE/job/rhceph-4-tier-1-object/39/consoleFull


Signed-off-by: ckulal <ckulal@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
