### PR TITLE
sts: fix typo of server side copy test case script name

### DIFF
--- a/suites/nautilus/rgw/tier_1_object.yaml
+++ b/suites/nautilus/rgw/tier_1_object.yaml
@@ -113,6 +113,6 @@ tests:
       polarion-id: CEPH-83574522
       module: sanity_rgw.py
       config:
-        script-name: test_sts_using_boto_servser_side_copy.py
+        script-name: test_sts_using_boto_server_side_copy.py
         config-file-name: test_sts_using_boto_server_side_copy.yaml
         timeout: 500

--- a/suites/pacific/rgw/tier_1_object.yaml
+++ b/suites/pacific/rgw/tier_1_object.yaml
@@ -137,12 +137,16 @@ tests:
         script-name: test_object_lock.py
         config-file-name: test_object_lock.yaml
         timeout: 500
-  - test:
-      name: STS Tests
-      desc: Perform Server Side Copy
-      polarion-id: CEPH-83574522
-      module: sanity_rgw.py
-      config:
-        script-name: test_sts_using_boto_servser_side_copy.py
-        config-file-name: test_sts_using_boto_server_side_copy.yaml
-        timeout: 500
+# Commenting out the STS Server side copy test as the fix is not a part of
+# pacific release yet.
+# TODO : To uncomment this test as soon as we have the fix in the pacific build,
+# currently being tracked in BZ 2006194
+#  - test:
+#      name: STS Tests
+#      desc: Perform Server Side Copy
+#      polarion-id: CEPH-83574522
+#      module: sanity_rgw.py
+#      config:
+#        script-name: test_sts_using_boto_server_side_copy.py
+#        config-file-name: test_sts_using_boto_server_side_copy.yaml
+#        timeout: 500


### PR DESCRIPTION
Commenting out STS server side tests for pacific and Renamed test_sts…

Signed-off-by: Gaurav Sitlani <gsitlani@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
