### PR TITLE
[IBM-C] Support pulling of images from registry.redhat.io

### DIFF
--- a/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
+++ b/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
@@ -31,6 +31,7 @@ instance:
       expire: False
 
     runcmd:
+      - yum install -y yum-utils sudo
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
       - update-ca-trust

--- a/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
@@ -31,8 +31,9 @@ instance:
       expire: False
 
     runcmd:
-      - rpm -ivh  https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+      - yum install -y yum-utils sudo
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
       - update-ca-trust
+      - rpm -ivh  https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
       - touch /ceph-qa-ready


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we enable support for accessing Ceph Monitoring images from `registry.redhat.io` in the environment hosted in IBM-Cloud.

__Error__
https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/1/pipeline/49

__Log__
RHEL-7: /tmp/cephci-run-4F5LQ8
RHEL-8: /tmp/cephci-run-AGZBK3

OpenStack env: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/ibmc/rh7/