### PR TITLE
[RHCEPHQE-925] Adding support for interop pipeline scripts

### DIFF
--- a/pipeline/scripts/4/interop/README.md
+++ b/pipeline/scripts/4/interop/README.md
@@ -1,0 +1,47 @@
+## Interop Test suite
+The test suites in this folder are specifically created to be executed in RHEL
+interop pipeline. They are derived from the existingRed Hat Ceph Storage tier-0
+suites.
+
+They differ from them on the following points
+
+- Platform is dynamic and based on the passed inventory
+- Accepts VM spec file
+- Maybe a subset of the tier-0
+- A single set of scripts for the Major version.
+
+### CLI Arguments
+
+| Options | Description |
+| :---- | ----------- |
+| `--osp-cred <cred.yaml>` | OpenStack credential file |
+| `--add-repo <repo.repo>` | Additional repository file to be used. |
+| `--inventory <vm_spec.yaml>` | VM spec file to be used for deployment.|
+
+### Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| CEPH_PLATFORM | Operating System deployed in the systems |
+| PY_CMD | Python command to be used for execution. |
+| OSP_CRED_FILE | Absolute path to OpenStack credential |
+
+
+__Examples___
+```usage
+# Defaults
+bash pipeline/scripts/4/interop/<test-component.sh> \
+    --osp-cred cred.yaml \
+    --add-repo repo.repo \
+    --inventory test.yaml
+
+# Custom environment
+export PY_CMD=/home/fedora/cephci-env/bin/python
+bash pipeline/scripts/4/interop/<test-ceph-component.sh> \
+    --osp-cred rhos-d.yaml \
+    --add-repo file.repo \
+    --inventory rhel-8.5-latest.yaml 
+```
+
+It is recommended to execute the script from the root folder of this repo.
+This enables the script to execute `run.py` from a relative path.

--- a/pipeline/scripts/4/interop/test-cephfs-core-features.sh
+++ b/pipeline/scripts/4/interop/test-cephfs-core-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute CephFS Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="4.2"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 4.2 CephFS tier-0 test suite execution."
+
+TEST_SUITE="suites/nautilus/cephfs/tier_0_fs.yaml"
+TEST_CONF="conf/nautilus/cephfs/tier_0_fs.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/4/interop/test-rbd-core-features.sh
+++ b/pipeline/scripts/4/interop/test-rbd-core-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute RBD Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="4.2"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 4.2 Ceph RBD tier-0 test suite execution."
+
+TEST_SUITE="suites/nautilus/rbd/tier_0_rbd.yaml"
+TEST_CONF="conf/nautilus/rbd/tier_0_rbd.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/4/interop/test-rgw-core-features.sh
+++ b/pipeline/scripts/4/interop/test-rgw-core-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute RGW Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="4.2"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 4.2 Ceph RGW tier-0 test suite execution."
+
+TEST_SUITE="suites/nautilus/rgw/tier_0_rgw.yaml"
+TEST_CONF="conf/nautilus/rgw/tier_0_rgw.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/4/interop/test-rhceph-image-on-rhel-8.sh
+++ b/pipeline/scripts/4/interop/test-rhceph-image-on-rhel-8.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute Base Image Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="4.2"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 4.2 Ceph deployment tier-0 test suite execution."
+
+TEST_SUITE="suites/nautilus/ansible/tier_0_deploy_containerized_ceph.yaml"
+TEST_CONF="conf/nautilus/ansible/tier_0_deploy.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/4/interop/test-rhceph-rhel-8-rpm.sh
+++ b/pipeline/scripts/4/interop/test-rhceph-rhel-8-rpm.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute RPM install Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="4.2"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 4.2 Ceph RPM tier-0 test suite execution."
+
+TEST_SUITE="suites/nautilus/ansible/tier_0_deploy_rpm_ceph.yaml"
+TEST_CONF="conf/nautilus/ansible/tier_0_deploy.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/5/interop/README.md
+++ b/pipeline/scripts/5/interop/README.md
@@ -1,0 +1,47 @@
+## Interop Test suite
+The test suites in this folder are specifically created to be executed in RHEL
+interop pipeline. They are derived from the existingRed Hat Ceph Storage tier-0
+suites.
+
+They differ from them on the following points
+
+- Platform is dynamic and based on the passed inventory
+- Accepts VM spec file
+- Maybe a subset of the tier-0
+- A single set of scripts for the Major version.
+
+### CLI Arguments
+
+| Options | Description |
+| :---- | ----------- |
+| `--osp-cred <cred.yaml>` | OpenStack credential file |
+| `--add-repo <repo.repo>` | Additional repository file to be used. |
+| `--inventory <vm_spec.yaml>` | VM spec file to be used for deployment.|
+
+### Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| CEPH_PLATFORM | Operating System deployed in the systems |
+| PY_CMD | Python command to be used for execution. |
+| OSP_CRED_FILE | Absolute path to OpenStack credential |
+
+
+__Examples___
+```usage
+# Defaults
+bash pipeline/scripts/5/interop/<test-component.sh> \
+    --osp-cred cred.yaml \
+    --add-repo repo.repo \
+    --inventory test.yaml
+
+# Custom environment
+export PY_CMD=/home/fedora/cephci-env/bin/python
+bash pipeline/scripts/5/interop/<test-ceph-component.sh> \
+    --osp-cred rhos-d.yaml \
+    --add-repo file.repo \
+    --inventory rhel-8.5-latest.yaml 
+```
+
+It is recommended to execute the script from the root folder of this repo.
+This enables the script to execute `run.py` from a relative path.

