### PR TITLE
Disabling SSL verification by default

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -867,7 +867,7 @@ class Ceph(object):
             str:  iso file url
         """
         iso_file_path = base_url + "compose/Tools/x86_64/iso/"
-        iso_dir_html = requests.get(iso_file_path, timeout=10).content
+        iso_dir_html = requests.get(iso_file_path, timeout=10, verify=False).content
         match = re.search('<a href="(.*?)">(.*?)-x86_64-dvd.iso</a>', iso_dir_html)
         iso_file_name = match.group(1)
         logger.info("Using {}".format(iso_file_name))
@@ -889,7 +889,7 @@ class Ceph(object):
         for repo in repos:
             base_url = base_url.rstrip("/")
             repo_to_use = f"{base_url}/compose/{repo}/x86_64/os"
-            r = requests.get(repo_to_use, timeout=10)
+            r = requests.get(repo_to_use, timeout=10, verify=False)
             logger.info("Checking %s", repo_to_use)
             if r.status_code == 200:
                 logger.info("Using %s", repo_to_use)

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -842,7 +842,7 @@ def fetch_build(version, custom_build):
     builds = fetch_image_builds(version)
 
     def get_build_details(build):
-        build = requests.get(f"{DEFAULT_OSBS_SERVER}{build.name}").json()
+        build = requests.get(f"{DEFAULT_OSBS_SERVER}{build.name}", verify=False).json()
         return build.get("compose_url"), build.get("repository")
 
     # To fetch (N-1) ceph image and build compose

--- a/run.py
+++ b/run.py
@@ -483,12 +483,12 @@ def run(args):
 
         # get COMPOSE ID and ceph version
         if build not in ["released", "cvp"]:
-            id = requests.get(base_url + "/COMPOSE_ID")
+            id = requests.get(base_url + "/COMPOSE_ID", verify=False)
             compose_id = id.text
 
             if "rhel" == inventory.get("id"):
                 ceph_pkgs = requests.get(
-                    base_url + "/compose/Tools/x86_64/os/Packages/"
+                    base_url + "/compose/Tools/x86_64/os/Packages/", verify=False
                 )
                 m = re.search(r"ceph-common-(.*?).x86", ceph_pkgs.text)
                 ceph_version.append(m.group(1))

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -591,7 +591,7 @@ def get_latest_container(version):
     url = "http://magna002.ceph.redhat.com/cephci-jenkins/latest-rhceph-container-info/latest-RHCEPH-{}.json".format(
         version
     )
-    data = requests.get(url)
+    data = requests.get(url, verify=False)
     docker_registry, docker_tag = data.json()["repository"].split("/rh-osbs/rhceph:")
     docker_image = "rh-osbs/rhceph"
     return {
@@ -1052,7 +1052,7 @@ def fetch_build_artifacts(build, ceph_version, platform):
         base_url, container_registry, image-name, image-tag
     """
     url = f"{magna_rhcs_artifacts}RHCEPH-{ceph_version}.yaml"
-    data = requests.get(url)
+    data = requests.get(url, verify=False)
     yml_data = yaml.safe_load(data.text)
 
     build_info = yml_data.get(build)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Disable SSL verification by default in all the request HTTP methods being used in cephci. Mostly, we use self-signed certificates for our testing hence the PR allows us to avoid SSL_CERTIFICATE error being thrown in those cases.

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/ssl_false/