### PR TITLE
UMB message structure is modified

### DIFF
--- a/pipeline/tier-x.groovy
+++ b/pipeline/tier-x.groovy
@@ -6,15 +6,12 @@ def nodeName = "centos-7"
 def testStages = [:]
 def testResults = [:]
 def releaseContent = [:]
-def buildPhase
-def buildType
 def ciMap
 def sharedLib
 def majorVersion
 def minorVersion
-def postTierLevel
-def msgType
-def buildPhaseValue
+def tierLevel
+def previousTierLevel
 
 
 node(nodeName) {
@@ -50,9 +47,19 @@ node(nodeName) {
     stage('Prepare-Stages') {
         /* Prepare pipeline stages using RHCEPH version */
         ciMap = sharedLib.getCIMessageMap()
-        buildPhase = ciMap["artifact"]["phase"]
-        buildType = ciMap["test-run"]["type"]
-        cliArg = "--build ${buildPhase}"
+        previousTierLevel = ciMap.test.type
+
+        tierTypeStrings = previousTierLevel.split("-")
+        def tierLevelInt = tierTypeStrings[1].toInteger() + 1
+        tierLevel = tierTypeStrings[0] + "-" + tierLevelInt
+
+        // Once the pipeline matures, uncomment the below line
+        // cliArg = "--build ${tierLevel}"
+        def cliArgs = "--build tier-0"
+        if ( ciMap.artifact.build == "signed" ) {
+            cliArgs = "--build rc"
+        }
+
         def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
         majorVersion = rhcsVersion["major_version"]
         minorVersion = rhcsVersion["minor_version"]
@@ -66,7 +73,7 @@ node(nodeName) {
         )
 
         // Till the pipeline matures, using the build that has passed tier-0 suite.
-        testStages = sharedLib.fetchStages("--build tier-0", buildPhase, testResults)
+        testStages = sharedLib.fetchStages(cliArgs, tierLevel, testResults)
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."
@@ -79,37 +86,34 @@ node(nodeName) {
 
     stage('Publish Results') {
         /* Publish results through E-mail and Google Chat */
-        buildPhaseValue = buildPhase.split("-")
-        def postTierValue = buildPhaseValue[1].toInteger()+1
-        postTierLevel = buildPhaseValue[0]+"-"+postTierValue
 
         if ( ! ("FAIL" in testResults.values()) ) {
             def latestContent = sharedLib.readFromReleaseFile(
                 majorVersion, minorVersion
             )
-            if (releaseContent.containsKey(buildType)){
-                if (latestContent.containsKey(buildPhase)){
-                    latestContent[buildPhase] = releaseContent[buildType]
-                }
-                else {
-                    def updateContent = ["${buildPhase}": releaseContent[buildType]]
-                    latestContent += updateContent
-                }
-            }
-            else {
+            if ( ! releaseContent.containsKey(previousTierLevel) ) {
                 sharedLib.unSetLock(majorVersion, minorVersion)
-                error "No data found for pre tier level: ${buildType}"
+                error "No data found for pre tier level: ${previousTierLevel}"
+            }
+
+            if ( latestContent.containsKey(tierLevel) ) {
+                latestContent[tierLevel] = releaseContent[previousTierLevel]
+            } else {
+                def updateContent = [
+                    "${tierLevel}": releaseContent[previousTierLevel]
+                ]
+                latestContent += updateContent
             }
 
             sharedLib.writeToReleaseFile(majorVersion, minorVersion, latestContent)
             println "latest content is: ${latestContent}"
         }
 
-        sharedLib.sendGChatNotification(testResults, buildPhase.capitalize())
+        sharedLib.sendGChatNotification(testResults, tierLevel.capitalize())
         sharedLib.sendEmail(
             testResults,
             sharedLib.buildArtifactsDetails(releaseContent, ciMap, "tier-0"),
-            buildPhase.capitalize()
+            tierLevel.capitalize()
         )
     }
 
@@ -118,29 +122,50 @@ node(nodeName) {
 
         def artifactsMap = [
             "artifact": [
-                "type": "product-build-${buildPhase}",
+                "type": "product-build",
                 "name": "Red Hat Ceph Storage",
                 "version": ciMap["artifact"]["version"],
                 "nvr": ciMap["artifact"]["nvr"],
-                "phase": postTierLevel,
+                "phase": "testing",
+                "build": ciMap.artifact.build,
             ],
             "contact": [
                 "name": "Downstream Ceph QE",
-                "email": "ceph-qe@redhat.com",
+                "email": "cephci@redhat.com",
+            ],
+            "system": [
+                "os": "centos-7",
+                "label": "centos-7",
+                "provider": "openstack",
             ],
             "pipeline": [
                 "name": "rhceph-tier-x",
+                "id": currentBuild.number,
             ],
-            "test-run": [
-                "type": buildPhase,
-                "result": currentBuild.currentResult,
+            "run": [
                 "url": env.BUILD_URL,
                 "log": "${env.BUILD_URL}console",
+                "additional_urls": [
+                    "doc": "https://docs.engineering.redhat.com/display/rhcsqe/RHCS+QE+Pipeline",
+                    "repo": "https://github.com/red-hat-storage/cephci",
+                    "report": "https://reportportal-rhcephqe.apps.ocp4.prod.psi.redhat.com/",
+                    "tcms": "https://polarion.engineering.redhat.com/polarion/",
+                ],
             ],
+            "test": [
+                "type": tierLevel,
+                "category": "functional",
+                "result": currentBuild.currentResult,
+            ],
+            "generated_at": env.BUILD_ID,
             "version": "1.0.0"
         ]
-        if (buildPhase == "tier-2"){msgType = "Tier2ValidationTestingDone"}
-        else {msgType = buildPhaseValue[0].capitalize()+buildPhaseValue[1]+"TestingDone"}
+
+        def msgType = "Tier1TestingDone"
+        if ( tierLevel == "tier-2" ) {
+            msgType = "Tier2ValidationTestingDone"
+        }
+
         def msgContent = writeJSON returnText: true, json: artifactsMap
         println "${msgContent}"
 


### PR DESCRIPTION
# Description

In this PR, we align the UMB message to the schema at 

https://pagure.io/fedora-ci/messages/blob/master/f/schemas/product-build.test.complete.yaml
https://pagure.io/fedora-ci/messages/blob/master/f/examples/product-build.test.complete.json

Also, enabling support for executing all the tiers for signed candidates.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-0/148/console
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/blue/organizations/jenkins/rhceph-tier-x/detail/rhceph-tier-x/218/pipeline/56