### PR TITLE
add comment section in email template

### DIFF
--- a/run.py
+++ b/run.py
@@ -234,8 +234,12 @@ def create_nodes(
 
 
 def print_results(tc):
-    header = "\n{name:<30s}   {desc:<60s}   {duration:<30s}   {status:>15s}".format(
-        name="TEST NAME", desc="TEST DESCRIPTION", duration="DURATION", status="STATUS"
+    header = "\n{name:<30s}   {desc:<60s}   {duration:<30s}   {status:<15s}    {comments:>15s}".format(
+        name="TEST NAME",
+        desc="TEST DESCRIPTION",
+        duration="DURATION",
+        status="STATUS",
+        comments="COMMENTS",
     )
     print(header)
     for test in tc:
@@ -246,7 +250,8 @@ def print_results(tc):
         name = test["name"]
         desc = test["desc"] or "None"
         status = test["status"]
-        line = f"{name:<30.30s}   {desc:<60.60s}   {dur:<30s}   {status:>15s}"
+        comments = test["comments"]
+        line = f"{name:<30.30s}   {desc:<60.60s}   {dur:<30s}   {status:<15s}   {comments:>15s}"
         print(line)
 
 
@@ -578,6 +583,7 @@ def run(args):
         details["ceph-version-name"] = ceph_name
         details["duration"] = "0s"
         details["status"] = "Not Executed"
+        details["comments"] = var.get("comments")
         return details
 
     if reuse is None:

--- a/templates/result-email-template.html
+++ b/templates/result-email-template.html
@@ -124,6 +124,7 @@
             <th style="color: blue">Test Description</th>
             <th style="color: blue">Duration</th>
             <th style="color: blue">Status</th>
+            <th style="color: blue">Comments</th>
         </tr>
         {% for test in test_results %}
             <tr>
@@ -137,6 +138,7 @@
                 {% elif test.status == 'Not Executed' %}
                 <td style="color: grey">{{ test.status }}</td>
                 {% endif %}
+                <td>{{ test.comments }}</td>
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
Adding comments section in the email template. this section can be used add to comments to tests if they are BZ associated to it.  

this can be added in the test section like this: 
```
  - test:
      config:
        script-name: test_swift_basic_ops.py
        config-file-name: test_swift_basic_ops.yaml
        comments: known issue. BZ 123423424
        timeout: 300
      desc: Test object operations with swift
      module: sanity_rgw.py
      name: Swift based tests
      polarion-id: CEPH-11019
```


[example email template](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WK0ERH/)

Signed-off-by: rakeshgm <rakeshgm@redhat.com>

