### PR TITLE
Added fix for others VM getting deleted if mentioned instance name is available as part of existing instances

### DIFF
--- a/run.py
+++ b/run.py
@@ -164,7 +164,8 @@ def create_nodes(
         )
 
     log.info("Destroying existing osp instances..")
-    cleanup_ceph_nodes(osp_cred, instances_name)
+    instance_name = f"-{instances_name}-"
+    cleanup_ceph_nodes(osp_cred, instance_name)
     ceph_cluster_dict = {}
 
     log.info("Creating osp instances")


### PR DESCRIPTION
Added fix for others VM getting deleted if mentioned instance name is available as part of existing instances

Example:

If there is a set of VMs available in the name of s3cmd and if instance name is given as cmd, all VMs with the name s3cmd also getting destroyed.