### PR TITLE
Adding support for Multisite having RGW SSL endpoint

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -458,7 +458,7 @@ def setup_deb_cdn_repo(node, build=None):
     node.exec_command(sudo=True, cmd="apt-get update")
 
 
-def update_ca_cert(node, cert_url, out_file, timeout=120):
+def update_ca_cert(node, cert_url, out_file, timeout=120, check_ec=True):
     """
     Update CA cert in the nodes.
       by default options picked for RHEL platforms
@@ -468,6 +468,7 @@ def update_ca_cert(node, cert_url, out_file, timeout=120):
         cert_url: path to download certificate
         out_file: output file name
         timeout: timeout in seconds
+        check_ec: bool by default true, checks the error code
     """
     output_dir = "/etc/pki/ca-trust/source/anchors/"
     update_cmd = "update-ca-trust extract"
@@ -482,6 +483,7 @@ def update_ca_cert(node, cert_url, out_file, timeout=120):
             sudo=True,
             cmd=cmd,
             timeout=timeout,
+            check_ec=check_ec,
         )
 
 

--- a/pipeline/5/Jenkinsfile-tier-2-object-regression.groovy
+++ b/pipeline/5/Jenkinsfile-tier-2-object-regression.groovy
@@ -59,4 +59,15 @@ node(nodeName) {
         }
     }
 
+    stage('MultiSite with Secure Endpoint') {
+        withEnv([
+            "sutVMConf=conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml",
+            "sutConf=conf/${cephVersion}/rgw/rgw_mutlisite.yaml",
+            "testSuite=suites/${cephVersion}/rgw/tier_2_rgw_ssl_multisite_verify_io_from_primary.yaml",
+            "addnArgs=--post-results --log-level debug"
+        ]) {
+            sharedLib.runTestSuite()
+        }
+    }
+
 }

--- a/suites/pacific/rgw/tier_2_rgw_ssl_multisite_verify_io_from_primary.yaml
+++ b/suites/pacific/rgw/tier_2_rgw_ssl_multisite_verify_io_from_primary.yaml
@@ -1,0 +1,525 @@
+# Test suite for evaluating RGW multi-site having SSL endpoints.
+#
+# This suite deploys a single realm (India) spanning across two RHCS clusters. It has a
+# zonegroup (shared) which also spans across the clusters. There exists a master (pri)
+# and secondary (sec) zones within this group. The master zone is part of the pri
+# cluster whereas the sec zone is part of the sec datacenter (cluster).
+
+# The deployment is evaluated by running IOs across the environments.
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply_spec
+                  service: orch
+                  specs:
+                    - service_type: rgw
+                      service_id: shared.pri
+                      spec:
+                        ssl: true
+                        rgw_frontend_ssl_certificate: create-cert
+                      placement:
+                        nodes:
+                          - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply_spec
+                  service: orch
+                  specs:
+                    - service_type: rgw
+                      service_id: shared.sec
+                      placement:
+                        nodes:
+                          - node5
+                      spec:
+                        ssl: true
+                        rgw_frontend_ssl_certificate: create-cert
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints https://{node_ip:node5} --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints https://{node_ip:node5} --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph config set client.rgw rgw_verify_ssl False"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints https://{node_ip:node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw rgw_verify_ssl False"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+              - "sleep 120"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create user
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            config-file-name: test_Mbuckets_with_Nobjects.yaml
+            script-name: test_Mbuckets_with_Nobjects.py
+            timeout: 300
+            verify-io-on-site: [ "ceph-pri" ]
+      desc: Execute M buckets with N objects on secondary cluster
+      module: sanity_rgw_multisite.py
+      name: m buckets with n objects
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_compression on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_aws4 on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_delete on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_download on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_enc on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_multipart on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_sharding on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_unordered.yaml on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_copy_objects on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_copy_objects.py
+            config-file-name: test_versioning_copy_objects.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_enable on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_enable.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_acls on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_acls.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_copy on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_copy.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_delete on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_delete.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_enable on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_enable.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_suspend on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_suspend.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+
+  - test:
+      name: LargeObjGet_GC test
+      desc: test_LargeObjGet_GC on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_LargeObjGet_GC.py
+            config-file-name: test_LargeObjGet_GC.yaml
+            timeout: 300
+
+  - test:
+      name: create user
+      desc: create tenanted user
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_modify.yaml on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_modify.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_delete.yaml on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_delete.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_replace on secondary
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_replace.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300

--- a/tests/misc_env/exec.py
+++ b/tests/misc_env/exec.py
@@ -112,11 +112,12 @@ def translate_to_service_name(node, string: str) -> str:
     """
     replaced_string = string
     names = re.findall("{service_name:(.+?)}", string)
+    cmd = "ceph orch ls --format json"
 
-    out, _ = exec_command(
-        node, sudo=True, cmd="cephadm shell -- ceph orch ls --format json"
-    )
+    if "installer" in node.role:
+        cmd = f"cephadm shell {cmd}"
 
+    out, _ = exec_command(node, sudo=True, cmd=cmd)
     services_dict = json.loads(out)
 
     for name in names:
@@ -147,11 +148,12 @@ def translate_to_daemon_id(node, string: str) -> str:
     """
     replaced_string = string
     ids_ = re.findall("{daemon_id:(.+?)}", string)
+    cmd = "ceph orch ps --format json"
 
-    out, _ = exec_command(
-        node, sudo=True, cmd="cephadm shell -- ceph orch ps --format json"
-    )
+    if "installer" in node.role:
+        cmd = f"cephadm shell {cmd}"
 
+    out, _ = exec_command(node, sudo=True, cmd=cmd)
     daemon_details = json.loads(out)
 
     for id_ in ids_:
