### PR TITLE
Update git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ result.props
 *.log
 
 # ignore cephci execution residues
-*osd_scenarios_ceph*-osd
+osd_scenarios_*node*
+version_info.json
 rerun


### PR DESCRIPTION
- Update git ignore file to ignore `osd_scenario_` file created by rollover tests and other files.