### PR TITLE
Listener job for updating UMB message of Signed Release Candidate

### DIFF
--- a/pipeline/signed-compose-listener.groovy
+++ b/pipeline/signed-compose-listener.groovy
@@ -1,0 +1,100 @@
+/*
+    Pipeline script for signed/rc compose listener
+*/
+// Global variables section
+def nodeName = "centos-7"
+def sharedLib
+def versions
+def cephVersion
+def composeUrl
+
+// Pipeline script entry point
+node(nodeName) {
+    timeout(unit: "MINUTES", time: 30) {
+        stage('Install prereq') {
+            if (env.WORKSPACE) {
+                deleteDir() }
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'SubmoduleOption',
+                    disableSubmodules: false,
+                    parentCredentials: false,
+                    recursiveSubmodules: true,
+                    reference: '',
+                    trackingSubmodules: false]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git']]
+            ])
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+            sharedLib.prepareNode()
+        }
+    }
+
+    stage("Update Release File") {
+        def cimsg = sharedLib.getCIMessageMap()
+        versions = sharedLib.fetchMajorMinorOSVersion("signed-compose")
+        def composePath = cimsg["compose-path"].replace("/mnt/redhat/", "")
+        composeUrl = "http://download-node-02.eng.bos.redhat.com/${composePath}".toString()
+        cephVersion = sharedLib.fetchCephVersion(composeUrl)
+        def location = "/ceph/cephci-jenkins/latest-rhceph-container-info"
+        def fileName = "RHCEPH-${versions.major_version}.${versions.minor_version}.yaml"
+        def fileExists = sh (returnStatus: true, script: "ls -l ${location}/${fileName}")
+        if (fileExists != 0) {
+            currentBuild.result = 'ABORTED'
+            error "File:${fileName} does not exist...." }
+        def content = sharedLib.readFromReleaseFile(versions.major_version, versions.minor_version)
+        if (content["rc"]) {
+            def resp = sharedLib.compareCephVersion(content["rc"]["ceph-version"], cephVersion)
+            if (resp == -1) {
+                sharedLib.unSetLock(versions.major_version, versions.minor_version)
+                currentBuild.result = 'ABORTED'
+                error "Higher version of ceph already exist...." }
+            content["rc"]["ceph-version"] = cephVersion
+            content["rc"]["compose-label"] = cimsg["compose-label"]
+            if (content["rc"]["composes"][versions["platform"]]) {
+                content["rc"]["composes"][versions["platform"]] = composeUrl }
+            else {
+                def platform = ["${versions.platform}": composeUrl]
+                content["rc"]["composes"] += platform }
+        }
+        else {
+            def updateContent = [
+                "rc": [
+                    "ceph-version": cephVersion,
+                    "compose-label": cimsg["compose-label"],
+                    "composes": [
+                        "${versions.platform}": composeUrl]]]
+            content += updateContent }
+        sharedLib.writeToReleaseFile(versions.major_version, versions.minor_version, content)
+        println "Content Updated To FILE:${fileName} Successfully"
+    }
+
+    stage('Publish UMB') {
+        def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
+        println "Update UMB Message In Topic:${overrideTopic}"
+        def contentMap = [
+            "artifact": [
+                "build_action": "rc",
+                "name": "Red Hat Ceph Storage",
+                "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
+                "phase": "rc",
+                "type": "product-build",
+                "version": cephVersion],
+            "build": [
+                "compose-url": composeUrl],
+            "contact": [
+                "email": "ceph-qe@redhat.com",
+                "name": "Downstream Ceph QE"],
+            "run": [
+                "log": "${env.BUILD_URL}console",
+                "url": env.BUILD_URL],
+            "version": "1.0.0"]
+        def msgContent = writeJSON returnText: true, json: contentMap
+        sharedLib.SendUMBMessage(msgContent, overrideTopic, "ProductBuildDone")
+        println "Updated UMB Message Successfully"
+    }
+}


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Listener job for updating UMB message of Signed Release Candidate

updated umb message : 
   https://datagrepper.engineering.redhat.com/id?id=ID:ceph-downstream-jenkins-csb-storage-35341-1630500887382-1779:1:1:1:1&is_raw=true&size=extra-large

Scenarios tested:
1. file does not exist -- abort (https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/testing-anrao/6/console)

2.  release file has no attribute "rc" - update all content (https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/testing-anrao/7/console)

3. release file has attribute "rc" but older ceph-version is greater than new -- abort  (https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/testing-anrao/5/console)

4. release file has attribute "rc" but platform previously updated was rhel-7 now updating rhel-8 (https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/testing-anrao/3/console)

5. release file has attribute "rc" but old ceph-version is equal/lesser than new one (https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/testing-anrao/4/console)


# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
