### PR TITLE
Improving IBM-C 4.x tier-0 reliability

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -208,7 +208,7 @@ def setup_vm_node_ibm(node, ceph_nodes, **params):
     vm = None
     try:
         vm = CephVMNodeIBM(
-            accessKey=params["accesskey"], serviceUrl=params["service_url"]
+            access_key=params["accesskey"], service_url=params["service_url"]
         )
 
         vm.create(

--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -6,7 +6,7 @@ from libcloud.compute.base import Node
 
 from ceph.ceph import SSHConnectionManager
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class NetworkOpFailure(Exception):

--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -1,20 +1,11 @@
 """Collects the Baremetal information and creates the cephNode object."""
 import logging
+from copy import deepcopy
 from typing import List, Optional
-
-from libcloud.compute.base import Node
 
 from ceph.ceph import SSHConnectionManager
 
 LOG = logging.getLogger(__name__)
-
-
-class NetworkOpFailure(Exception):
-    pass
-
-
-class NodeError(Exception):
-    pass
 
 
 class CephBaremetalNode:
@@ -26,6 +17,7 @@ class CephBaremetalNode:
     ) -> None:
         """
         Initialize the instance node using the provided information.
+
         This will assign below properties to Baremetal Node
 
         params :
@@ -35,15 +27,11 @@ class CephBaremetalNode:
             Hostname
             root_login
             volumes
-
+            subnet
         """
-        self.node: Optional[Node] = None
         # CephVM attributes
-        self._subnet: list = list()
         self._roles: list = list()
 
-        # Fixme: determine if we can pick this information for OpenStack.
-        self.root_login: str
         self.osd_scenario: int
         self.keypair: Optional[str] = None
         self.params = params
@@ -64,8 +52,7 @@ class CephBaremetalNode:
     @property
     def ip_address(self) -> str:
         """Return the private IP address of the node."""
-        if self.params.get("ip"):
-            return self.params.get("ip")
+        return self.params.get("ip")
 
     @property
     def node_type(self) -> str:
@@ -74,27 +61,21 @@ class CephBaremetalNode:
     @property
     def hostname(self) -> str:
         """Return the hostname of the VM."""
-        if self.params.get("hostname"):
-            return self.params.get("hostname")
+        return self.params.get("hostname")
 
     @property
     def root_password(self) -> str:
         """Return root password for the machine"""
-        if self.params.get("root_password"):
-            return self.params.get("root_password")
-        else:
-            return "passwd"
+        return self.params.get("root_password", "passwd")
 
     @property
     def root_login(self) -> str:
-        return self.params.get("root_login", "")
+        return self.params.get("root_login", "root")
 
     @property
     def volumes(self):
         """Return the list of storage volumes attached to the node."""
-        if self.params.get("volumes"):
-            return self.params.get("volumes")
-        return []
+        return self.params.get("volumes", [])
 
     @property
     def no_of_volumes(self) -> int:
@@ -102,27 +83,9 @@ class CephBaremetalNode:
         return len(self.volumes)
 
     @property
-    def osd_scenario(self) -> int:
-        """Return the number of volumes attached to the VM."""
-        return 0
-
-    @property
     def subnet(self) -> str:
         """Return the subnet information."""
-        if self.node is None:
-            return ""
-
-        if self._subnet:
-            return self._subnet[0]
-
-        networks = self.node.extra.get("addresses")
-        for network in networks:
-            net = self._get_network_by_name(name=network)
-            subnet_id = net.extra.get("subnets")
-            self._subnet.append(self._get_subnet_cidr(subnet_id))
-
-        # Fixme: The CIDR returned needs to be part of the required network.
-        return self._subnet[0]
+        return self.params.get("subnet")
 
     @property
     def role(self) -> List:
@@ -132,6 +95,4 @@ class CephBaremetalNode:
     @role.setter
     def role(self, roles: list) -> None:
         """Set the roles for the VM."""
-        from copy import deepcopy
-
         self._roles = deepcopy(roles)

--- a/compute/exceptions.py
+++ b/compute/exceptions.py
@@ -1,0 +1,25 @@
+"""Custom exceptions for compute driver implementations."""
+
+
+class ResourceNotFound(Exception):
+    pass
+
+
+class ExactMatchFailed(Exception):
+    pass
+
+
+class VolumeOpFailure(Exception):
+    pass
+
+
+class NetworkOpFailure(Exception):
+    pass
+
+
+class NodeError(Exception):
+    pass
+
+
+class NodeDeleteFailure(Exception):
+    pass