@@ -203,6 +205,7 @@ def run(ceph_cluster, **kwargs: Any) -> int:
     """
     LOG.info("Executing command")
     config = kwargs["config"]
+    build = config.get("build", config.get("rhbuild"))
 
     command = config.get("cmd")
     LOG.warning("Usage of cmd is deprecated instead use commands.")
@@ -230,7 +233,8 @@ def run(ceph_cluster, **kwargs: Any) -> int:
             sudo = True
             long_running = False
 
-            # Reconstruct cephadm specific lookups
+        # Reconstruct cephadm specific lookups
+        if not build.startswith("4"):
             cmd = translate_to_daemon_id(node, cmd)
             cmd = translate_to_service_name(node, cmd)
 

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -79,6 +79,14 @@ def install_prereq(
         cert_url="https://password.corp.redhat.com/RH-IT-Root-CA.crt",
         out_file="RH-IT-Root-CA.crt",
     )
+
+    # Update CephCI Cert to all nodes. Useful when creating self-signed certificates.
+    update_ca_cert(
+        node=ceph,
+        cert_url="http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem",
+        out_file="cephqe-ca.pem",
+        check_ec=False,
+    )
     distro_info = ceph.distro_info
     distro_ver = distro_info["VERSION_ID"]
     log.info("distro name: {name}".format(name=distro_info["NAME"]))

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -9,7 +9,8 @@ import traceback
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from string import ascii_uppercase, digits
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
+from urllib import request
 
 import requests
 import yaml
@@ -943,6 +944,24 @@ def generate_node_name(cluster_name, instance_name, run_id, node, role):
     return node_name
 
 
+def get_cephqe_ca() -> Optional[Tuple]:
+    """Retrieve CephCI QE CA certificate and key."""
+    base_uri = "http://magna002.ceph.redhat.com/cephci-jenkins"
+    ca_cert = None
+    ca_key = None
+
+    try:
+        with request.urlopen(url=f"{base_uri}/.cephqe-ca.pem") as fd:
+            ca_cert = crypto.load_certificate(crypto.FILETYPE_PEM, fd.read())
+
+        with request.urlopen(url=f"{base_uri}/.cephqe-ca.key") as fd:
+            ca_key = crypto.load_privatekey(crypto.FILETYPE_PEM, fd.read())
+    except BaseException as be:
+        log.debug(be)
+
+    return ca_key, ca_cert
+
+
 def generate_self_signed_certificate(subject: Dict) -> Tuple:
     """
     Create and return a self-signed certificate using the provided subject information.
@@ -951,11 +970,15 @@ def generate_self_signed_certificate(subject: Dict) -> Tuple:
         subject     Dictionary holding the certificate subject key/value pair
 
     Returns:
-        cert, key   Tuple as strings
+        device_key, device_cert, ca_cert   Tuple as strings
     """
+    ca_key, ca_cert = get_cephqe_ca()
+
+    # Generate the private key
     keyout = crypto.PKey()
     keyout.generate_key(crypto.TYPE_RSA, 2048)
 
+    # Create CSR
     cert = crypto.X509()
     cert.get_subject().C = subject.get("country", "IN")
     cert.get_subject().ST = subject.get("state", "Karnataka")
@@ -963,14 +986,46 @@ def generate_self_signed_certificate(subject: Dict) -> Tuple:
     cert.get_subject().O = subject.get("company", "Red Hat Inc")
     cert.get_subject().OU = subject.get("department", "Storage")
     cert.get_subject().CN = subject["common_name"]
-    cert.set_serial_number(1000)
+    cert.set_serial_number(random.randint(200, 50000))
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
+
+    extensions = [
+        crypto.X509Extension(
+            b"keyUsage", False, b"Digital Signature, Non Repudiation, Key Encipherment"
+        ),
+        crypto.X509Extension(b"basicConstraints", False, b"CA:FALSE"),
+        crypto.X509Extension(b"extendedKeyUsage", False, b"serverAuth, clientAuth"),
+        crypto.X509Extension(
+            b"subjectAltName", False, f"IP:{subject['ip_address']}".encode()
+        ),
+    ]
+    cert.add_extensions(extensions)
+
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(keyout)
     cert.sign(keyout, "sha256")
 
+    # Sign CSR
+    if ca_cert and ca_key:
+        signed_cert = crypto.X509()
+        signed_cert.set_serial_number(random.randint(10, 10000))
+        signed_cert.gmtime_adj_notBefore(0)
+        signed_cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
+        signed_cert.set_subject(cert.get_subject())
+        signed_cert.add_extensions(extensions)
+        signed_cert.set_issuer(ca_cert.get_subject())
+        signed_cert.set_pubkey(cert.get_pubkey())
+        signed_cert.sign(ca_key, "sha256")
+
+        return (
+            crypto.dump_privatekey(crypto.FILETYPE_PEM, keyout).decode("utf-8"),
+            crypto.dump_certificate(crypto.FILETYPE_PEM, signed_cert).decode("utf-8"),
+            crypto.dump_certificate(crypto.FILETYPE_PEM, ca_cert).decode("utf-8"),
+        )
+
     return (
-        crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"),
         crypto.dump_privatekey(crypto.FILETYPE_PEM, keyout).decode("utf-8"),
+        crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode("utf-8"),
+        "",
     )


### PR DESCRIPTION
# Description

In this PR, the following support is being added
- support self-signed certificate signing using CephCI self CA
- coping the CephCI's CA to all the nodes in SUT by default.
- support deployment of MS with SSL endpoint

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [x] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test

# Logs
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/ms_ssl/

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>