### PR TITLE
Support passing of multiple CLI arguments from pipeline scripts

### DIFF
--- a/pipeline/cvp.groovy
+++ b/pipeline/cvp.groovy
@@ -7,7 +7,7 @@ def nodeName = "centos-7"
 def tierLevel = "tier-0"
 def testStages = [:]
 def testResults = [:]
-def buildAction = "cvp"
+def cliArgs = "--build cvp"
 def sharedLib
 def jobStatus
 
@@ -107,7 +107,9 @@ node(nodeName) {
         def writeToFile = sharedLib.writeToReleaseFile(
             versions.major_version, versions.minor_version, releaseContent
         )
-        testStages = sharedLib.fetchStages(buildAction, tierLevel, testResults)
+        testStages = sharedLib.fetchStages(cliArgs, tierLevel, testResults)
+
+        currentBuild.description = ciMessageMap.artifact.nvr
     }
 
     parallel testStages

--- a/pipeline/released.groovy
+++ b/pipeline/released.groovy
@@ -1,4 +1,5 @@
-// Script to trigger when a RH Ceph is released and execute Tier-0 using the bits available in the external repository.
+// Script to trigger when a RH Ceph is released and execute Tier-0 using the bits
+// available in the external repository.
 // Global variables section
 def nodeName = "centos-7"
 def sharedLib
@@ -6,7 +7,7 @@ def versions
 def cephVersion
 def composeUrl
 def containerImage
-def buildPhase = "released"
+def cliArgs = "--build released"
 def tierLevel = "tier-0"
 def testStages = [:]
 def testResults = [:]
@@ -58,7 +59,9 @@ node(nodeName) {
         println "repo url : ${composeUrl}"
 
         cephVersion = sharedLib.fetchCephVersion(composeUrl)
-        testStages = sharedLib.fetchStages(buildPhase, tierLevel, testResults)
+        testStages = sharedLib.fetchStages(cliArgs, tierLevel, testResults)
+
+        currentBuild.description = "RHCEPH-${majorVersion}.${minorVersion}"
     }
 
     parallel testStages

