### PR TITLE
Fix 5.1 deploy: Increase OSD numbers to avoid PG issues.

### DIFF
--- a/conf/pacific/cephadm/sanity-cephadm.yaml
+++ b/conf/pacific/cephadm/sanity-cephadm.yaml
@@ -43,9 +43,12 @@ globals:
       node6:
         role:
           - mon
+          - osd
           - rgw
           - node-exporter
           - crash
+        no-of-volumes: 4
+        disk-size: 15
       node7:
         role:
           - rgw


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- FIx pool creation issue by increasing number of OSDs.

Failed build: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/rhceph-tier-0/90/
```
2021-10-06 07:03:07,959 - ceph.ceph - INFO - Running command cephadm -v shell -- ceph osd pool create nfs-ganesha-pool on 10.0.209.69
2021-10-06 07:03:10,968 - ceph.ceph - ERROR - Error 34 during cmd, timeout 300
..
..
Running command (timeout=None): /usr/bin/podman run --rm --ipc=host --net=host --privileged --group-add=disk --init -i -e CONTAINER_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/rhceph@sha256:59910be80896465b6e6c3515f6b04c43112140ca1834cd7ec5daef70012837b8 -e NODE_NAME=ceph-psimsvv9-80sou9-node1-installer -e CEPH_USE_RANDOM_NONCE=1 -v /var/run/ceph/f64f341c-655d-11eb-8778-fa163e914bcc:/var/run/ceph:z -v /var/log/ceph/f64f341c-655d-11eb-8778-fa163e914bcc:/var/log/ceph:z -v /var/lib/ceph/f64f341c-655d-11eb-8778-fa163e914bcc/crash:/var/lib/ceph/crash:z -v /dev:/dev -v /run/udev:/run/udev -v /sys:/sys -v /run/lvm:/run/lvm -v /run/lock/lvm:/run/lock/lvm -v /var/lib/ceph/f64f341c-655d-11eb-8778-fa163e914bcc/selinux:/sys/fs/selinux:ro -v /etc/ceph/ceph.conf:/etc/ceph/ceph.conf:z -v /etc/ceph/ceph.client.admin.keyring:/etc/ceph/ceph.keyring:z --entrypoint ceph registry-proxy.engineering.redhat.com/rh-osbs/rhceph@sha256:59910be80896465b6e6c3515f6b04c43112140ca1834cd7ec5daef70012837b8 osd pool create nfs-ganesha-pool
Error ERANGE:  pg_num 32 size 3 would mean 3072 total pgs, which exceeds max 3000 (mon_max_pg_per_osd 250 * num_in_osds 12)
```

Test results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W6732G/
