### PR TITLE
RHCEPH 5.1: Add _admin label role to installer nodes

### DIFF
--- a/conf/pacific/ansible/sanity-ceph-ansible.yaml
+++ b/conf/pacific/ansible/sanity-ceph-ansible.yaml
@@ -3,6 +3,7 @@ globals:
        name: ceph
        node1:
          role:
+            - _admin
             - mon
             - mgr
             - installer

--- a/conf/pacific/cephadm/sanity-cephadm.yaml
+++ b/conf/pacific/cephadm/sanity-cephadm.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
+++ b/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - installer
           - mon
           - mgr

--- a/conf/pacific/cephfs/sanity_fs.yaml
+++ b/conf/pacific/cephfs/sanity_fs.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - mds

--- a/conf/pacific/cephfs/tier_0_fs.yaml
+++ b/conf/pacific/cephfs/tier_0_fs.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/cephfs/tier_1_cephfs_mirror.yaml
+++ b/conf/pacific/cephfs/tier_1_cephfs_mirror.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph1
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer
@@ -36,6 +37,7 @@ globals:
       name: ceph2
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/cephfs/tier_1_fs.yaml
+++ b/conf/pacific/cephfs/tier_1_fs.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/rados/sanity_rados.yaml
+++ b/conf/pacific/rados/sanity_rados.yaml
@@ -10,6 +10,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/rados/tier_2_rados.yaml
+++ b/conf/pacific/rados/tier_2_rados.yaml
@@ -3,6 +3,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/rbd/tier_0_rbd.yaml
+++ b/conf/pacific/rbd/tier_0_rbd.yaml
@@ -4,6 +4,7 @@ globals:
       name: ceph
       node1:
         role:
+          - _admin
           - installer
           - mon
           - mgr

--- a/conf/pacific/rbd/tier_1_rbd_mirror.yaml
+++ b/conf/pacific/rbd/tier_1_rbd_mirror.yaml
@@ -3,6 +3,7 @@ globals:
      name: ceph-rbd1
      node1:
        role:
+          - _admin
           - mon
           - mgr
           - installer
@@ -31,6 +32,7 @@ globals:
       name: ceph-rbd2
       node1:
         role:
+          - _admin
           - mon
           - mgr
           - installer

--- a/conf/pacific/rgw/rgw_mutlisite.yaml
+++ b/conf/pacific/rgw/rgw_mutlisite.yaml
@@ -5,6 +5,7 @@ globals:
 
       node1:
         role:
+          - _admin
           - installer
           - mgr
           - mon
@@ -46,6 +47,7 @@ globals:
 
       node1:
         role:
+          - _admin
           - installer
           - mgr
           - mon

--- a/conf/pacific/rgw/tier_0_rgw.yaml
+++ b/conf/pacific/rgw/tier_0_rgw.yaml
@@ -7,6 +7,7 @@ globals:
         disk-size: 20
         no-of-volumes: 4
         role:
+          - _admin
           - installer
           - mgr
           - mon

--- a/conf/pacific/rgw/tier_1_rgw_cephadm.yaml
+++ b/conf/pacific/rgw/tier_1_rgw_cephadm.yaml
@@ -5,6 +5,7 @@ globals:
 
       node1:
         role:
+          - _admin
           - installer
           - mgr
           - mon

--- a/conf/pacific/rgw/tier_2_rgw_regression.yaml
+++ b/conf/pacific/rgw/tier_2_rgw_regression.yaml
@@ -7,6 +7,7 @@ globals:
         disk-size: 20
         no-of-volumes: 4
         role:
+          - _admin
           - installer
           - mgr
           - mon

--- a/conf/pacific/upgrades/upgrade_from4x_big_cluster.yml
+++ b/conf/pacific/upgrades/upgrade_from4x_big_cluster.yml
@@ -3,6 +3,7 @@ globals:
      name: ceph
      node1:
        role:
+         - _admin
          - mon
          - mgr
          - installer

--- a/conf/pacific/upgrades/upgrade_from4x_small_cluster.yml
+++ b/conf/pacific/upgrades/upgrade_from4x_small_cluster.yml
@@ -3,6 +3,7 @@ globals:
      name: ceph
      node1:
        role:
+         - _admin
          - mon
          - mgr
          - osd


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Fix `_admin` label issue with workaround.

Test results:
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UT4SRV/ (5.0z1 build) - PASSED
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W2GVSH/ (5.1 build) - FAILED (not related to `_admin` label)