### PR TITLE
added purge dashboard test

### DIFF
--- a/suites/nautilus/ansible/sanity_ceph_ansible.yaml
+++ b/suites/nautilus/ansible/sanity_ceph_ansible.yaml
@@ -290,6 +290,12 @@ tests:
       desc: shrink osd
 
    - test:
+      name: Purge ceph dashboard
+      polarion-id: CEPH-83573277
+      module: purge_dashboard.py
+      desc: Purges ceph dashboard
+
+   - test:
       name: ceph ansible purge
       polarion-id: CEPH-83571498
       module: purge_cluster.py

--- a/suites/nautilus/dashboard/sanity_containerized_ceph_dashboard.yaml
+++ b/suites/nautilus/dashboard/sanity_containerized_ceph_dashboard.yaml
@@ -85,6 +85,12 @@ tests:
       desc: Perform rgw tests
 
    - test:
+      name: Purge ceph dashboard
+      module: purge_dashboard.py
+      polarion-id: CEPH-83573277
+      desc: Purges ceph dashboard
+
+   - test:
       name: ceph ansible purge
       module: purge_cluster.py
       config:

--- a/tests/ceph_ansible/purge_dashboard.py
+++ b/tests/ceph_ansible/purge_dashboard.py
@@ -1,0 +1,63 @@
+""" Module to purge ceph dashboard."""
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class DashboardValidationFailure(Exception):
+    pass
+
+
+def run(ceph_cluster, **kw):
+    """Module to purge ceph dashboard.
+
+    Args:
+        kw: Arbitrary keyword arguments.
+        ceph_cluster (ceph.ceph.Ceph): ceph cluster.
+
+    Returns:
+        0 on success and non-zero for failures.
+    """
+    log.info("Running purge-dashboard test")
+    installer_node = ceph_cluster.get_ceph_object("installer")
+    ansible_dir = "/usr/share/ceph-ansible"
+    inventory = "hosts"
+    playbook_command = (
+        "infrastructure-playbooks/purge-dashboard.yml --extra-vars 'ireallymeanit=yes'"
+    )
+
+    # command to be formed ansible-playbook -vvvv -i hosts infrastructure-playbooks/purge-dashboard.yml
+
+    cmd = f"cd {ansible_dir} ; ansible-playbook -vvvv -i {inventory} {playbook_command}"
+
+    # executing the command to purge dashboard
+    out, rc = installer_node.exec_command(cmd=cmd, long_running=True)
+
+    if rc != 0:
+        log.info("ansible-playbook failed to purge ceph dashboard")
+        return 1
+
+    log.info("ansible-playbook purge dashboard is successfull")
+    mon_node = ceph_cluster.get_ceph_object("mon")
+    validate_purge_dashboard(mon_node)
+    return 0
+
+
+def validate_purge_dashboard(node):
+    """Method to validate purge dashboard playbook.
+
+    After purging the dashboard module
+    validating by no more dashboard service enabled.
+
+    Args:
+        node (Ceph object): Mon node to execute ceph commands.
+    """
+    log.info("Validating purge dashboard")
+    out, rc = node.exec_command(sudo=True, cmd="ceph mgr module ls")
+    output = json.loads(out.read().decode().rstrip())
+    if "dashboard" in output["enabled_modules"]:
+        raise DashboardValidationFailure(
+            "Dashboard module is still enabled after purge-dashboard"
+        )
+    log.info("Dashboard module not enabled as expected")


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
In RHCEPH 4.3 onwards to purge ceph dashboard we have new playbook called purge-dashboard.yml
hence added purge dashboard test in existing suite.
bz: [1786691](https://bugzilla.redhat.com/show_bug.cgi?id=1786691)
polarion link:[ CEPH-83573277](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573277)
Success logs: [cephci-run-WFK8QW](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WFK8QW/)

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