--- a/pipeline/scripts/4/2/tier-0/test-cephfs-core-features.sh
+++ b/pipeline/scripts/4/2/tier-0/test-cephfs-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 CephFS Functional testing with $1 build_type...."
+echo "Beginning Ceph CephFS core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/cephfs/tier_0_fs.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/cephfs/tier_0_fs.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-0/test-rbd-core-features.sh
+++ b/pipeline/scripts/4/2/tier-0/test-rbd-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/rbd/tier_0_rbd.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rbd/tier_0_rbd.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-0/test-rgw-core-features.sh
+++ b/pipeline/scripts/4/2/tier-0/test-rgw-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/rgw/tier_0_rgw.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_0_rgw.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-0/test-rhceph-image-on-rhel-7.sh
+++ b/pipeline/scripts/4/2/tier-0/test-rhceph-image-on-rhel-7.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 Image testing with $1 build_type...."
+echo "Beginning Red Hat Ceph Container Image testing on RHEL-7"
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/ansible/tier_0_deploy_containerized_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-0/test-rhceph-image-on-rhel-8.sh
+++ b/pipeline/scripts/4/2/tier-0/test-rhceph-image-on-rhel-8.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Image testing with $1 build_type...."
+echo "Beginning Red Hat Ceph Container image testing on RHEL-8 platform."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/ansible/tier_0_deploy_containerized_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-0/test-rhceph-rhel-7-rpm.sh
+++ b/pipeline/scripts/4/2/tier-0/test-rhceph-rhel-7-rpm.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RPM testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RPM based install on RHEL-7."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/ansible/tier_0_deploy_rpm_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-0/test-rhceph-rhel-8-rpm.sh
+++ b/pipeline/scripts/4/2/tier-0/test-rhceph-rhel-8-rpm.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RPM testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RPM based install verification."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/ansible/tier_0_deploy_rpm_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-cephfs-extended-mat.sh
+++ b/pipeline/scripts/4/2/tier-1/test-cephfs-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Cephfs Extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat Ceph CephFS additional functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/cephfs/tier_1_fs.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/cephfs/tier_1_fs.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-rbd-extended-mat.sh
+++ b/pipeline/scripts/4/2/tier-1/test-rbd-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD additional functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/rbd/tier_1_rbd.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rbd/tier_0_rbd.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-rbd-mirror-functionality.sh
+++ b/pipeline/scripts/4/2/tier-1/test-rbd-mirror-functionality.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Mirror testing with $1 build_type...."
+echo "Beginning Ceph RBD mirror functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/rbd/tier_1_rbd_mirror.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rbd/tier_1_rbd_mirror.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-rgw-multi-site-primary-to-secondary.sh
+++ b/pipeline/scripts/4/2/tier-1/test-rgw-multi-site-primary-to-secondary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RGW Multi-site primary to secondary testing with $1 build_type...."
+echo "Beginning Ceph RGW Multisite verification done on secondary site."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/rgw/tier_1_rgw_multisite_primary_to_secondary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_1_rgw_multisite.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-rgw-multi-site-secondary-to-primary.sh
+++ b/pipeline/scripts/4/2/tier-1/test-rgw-multi-site-secondary-to-primary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RGW Multi-site secondary to primary testing with $1 build_type...."
+echo "Beginning Ceph RGW Multisite primary site verification testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/rgw/tier_1_rgw_multisite_secondary_to_primary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_1_rgw_multisite.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-rgw-single-site.sh
+++ b/pipeline/scripts/4/2/tier-1/test-rgw-single-site.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RGW Single-site testing with $1 build_type...."
+echo "Beginning testing of Ceph RGW single site use cases."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/rgw/tier_1_object.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_1_rgw.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-rhceph-rhel-7-rpm-deployment.sh
+++ b/pipeline/scripts/4/2/tier-1/test-rhceph-rhel-7-rpm-deployment.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RPM Deploy testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph RPM based deployment."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/ansible/tier_1_deploy.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_1_deploy.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-upgrade-of-rpm-based-deployments.sh
+++ b/pipeline/scripts/4/2/tier-1/test-upgrade-of-rpm-based-deployments.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 Upgrade RPM testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph RPM based upgrade."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.2"
 test_suite="suites/nautilus/upgrades/tier_1_upgrade_rpm.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/upgrades/tier_1_upgrade.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/2/tier-1/test-upgrade-on-container-based-deployments.sh
+++ b/pipeline/scripts/4/2/tier-1/test-upgrade-on-container-based-deployments.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Upgrade Image testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph Container based upgrade scenario."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.2"
 test_suite="suites/nautilus/upgrades/tier_1_upgrade_container.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/upgrades/tier_1_upgrade.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-cephfs-core-features.sh
+++ b/pipeline/scripts/4/3/tier-0/test-cephfs-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 CephFS Functional testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph CephFS core features."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/cephfs/tier_0_fs.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/cephfs/tier_0_fs.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-rbd-core-features.sh
+++ b/pipeline/scripts/4/3/tier-0/test-rbd-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/rbd/tier_0_rbd.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rbd/tier_0_rbd.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-rgw-core-features.sh
+++ b/pipeline/scripts/4/3/tier-0/test-rgw-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/rgw/tier_0_rgw.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_0_rgw.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-rhceph-image-on-rhel-7.sh
+++ b/pipeline/scripts/4/3/tier-0/test-rhceph-image-on-rhel-7.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 Image testing with $1 build_type...."
+echo "Beginning Red Hat Ceph deployment using images on RHEL-7."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/ansible/tier_0_deploy_containerized_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-rhceph-image-on-rhel-8.sh
+++ b/pipeline/scripts/4/3/tier-0/test-rhceph-image-on-rhel-8.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Image testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph Images on RHEL-8."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/ansible/tier_0_deploy_containerized_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-rhceph-rhel-7-rpm.sh
+++ b/pipeline/scripts/4/3/tier-0/test-rhceph-rhel-7-rpm.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RPM testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph RPM install on RHEL-7"
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/ansible/tier_0_deploy_rpm_ceph.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-0/test-rhceph-rhel-8-rpm.sh
+++ b/pipeline/scripts/4/3/tier-0/test-rhceph-rhel-8-rpm.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RPM testing with $1 build_type...."
+echo "Begin testing of Red Hat Ceph RPM install on RHEL-8."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/ansible/tier_0_deploy_rpm_ceph.yaml"
@@ -11,16 +10,30 @@ test_conf="conf/nautilus/ansible/tier_0_deploy.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}
+

