### PR TITLE
/pipeline/vars/lib.groovy: Fix CpsCompilationErrorsException issue

### DIFF
--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -147,8 +147,8 @@ def compareCephVersion(def oldCephVer, def newCephVer){
 
     if (newCephVer == oldCephVer){return 0}
 
-    def oldVer = oldCephVer.split("\\.|-")*.toInteger()
-    def newVer= newCephVer.split("\\.|-")*.toInteger()
+    def oldVer = oldCephVer.split("\\.|-").collect { it.toInteger() }
+    def newVer = newCephVer.split("\\.|-").collect { it.toInteger() }
 
     if (newVer[0] > oldVer[0]){return 1}
     else if (newVer[0] < oldVer[0]){return -1}


### PR DESCRIPTION
/pipeline/vars/lib.groovy: Fix CpsCompilationErrorsException issue
**Issue:**
``` 
org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException: startup failed:
Script1.groovy: 150: spread not yet supported for CPS transformation @ line 150, column 18.
       def oldVer = oldCephVer.split("\\.|-")*.toInteger()
                    ^

Script1.groovy: 151: spread not yet supported for CPS transformation @ line 151, column 17.
       def newVer= newCephVer.split("\\.|-")*.toInteger()
                   ^

2 errors

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
```

**Solution:**
```
def ver = "16.2.0-117"

ver = ver.split("\\.|-")
println  ver[0].getClass()

ver = ver.collect { it.toInteger() }
println ver[0].getClass()

Result:
---------
class java.lang.String
class java.lang.Integer
```
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/rhceph-generic-tier-0/17/console

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

