### PR TITLE
Increase OSD count to correct mon_max_pg_per_osd PG issue

### DIFF
--- a/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
+++ b/conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml
@@ -13,7 +13,7 @@ globals:
           - grafana
           - prometheus
           - crash
-        no-of-volumes: 4
+        no-of-volumes: 6
         disk-size: 15
       node2:
         role:
@@ -25,7 +25,7 @@ globals:
           - alertmanager
           - crash
           - rgw
-        no-of-volumes: 4
+        no-of-volumes: 6
         disk-size: 15
       node3:
         role:
@@ -35,7 +35,7 @@ globals:
           - crash
           - rgw
           - mds
-        no-of-volumes: 4
+        no-of-volumes: 6
         disk-size: 15
       node4:
         role:


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

**Issue:** Pool creation was failing due to mon_max_pg_per_osd(250 PGs).
**Sol:** Increased OSD count.

Test results:
service_apply_spec: PASSED
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MYKIY0

ssl-dashboard-port:  FAILED for different reason.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NYCZ1G