--- a/pipeline/scripts/4/3/tier-1/test-cephfs-extended-mat.sh
+++ b/pipeline/scripts/4/3/tier-1/test-cephfs-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Cephfs Extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat Ceph CephFS additional use case testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/cephfs/tier_1_fs.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/cephfs/tier_1_fs.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-rbd-extended-mat.sh
+++ b/pipeline/scripts/4/3/tier-1/test-rbd-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD additional use case testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/rbd/tier_1_rbd.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rbd/tier_0_rbd.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-rbd-mirror-functionality.sh
+++ b/pipeline/scripts/4/3/tier-1/test-rbd-mirror-functionality.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Mirror testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD Mirror functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/rbd/tier_1_rbd_mirror.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rbd/tier_1_rbd_mirror.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-rgw-multi-site-primary-to-secondary.sh
+++ b/pipeline/scripts/4/3/tier-1/test-rgw-multi-site-primary-to-secondary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RGW Multi-site primary to secondary testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW multisite io verification on secondary."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/rgw/tier_1_rgw_multisite_primary_to_secondary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_1_rgw_multisite.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-rgw-multi-site-secondary-to-primary.sh
+++ b/pipeline/scripts/4/3/tier-1/test-rgw-multi-site-secondary-to-primary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RGW Multi-site secondary to primary testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW primary IO verification tests."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/rgw/tier_1_rgw_multisite_secondary_to_primary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_1_rgw_multisite.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-rgw-single-site.sh
+++ b/pipeline/scripts/4/3/tier-1/test-rgw-single-site.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RGW Single-site testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW single site testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/rgw/tier_1_object.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/rgw/tier_1_rgw.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-rhceph-rhel-7-rpm-deployment.sh
+++ b/pipeline/scripts/4/3/tier-1/test-rhceph-rhel-7-rpm-deployment.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 RPM Deploy testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RPM deployment use case testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/ansible/tier_1_deploy.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/ansible/tier_1_deploy.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-upgrade-of-rpm-based-deployments.sh
+++ b/pipeline/scripts/4/3/tier-1/test-upgrade-of-rpm-based-deployments.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-7 Upgrade RPM testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RPM based upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-7"
 rhbuild="4.3"
 test_suite="suites/nautilus/upgrades/tier_1_upgrade_rpm.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/upgrades/tier_1_upgrade.yaml"
 test_inventory="conf/inventory/rhel-7.9-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/4/3/tier-1/test-upgrade-on-container-based-deployments.sh
+++ b/pipeline/scripts/4/3/tier-1/test-upgrade-on-container-based-deployments.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Upgrade Image testing with $1 build_type...."
+echo "Beginning Red Hat Ceph image based upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="4.3"
 test_suite="suites/nautilus/upgrades/tier_1_upgrade_container.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/nautilus/upgrades/tier_1_upgrade.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-0/test-cephfs-core-features.sh
