### PR TITLE
Support for 4x ibm deployment

### DIFF
--- a/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
@@ -31,6 +31,7 @@ instance:
       expire: False
 
     runcmd:
+      - rpm -ivh  https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
       - update-ca-trust

--- a/tests/ceph_ansible/test_ansible_roll_over.py
+++ b/tests/ceph_ansible/test_ansible_roll_over.py
@@ -30,6 +30,7 @@ def run(ceph_cluster, **kw):
     config = kw.get("config")
     filestore = config.get("filestore")
     hotfix_repo = config.get("hotfix_repo")
+    cloud_type = config.get("cloud-type", "openstack")
     test_data = kw.get("test_data")
     cluster_name = config.get("cluster")
 
@@ -85,7 +86,7 @@ def run(ceph_cluster, **kw):
     ceph_cluster.setup_ceph_firewall()
 
     ceph_cluster.setup_packages(
-        base_url, hotfix_repo, installer_url, ubuntu_repo, build
+        base_url, hotfix_repo, installer_url, ubuntu_repo, build, cloud_type
     )
 
     ceph_installer.install_ceph_ansible(build)

--- a/tests/ceph_ansible/test_ansible_upgrade.py
+++ b/tests/ceph_ansible/test_ansible_upgrade.py
@@ -24,6 +24,7 @@ def run(ceph_cluster, **kw):
 
     ubuntu_repo = config.get("ubuntu_repo")
     hotfix_repo = config.get("hotfix_repo")
+    cloud_type = config.get("cloud-type", "openstack")
     base_url = config.get("base_url")
     installer_url = config.get("installer_url")
     config["ansi_config"]["public_network"] = get_public_network(ceph_nodes[0])
@@ -50,7 +51,7 @@ def run(ceph_cluster, **kw):
 
     # setup packages based on build
     ceph_cluster.setup_packages(
-        base_url, hotfix_repo, installer_url, ubuntu_repo, build
+        base_url, hotfix_repo, installer_url, ubuntu_repo, build, cloud_type
     )
 
     # backup existing hosts file and ansible config

--- a/tests/ceph_installer/test_ansible.py
+++ b/tests/ceph_installer/test_ansible.py
@@ -20,6 +20,7 @@ def run(ceph_cluster, **kw):
     k_and_m = config.get("ec-pool-k-m")
     hotfix_repo = config.get("hotfix_repo")
     test_data = kw.get("test_data")
+    cloud_type = config.get("cloud-type", "openstack")
 
     ubuntu_repo = config.get("ubuntu_repo", None)
     base_url = config.get("base_url", None)
@@ -61,7 +62,7 @@ def run(ceph_cluster, **kw):
     ceph_cluster.setup_ssh_keys()
 
     ceph_cluster.setup_packages(
-        base_url, hotfix_repo, installer_url, ubuntu_repo, build
+        base_url, hotfix_repo, installer_url, ubuntu_repo, build, cloud_type
     )
 
     ceph_installer.install_ceph_ansible(build)


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

IBM:

4.2-rbd-tier1: 
2021-10-26 09:35:33,718 - __main__ - INFO - ceph Version 14.2.11-203.el8cp
2021-10-26 09:35:33,718 - __main__ - INFO - ceph_clusters_file rerun/testibm-M7MQQ0
2021-10-26 09:35:33,720 - __main__ - INFO - Test <module 'test_rbd' from '/home/ckulal/october21/cephci/tests/rbd/test_rbd.py'> passed
Test <module 'test_rbd' from '/home/ckulal/october21/cephci/tests/rbd/test_rbd.py'> passed
2021-10-26 09:35:33,720 - __main__ - INFO - 
All test logs located here: /tmp/cephci-run-M7MQQ0

All test logs located here: /tmp/cephci-run-M7MQQ0

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:03:32.280698                   Pass                             
ceph ansible                     setup four node cluster using ceph ansible                     0:11:00.962550                   Pass                             
1_librbd_python                  Executig upstream LibRBD scenarios                             0:00:08.902433                   Pass   


4.2-cephfs-tier0:
2021-10-26 10:04:21,415 - __main__ - INFO - ceph Version 14.2.11-203.el8cp
2021-10-26 10:04:21,415 - __main__ - INFO - ceph_clusters_file rerun/testibm-JF6L7Y
2021-10-26 10:04:21,416 - __main__ - INFO - Test <module 'cephfs_basic_tests' from '/home/ckulal/october21/cephci/tests/cephfs/cephfs_basic_tests.py'> passed
Test <module 'cephfs_basic_tests' from '/home/ckulal/october21/cephci/tests/cephfs/cephfs_basic_tests.py'> passed
2021-10-26 10:04:21,416 - __main__ - INFO - 
All test logs located here: /tmp/cephci-run-JF6L7Y

All test logs located here: /tmp/cephci-run-JF6L7Y

TEST NAME                            TEST DESCRIPTION             DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                               0:04:18.092508                   Pass                             
ceph ansible                     test cluster setup using ceph-ansible   0:15:43.568201                   Pass                             
recreate cephfs with ec pools    
Creates ec pools and Creates Filesystem using ec pools                   0:00:31.905122                   Pass                             
cephfs-basics                    cephfs basic operations                                        0:00:33.378523                   Pass

4.2-rbd-tier0: /tmp/cephci-run-JZVL55
 
Openstack:

4.2-rbd-tier1-rhel8:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ULFRL1/

4.2-cephfs-tier1:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XXBP65/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
