### PR TITLE
Using add-osd for scaling up OSD is deprecated

### DIFF
--- a/tests/ceph_ansible/test_ansible_roll_over.py
+++ b/tests/ceph_ansible/test_ansible_roll_over.py
@@ -127,7 +127,6 @@ def run(ceph_cluster, **kw):
         "3": {"mon": "%s" % yaml, "osd": "add-osd.yml"},
         "4": {
             "mon": "infrastructure-playbooks/add-mon.yml",
-            "osd": "infrastructure-playbooks/add-osd.yml",
         },
     }
     yaml_file = yaml_dict[build_starts].get(daemon, "%s --limit %ss" % (yaml, daemon))


### PR DESCRIPTION
add-osd.yml should be avoided to scale up the cluster

Closes : RHCEPHQE-341
Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
