### PR TITLE
Handling exception from report portal.

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -513,12 +513,15 @@ def create_report_portal_session():
     """
     cfg = get_cephci_config()["report-portal"]
 
-    return ReportPortalService(
-        endpoint=cfg["endpoint"],
-        project=cfg["project"],
-        token=cfg["token"],
-        verify_ssl=False,
-    )
+    try:
+        return ReportPortalService(
+            endpoint=cfg["endpoint"],
+            project=cfg["project"],
+            token=cfg["token"],
+            verify_ssl=False,
+        )
+    except BaseException:  # noqa
+        print("Encountered an issue in connecting to report portal.")
 
 
 def timestamp():


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
When there is an exception in pushing information to Report Portal, the entire test suite is aborted. Due to this, the pipeline becomes unhealthy.

In this PR, we ignore this exception however, we do log a debug message indicate a failure had occurred. 

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-x/270/console

__Error__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-tier-x/266/console