### PR TITLE
Updating grafana image

### DIFF
--- a/suites/pacific/cephadm/tier1_cephadm_upgrade.yaml
+++ b/suites/pacific/cephadm/tier1_cephadm_upgrade.yaml
@@ -105,10 +105,6 @@ tests:
                     - node1
                   limit: 1
                   sep: ";"
-          - config:             # Set custom grafana image BZ-1975887 work-around until GA
-              command: shell
-              args:
-                - "ceph config set mgr mgr/cephadm/container_image_grafana registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest"
           - config:
               command: apply
               service: grafana

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal.yaml
@@ -117,7 +117,7 @@ tests:
         grafana_admin_user: admin
         grafana_admin_password: p@ssw0rd
         node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
-        grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
         prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
         alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
         ceph_conf_overrides:

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal_without_dashboard.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal_without_dashboard.yaml
@@ -119,7 +119,7 @@ tests:
         grafana_admin_user: admin
         grafana_admin_password: p@ssw0rd
         node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
-        grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
         prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
         alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
         ceph_conf_overrides:

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_containerized.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_containerized.yaml
@@ -95,7 +95,7 @@ tests:
         grafana_admin_user: admin
         grafana_admin_password: p@ssw0rd
         node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
-        grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
         prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
         alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
         ceph_conf_overrides:

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5x_multisite.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5x_multisite.yaml
@@ -157,7 +157,7 @@ tests:
               grafana_admin_user: admin
               grafana_admin_password: p@ssw0rd
               node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
-              grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
               prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
               alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               ceph_conf_overrides:
@@ -192,7 +192,7 @@ tests:
               grafana_admin_user: admin
               grafana_admin_password: p@ssw0rd
               node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
-              grafana_container_image: registry-proxy.engineering.redhat.com/rh-osbs/grafana:5-26
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
               prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
               alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               ceph_conf_overrides:


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Since 5.0 is GAed for upgrade and regular install test suites we will be using GAed grafana image
which is `registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8` also in this grafana image some of the failed grafana tests got fixed, hence updated the grafana images accordingly.

Success logs on the new grafana image
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TEPJ4A/