--- a/pipeline/scripts/5/interop/test-cephfs-core-features.sh
+++ b/pipeline/scripts/5/interop/test-cephfs-core-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute CephFS Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="5.0"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 5.0 CephFS tier-0 test suite execution."
+
+TEST_SUITE="suites/pacific/cephfs/tier_0_fs.yaml"
+TEST_CONF="conf/pacific/cephfs/tier_0_fs.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/5/interop/test-rbd-core-features.sh
+++ b/pipeline/scripts/5/interop/test-rbd-core-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute Ceph RBD Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="5.0"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 5.0 Ceph RBD tier-0 test suite execution."
+
+TEST_SUITE="suites/pacific/rbd/tier_0_rbd.yaml"
+TEST_CONF="conf/pacific/rbd/tier_0_rbd.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/5/interop/test-rgw-core-features.sh
+++ b/pipeline/scripts/5/interop/test-rgw-core-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute RGW Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="5.0"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 5.0 Ceph RGW tier-0 test suite execution."
+
+TEST_SUITE="suites/pacific/rgw/tier_0_rgw.yaml"
+TEST_CONF="conf/pacific/rgw/tier_0_rgw.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}

--- a/pipeline/scripts/5/interop/test-rhceph-deployment-features.sh
+++ b/pipeline/scripts/5/interop/test-rhceph-deployment-features.sh
@@ -1,0 +1,88 @@
+#! /usr/bin/env bash
+
+# Script to execute install Tier-0 test suite of Red Hat Ceph.
+# Maintainers: cephci@redhat.com
+# Version: 1.0
+
+# DEFAULT VARIABLES
+RHCS_VERSION="5.0"
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+VM_PREFIX="ci-${random_string}"
+
+# Environment variable overrides
+CEPH_PLATFORM=${CEPH_PLATFORM:-"rhel-8"}
+PY_CMD=${PY_CMD:-"${HOME}/cephci-venv/bin/python"}
+OSP_CRED_FILE=${OSP_CRED_FILE:-}
+REPO_FILE=${REPO_FILE:-}
+VM_SPEC=${VM_SPEC:-}
+
+echo "Red Hat Ceph Storage 5.0 Ceph deploy tier-0 test suite execution."
+
+TEST_SUITE="suites/pacific/cephadm/tier_0_cephadm.yaml"
+TEST_CONF="conf/pacific/cephadm/sanity-cephadm.yaml"
+return_code=0
+
+while [[ $# -gt 0 ]] ; do
+    key=$1
+    case $key in
+        --osp-cred)
+            OSP_CRED_FILE=$2
+            shift 2 ;;
+        --add-repo)
+            REPO_FILE=$2
+            shift 2 ;;
+        --inventory)
+            VM_SPEC=$2
+            shift 2 ;;
+        --platform)
+            CEPH_PLATFORM=$2
+            shift 2 ;;
+        *)
+            echo "$1 is unsupported."
+            shift 1 ;;
+    esac
+done
+
+if [ -z "${REPO_FILE}" ] ; then
+    echo "Require --add-repo argument."
+    exit 1
+fi
+
+if [ -z "${VM_SPEC}" ] ; then
+    echo "Require --inventory argument."
+    exit 1
+fi
+
+if [ -z "${OSP_CRED_FILE}" ] ; then
+    echo "Require --osp-cred argument."
+    exit 1
+fi
+
+${PY_CMD} run.py --v2 \
+    --log-level DEBUG \
+    --xunit-results \
+    --skip-enabling-rhel-rpms \
+    --rhbuild ${RHCS_VERSION} \
+    --platform ${CEPH_PLATFORM} \
+    --build rc \
+    --suite ${TEST_SUITE} \
+    --global-conf ${TEST_CONF} \
+    --instances-name ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --inventory ${VM_SPEC} \
+    --add-repo ${REPO_FILE}
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+${PY_CMD} run.py --cleanup ${VM_PREFIX} \
+    --osp-cred ${OSP_CRED_FILE} \
+    --log-level debug
+
+if [ $? -ne 0 ]; then
+    echo "SUT cleanup failed for instance having ${VM_PREFIX} prefix."
+fi
+
+exit ${return_code}


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we are adding support for RHEL interop pipeline scripts that would evaluate Ceph against a development RHEL platform.

