### PR TITLE
nautilus: Adding correct command for purging containerized cluster

### DIFF
--- a/suites/nautilus/rgw/sanity_containerized_rgw.yaml
+++ b/suites/nautilus/rgw/sanity_containerized_rgw.yaml
@@ -450,12 +450,13 @@ tests:
    # resharding tests
 
    - test:
-       name: ceph ansible purge
-       polarion-id: CEPH-83571498
-       module: purge_cluster.py
-       config:
-         ansible-dir: /usr/share/ceph-ansible
-       desc: Purge ceph cluster
+      name: ceph ansible purge
+      polarion-id: CEPH-83571493
+      module: purge_cluster.py
+      config:
+           ansible-dir: /usr/share/ceph-ansible
+           playbook-command: purge-docker-cluster.yml -e ireallymeanit=yes -e remove_packages=yes
+      desc: Purge ceph cluster
 
    - test:
       name: containerized ceph ansible
@@ -529,14 +530,15 @@ tests:
          script-name: test_Mbuckets_with_Nobjects.py
          config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
          timeout: 300
-
+         
    - test:
-       name: ceph ansible purge
-       polarion-id: CEPH-83571498
-       module: purge_cluster.py
-       config:
-         ansible-dir: /usr/share/ceph-ansible
-       desc: Purge ceph cluster
+      name: ceph ansible purge
+      polarion-id: CEPH-83571493
+      module: purge_cluster.py
+      config:
+           ansible-dir: /usr/share/ceph-ansible
+           playbook-command: purge-docker-cluster.yml -e ireallymeanit=yes -e remove_packages=yes
+      desc: Purge ceph cluster
 
    - test:
       name: containerized ceph ansible
@@ -657,13 +659,15 @@ tests:
          script-name: test_frontends_with_ssl.py
          config-file-name: test_ssl_beast.yaml
          timeout: 500
+
    - test:
-       name: ceph ansible purge
-       polarion-id: CEPH-83571498
-       module: purge_cluster.py
-       config:
-         ansible-dir: /usr/share/ceph-ansible
-       desc: Purge ceph cluster
+      name: ceph ansible purge
+      polarion-id: CEPH-83571493
+      module: purge_cluster.py
+      config:
+           ansible-dir: /usr/share/ceph-ansible
+           playbook-command: purge-docker-cluster.yml -e ireallymeanit=yes -e remove_packages=yes
+      desc: Purge ceph cluster
 
   # upstream s3-tests
 


### PR DESCRIPTION
Signed-off-by: gauravsitlani <gsitlani@redhat.com>

# Description

nautilus : sanity_containerized_rgw [logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5TBXNK/)

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