--- a/compute/ibm_vpc.py
+++ b/compute/ibm_vpc.py
@@ -1,10 +1,11 @@
+"""IBM-Cloud VPC provider implementation for CephVMNode."""
 import logging
 import re
 import socket
 from copy import deepcopy
 from datetime import datetime, timedelta
 from time import sleep
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from ibm_cloud_networking_services import DnsSvcsV1
 from ibm_cloud_networking_services.dns_svcs_v1 import (
@@ -15,238 +16,213 @@ from ibm_cloud_sdk_core.api_exception import ApiException
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from ibm_vpc import VpcV1  # noqa
 
-from ceph.parallel import parallel
+from .exceptions import NodeDeleteFailure, NodeError, ResourceNotFound
 
 LOG = logging.getLogger(__name__)
-
-socket.setdefaulttimeout(280)
 
 
 def get_ibm_service(access_key: str, service_url: str):
     """
-    Get ibm service
+    Return the authenticated connection from the given service_url.
+
     Args:
-        accessKey    The access key(API key) of the user.
+        access_key (str):   The access key(API key) of the user.
+        service_url (str):  VPC endpoint to be used for provisioning.
     """
     authenticator = IAMAuthenticator(access_key)
+
     service = VpcV1(authenticator=authenticator)
-    service.set_service_url(service_url)
+    service.set_service_url(service_url=service_url)
+
     return service
 
 
-def get_dns_service(access_key: str):
+def get_dns_service(
+    access_key: str,
+    service_url: Optional[str] = "https://api.dns-svcs.cloud.ibm.com/v1",
+):
     """
-    Get dns service
+    Return the authenticated connection from the given endpoint.
     Args:
         accessKey    The access key(API key) of the user.
     """
     authenticator = IAMAuthenticator(access_key)
+
     dnssvc = DnsSvcsV1(authenticator=authenticator)
-    dnssvc.set_service_url("https://api.dns-svcs.cloud.ibm.com/v1")
+    dnssvc.set_service_url(service_url=service_url)
+
     return dnssvc
 
 
-def get_id_by_name(name_of_resource, json_obj):
+def get_resource_id(resource_name: str, response: Dict) -> str:
     """
-    Gets ID of the resource when name of the resource is given
+    Retrieve the ID of the given resource from the provided response.
+
     Args:
-        name_of_resource    Name of the resource.
-        json_obj            json object
+        resource_name (str):    Name of the resource.
+        response (Dict):        DetailedResponse returned from the collections.
+
+    Returns:
+        Resource id (str)
+
+    Raises:
+        ResourceNotFound    when there is a failure to retrieve the ID.
     """
-    resource_url = json_obj["first"]["href"]
+    resource_url = response["first"]["href"]
     resource_list_name = re.search(r"v1/(.*?)\?", resource_url).group(1)
-    for i in json_obj[resource_list_name]:
-        if i["name"] == name_of_resource:
+
+    for i in response[resource_list_name]:
+        if i["name"] == resource_name:
             return i["id"]
-    return []
+
+    raise ResourceNotFound(f"Failed to retrieve the ID of {resource_name}.")
 
 
-def get_id_by_name_zones(name_of_zone, json_obj):
+def get_dns_zone_id(zone_name: str, response: Any) -> str:
     """
-    Gets the Zone ID with Zone name
+    Retrieve the DNS Zone ID for the provided zone name using the provided response.
+
     Args:
-        name_of_zone    Name of the zone.
-        json_obj        json object
+        zone_name (str):    DNS Zone whose ID needs to be retrieved.
+        response (Dict):    Response returned from the collection.
+
+    Returns:
+        DNS Zone ID (str)
+
+    Raises:
+        ResourceNotFound    when there is a failure to retrieve the given zone ID.
     """
-    for i in json_obj["dnszones"]:
-        if i["name"] == name_of_zone:
+    for i in response["dnszones"]:
+        if i["name"] == zone_name:
             return i["id"]
-    return []
 
-
-def clean_up_dns_record(access_key, name, zone_name):
-    """
-    Removes DNS Records
-    Args:
-        access_key    The access key(API key) of the user.
-        name          Name(pattern) of DNS records for type:A
-        zone_name     Name of a zone
-    """
-    LOG.info(f"Removing DNS records which has name: {name}")
-    try:
-        dnssvc = get_dns_service(access_key)
-        dns_zone = dnssvc.list_dnszones("a55534f5-678d-452d-8cc6-e780941d8e31")
-        dns_zone_id = get_id_by_name_zones(zone_name, dns_zone.get_result())
-        resource = dnssvc.list_resource_records(
-            instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
-            dnszone_id=dns_zone_id,
-        )
-        records_a = [
-            i
-            for i in resource.get_result()["resource_records"]
-            if i["type"] == "A" and name in i["name"]
-        ]
-        for record in records_a:
-            if record["linked_ptr_record"] is not None:
-                LOG.info(f"Deleting dns record {record['linked_ptr_record']['name']}")
-                dnssvc.delete_resource_record(
-                    instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
-                    dnszone_id=dns_zone_id,
-                    record_id=record["linked_ptr_record"]["id"],
-                )
-            LOG.info(f"Deleting dns record {record['name']}")
-            dnssvc.delete_resource_record(
-                instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
-                dnszone_id=dns_zone_id,
-                record_id=record["id"],
-            )
-    except Exception:
-        raise AssertionError(f"Failed to remove DNS record: {name}")
-
-
-# Custom exception objects
-class ResourceNotFound(Exception):
-    pass
-
-
-class ExactMatchFailed(Exception):
-    pass
-
-
-class VolumeOpFailure(Exception):
-    pass
-
-
-class NetworkOpFailure(Exception):
-    pass
-
-
-class NodeError(Exception):
-    pass
-
-
-class NodeDeleteFailure(Exception):
-    pass
+    raise ResourceNotFound(f"Failed to retrieve the ID of {zone_name}.")
 
 
 class CephVMNodeIBM:
-    """Represent the VMNode required for cephci."""
+    """Represents a VMNode object created by softlayer driver."""
 
-    def __init__(self, access_key: str, service_url: str) -> None:
+    def __init__(
+        self,
+        access_key: str,
+        service_url: str,
+        vsi_id: Optional[str] = None,
+        node: Optional[Dict] = None,
+    ) -> None:
         """
-        Initialize the instance using the provided information.
+        Initializes the instance using the provided information.
 
         Args:
-            access_key    The access key(API key) of the user.
-            service_url   Url for IBM cloud
+            access_key (str):   Service credential secret token
+            service_url (str):  Endpoint of the service provider
+            vsi_id (str):       The VSI node ID to be retrieved
+            node (dict):
         """
-        self.service = get_ibm_service(access_key, service_url)
-        self.node = None
-
         # CephVM attributes
         self._subnet: list = list()
         self._roles: list = list()
+        self.node = None
 
-    def wait_until_vm_state_running(self, instance_id):
-        """
-        Wait till the VM moves to running state.
-        Args:
-            instance_id    Id of node instance
-        """
-        start_time = datetime.now()
-        end_time = start_time + timedelta(seconds=1200)
+        self.service = get_ibm_service(access_key=access_key, service_url=service_url)
+        self.dns_service = get_dns_service(access_key=access_key)
 
-        node_details = None
-        while end_time > datetime.now():
-            sleep(5)
-            node = self.service.get_instance(instance_id)
-            node_details = node.get_result()
+        if vsi_id:
+            self.node = self.service.get_instance(id=vsi_id).get_result()
 
-            if node_details["status"] == "running":
-                end_time = datetime.now()
-                duration = (end_time - start_time).total_seconds()
-                LOG.info(
-                    "%s moved to running state in %d seconds.",
-                    node_details["name"],
-                    int(duration),
-                )
-                return
+        if node:
+            self.node = node
 
-            if node_details["status"].lower() in ["error", "failed"]:
-                msg = (
-                    "Unknown Error"
-                    if not node.extra
-                    else node.extra.get("fault").get("message")
-                )
-                raise NodeError(msg)
+    # properties
 
-        raise NodeError(f"{node_details['name']} is in {node_details['status']} state.")
+    @property
+    def ip_address(self) -> str:
+        """Return the private IP address of the node."""
+        return self.node["primary_network_interface"]["primary_ipv4_address"]
 
-    def wait_until_node_del(self, node_name, timeout):
-        """
-        Wait till the VM deleted
-        Args:
-            node_names     Name(patter) of the instance Name
-            timeout        Max time to wait for the deletion to complete
-        """
-        try:
-            start_time = datetime.now()
-            end_time = start_time + timedelta(seconds=timeout)
-            while end_time > datetime.now():
-                sleep(5)
-                instance_list = self.service.list_instances()
-                node_list = [
-                    i
-                    for i in instance_list.get_result()["instances"]
-                    if node_name in i["name"]
-                ]
-                if not node_list:
-                    return
-            instance_list = self.service.list_instances()
-            node_list = [
-                i
-                for i in instance_list.get_result()["instances"]
-                if node_name in i["name"]
-            ]
-            if not node_list:
-                return
-            else:
-                raise NodeError(f"Unable to delete instance : {node_list}")
-        except ApiException as ae:
-            if ae.code == 404:
-                return
-            raise NodeError("Unable to delete the node")
+    @property
+    def floating_ips(self) -> List[str]:
+        """Return the list of floating IP's"""
+        if not self.node:
+            return []
 
-    def clean_up_instances(self, access_key, node_name, zone_name, timeout):
-        """
-        Method to clean up instances in ibm cloud.
-        Args:
-            access_key   The access key(API key) of the user.
-            node_name    Name of node instance
-            zone_name    Name of zone
-            timeout      Max time to wait for the deletion to complete
-        """
-        pattern = node_name
-        clean_up_dns_record(access_key, pattern, zone_name)
-        instance_list = self.service.list_instances()
-        del_instance_list = [
-            i for i in instance_list.get_result()["instances"] if pattern in i["name"]
+        resp = self.service.list_instance_network_interface_floating_ips(
+            instance_id=self.node["id"],
+            network_interface_id=self.node["primary_network_interface"]["id"],
+        )
+
+        return [
+            x["address"] for x in resp.get("floating_ips") if x["status"] == "available"
         ]
-        with parallel() as p:
-            for instance in del_instance_list:
-                LOG.info(f"Destroying node {instance['name']} with timeout:{timeout}")
-                p.spawn(self.service.delete_instance, instance["id"])
-            self.wait_until_node_del(node_name, timeout)
+
+    @property
+    def public_ip_address(self) -> str:
+        """Return the public IP address of the node."""
+        return self.floating_ips[0]
+
+    @property
+    def hostname(self) -> str:
+        """Return the hostname of the VM."""
+        end_time = datetime.now() + timedelta(seconds=30)
+        while end_time > datetime.now():
+            try:
+                name, _, _ = socket.gethostbyaddr(self.ip_address)
+
+                if name is not None:
+                    return name
+
+            except socket.herror:
+                break
+            except BaseException as be:  # noqa
+                LOG.warning(be)
+
+            sleep(5)
+
+        return self.node["name"]
+
+    @property
+    def volumes(self) -> List:
+        """Return the list of storage volumes attached to the node."""
+        if self.node is None:
+            return []
+
+        # Removing boot volume from the list
+        volume_attachments = []
+        for i in self.node["volume_attachments"]:
+            volume_detail = self.service.get_volume(i["volume"]["id"])
+            for vol in volume_detail.get_result()["volume_attachments"]:
+                if vol["type"] == "data":
+                    volume_attachments.append(vol)
+
+        return volume_attachments
+
+    @property
+    def subnet(self) -> str:
+        """Return the subnet information."""
+        subnet_details = self.service.get_subnet(
+            self.node["primary_network_interface"]["subnet"]["id"]
+        )
+
+        return subnet_details.get_result()["ipv4_cidr_block"]
+
+    @property
+    def shortname(self) -> str:
+        """Return the short form of the hostname."""
+        return self.hostname.split(".")[0]
+
+    @property
+    def no_of_volumes(self) -> int:
+        """Return the number of volumes attached to the VM."""
+        return len(self.volumes)
+
+    @property
+    def role(self) -> List:
+        """Return the Ceph roles of the instance."""
+        return self._roles
+
+    @role.setter
+    def role(self, roles: list) -> None:
+        """Set the roles for the VM."""
+        self._roles = deepcopy(roles)
 
     def create(
         self,
@@ -254,7 +230,6 @@ class CephVMNodeIBM:
         image_name: str,
         network_name: str,
         private_key: str,
-        access_key: str,
         vpc_name: str,
         profile: str,
         group_access: str,
@@ -283,39 +258,22 @@ class CephVMNodeIBM:
             userdata            user related data
 
         """
-        LOG.info("Starting to create VM with name %s", node_name)
+        LOG.info(f"Starting to create VM with name {node_name}")
         try:
+            # Construct a dict representation of a VPCIdentityById model
+            vpcs = self.service.list_vpcs()
+            vpc_id = get_resource_id(vpc_name, vpcs.get_result())
+            vpc_identity_model = dict({"id": vpc_id})
 
             subnets = self.service.list_subnets()
-            subnet_id = get_id_by_name(network_name, subnets.get_result())
-            images = self.service.list_images()
-            image_id = get_id_by_name(image_name, images.get_result())
+            subnet_id = get_resource_id(network_name, subnets.get_result())
+            subnet_identity_model = dict({"id": subnet_id})
 
-            keys = self.service.list_keys()
-            key_id = get_id_by_name(private_key, keys.get_result())
             security_group = self.service.list_security_groups()
-            security_group_id = get_id_by_name(
+            security_group_id = get_resource_id(
                 group_access, security_group.get_result()
             )
-            vpcs = self.service.list_vpcs()
-            vpc_id = get_id_by_name(vpc_name, vpcs.get_result())
-
-            # Construct a dict representation of a KeyIdentityById model
-            key_identity_model = dict({"id": key_id})
-            key_identity_shared = {
-                "fingerprint": "SHA256:OkzMbGLDIzqUcZoH9H/j5o/v01trlqKqp5DaUpJ0tcQ"
-            }
-
-            # Construct a dict representation of a SecurityGroupIdentityById model
             security_group_identity_model = dict({"id": security_group_id})
-
-            # Construct a dict representation of a ResourceIdentityById model
-            resource_group_identity_model = dict(
-                {"id": "cb8d87c33ca04965a180fd7ab7383936"}
-            )
-
-            # Construct a dict representation of a SubnetIdentityById model
-            subnet_identity_model = dict({"id": subnet_id})
 
             # Construct a dict representation of a NetworkInterfacePrototype model
             network_interface_prototype_model = dict(
@@ -326,13 +284,35 @@ class CephVMNodeIBM:
                 }
             )
 
+            # Construct a dict representation of a ImageIdentityById model
+            images = self.service.list_images()
+            image_id = get_resource_id(image_name, images.get_result())
+            image_identity_model = dict({"id": image_id})
+
+            # Construct a dict representation of a KeyIdentityById model
+            keys = self.service.list_keys()
+            key_id = get_resource_id(private_key, keys.get_result())
+
+            key_identity_model = dict({"id": key_id})
+            key_identity_shared = {
+                "fingerprint": "SHA256:OkzMbGLDIzqUcZoH9H/j5o/v01trlqKqp5DaUpJ0tcQ"
+            }
+
+            # Construct a dict representation of a ResourceIdentityById model
+            resource_group_identity_model = dict(
+                {"id": "cb8d87c33ca04965a180fd7ab7383936"}
+            )
+
             # Construct a dict representation of a InstanceProfileIdentityByName model
             instance_profile_identity_model = dict({"name": profile})
+
+            # Construct a dict representation of a ZoneIdentityByName model
+            zone_identity_model = dict({"name": zone_id_model_name})
 
             # Construct a dict representation of a VolumeProfileIdentityByName model
             volume_profile_identity_model = dict({"name": "general-purpose"})
 
-            volume_attachement_list = []
+            volume_attachment_list = []
             for i in range(0, no_of_volumes):
                 volume_attachment_volume_prototype_instance_context_model1 = dict(
                     {
@@ -349,20 +329,11 @@ class CephVMNodeIBM:
                     }
                 )
 
-                volume_attachement_list.append(
+                volume_attachment_list.append(
                     volume_attachment_prototype_instance_context_model1
                 )
 
-            # Construct a dict representation of a VPCIdentityById model
-            vpc_identity_model = dict({"id": vpc_id})
-
-            # Construct a dict representation of a ImageIdentityById model
-            image_identity_model = dict({"id": image_id})
-
-            # Construct a dict representation of a ZoneIdentityByName model
-            zone_identity_model = dict({"name": zone_id_model_name})
-
-            # Construct a dict representation of InstancePrototypeInstanceByImage model
+            # Prepare the VSI payload
             instance_prototype_model = dict(
                 {"keys": [key_identity_model, key_identity_shared]}
             )
@@ -371,7 +342,7 @@ class CephVMNodeIBM:
             instance_prototype_model["profile"] = instance_profile_identity_model
             instance_prototype_model["resource_group"] = resource_group_identity_model
             instance_prototype_model["user_data"] = userdata
-            instance_prototype_model["volume_attachments"] = volume_attachement_list
+            instance_prototype_model["volume_attachments"] = volume_attachment_list
             instance_prototype_model["vpc"] = vpc_identity_model
             instance_prototype_model["image"] = image_identity_model
             instance_prototype_model[
@@ -384,14 +355,17 @@ class CephVMNodeIBM:
             response = self.service.create_instance(instance_prototype)
 
             instance_id = response.get_result()["id"]
+            self.node = response.get_result()
             self.wait_until_vm_state_running(instance_id)
-            self.node = self.service.get_instance(instance_id).get_result()
 
-            dnssvc = get_dns_service(access_key)
-            dns_zone = dnssvc.list_dnszones("a55534f5-678d-452d-8cc6-e780941d8e31")
-            dns_zone_id = get_id_by_name_zones(zone_name, dns_zone.get_result())
+            # DNS record creation phase
+            LOG.debug(f"Adding DNS records for {node_name}")
+            dns_zone = self.dns_service.list_dnszones(
+                "a55534f5-678d-452d-8cc6-e780941d8e31"
+            )
+            dns_zone_id = get_dns_zone_id(zone_name, dns_zone.get_result())
 
-            resource = dnssvc.list_resource_records(
+            resource = self.dns_service.list_resource_records(
                 instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
                 dnszone_id=dns_zone_id,
             )
@@ -405,7 +379,7 @@ class CephVMNodeIBM:
                 == self.node["primary_network_interface"]["primary_ipv4_address"]
             ]
             if records_ip:
-                dnssvc.update_resource_record(
+                self.dns_service.update_resource_record(
                     instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
                     dnszone_id=dns_zone_id,
                     record_id=records_ip[0]["id"],
@@ -416,7 +390,7 @@ class CephVMNodeIBM:
             a_record = ResourceRecordInputRdataRdataARecord(
                 self.node["primary_network_interface"]["primary_ipv4_address"]
             )
-            dnssvc.create_resource_record(
+            self.dns_service.create_resource_record(
                 instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
                 dnszone_id=dns_zone_id,
                 type="A",
@@ -428,7 +402,7 @@ class CephVMNodeIBM:
             ptr_record = ResourceRecordInputRdataRdataPtrRecord(
                 f"{self.node['name']}.{zone_name}"
             )
-            dnssvc.create_resource_record(
+            self.dns_service.create_resource_record(
                 instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
                 dnszone_id=dns_zone_id,
                 type="PTR",
@@ -437,86 +411,133 @@ class CephVMNodeIBM:
                 rdata=ptr_record,
             )
 
-        except (ResourceNotFound, NetworkOpFailure, NodeError, VolumeOpFailure):
+        except NodeError:
             raise
         except BaseException as be:  # noqa
             LOG.error(be, exc_info=True)
             raise NodeError(f"Unknown error. Failed to create VM with name {node_name}")
 
-    # properties
+    def delete(self, zone_name: Optional[str] = None) -> None:
+        """
+        Removes the VSI instance from the platform along with its DNS record.
 
-    @property
-    def ip_address(self) -> str:
-        """Return the private IP address of the node."""
-        return self.node["primary_network_interface"]["primary_ipv4_address"]
+        Args:
+            zone_name (str):    DNS Zone name associated with the instance.
+        """
+        if not self.node:
+            return
 
-    @property
-    def floating_ips(self) -> List[str]:
-        """Return the list of floating IP's"""
-        return self.node.public_ips if self.node else []
+        node_id = self.node["id"]
+        node_name = self.node["name"]
 
-    @property
-    def public_ip_address(self) -> str:
-        """Return the public IP address of the node."""
-        return self.node.public_ips[0]
+        try:
+            self.remove_dns_records(zone_name)
+        except BaseException:  # noqa
+            LOG.warning(f"Encountered an error in removing DNS records of {node_name}")
 
-    @property
-    def hostname(self) -> str:
-        """Return the hostname of the VM."""
-        end_time = datetime.now() + timedelta(seconds=30)
+        LOG.info(f"Preparing to remove {node_name}")
+        resp = self.service.delete_instance(node_id)
+
+        if resp.get_status_code() != 204:
+            LOG.debug(f"{node_name} cannot be found.")
+            return
+
+        # Wait for the VM to be delete
+        end_time = datetime.now() + timedelta(seconds=600)
         while end_time > datetime.now():
-            try:
-                name, _, _ = socket.gethostbyaddr(self.ip_address)
-
-                if name is not None:
-                    return name
-
-            except socket.herror:
-                break
-            except BaseException as be:  # noqa
-                LOG.warning(be)
-
             sleep(5)
-        return self.node["name"]
+            try:
+                resp = self.service.get_instance(node_id)
+                if resp.get_status_code == 404:
+                    LOG.info(f"Successfully removed {node_name}")
+                    return
+            except ApiException:
+                LOG.info(f"Successfully removed {node_name}")
+                self.remove_dns_records(zone_name)
+                return
 
-    @property
-    def volumes(self) -> List:
-        """Return the list of storage volumes attached to the node."""
-        if self.node is None:
-            return []
-        # Removing boot volume from the list
-        volume_attachments = []
-        for i in self.node["volume_attachments"]:
-            volume_detail = self.service.get_volume(i["volume"]["id"])
-            for vol in volume_detail.get_result()["volume_attachments"]:
-                if vol["type"] == "data":
-                    volume_attachments.append(vol)
-        return volume_attachments
+        LOG.debug(resp.get_result())
+        raise NodeDeleteFailure(f"Failed to remove {node_name}")
 
-    @property
-    def subnet(self) -> str:
-        """Return the subnet information."""
-        subnet_details = self.service.get_subnet(
-            self.node["primary_network_interface"]["subnet"]["id"]
+    def wait_until_vm_state_running(self, instance_id: str) -> None:
+        """
+        Waits until the VSI moves to a running state within the specified time.
+
+        Args:
+            instance_id (str)   The ID of the VSI to be checked.
+
+        Returns:
+            None
+
+        Raises:
+            NodeError
+        """
+        start_time = datetime.now()
+        end_time = start_time + timedelta(seconds=1200)
+
+        node_details = None
+        while end_time > datetime.now():
+            sleep(5)
+            resp = self.service.get_instance(instance_id)
+            if resp.get_status_code() != 200:
+                LOG.debug("Encountered an error getting the instance.")
+                sleep(5)
+                continue
+
+            node_details = resp.get_result()
+            if node_details["status"] == "running":
+                end_time = datetime.now()
+                duration = (end_time - start_time).total_seconds()
+                LOG.info(
+                    "%s moved to running state in %d seconds.",
+                    node_details["name"],
+                    int(duration),
+                )
+                return
+
+            if node_details["status"] == "failed":
+                raise NodeError(node_details["status_reasons"])
+
+        raise NodeError(f"{node_details['name']} is in {node_details['status']} state.")
+
+    def remove_dns_records(self, zone_name):
+        """
+        Remove the DNS records associated this VSI.
+
+        Args:
+            zone_name (str):    DNS zone name associated with this VSI
+        """
+        zones = self.dns_service.list_dnszones("a55534f5-678d-452d-8cc6-e780941d8e31")
+        zone_id = get_dns_zone_id(zone_name, zones.get_result())
+
+        resp = self.dns_service.list_resource_records(
+            instance_id="a55534f5-678d-452d-8cc6-e780941d8e31", dnszone_id=zone_id
         )
-        return subnet_details.get_result()["ipv4_cidr_block"]
+        records = resp.get_result()
 
-    @property
-    def shortname(self) -> str:
-        """Return the short form of the hostname."""
-        return self.hostname.split(".")[0]
+        # ToDo: There is a maximum of 200 records that can be retrieved at a time.
+        #       Support pagination is required.
+        for record in records["resource_records"]:
+            if record["type"] == "A" and self.node.get("name") in record["name"]:
+                if record.get("linked_ptr_record"):
+                    LOG.info(
+                        f"Deleting PTR record {record['linked_ptr_record']['name']}"
+                    )
+                    self.dns_service.delete_resource_record(
+                        instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
+                        dnszone_id=zone_id,
+                        record_id=record["linked_ptr_record"]["id"],
+                    )
 
-    @property
-    def no_of_volumes(self) -> int:
-        """Return the number of volumes attached to the VM."""
-        return len(self.volumes)
+                LOG.info(f"Deleting Address record {record['name']}")
+                self.dns_service.delete_resource_record(
+                    instance_id="a55534f5-678d-452d-8cc6-e780941d8e31",
+                    dnszone_id=zone_id,
+                    record_id=record["id"],
+                )
 
-    @property
-    def role(self) -> List:
-        """Return the Ceph roles of the instance."""
-        return self._roles
+                return
 
-    @role.setter
-    def role(self, roles: list) -> None:
-        """Set the roles for the VM."""
-        self._roles = deepcopy(roles)
+        # This code path can happen if there are no matching/associated DNS records
+        # Or we have a problem
+        LOG.debug(f"No matching DNS records found for {self.node['name']}")

--- a/compute/openstack.py
+++ b/compute/openstack.py
@@ -15,7 +15,7 @@ from libcloud.compute.drivers.openstack import (
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 # libcloud does not have a timeout enabled for Openstack calls to
 # ``create_node``, and it uses the default timeout value from socket which is

--- a/compute/openstack.py
+++ b/compute/openstack.py
@@ -15,6 +15,15 @@ from libcloud.compute.drivers.openstack import (
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 
+from .exceptions import (
+    ExactMatchFailed,
+    NetworkOpFailure,
+    NodeDeleteFailure,
+    NodeError,
+    ResourceNotFound,
+    VolumeOpFailure,
+)
+
 LOG = logging.getLogger(__name__)
 
 # libcloud does not have a timeout enabled for Openstack calls to
@@ -63,31 +72,6 @@ def get_openstack_driver(
         ex_domain_name=domain_name,
         ex_tenant_domain_id=tenant_domain_id,
     )
-
-
-# Custom exception objects
-class ResourceNotFound(Exception):
-    pass
-
-
-class ExactMatchFailed(Exception):
-    pass
-
-
-class VolumeOpFailure(Exception):
-    pass
-
-
-class NetworkOpFailure(Exception):
-    pass
-
-
-class NodeError(Exception):
-    pass
-
-
-class NodeDeleteFailure(Exception):
-    pass
 
 
 class CephVMNodeV2:

--- a/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
+++ b/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
@@ -2,7 +2,7 @@ version_id: 7.9
 id: rhel
 instance:
   create:
-    image-name: ibm-redhat-7-9-minimal-amd64-3
+    image-name: rhel-server-79-x86-64-kvm
     network_name: sn-01-cephqe-pvt-network
     private_key: ibmc-shared
     group_access: cephqe-sec-grp-all-access
@@ -26,18 +26,13 @@ instance:
 
     chpasswd:
       list: |
-        root: Welcome123#
+        root: passwd
         cephuser: pass123
       expire: False
 
     runcmd:
-      - yum install -y yum-utils sudo
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
       - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.4/.RH-IT-Root-CA.crt
       - update-ca-trust
-      - subscription-manager unregister
-      - rpm -e katello-ca-consumer-rhncapsyd0102.service.networklayer.com-1.0-4.noarch
-      - subscription-manager clean
-      - rm -f /etc/pki/ca-trust/source/anchors/katello-server-ca.pem
       - touch /ceph-qa-ready

--- a/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
@@ -2,7 +2,7 @@ version_id: 8.4
 id: rhel
 instance:
   create:
-    image-name: ibm-redhat-8-4-minimal-amd64-1
+    image-name: rhel-server-84-x86-64-kvm
     network_name: sn-01-cephqe-pvt-network
     private_key: ibmc-shared
     group_access: cephqe-sec-grp-all-access
@@ -26,18 +26,13 @@ instance:
 
     chpasswd:
       list: |
-        root: Welcome123#
+        root: passwd
         cephuser: pass123
       expire: False
 
     runcmd:
-      - yum install -y yum-utils sudo
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.4/.ceph-qe-ca.pem
       - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.4/.RH-IT-Root-CA.crt
       - update-ca-trust
-      - subscription-manager unregister
-      - rpm -e katello-ca-consumer-rhncapsyd0102.service.networklayer.com-1.0-4.noarch
-      - subscription-manager clean
-      - rm -f /etc/pki/ca-trust/source/anchors/katello-server-ca.pem
       - touch /ceph-qa-ready

--- a/mita/v2.py
+++ b/mita/v2.py
@@ -15,7 +15,7 @@ from libcloud.compute.drivers.openstack import (
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 # libcloud does not have a timeout enabled for Openstack calls to
 # ``create_node``, and it uses the default timeout value from socket which is


### PR DESCRIPTION
# Description

In this PR, the following issues are being addressed

- 4.x RHEL-7 baremetal deployments are getting stuck
- Connection Pool limits being exceeded during VSI cleanup
- Moving to common exception module.
- Supporting floating IP address retrieval

__Logs__
RHEL-7: https://159.23.92.24/job/Custom%20Test%20Run/24/console
Tier-0: https://159.23.92.24/job/tier-0/22/
cleanup: /tmp/cephci-run-0OYHZ6/startup.log
OpenStack: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/ibmc/osp/