### PR TITLE
NFS namespace argument is not supported in 5.1

### DIFF
--- a/ceph/ceph_admin/jinja_templates/nfs.jinja
+++ b/ceph/ceph_admin/jinja_templates/nfs.jinja
@@ -12,4 +12,5 @@ placement:
 {%- if spec['placement']['host_pattern'] -%}{{ nlt }}host_pattern: '{{ spec['placement']['host_pattern'] }}'{%- endif %}
 spec:
   pool: {{ spec['spec']['pool'] }}
-  namespace: {{ spec['spec']['namespace'] }}{{ newline }}
+  {%- if spec['spec']['namespace'] -%}{{ nlt }}namespace: {{ spec['spec']['namespace'] }}{%- endif %}
+

--- a/ceph/ceph_admin/nfs.py
+++ b/ceph/ceph_admin/nfs.py
@@ -30,7 +30,7 @@ class NFS(ApplyMixin, Orch):
                     - india             # service identity
                     - southpool         # name of the pool
                 args:
-                    namespace: <name>       # namespace
+                    namespace: <name>       # namespace (supported only in RHCeph 5.0)
                     placement:
                         label: nfs    # either label or node.
                         nodes:

--- a/suites/pacific/cephadm/tier1_service_apply_spec.yaml
+++ b/suites/pacific/cephadm/tier1_service_apply_spec.yaml
@@ -210,7 +210,7 @@ tests:
                       - node4
                   spec:
                     pool: nfs-rgw-pool
-                    namespace: nfs-rgw-namespace
+                    # namespace: nfs-rgw-namespace   # Supported only in RHCeph 5.0
           - config:
               command: shell
               args:              # sleep to get all services deployed

--- a/suites/pacific/cephadm/tier_0_cephadm.yaml
+++ b/suites/pacific/cephadm/tier_0_cephadm.yaml
@@ -584,7 +584,7 @@ tests:
           - mynfs                         # nfs service ID
           - nfs-ganesha-pool              # name of the pool
         args:
-          namespace: mynfs-ns             # specify namespace
+          # namespace: mynfs-ns           # specify namespace(supported only in RHCeph 5.0)
           placement:
             nodes:
               - node8


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- `--namespace` arg is not supported in RHCeph 5.1.
- Fix 5.1 Tier-0 deploy test suite.

```
 # ceph orch apply nfs mynfs nfs-ganesha-pool --placement='2'
Scheduled nfs.mynfs update...
```

**Test results:**
```
Data content:
============
    {
        "service_type": "nfs", "service_id": "mynfs",
        "placement": {"count": 5, "host_pattern": "*"},
        "unmanaged": True,
        "spec": {"pool": "pool1"}
    },
    {
        "service_type": "nfs", "service_id": "mynfs",
        "placement": {"count": 5, "hosts": ["node1", "node2", "node3"]},
        "spec": {"pool": "pool1"}
    },
    {
        "service_type": "nfs", "service_id": "mynfs",
        "placement": {"label": "nfs"},
        "spec": {"pool": "pool1", "namespace": "mynfsspace"}
    },


Rendered yaml content:
=======================
 ---
service_type: nfs
service_id: mynfs
unmanaged: True
placement:
  count: 5
  host_pattern: '*'
spec:
  pool: pool1
---
service_type: nfs
service_id: mynfs
placement:
  count: 5
  hosts: ['node1', 'node2', 'node3']
spec:
  pool: pool1
---
service_type: nfs
service_id: mynfs
placement:
  label: nfs
spec:
  pool: pool1
  namespace: mynfsspace
---
```
