### PR TITLE
nautilus: Added fix for lifecycle s3tests in containerized environment

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -464,11 +464,11 @@ def _rgw_lc_debug_conf(cluster: Ceph, add: bool = True) -> None:
         None
     """
     if add:
-        command = "sed -i -e '$argw lc debug interval = 10' /etc/ceph/ceph.conf"
+        command = "sed -i '/global/a rgw lc debug interval = 10' /etc/ceph/ceph.conf"
     else:
         command = "sed -i '/rgw lc debug interval/d' /etc/ceph/ceph.conf"
 
-    command += " && systemctl restart ceph-radosgw.target"
+    command += " && systemctl restart ceph-radosgw@rgw.`hostname -s`.rgw0.service"
 
     for node in cluster.get_nodes(role="rgw"):
         node.exec_command(sudo=True, cmd=command)


### PR DESCRIPTION
Signed-off-by: gauravsitlani <gsitlani@redhat.com>

# Description
Added a fix for recent s3tests we encountered with nautilus containerized build.

Logs:

- Containerized environment [logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-R1P676)
- Non Containerized environment [logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JP83WK)


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
