### PR TITLE
Fix RGW Tier 1 single site test failure

### DIFF
--- a/suites/pacific/rgw/tier_1_object.yaml
+++ b/suites/pacific/rgw/tier_1_object.yaml
@@ -1,7 +1,7 @@
-"""
-Note: If the following tests are being called and executed manually or via pipeline.
-      Please use conf/pacific/rgw/tier_0_rgw.yaml
-"""
+# Tier-1: Downstream RGW test suite focusing on verifying the core features.
+
+# Config:  conf/pacific/rgw/tier_0_rgw.yaml
+
 tests:
   - test:
       abort-on-fail: true


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes an incorrect syntax issue in single site test suite.

__Logs__
error: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/blue/organizations/jenkins/rhceph-tier-x/detail/rhceph-tier-x/136/pipeline/58/