### PR TITLE
Execute the tier X irrespective of the previous result

### DIFF
--- a/pipeline/tier-0.groovy
+++ b/pipeline/tier-0.groovy
@@ -88,6 +88,13 @@ node(nodeName) {
 
     stage('Publish UMB') {
         /* send UMB message */
+        if ( "FAIL" in testResults.values() ) {
+            // As part of executing all tiers, we are not publishing this message when
+            // there is a failure. This way we prevent execution of Tier-1 and
+            // subsequently the other tiers in the pipeline.
+            println "Not posting the UMB message..."
+            return
+        }
         def buildState = buildPhase
 
         if ( buildPhase == "latest" ) {

--- a/pipeline/tier-x.groovy
+++ b/pipeline/tier-x.groovy
@@ -63,7 +63,9 @@ node(nodeName) {
         releaseContent = sharedLib.readFromReleaseFile(
             majorVersion, minorVersion, lockFlag=false
         )
-        testStages = sharedLib.fetchStages(buildType, buildPhase, testResults)
+
+        // Till the pipeline matures, using the build that has passed tier-0 suite.
+        testStages = sharedLib.fetchStages("tier-0", buildPhase, testResults)
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Till the pipeline matures, execution of tier-2 is triggered irrespective of the result of tier-1.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-x/94/console