### PR TITLE
Incorrect ceph version mentioned in the email

### DIFF
--- a/pipeline/tier-0.groovy
+++ b/pipeline/tier-0.groovy
@@ -100,7 +100,7 @@ node(nodeName) {
 
         sharedLib.sendGChatNotification(testResults, updateKey.capitalize())
         sharedLib.sendEmail(testResults, sharedLib.buildArtifactsDetails(
-            releaseContent, ciMap, updateKey), tierLevel.capitalize()
+            releaseContent, ciMap, sourceKey), tierLevel.capitalize()
         )
     }
 

--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -328,7 +328,7 @@ def sendEmail(def testResults, def artifactDetails, def tierLevel) {
         status = "UNSTABLE"
     }
 
-    def subject = "${tierLevel} test report status of ${artifactDetails.version} is ${status}"
+    def subject = "${tierLevel} test report status of ${artifactDetails.version} - ${artifactDetails.ceph_version} is ${status}"
 
     emailext (
         mimeType: 'text/html',


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
The email being sent out for Tier-0 stage results contains an incorrect ceph version. In this PR, this issue is fixed along with the change to add the details to the subject line.