### PR TITLE
Fix incorrect section update in case of RC/signed builds.

### DIFF
--- a/pipeline/tier-0.groovy
+++ b/pipeline/tier-0.groovy
@@ -84,14 +84,15 @@ node(nodeName) {
             )
 
             if ( buildType == "rc" ) {
+                sourceKey = "rc"
                 updateKey = "rc"
             }
 
-            if ( latestContent.containsKey(updateKey) ) {
-                latestContent[updateKey] = releaseContent[sourceKey]
+            if ( latestContent.containsKey(tierLevel) ) {
+                latestContent[tierLevel] = releaseContent[sourceKey]
             }
             else {
-                def updateContent = ["${updateKey}": releaseContent[sourceKey]]
+                def updateContent = ["${tierLevel}": releaseContent[sourceKey]]
                 latestContent += updateContent
             }
             sharedLib.writeToReleaseFile(majorVersion, minorVersion, latestContent)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

A regression issue was caused when the UMB message was refactored. This fixes the regression issue wherein the `tier-0` section was not properly update when the build was of type RC

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-0/151/