### PR TITLE
ceph.ceph.CommandFailed: yum install -y ceph-ansible Error:  Error: Nothing to do

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -905,9 +905,9 @@ class Ceph(object):
         for repo in repos:
             base_url = base_url.rstrip("/")
             if cloud_type == "ibmc":
-                repo_to_use = f"{base_url}/{repo}"
+                repo_to_use = f"{base_url}/{repo}/"
             else:
-                repo_to_use = f"{base_url}/compose/{repo}/x86_64/os"
+                repo_to_use = f"{base_url}/compose/{repo}/x86_64/os/"
 
             logger.info(f"repo to use is {repo_to_use}")
             r = requests.get(repo_to_use, timeout=10, verify=False)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes an issue observed during the execution of RC builds.

__Error__
```
2021-11-12 02:39:30,158 - __main__ - ERROR - Traceback (most recent call last):
  File "run.py", line 916, in run
    clients=clients,
  File "/home/jenkins-build/workspace/rhceph-tier-0/tests/ceph_installer/test_ansible.py", line 68, in run
    ceph_installer.install_ceph_ansible(build)
  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph.py", line 2249, in install_ceph_ansible
    self.exec_command(sudo=True, cmd="yum install -y ceph-ansible")
  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph.py", line 1948, in exec_command
    return self.node.exec_command(cmd=cmd, **kw)
  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph.py", line 1455, in exec_command
    + str(self.ip_address)
ceph.ceph.CommandFailed: yum install -y ceph-ansible Error:  Error: Nothing to do
 10.0.211.73
```

__Logs__
```
>>> requests.get('http://download-node-02.eng.bos.redhat.com/rel-eng/rhel-8/RHCEPH-4/RHCEPH-4.2-RHEL-8-20211111.0/compose/MON/x86_64/os', verify=False)
/home/psathyan/venv/cephci.venv/lib64/python3.6/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
<Response [404]>
>>> requests.get('http://download-node-02.eng.bos.redhat.com/rel-eng/rhel-8/RHCEPH-4/RHCEPH-4.2-RHEL-8-20211111.0/compose/MON/x86_64/os/', verify=False)
<Response [200]>
>>> x = requests.get('http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.1-rhel-8/RHCEPH-5.1-RHEL-8-20211111.ci.0/compose/Tools/x86_64/os/', verify=False)
>>> x.status_code
200
>>> requests.get('http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.1-rhel-8/RHCEPH-5.1-RHEL-8-20211111.ci.0/compose/Tools/x86_64/os', verify=False)
<Response [200]>
>>> 
```
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rc_repo_url/