+++ b/pipeline/scripts/5/0/tier-0/test-cephfs-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 CephFS Functional testing with $1 build_type...."
+echo "Beginning Red Hat CephFS core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephfs/tier_0_fs.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephfs/tier_0_fs.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-0/test-rbd-core-features.sh
+++ b/pipeline/scripts/5/0/tier-0/test-rbd-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rbd/tier_0_rbd.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rbd/tier_0_rbd.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-0/test-rgw-core-features.sh
+++ b/pipeline/scripts/5/0/tier-0/test-rgw-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_0_rgw.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rgw/tier_0_rgw.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-0/test-rhceph-deployment-features.sh
+++ b/pipeline/scripts/5/0/tier-0/test-rhceph-deployment-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Deployment tier 0 testing with $1 build_type...."
+echo "Beginning Red Hat Ceph Adm functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephadm/tier_0_cephadm.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephadm/sanity-cephadm.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-bootstrap-custom-ssl-dashboard-port-and-apply-spec.sh
+++ b/pipeline/scripts/5/0/tier-1/test-bootstrap-custom-ssl-dashboard-port-and-apply-spec.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Bootstrap suite: custom ssl dashboard port and apply-spec testing with $1 build_type...."
+echo "Beginning to evaluate bootstrapping of dashboard with SSL and Apply Spec."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephadm/tier1_ssl_dashboard_port.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-bootstrap-skip-dashboard-and-custom-ceph-directory-organisation.sh
+++ b/pipeline/scripts/5/0/tier-1/test-bootstrap-skip-dashboard-and-custom-ceph-directory-organisation.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Bootstrap suite: skip dashboard and custom ceph directory testing with $1 build_type...."
+echo "Beginning Ceph Adm custom option testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephadm/tier1_skip_dashboard.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-cephadm-apply-service-spec.sh
+++ b/pipeline/scripts/5/0/tier-1/test-cephadm-apply-service-spec.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Cephadm suite: Apply service spec testing for $1 build_type...."
+echo "Beginning Red Hat CephAdm apply spec functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephadm/tier1_service_apply_spec.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-cephadm-upgrade-build-to-build-5x.sh
+++ b/pipeline/scripts/5/0/tier-1/test-cephadm-upgrade-build-to-build-5x.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Cephadm upgrade suite: Upgrade build to build 5x testing with $1 build_type...."
+echo "Beginning Red Hat CephAdm build to build upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephadm/tier1_cephadm_upgrade.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-cephfs-extended-mat.sh
+++ b/pipeline/scripts/5/0/tier-1/test-cephfs-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "CephFS Extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat Ceph FS additional feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/cephfs/tier_1_fs.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/cephfs/tier_1_fs.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-rbd-extended-mat.sh
+++ b/pipeline/scripts/5/0/tier-1/test-rbd-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RBD extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD additional feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rbd/tier_1_rbd.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rbd/tier_0_rbd.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-rbd-mirror-functionality.sh
+++ b/pipeline/scripts/5/0/tier-1/test-rbd-mirror-functionality.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RBD mirror functionality testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD Mirror functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rbd/tier_1_rbd_mirror.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rbd/tier_1_rbd_mirror.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-rgw-multi-site-primary-to-secondary.sh
+++ b/pipeline/scripts/5/0/tier-1/test-rgw-multi-site-primary-to-secondary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW multisite primary to secondary testing with $1 build_type...."
+echo "Beginning Ceph RGW Multisite secondary site verification."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier1_rgw_multisite_primary_to_secondary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rgw/rgw_mutlisite.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-rgw-multi-site-secondary-to-primary.sh
+++ b/pipeline/scripts/5/0/tier-1/test-rgw-multi-site-secondary-to-primary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW multisite secondary to primary testing with $1 build_type...."
+echo "Beginning Ceph RGW Multisite verification on primary site."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier1_rgw_multisite_secondary_to_primary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rgw/rgw_mutlisite.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-rgw-single-site.sh
+++ b/pipeline/scripts/5/0/tier-1/test-rgw-single-site.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW single site testing with $1 build_type...."
+echo "Beginning Ceph RGW single site feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_1_object.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-upgrade-4x-container-to-5x-container.sh
+++ b/pipeline/scripts/5/0/tier-1/test-upgrade-4x-container-to-5x-container.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Upgrade suite: 4x container to 5x container testing with $1 build_type...."
+echo "Beginning Ceph 4x to 5x container based upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_containerized.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/upgrades/upgrade_from4x_small_cluster.yml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-1/test-upgrade-4x-rpm-to-5x-container.sh
+++ b/pipeline/scripts/5/0/tier-1/test-upgrade-4x-rpm-to-5x-container.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Upgrade suite: 4x rpm to 5x container testing with $1 build_type...."
+echo "Beginning Ceph 4x RPM to 5x container based upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/upgrades/upgrade_from4x_big_cluster.yml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rados-regression.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rados-regression.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 rados regression testing with $1 build_type...."
+echo "Beginning Ceph RADOS regression testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rados/tier_2_rados.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rados/tier_2_rados.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-multirealm-deployment.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-multirealm-deployment.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW multi-realm deployment test using $1 build."
+echo "Beginning Ceph RGW Multi-realm installation verification."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_1_rgw_cephadm.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-multisite-primary-to-secondary-tier-1-extd.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-multisite-primary-to-secondary-tier-1-extd.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW Tier-1 extended MultiSite scenario run using $1 build."
+echo "Beginning Ceph RGW Multisite additional feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_1_extn_rgw_multisite_primary_to_secondary.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup ${instance_name} \
-  --osp-cred "${HOME}"/osp-cred-ci-2.yaml \
-  --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance ${instance_name}"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-multisite-secondary-to-primary-tier-1-extd.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-multisite-secondary-to-primary-tier-1-extd.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW Tier-1 extended MultiSite scenario run using $1 build."
+echo "Beginning Ceph RGW Multisite additional feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_1_extn_rgw_multisite_secondary_to_primary.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-regression.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-regression.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW Regression testing with $1 build_type...."
+echo "Beginning Ceph RGW regression testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_2_rgw_regression.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rgw/tier_2_rgw_regression.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-secure-s3.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-secure-s3.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Executing external S3Tests on RGW using $1 build."
+echo "Beginning Ceph RGW with SSL testing using S3Test suite."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_2_rgw_ssl_s3tests.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-ssl-multisite-verify-io-from-primary.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-ssl-multisite-verify-io-from-primary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW MultiSite with Secure Endpoint testing with $1 build_type...."
+echo "Beginning Ceph RGW multisite with SSL testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_2_rgw_ssl_multisite_verify_io_from_primary.yaml"
@@ -11,16 +10,29 @@ test_conf="conf/pacific/rgw/rgw_mutlisite.yaml"
 test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
