### PR TITLE
Moving to element contains in pipeline

### DIFF
--- a/pipeline/vars/common.groovy
+++ b/pipeline/vars/common.groovy
@@ -41,14 +41,12 @@ def getCvpVariable() {
     /*
         Returns the cvp variable after processing the CI message
     */
-    def ciMessage = "${params.CI_MESSAGE}" ?: ""
-    def cvp
-    if (! ciMessage?.trim() ) {
-        cvp = false
-    } else {
-        cvp = ciMessage.CVP ?: false
+    def ciMap = getCIMessageMap()
+    if (ciMap.containsKey("CVP")) {
+        return ciMap.CVP
     }
-    return cvp
+
+    return false
 }
 
 def getCLIArgsFromMessage() {


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

## Error
```
No such property: CVP for class: org.codehaus.groovy.runtime.GStringImpl
```

# Fix

The pipeline is broken due to missing `CVP` key. Opting to use `map.containsKey` to determine the value of that particular key.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%205%20QE/job/rhceph-5-tier-0/303/console