### PR TITLE
rados tier2-tests: EC pool with over-writes

### DIFF
--- a/suites/pacific/rados/tier_2_rados.yaml
+++ b/suites/pacific/rados/tier_2_rados.yaml
@@ -166,6 +166,30 @@ tests:
       desc: Create LRC EC pools and run IO
 
   - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          erasure_code_use_overwrites: "true"
+          k: 3
+          m: 2
+          plugin: jerasure
+          rados_write_duration: 50
+          rados_read_duration: 30
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool
+
+  - test:
       name: Deploy stretch Cluster
       module: stretch_cluster.py
       polarion-id: CEPH-83573621
@@ -217,7 +241,7 @@ tests:
         configure_balancer:
           configure: true
           balancer_mode: upmap
-          target_max_misplaced_ratio: 0.4
+          target_max_misplaced_ratio: 0.04
           sleep_interval: 60
       desc: Ceph balancer plugins CLI validation
 

--- a/tests/rados/mute_alerts.py
+++ b/tests/rados/mute_alerts.py
@@ -36,8 +36,8 @@ def run(ceph_cluster, **kw):
 
     # Scenario 1 : Verify the auto-unmute of alert after TTL
     log.info("Scenario 1: Verify the auto-unmute of alert after TTL")
-    alert = alert_list[0]
-    if not verify_alert_with_ttl(node=cephadm, alert=alert, ttl=8):
+    alert = alert_list[1]
+    if not verify_alert_with_ttl(node=cephadm, alert=alert, ttl=8, flag="noscrub"):
         log.error(f"Scenario 1 for alert : {alert} has failed")
         return 1
 

--- a/tests/rados/rados_prep.py
+++ b/tests/rados/rados_prep.py
@@ -38,11 +38,18 @@ def run(ceph_cluster, **kw):
         if not rados_obj.create_erasure_pool(name=uuid, **ec_config):
             log.error("Failed to create the EC Pool")
             return 1
-        if not rados_obj.bench_write(**ec_config):
-            log.error("Failed to write objects into the EC Pool")
-            return 1
-        rados_obj.bench_read(**ec_config)
-        log.info("Created the EC Pool, Finished writing data into the pool")
+
+        if ec_config.get("test_overwrites_pool"):
+            if not rados_obj.verify_ec_overwrites(**ec_config):
+                log.error("Failed to create the EC Pool")
+                return 1
+        else:
+            if not rados_obj.bench_write(**ec_config):
+                log.error("Failed to write objects into the EC Pool")
+                return 1
+            rados_obj.bench_read(**ec_config)
+            log.info("Created the EC Pool, Finished writing data into the pool")
+
         if ec_config.get("delete_pool"):
             if not rados_obj.detete_pool(pool=ec_config["pool_name"]):
                 log.error("Failed to delete EC Pool")


### PR DESCRIPTION
1. Added test to verify EC pool with over-writes ( CEPH-83571730 )
2. fixes issue #875, Unable to mute health alerts

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