-$WORKSPACE/.venv/bin/python run.py --v2 --osp-cred $HOME/osp-cred-ci-2.yaml --rhbuild $rhbuild --platform $platform --build $build_type --instances-name $instance_name --global-conf $test_conf --suite $test_suite --inventory $test_inventory --post-results --log-level DEBUG --report-portal
+$WORKSPACE/.venv/bin/python run.py --v2 \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
-$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name --osp-cred $HOME/osp-cred-ci-2.yaml --log-level debug
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-sts.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-sts.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Executing STS scenario on RGW using $1 build."
+echo "Beginning Ceph RGW STS functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/tier_1_extn_object.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/0/tier-2/test-rgw-using-s3cmd.sh
+++ b/pipeline/scripts/5/0/tier-2/test-rgw-using-s3cmd.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Testing RGW via s3cmd client with $1 build."
+echo "Beginning Ceph RGW endpoint testing using S3CMD."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/rgw/sanity_rgw_s3cmd.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance ${instance_name}"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-0/test-cephfs-core-features.sh
+++ b/pipeline/scripts/5/1/tier-0/test-cephfs-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 CephFS Functional testing with $1 build_type...."
+echo "Beginning Red Hat CephFS Core Feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephfs/tier_0_fs.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-0/test-rbd-core-features.sh
+++ b/pipeline/scripts/5/1/tier-0/test-rbd-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 RBD Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RBD core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rbd/tier_0_rbd.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-0/test-rgw-core-features.sh
+++ b/pipeline/scripts/5/1/tier-0/test-rgw-core-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW Functional testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW Core feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
 instance_name="psi${random_string}"
