### PR TITLE
Fix unsigned-container-image-listener job with release lock file

### DIFF
--- a/pipeline/unsigned-container-image-listener.groovy
+++ b/pipeline/unsigned-container-image-listener.groovy
@@ -48,6 +48,7 @@ node(nodeName) {
             versions.major_version, versions.minor_version
         )
         if ( !releaseDetails?.latest?."ceph-version") {
+            lib.unSetLock(versions.major_version, versions.minor_version)
             currentBuild.results = "ABORTED"
             error("Unable to retrieve release information")
         }
@@ -56,6 +57,7 @@ node(nodeName) {
         def compare = lib.compareCephVersion(currentCephVersion, cephVersion)
 
         if (compare != 0) {
+            lib.unSetLock(versions.major_version, versions.minor_version)
             currentBuild.result = "ABORTED"
             println "Build Ceph Version: ${cephVersion}"
             println "Found Ceph Version: ${currentCephVersion}"


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Fix unsigned-container-image-listener job with release lock file

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
