### PR TITLE
A fix is needed for 'remove_subvolume' for **kwargs from 'retain-snapshot' to 'retain_snapshot'.

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -556,7 +556,7 @@ class FsUtils(object):
             validate:
             **kwargs:
                 group_name : str
-                retain-snapshots : boolean
+                retain_snapshots : boolean
                 force : boolean
                 check_ec : boolean
         Returns:
@@ -565,7 +565,7 @@ class FsUtils(object):
         rmsubvolume_cmd = f"ceph fs subvolume rm {vol_name} {subvol_name}"
         if kwargs.get("group_name"):
             rmsubvolume_cmd += f" --group_name {kwargs.get('group_name')}"
-        if kwargs.get("retain-snapshots"):
+        if kwargs.get("retain_snapshots"):
             rmsubvolume_cmd += " --retain-snapshots"
         if kwargs.get("force"):
             rmsubvolume_cmd += " --force"


### PR DESCRIPTION
A fix is needed for 'remove_subvolume' for **kwargs from 'retain-snapshot' to 'retain_snapshot'.

Signed-off-by: Julius Park julpark@redhat.com

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