-build_type=${1:-'released'}
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_0_rgw.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-0/test-rhceph-deployment-features.sh
+++ b/pipeline/scripts/5/1/tier-0/test-rhceph-deployment-features.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Deployment tier 0 testing with $1 build_type...."
+echo "Beginning Red Hat Ceph Adm testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephadm/tier_0_cephadm.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-bootstrap-custom-ssl-dashboard-port-and-apply-spec.sh
+++ b/pipeline/scripts/5/1/tier-1/test-bootstrap-custom-ssl-dashboard-port-and-apply-spec.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Bootstrap suite: custom ssl dashboard port and apply-spec testing with $1 build_type...."
+echo "Beginning custom ssl dashboard port and apply-spec test suite execution."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephadm/tier1_ssl_dashboard_port.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-bootstrap-skip-dashboard-and-custom-ceph-directory-organisation.sh
+++ b/pipeline/scripts/5/1/tier-1/test-bootstrap-skip-dashboard-and-custom-ceph-directory-organisation.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Bootstrap suite: skip dashboard and custom ceph directory testing with $1 build_type...."
+echo "Beginning skip dashboard and custom ceph directory testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephadm/tier1_skip_dashboard.yaml"
@@ -15,25 +14,25 @@ $WORKSPACE/.venv/bin/python run.py --v2 \
   --osp-cred $HOME/osp-cred-ci-2.yaml \
   --rhbuild $rhbuild \
   --platform $platform \
-  --build $build_type \
   --instances-name $instance_name \
   --global-conf $test_conf \
   --suite $test_suite \
   --inventory $test_inventory \
   --post-results \
   --log-level DEBUG \
-  --report-portal
+  --report-portal \
+  $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-cephadm-apply-service-spec.sh
+++ b/pipeline/scripts/5/1/tier-1/test-cephadm-apply-service-spec.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Cephadm suite: Apply service spec testing for $1 build_type...."
+echo "Beginning Cephadm Apply service spec testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephadm/tier1_service_apply_spec.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-cephadm-upgrade-build-to-build-5x.sh
+++ b/pipeline/scripts/5/1/tier-1/test-cephadm-upgrade-build-to-build-5x.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Cephadm upgrade suite: Upgrade build to build 5x testing with $1 build_type...."
+echo "Beginning Upgrade build to build 5x testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephadm/tier1_cephadm_upgrade.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-cephfs-extended-mat.sh
+++ b/pipeline/scripts/5/1/tier-1/test-cephfs-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "CephFS Extended MAT testing with $1 build_type...."
+echo "Beginning CephFS additional feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephfs/tier_1_fs.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-rbd-extended-mat.sh
+++ b/pipeline/scripts/5/1/tier-1/test-rbd-extended-mat.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RBD extended MAT testing with $1 build_type...."
+echo "Beginning Red Hat RBD additional feature testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rbd/tier_1_rbd.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-rbd-mirror-functionality.sh
+++ b/pipeline/scripts/5/1/tier-1/test-rbd-mirror-functionality.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RBD mirror functionality testing with $1 build_type...."
+echo "Beginning Ceph RBD mirror functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rbd/tier_1_rbd_mirror.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-rgw-multi-site-primary-to-secondary.sh
+++ b/pipeline/scripts/5/1/tier-1/test-rgw-multi-site-primary-to-secondary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW multisite primary to secondary testing with $1 build_type...."
+echo "Beginning RGW multisite secondary site verification."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier1_rgw_multisite_primary_to_secondary.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-rgw-multi-site-secondary-to-primary.sh
+++ b/pipeline/scripts/5/1/tier-1/test-rgw-multi-site-secondary-to-primary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW multisite secondary to primary testing with $1 build_type...."
+echo "Beginning RGW multisite primary site verification."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier1_rgw_multisite_secondary_to_primary.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-rgw-single-site.sh
+++ b/pipeline/scripts/5/1/tier-1/test-rgw-single-site.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW single site testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW single site testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_1_object.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-upgrade-4x-container-to-5x-container.sh
+++ b/pipeline/scripts/5/1/tier-1/test-upgrade-4x-container-to-5x-container.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Upgrade suite: 4x container to 5x container testing with $1 build_type...."
+echo "Beginning RHCS 4x to 5x container upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_containerized.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-1/test-upgrade-4x-rpm-to-5x-container.sh
+++ b/pipeline/scripts/5/1/tier-1/test-upgrade-4x-rpm-to-5x-container.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Upgrade suite: 4x rpm to 5x container testing with $1 build_type...."
+echo "Beginning RHCS 4x rpm to 5x container upgrade testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rados-regression.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rados-regression.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 rados regression testing with $1 build_type...."
+echo "Beginning Ceph RADOS regression testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rados/tier_2_rados.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-multirealm-deployment.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-multirealm-deployment.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW multi-realm deployment test using $1 build."
+echo "Beginning RGW multi-realm deployment testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_1_rgw_cephadm.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-multisite-primary-to-secondary-tier-1-extd.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-multisite-primary-to-secondary-tier-1-extd.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RGW Tier-1 extended MultiSite scenario run using $1 build."
+echo "Beginning RGW MultiSite additional use case testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_1_extn_rgw_multisite_primary_to_secondary.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup ${instance_name} \
-  --osp-cred "${HOME}"/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred "${HOME}"/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance ${instance_name}"
+    echo "cleanup instance failed for instance ${instance_name}"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-multisite-secondary-to-primary-tier-1-extd.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-multisite-secondary-to-primary-tier-1-extd.sh
@@ -1,9 +1,9 @@
 #! /bin/sh
