### PR TITLE
inventory: make softlinks for rhel-8.x and rhel-7x

### DIFF
--- a/conf/inventory/rhel-7-latest.yaml
+++ b/conf/inventory/rhel-7-latest.yaml
@@ -1,0 +1,1 @@
+rhel-7.9-server-x86_64.yaml

--- a/conf/inventory/rhel-8-latest.yaml
+++ b/conf/inventory/rhel-8-latest.yaml
@@ -1,0 +1,1 @@
+rhel-8.5-server-x86_64.yaml


### PR DESCRIPTION
adding softlinks for rhel-8 and rhel-7 inventory files

`rhel-8-latest.yaml` -> `rhel-8.5-server-x86_64.yaml`
`rhel-7-latest.yaml` -> `rhel-7.9-server-x86_64.yaml`

Signed-off-by: rakeshgm <rakeshgm@redhat.com>
