### PR TITLE
fix push-recipe: make releaseDetails global

### DIFF
--- a/pipeline/unsigned-container-image-listener.groovy
+++ b/pipeline/unsigned-container-image-listener.groovy
@@ -7,6 +7,7 @@ def lib
 def versions
 def cephVersion
 def compose
+def releaseDetails = [:]
 
 // Pipeline script entry point
 
@@ -44,7 +45,7 @@ node(nodeName) {
         versions = lib.fetchMajorMinorOSVersion('unsigned-container-image')
         cephVersion = lib.fetchCephVersion(compose.compose_url)
 
-        def releaseDetails = lib.readFromReleaseFile(
+        releaseDetails = lib.readFromReleaseFile(
             versions.major_version, versions.minor_version
         )
         if ( !releaseDetails?.latest?."ceph-version") {


### PR DESCRIPTION
- Fix push recipe issue, by making `releaseDetails` as global in groovy.
```
groovy.lang.MissingPropertyException: No such property: releaseDetails for class: groovy.lang.Binding
	at groovy.lang.Binding.getVariable(Binding.java:63)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:271)
	at org.kohsuke.groovy.sandbox.impl.Checker$7.call(Checker.java:353)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:357)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:333)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:333)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:29)
	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
	at WorkflowScript.run(WorkflowScript:114)
	at ___cps.transform___(Native Method)
```

Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