-echo "RGW Tier-1 extended MultiSite scenario run using $1 build."
+echo "Beginning RGW MultiSite primary use case testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
+
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_1_extn_rgw_multisite_secondary_to_primary.yaml"
@@ -12,28 +12,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-regression.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-regression.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW Regression testing with $1 build_type...."
+echo "Beginning Red Hat Ceph RGW Regression testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_2_rgw_regression.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-secure-s3.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-secure-s3.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Executing external S3Tests on RGW using $1 build."
+echo "Beginning execution of S3Tests against Red Hat RGW with SSL."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_2_rgw_ssl_s3tests.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-ssl-multisite-verify-io-from-primary.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-ssl-multisite-verify-io-from-primary.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "RHEL-8 Object/RGW MultiSite with Secure Endpoint testing with $1 build_type...."
+echo "Beginning Ceph RGW Multisite with SSL testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_2_rgw_ssl_multisite_verify_io_from_primary.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64-medlarge.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-sts.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-sts.sh
@@ -1,9 +1,8 @@
 #! /bin/sh
-echo "Executing STS scenario on RGW using $1 build."
+echo "Beginning Ceph RGW STS functionality testing."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/tier_1_extn_object.yaml"
@@ -12,28 +11,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance $instance_name"
+    echo "cleanup instance failed for instance $instance_name"
 fi
 
 exit ${return_code}

--- a/pipeline/scripts/5/1/tier-2/test-rgw-using-s3cmd.sh
+++ b/pipeline/scripts/5/1/tier-2/test-rgw-using-s3cmd.sh
@@ -1,9 +1,9 @@
 #! /bin/sh
-echo "Testing RGW via s3cmd client with $1 build."
+echo "Beginning Ceph RGW testing using S3CMD CLI commands."
 
 random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
-instance_name="psi${random_string}"
-build_type=${1:-'released'}
+instance_name="ci-${random_string}"
+
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/rgw/sanity_rgw_s3cmd.yaml"
@@ -12,28 +12,28 @@ test_inventory="conf/inventory/rhel-8.4-server-x86_64.yaml"
 return_code=0
 
 $WORKSPACE/.venv/bin/python run.py --v2 \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --rhbuild $rhbuild \
