### PR TITLE
Add support for reading the build information

### DIFF
--- a/cephci.yaml.template
+++ b/cephci.yaml.template
@@ -43,3 +43,6 @@
 #  endpoint: <resource-public-endpoint>
 #  resource-id: <deployed-instance-resource-id>
 #  location-constraint: <storage-class>
+
+# URI to be used for retrieving the RHCS build details
+# build-url: <URI to fileserver>

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1051,7 +1051,8 @@ def fetch_build_artifacts(build, ceph_version, platform):
     Returns:
         base_url, container_registry, image-name, image-tag
     """
-    url = f"{magna_rhcs_artifacts}RHCEPH-{ceph_version}.yaml"
+    recipe_url = get_cephci_config().get("build-url", magna_rhcs_artifacts)
+    url = f"{recipe_url}RHCEPH-{ceph_version}.yaml"
     data = requests.get(url, verify=False)
     yml_data = yaml.safe_load(data.text)
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Red Hat Ceph Storage build details could be stored in different file servers. In this PR, we add support for enabling the fileserver information to be configurable. The fileserver information is added to `.cephci.yaml` 

```
build-url: http://magna002.ceph.redhat.com/cephci-jenkins/latest-rhceph-container-info/
```

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/build_url/