### PR TITLE
Improved Polarion test run updates.

### DIFF
--- a/run.py
+++ b/run.py
@@ -29,7 +29,7 @@ from ceph.utils import (
     create_ceph_nodes,
     create_ibmc_ceph_nodes,
 )
-from utility.polarion import post_to_polarion
+from utility.polarion import post_to_polarion_v2
 from utility.retry import retry
 from utility.utils import (
     TestSetupFailure,
@@ -928,8 +928,6 @@ def run(args):
                     item_id=item_id, end_time=timestamp(), status="PASSED"
                 )
 
-            if post_results:
-                post_to_polarion(tc=tc)
         else:
             tc["status"] = "Failed"
             msg = "Test {} failed".format(test_mod)
@@ -941,9 +939,6 @@ def run(args):
                 service.finish_test_item(
                     item_id=item_id, end_time=timestamp(), status="FAILED"
                 )
-
-            if post_results:
-                post_to_polarion(tc=tc)
 
             if test.get("abort-on-fail", False):
                 log.info("Aborting on test failure")
@@ -980,6 +975,22 @@ def run(args):
     if post_to_report_portal:
         service.finish_launch(end_time=timestamp())
         service.terminate()
+
+    if post_results:
+        test_run = {
+            "polarion-project-id": "CEPH",
+            "suite-name": suite_name,
+            "distro": distro,
+            "ceph-version": ceph_version,
+            "ceph-ansible-version": ceph_ansible_version,
+            "test_cases": tcs,
+            "base_url": base_url,
+            "container-registry": docker_registry,
+            "container-image": docker_image,
+            "container-tag": docker_tag,
+            "compose-id": compose_id,
+        }
+        post_to_polarion_v2(test_run=test_run)
 
     if xunit_results:
         create_xunit_results(suite_name, tcs, run_dir)

--- a/templates/polarion-test-run-template.xml
+++ b/templates/polarion-test-run-template.xml
@@ -1,0 +1,15 @@
+<testsuites>
+    <properties>
+        <property name="polarion-project-id" value="{{ test_run['polarion-project-id'] }}"/>
+        <property name="polarion-testrun-id" value="{{ test_run['test_run_id'] }}"/>
+        <property name="polarion-group-id" value="ceph-build: {{ test_run['ceph-build'] }} {{ test_run['docker-container'] }}"/>
+    </properties>
+    <testsuite name="{{ test_run['suite-name'] }} test suite" tests="{{ test_run['tests'] }}" failures="{{ test_run['failed'] }}">
+    {% for tc in test_run["test_cases"] %}
+    <testcase name="{{ tc['name'] }}">{{tc['result']}}
+            <properties>
+                <property name="polarion-testcase-id" value="{{ tc['polarion-id'] }}"/>
+            </properties>
+        </testcase>
+    {%+ endfor %}</testsuite>
+</testsuites>

--- a/utility/polarion.py
+++ b/utility/polarion.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from copy import deepcopy
 from subprocess import call
 from tempfile import NamedTemporaryFile
 
@@ -88,3 +89,98 @@ def post_to_polarion(tc):
                 ]
             )
             os.unlink(f.name)
+
+
+def post_to_polarion_v2(test_run):
+    """Function to post test results to polarion.
+
+    It returns nothing and is essentially like noop
+    in case of no polarion details found in test object
+
+    Args:
+       test_run: test case object with details
+
+    """
+    test_run["suite-name"] = test_run["suite-name"].split("/")[-1].split(".")[0]
+    test_run["test_run_id"] = "_".join(
+        [
+            test_run["ceph-version"],
+            test_run["suite-name"],
+            test_run["distro"],
+            "Automated_Smoke_Runs",
+        ]
+    )
+    test_run["test_run_id"] = test_run["test_run_id"].replace(".", "_")
+
+    test_run["ceph-build"] = "_".join(
+        [
+            test_run["ceph-version"],
+            test_run["ceph-ansible-version"],
+            test_run["compose-id"],
+        ]
+    )
+
+    test_run["docker-container"] = test_run["test_cases"][0]["docker-containers-list"]
+
+    test_cases = []
+    test_run["tests"] = 0
+    test_run["failed"] = 0
+    for test_case in test_run["test_cases"]:
+        ids = test_case.get("polarion-id").split(",")
+
+        # In-case of zero polarion test case IDs
+        if not ids:
+            continue
+
+        test_cases_ = []
+        for id_ in ids:
+            tc = deepcopy(test_case)
+            test_run["tests"] += 1
+            tc["polarion-id"] = id_
+            if test_case["status"] == "Pass":
+                tc["result"] = ""
+            else:
+                tc["result"] = '<failure message="{log_link}" type="failure"/>'.format(
+                    log_link=tc["log-link"]
+                )
+                test_run["failed"] += 1
+            test_cases_.append(tc)
+        test_cases.extend(test_cases_)
+
+    # If no test cases found
+    if not test_cases:
+        log.warning("No Polarion test cases found")
+        return
+
+    test_run["test_cases"] = test_cases
+
+    current_dir = os.getcwd() + "/templates/"
+    j2_env = Environment(loader=FileSystemLoader(current_dir), trim_blocks=True)
+    f = NamedTemporaryFile(delete=False)
+    test_results = j2_env.get_template("polarion-test-run-template.xml").render(
+        test_run=test_run
+    )
+
+    print(test_results)
+
+    log.info(f"updating results for {test_run['suite-name']}")
+    f.write(test_results.encode())
+    f.close()
+    polarion_cred = get_cephci_config()["polarion"]
+    url = polarion_cred.get("url")
+    user = polarion_cred.get("username")
+    pwd = polarion_cred.get("password")
+    call(
+        [
+            "curl",
+            "-k",
+            "-u",
+            "{user}:{pwd}".format(user=user, pwd=pwd),
+            "-X",
+            "POST",
+            "-F",
+            "file=@{name}".format(name=f.name),
+            url,
+        ]
+    )
+    os.unlink(f.name)

--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -18,6 +18,7 @@ def create_xunit_results(suite_name, test_cases, run_dir):
 
     Returns: None
     """
+    suite_name = suite_name.split("/")[-1].split(".")[0]
     xml_file = f"{run_dir}/{suite_name}.xml"
 
     log.info(f"Creating xUnit result file for test suite: {suite_name}")


### PR DESCRIPTION
- Improved update of polarion test run. 
- Fix suite name issue, to retrieve only suite name and not the suite file path.

**Test Runs:** 
( https://polarion.engineering.redhat.com/polarion/#/project/CEPH/testruns?query=author.id%3Asunnagar )

- **PASSED:**  

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/testrun?id=test%5Fonly%5Ftrial1%5F16%5F2%5F6%2D11%5Fel8cp%5Ftier1%5Fssl%5Fdashboard%5Fport%5Frhel%2D8%5F4%5F0%2Dx86%5F64%2Dreleased%5FAutomated%5FSmoke%5FRuns

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CIQF3Z

xUnit: /ceph/cephci-jenkins/cephci-run-CIQF3Z/tier1_ssl_dashboard_port.xml

- **FAILED:**

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/testrun?id=test%5Fonly%5Ftrial2%5F16%5F2%5F6%2D11%5Fel8cp%5Ftier1%5Fssl%5Fdashboard%5Fport%5Frhel%2D8%5F4%5F0%2Dx86%5F64%2Dreleased%5FAutomated%5FSmoke%5FRuns

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ISAFL5

xUnit: /ceph/cephci-jenkins/cephci-run-ISAFL5/tier1_ssl_dashboard_port.xml



Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