-  --platform $platform \
-  --build $build_type \
-  --instances-name $instance_name \
-  --global-conf $test_conf \
-  --suite $test_suite \
-  --inventory $test_inventory \
-  --post-results \
-  --log-level DEBUG \
-  --report-portal
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --post-results \
+    --log-level DEBUG \
+    --report-portal \
+    $@
 
 if [ $? -ne 0 ]; then
-  return_code=1
+    return_code=1
 fi
 
 $WORKSPACE/.venv/bin/python run.py --cleanup $instance_name \
-  --osp-cred $HOME/osp-cred-ci-2.yaml \
-  --log-level debug
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --log-level debug
 
 if [ $? -ne 0 ]; then
-  echo "cleanup instance failed for instance ${instance_name}"
+    echo "cleanup instance failed for instance ${instance_name}"
 fi
 
 exit ${return_code}

--- a/pipeline/tier-0.groovy
+++ b/pipeline/tier-0.groovy
@@ -49,6 +49,7 @@ node(nodeName) {
         /* Prepare pipeline stages using RHCEPH version */
         ciMap = sharedLib.getCIMessageMap()
         buildPhase = ciMap["artifact"]["build_action"]
+        cliArg = "--build ${buildPhase}"
         def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
         majorVersion = rhcsVersion["major_version"]
         minorVersion = rhcsVersion["minor_version"]
@@ -60,11 +61,13 @@ node(nodeName) {
         releaseContent = sharedLib.readFromReleaseFile(
             majorVersion, minorVersion, lockFlag=false
         )
-        testStages = sharedLib.fetchStages(buildPhase, tierLevel, testResults)
+        testStages = sharedLib.fetchStages(cliArg, tierLevel, testResults)
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test scripts were found for execution."
         }
+
+        currentBuild.description = ciMap.artifact.version
     }
 
     parallel testStages

--- a/pipeline/tier-x.groovy
+++ b/pipeline/tier-x.groovy
@@ -52,6 +52,7 @@ node(nodeName) {
         ciMap = sharedLib.getCIMessageMap()
         buildPhase = ciMap["artifact"]["phase"]
         buildType = ciMap["test-run"]["type"]
+        cliArg = "--build ${buildPhase}"
         def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
         majorVersion = rhcsVersion["major_version"]
         minorVersion = rhcsVersion["minor_version"]
@@ -65,11 +66,13 @@ node(nodeName) {
         )
 
         // Till the pipeline matures, using the build that has passed tier-0 suite.
-        testStages = sharedLib.fetchStages("tier-0", buildPhase, testResults)
+        testStages = sharedLib.fetchStages("--build tier-0", buildPhase, testResults)
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."
         }
+
+        currentBuild.description = ciMap.artifact.version
     }
 
     parallel testStages

--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -393,10 +393,10 @@ def fetchStages(def scriptArg, def tierLevel, def testResults) {
         TIER-x  -   Tier level number (ex., tier-0)
     */
     def RHCSVersion = [:]
-    if (scriptArg != "released") {
-      RHCSVersion = getRHCSVersionFromArtifactsNvr()
+    if ( scriptArg.contains('released') ) {
+        RHCSVersion = fetchMajorMinorOSVersion("released")
     } else {
-      RHCSVersion = fetchMajorMinorOSVersion("released")
+        RHCSVersion = getRHCSVersionFromArtifactsNvr()
     }
     def majorVersion = RHCSVersion.major_version
     def minorVersion = RHCSVersion.minor_version
@@ -405,7 +405,7 @@ def fetchStages(def scriptArg, def tierLevel, def testResults) {
 
     def testStages = [:]
     def scriptFiles = sh (returnStdout: true, script: "ls ${scriptPath}*.sh | cat")
-    if (! scriptFiles){
+    if (! scriptFiles ) {
         return testStages
     }
     def fileNames = scriptFiles.split("\\n")


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, the pipeline scripts are modified to pass the CLI arguments directly from groovy to the bash scripts. This help us to reuse the same scripts in PSI and IBM environments.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-0/104/
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-0/105/console