### PR TITLE
Remove --skip-subscription CLI option from pipeline

### DIFF
--- a/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
+++ b/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
@@ -34,6 +34,10 @@ instance:
       - yum install -y yum-utils sudo
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
+      - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.4/.RH-IT-Root-CA.crt
       - update-ca-trust
-      - rpm -ivh  https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+      - subscription-manager unregister
+      - rpm -e katello-ca-consumer-rhncapsyd0102.service.networklayer.com-1.0-4.noarch
+      - subscription-manager clean
+      - rm -f /etc/pki/ca-trust/source/anchors/katello-server-ca.pem
       - touch /ceph-qa-ready

--- a/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
@@ -34,6 +34,10 @@ instance:
       - yum install -y yum-utils sudo
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
+      - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.4/.RH-IT-Root-CA.crt
       - update-ca-trust
-      - rpm -ivh  https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+      - subscription-manager unregister
+      - rpm -e katello-ca-consumer-rhncapsyd0102.service.networklayer.com-1.0-4.noarch
+      - subscription-manager clean
+      - rm -f /etc/pki/ca-trust/source/anchors/katello-server-ca.pem
       - touch /ceph-qa-ready

--- a/pipeline/ibm-tier-0.groovy
+++ b/pipeline/ibm-tier-0.groovy
@@ -48,7 +48,12 @@ node(nodeName) {
         if ((! rhcephVersion?.trim()) && (! buildType?.trim())) {
             error "Required Prameters are not provided.."
         }
-        testStages = sharedLib.fetchStages("--build ${buildType} --cloud ibmc --skip-subscription", buildPhase, testResults, rhcephversion)
+        testStages = sharedLib.fetchStages(
+            "--build ${buildType} --cloud ibmc ",
+            buildPhase,
+            testResults,
+            rhcephversion
+        )
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."

--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -51,7 +51,9 @@ node(nodeName) {
         buildPhase = buildPhaseValue[1].toInteger()+1
         buildPhase = buildPhaseValue[0]+"-"+buildPhase
         // Till the pipeline matures, using the build that has passed tier-0 suite.
-        testStages = sharedLib.fetchStages("--build tier-0 --cloud ibmc --skip-subscription", buildPhase, testResults, rhcephversion)
+        testStages = sharedLib.fetchStages(
+            "--build tier-0 --cloud ibmc", buildPhase, testResults, rhcephversion
+        )
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, the following changes are being made

- Removing the `--skip-subscription` option from the pipeline scripts
- Using packages from CDN due to unavailability of `ansible` repo in IBM-C

__Logs__
`IBM-C`
RHEL-7: https://159.23.92.24/job/Custom%20Test%20Run/11/console
RHEL-8: https://159.23.92.24/job/Custom%20Test%20Run/13/console

`OpenStack`
RHEL-8: 
```
All test logs located here: /tmp/cephci-run-E0G9CI

All test logs located here: /tmp/cephci-run-E0G9CI

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:05:47.634791                   Pass                             
ceph ansible                     ceph deployment using site.yaml(RPM) playbook with lvm scena   0:24:16.640893                   Pass                             
check-ceph-health                Check for ceph health debug info                               0:00:04.032241                   Pass                             
generate sosreport               generate sosreport                                             0:03:43.600912                   Pass                             
ceph ansible purge               Purge ceph cluster                                             0:03:21.228127                   Pass
```