### PR TITLE
rgw: add external IO config 

### DIFF
--- a/suites/nautilus/rgw/tier_1_rgw_multisite_primary_to_secondary.yaml
+++ b/suites/nautilus/rgw/tier_1_rgw_multisite_primary_to_secondary.yaml
@@ -1,8 +1,6 @@
-#Below are the multi-site test scenarios run on the master and verified the sync on the slave
-
-#where :
-#ceph-rgw1 is master/primary site
-#ceph-rgw2 is slave/secondary site
+# Below are the multi-site test scenarios run on the master and verified the sync/io on the slave
+# ceph-rgw1 is master/primary site
+# ceph-rgw2 is slave/secondary site
 
 tests:
   - test:

--- a/suites/nautilus/rgw/tier_1_rgw_multisite_secondary_to_primary.yaml
+++ b/suites/nautilus/rgw/tier_1_rgw_multisite_secondary_to_primary.yaml
@@ -1,3 +1,7 @@
+# Below are the multi-site test scenarios run on the secondary and verified the sync/io on the primary
+# ceph-rgw1 is master/primary site
+# ceph-rgw2 is slave/secondary site
+
 tests:
   - test:
       name: pre-req


### PR DESCRIPTION
Support to add rgw external IO config in RGW suites. 
we can now add IO config in rgw suites ( refer structure from ceph-qe-scripts/rgw)

[Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LBT4BT)