### PR TITLE
Using sudo to execute the upload command

### DIFF
--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -392,11 +392,12 @@ def uploadCompose(def rhBuild, def cephVersion, def baseUrl) {
             baseUrl     The compose base URL
     */
     try {
-        def cmd = "${env.WORKSPACE}/.venv/bin/python"
+        def cpFile = "sudo cp ${env.HOME}/.cephci.yaml /root/"
+        def cmd = "sudo ${env.WORKSPACE}/.venv/bin/python"
         def scriptFile = "pipeline/scripts/ci/upload_compose.py"
         def args = "${rhBuild} ${cephVersion} ${baseUrl}"
 
-        sh "${cmd} ${scriptFile} ${args}"
+        sh script: "${cpFile} && ${cmd} ${scriptFile} ${args}"
     } catch(Exception exc) {
         println "Encountered a failure during compose upload."
         println exc


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Missing privileges to complete execution of `upload_compose.py`

__Error__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-unsigned-compose-listener/63/

__Log__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-unsigned-compose-listener/69/console