### PR TITLE
Modified the suite to enable dashboard in multisite

### DIFF
--- a/suites/nautilus/rgw/sanity_rgw_multisite.yaml
+++ b/suites/nautilus/rgw/sanity_rgw_multisite.yaml
@@ -22,7 +22,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -59,7 +67,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description

Added dashboard enable chnages in **sanity_rgw_multisite.yaml** suite,
so that It helps to perform dashboard related tests on rgw-multisite set up.

_CLI used to run this suite_
```python run.py --rhbuild 4.3-rhel-8 --global-conf conf/nautilus/rgw/tier_1_rgw_multisite.yaml --osp-cred osp/osp-cred-ci-2.yaml --inventory conf/inventory/rhel-8.3-server-x86_64.yaml --suite suites/nautilus/rgw/sanity_rgw_multisite.yaml --log-level info --rhs-ceph-repo http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-4.3-rhel-8/latest-RHCEPH-4-RHEL-8/ --instances-name multi --store```