__Logs__
```
(cephci.venv) [psathyan@psathyan cephci]$ bash pipeline/scripts/5/interop/test-rgw-core-features.sh --inventory /tmp/rhel-8.5-server-x86_64-medlarge.yaml --osp-cred ~/.osp.yaml 
Red Hat Ceph Storage 5.0 Ceph RGW tier-0 test suite execution.

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
2021-10-18 15:04:39,321 - __main__ - INFO - Startup log location: /tmp/cephci-run-ASSYS8/startup.log
2021-10-18 15:04:40,022 - __main__ - INFO - The CLI for the current run :
/home/psathyan/venv/cephci.venv/bin/python run.py --v2 --log-level DEBUG --xunit-results --skip-enabling-rhel-rpms --rhbuild 5.0 --platform rhel-8 --build rc --suite suites/pacific/rgw/tier_0_rgw.yaml --global-conf conf/pacific/rgw/tier_0_rgw.yaml --instances-name ci-4rc9u --osp-cred /home/psathyan/.osp.yaml --inventory /tmp/rhel-8.5-server-x86_64-medlarge.yaml

2021-10-18 15:04:40,022 - __main__ - INFO - RPM Compose source - http://download-node-02.eng.bos.redhat.com/rel-eng/rhel-8/RHCEPH-5/RHCEPH-5.0-RHEL-8-20211001.0
2021-10-18 15:04:40,022 - __main__ - INFO - Red Hat Ceph Image used - registry-proxy.engineering.redhat.com/rh-osbs/rhceph:5-17
2021-10-18 15:04:41,976 - __main__ - INFO - Compose id is: RHCEPH-5.0-RHEL-8-20211001.0
2021-10-18 15:04:41,977 - __main__ - INFO - Testing Ceph Version: 16.2.0-140.el8cp
2021-10-18 15:04:41,977 - __main__ - INFO - Testing Ceph Ansible Version: 6.0.15-1.el8cp.noarch

```