### PR TITLE
add support to specify role in config for exec.py

### DIFF
--- a/tests/misc_env/exec.py
+++ b/tests/misc_env/exec.py
@@ -178,7 +178,7 @@ def run(ceph_cluster, **kwargs: Any) -> int:
 
     Args:
         ceph_cluster:   The participating Ceph cluster object
-        kwargs:         Supported key value pairs are
+        kwargs:         Supported key value pairs for the key config are
                         cmd             | Depreciated - command to be executed
                         idx             | Default 0, index to be used
                         sudo            | Execute in the privileged mode
@@ -220,7 +220,7 @@ def run(ceph_cluster, **kwargs: Any) -> int:
     sudo = config.get("sudo", False)
     long_running = config.get("long_running", False)
 
-    role = kwargs.get("role", "client")
+    role = config.get("role", "client")
     if cephadm:
         role = "installer"
 


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Add support to specify role in config for exec.py

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

# Checklist:

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
