### PR TITLE
Exclude tests tagged with lifecycle expiration

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 from json import loads
+from time import sleep
 from typing import Dict, Optional, Tuple
 
 from jinja2 import Template
@@ -167,7 +168,8 @@ def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> in
         tests = "s3tests"
 
         if build.startswith("5"):
-            extra_args = "-a '!fails_on_aws,!fails_on_rgw,!fails_strict_rfc2616"
+            extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!fails_on_aws"
+            extra_args += ",!lifecycle_expiration"
 
             if not encryption:
                 extra_args += ",!encryption"
@@ -471,6 +473,9 @@ def _rgw_lc_debug_conf(cluster: Ceph, add: bool = True) -> None:
     for node in cluster.get_nodes(role="rgw"):
         node.exec_command(sudo=True, cmd=command)
 
+    # Service restart can take time
+    sleep(60)
+
     log.debug("Lifecycle dev configuration set to 10")
 
 
@@ -511,3 +516,6 @@ def _rgw_lc_debug(cluster: Ceph, add: bool = True) -> None:
 
     for service in rgw_services:
         node.exec_command(sudo=True, cmd=f"ceph orch restart {service}")
+
+    # Restart can take time
+    sleep(60)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

After the service restart, we are waiting for sometime, before initializing the tests. There were some failures observed at the start. This PR aligns with the exclusion policy to get a baseline for s3tests

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3/5.0-nossl/
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3/5.0-ssl/

__Note__
```
s3tests_boto3.functional.test_s3.test_object_acl_canned_bucketownerread ... FAIL
s3tests_boto3.functional.test_s3.test_object_acl_canned_bucketownerfullcontrol ... FAIL
```
The above tests fail for non SSL termination however they work for SSL