### PR TITLE
Correcting the sut configuration file

### DIFF
--- a/pipeline/scripts/5/0/tier-1/test-rgw-single-site.sh
+++ b/pipeline/scripts/5/0/tier-1/test-rgw-single-site.sh
@@ -7,17 +7,30 @@ build_type=${1:-'released'}
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_1_object.yaml"
-test_conf="conf/pacific/rgw/tier_1_rgw_cephadm.yaml"
+test_conf="conf/pacific/rgw/tier_0_rgw.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+  --osp-cred $HOME/osp-cred-ci-2.yaml \
+  --rhbuild $rhbuild \
+  --platform $platform \
+  --build $build_type \
+  --instances-name $instance_name \
+  --global-conf $test_conf \
+  --suite $test_suite \
+  --inventory $test_inventory \
+  --post-results \
+  --log-level DEBUG \
+  --report-portal
 
 if [ $? -ne 0 ]; then
   return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+  --osp-cred $HOME/osp-cred-ci-2.yaml \
+  --log-level debug
 
 if [ $? -ne 0 ]; then
   echo "cleanup instance failed for instance $instance_name"


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR changes the configuration file used for Tier-1 tests. The current file has more than one node having RGW role however the test suite configures only one node. This will lead to an issue observed in 

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-T2KF23/