### PR TITLE
Fix test failures due to missing ceph-common package

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -87,7 +87,7 @@ def run(**kw):
         set_test_env(config, primary_rgw_node)
         set_test_env(config, secondary_rgw_node)
 
-        if primary_cluster.rhcs_version == "5.0":
+        if primary_cluster.rhcs_version.version[0] == 5:
             setup_cluster_access(primary_cluster, primary_rgw_node)
             setup_cluster_access(secondary_cluster, secondary_rgw_node)
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
Enabling `ceph-common` package installation for RHCS 5.1

__Error__
```
2021-10-13 02:56:29,957 - __main__ - ERROR - Traceback (most recent call last):
  File "run.py", line 895, in run
    clients=clients,
  File "/home/jenkins-build/workspace/rhceph-tier-x/tests/rgw/sanity_rgw_multisite.py", line 122, in run
    timeout=timeout,
  File "/home/jenkins-build/workspace/rhceph-tier-x/ceph/ceph.py", line 1441, in exec_command
    + str(self.ip_address)
ceph.ceph.CommandFailed: sudo python3 /home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/user_create.py -c rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/multisite_configs/non_tenanted_user.yaml Error:  2021-10-12 22:56:30,746 INFO: got config:
```
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0RLKV9/create_user_0.log

__Log__
