### PR TITLE
Moving to shallow clone

### DIFF
--- a/pipeline/signed-container-image-listener.groovy
+++ b/pipeline/signed-container-image-listener.groovy
@@ -1,82 +1,79 @@
-/*
-    Pipeline script for signed/rc compose listener
-*/
+// Script to update the container build information into QE recipes.
 // Global variables section
 def nodeName = "centos-7"
 def sharedLib
 def versions
 def cephVersion
 def composeUrl
+def containerImage
 
 // Pipeline script entry point
 node(nodeName) {
+
     timeout(unit: "MINUTES", time: 30) {
-        stage('Install prereq') {
-            if (env.WORKSPACE) {
-                deleteDir() }
+        stage('Preparing') {
+            if (env.WORKSPACE) { deleteDir()  }
             checkout([
                 $class: 'GitSCM',
-                branches: [[name: '*/master']],
+                branches: [[ name: '*/master' ]],
                 doGenerateSubmoduleConfigurations: false,
                 extensions: [[
-                    $class: 'SubmoduleOption',
-                    disableSubmodules: false,
-                    parentCredentials: false,
-                    recursiveSubmodules: true,
+                    $class: 'CloneOption',
+                    shallow: true,
+                    noTags: false,
                     reference: '',
-                    trackingSubmodules: false]],
+                    depth: 0
+                ]],
                 submoduleCfg: [],
                 userRemoteConfigs: [[
-                    url: 'https://github.com/red-hat-storage/cephci.git']]
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
             ])
             sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
-            sharedLib.prepareNode()
+            sharedLib.prepareNode(1)
         }
     }
 
-    stage("Update Release File") {
-        def cimsg = sharedLib.getCIMessageMap()
+    stage("Updating") {
         versions = sharedLib.fetchMajorMinorOSVersion("signed-container-image")
+        def majorVersion = versions.major_version
+        def minorVersion = versions.minor_version
+
+        def cimsg = sharedLib.getCIMessageMap()
         def repoDetails = cimsg.build.extra.image
-        def containerImage = repoDetails.index.pull.find({x -> !(x.contains("sha"))})
-        def repoUrl = repoDetails.yum_repourls.find({x -> x.contains("Tools")})
-        composeUrl = repoUrl.split("work").find({x -> x.contains("RHCEPH-${versions.major_version}.${versions.minor_version}")})
+
+        containerImage = repoDetails.index.pull.find({ x -> !(x.contains("sha")) })
+
+        def repoUrl = repoDetails.yum_repourls.find({ x -> x.contains("Tools") })
+        composeUrl = repoUrl.split("work").find({
+            x -> x.contains("RHCEPH-${majorVersion}.${minorVersion}")
+        })
         println "repo url : ${composeUrl}"
+
         cephVersion = sharedLib.fetchCephVersion(composeUrl)
-        def fileName = "RHCEPH-${versions.major_version}.${versions.minor_version}.yaml"
-        def content = sharedLib.readFromReleaseFile(versions.major_version, versions.minor_version)
-        if(!content)
-        {
-            sharedLib.unSetLock(versions.major_version, versions.minor_version)
-            currentBuild.result = 'ABORTED'
-            error "File:${fileName} does not exist...."
+        def releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
+
+        if ( releaseMap.isEmpty() || !releaseMap?.rc?."ceph-version" ) {
+            sharedLib.unSetLock(majorVersion, minorVersion)
+            currentBuild.result = "ABORTED"
+            error "Unable to retrieve release build recipes."
         }
-        if (content["rc"]) {
-            def resp = sharedLib.compareCephVersion(content["rc"]["ceph-version"], cephVersion)
-            if (resp != 0) {
-                sharedLib.unSetLock(versions.major_version, versions.minor_version)
-                currentBuild.result = 'ABORTED'
-                error "Higher version of ceph already exist...." }
-            if (content["rc"]["repository"]) {
-            content["rc"]["repository"] = containerImage
-            }
-            else{
-            def repository = ["repository" : containerImage]
-            content["rc"] += repository
-            }
-            }
-        else {
-                sharedLib.unSetLock(versions.major_version, versions.minor_version)
-                currentBuild.result = 'ABORTED'
-                error "No RC Contents present in yaml file"
-                }
-        sharedLib.writeToReleaseFile(versions.major_version, versions.minor_version, content)
-        println "Content Updated To FILE:${fileName} Successfully"
+
+        def currentCephVersion = releaseMap.rc."ceph-version"
+        def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
+        if ( compare != 0 ) {
+            sharedLib.unSetLock(majorVersion, minorVersion)
+            println "Current Ceph Version : ${currentCephVersion}"
+            println "New Ceph Version : ${cephVersion}"
+        }
+
+        releaseMap.rc.repository = containerImage
+        sharedLib.writeToReleaseFile(majorVersion, minorVersion, releaseMap)
+
+        println "Success: Updated below information \n ${releaseMap}"
     }
 
-    stage('Publish UMB') {
-        def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
-        println "Update UMB Message In Topic:${overrideTopic}"
+    stage('Publishing') {
         def contentMap = [
             "artifact": [
                 "build_action": "rc",
@@ -84,17 +81,24 @@ node(nodeName) {
                 "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
                 "phase": "rc",
                 "type": "product-build",
-                "version": cephVersion],
+                "version": cephVersion
+            ],
             "build": [
-                "compose-url": composeUrl],
+                "repository": containerImage
+            ],
             "contact": [
                 "email": "ceph-qe@redhat.com",
-                "name": "Downstream Ceph QE"],
+                "name": "Downstream Ceph QE"
+            ],
             "run": [
                 "log": "${env.BUILD_URL}console",
-                "url": env.BUILD_URL],
-            "version": "1.0.0"]
+                "url": env.BUILD_URL
+            ],
+            "version": "1.0.0"
+        ]
         def msgContent = writeJSON returnText: true, json: contentMap
+        def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
+
         sharedLib.SendUMBMessage(msgContent, overrideTopic, "ProductBuildDone")
         println "Updated UMB Message Successfully"
     }


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Moving the signed compose/container image scripts to use `shallow clone` with minor code changes. Also prevents the compose listener from triggering tier-0.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-signed-container-image-listener/46/console
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-signed-compose-listener/2/console
