### PR TITLE
/misc-env/exec.py:Fix translate definition issue

### DIFF
--- a/tests/misc_env/exec.py
+++ b/tests/misc_env/exec.py
@@ -112,6 +112,8 @@ def translate_to_service_name(node, string: str) -> str:
     """
     replaced_string = string
     names = re.findall("{service_name:(.+?)}", string)
+    if not names:
+        return replaced_string
     cmd = "ceph orch ls --format json"
 
     if "installer" in node.role:
@@ -148,6 +150,8 @@ def translate_to_daemon_id(node, string: str) -> str:
     """
     replaced_string = string
     ids_ = re.findall("{daemon_id:(.+?)}", string)
+    if not ids_:
+        return replaced_string
     cmd = "ceph orch ps --format json"
 
     if "installer" in node.role:


### PR DESCRIPTION
- Fix issue with translate definition, which returns orchestration command as prefix even when there is no matches.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ELHXQU/check-ceph-health_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G7DXKR/check-ceph-health_0.log

**Solution:** Return same command if no matches.

**Test case:**
```
- test:
    name: check-ceph-health
    module: exec.py
    config:
      cmd: ceph -s
      sudo: True
    desc: Check for ceph health debug info
```
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1DNNMS

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

