### PR TITLE
Adding support for deploying a ceph cluster via UMB message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ result.props
 osd_scenarios_*node*
 version_info.json
 rerun
+sut.yaml

--- a/conf/nautilus/integrations/7_node_ceph.yaml
+++ b/conf/nautilus/integrations/7_node_ceph.yaml
@@ -1,0 +1,54 @@
+# System Under Test environment configuration for OCS-RHCeph integration.
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        role:
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mgr
+          - mon
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node6:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node7:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - osd
+          - rgw

--- a/conf/pacific/integrations/7_node_ceph.yaml
+++ b/conf/pacific/integrations/7_node_ceph.yaml
@@ -1,0 +1,56 @@
+# System Under Test environment configuration for OCS-RHCeph integration.
+---
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mgr
+          - mon
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node6:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node7:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - osd
+          - rgw

--- a/fragments/README.md
+++ b/fragments/README.md
@@ -1,0 +1,9 @@
+## Test Cases
+Place all the automated test cases of Red Hat Ceph Storage in this directory.
+
+### Guidelines
+- One test case definition per file.
+- The name of the file is descriptive.
+- There is a direct mapping to TCMS (Test Case Management System) via an identifier.
+- Each test case has a top level description.
+- Keep a linear structure.

--- a/fragments/generic/gather_system_info.yaml
+++ b/fragments/generic/gather_system_info.yaml
@@ -1,0 +1,8 @@
+# The purpose of this file implements the requirements of OCS integration.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Gather system details
+      module: gather_cluster_info.py
+      name: Retreive cluster details for OCS

--- a/fragments/generic/verify_ceph_cluster_health.yaml
+++ b/fragments/generic/verify_ceph_cluster_health.yaml
@@ -1,0 +1,13 @@
+# The purpose of this test is to verify the health of the Ceph Cluster by issuing the
+# command `ceph -s`
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        commands:
+          - "ceph -s"
+        sudo: true
+      desc: Verify the health of Ceph Cluster.
+      module: exec.py
+      name: Verify cluster health

--- a/fragments/install/ansible/test_ceph_ansible_deploy_cluster_mds_override.yaml
+++ b/fragments/install/ansible/test_ceph_ansible_deploy_cluster_mds_override.yaml
@@ -1,0 +1,29 @@
+# The purpose of this test is to deploy a cluster with MDS customization.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        ansi_config:
+          ceph_test: True
+          ceph_origin: distro
+          ceph_repository: rhcs
+          osd_scenario: lvm
+          osd_auto_discovery: False
+          ceph_stable: True
+          ceph_stable_rh_storage: True
+          fetch_directory: ~/fetch
+          copy_admin_key: true
+          dashboard_enabled: False
+          ceph_conf_overrides:
+            global:
+              mon_warn_on_insecure_global_id_reclaim_allowed: false
+          cephfs_pools:
+            - name: "cephfs_data"
+              pgs: "8"
+            - name: "cephfs_metadata"
+              pgs: "16"
+      desc: Deploy the Ceph cluster using ansible
+      destory-cluster: false
+      module: test_ansible.py
+      name: deploy ceph cluster

--- a/fragments/install/cephadm/test_cephadm_add_hosts_with_labels.yaml
+++ b/fragments/install/cephadm/test_cephadm_add_hosts_with_labels.yaml
@@ -1,0 +1,16 @@
+# The purpose of this test is to verify adding of hosts to an existing cluster with
+# labels and ip addresses
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          attach_ip_address: true
+          labels: apply-all-labels
+        command: add_hosts
+        service: host
+      desc: Adding hosts to the cluster with labels and IP information.
+      destroy-cluster: false
+      module: test_host.py
+      name: Test adding of hosts to the cluster

--- a/fragments/install/cephadm/test_cephadm_add_osds.yaml
+++ b/fragments/install/cephadm/test_cephadm_add_osds.yaml
@@ -1,0 +1,15 @@
+# The purpose of this test is to deploy OSD daemons using cephadm with
+# all-available-devices option enabled.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          all-available-devices: true
+        command: apply
+        service: osd
+      desc: Test deploying OSD daemons with all-available-devices enabled.
+      destroy-cluster: false
+      module: test_osd.py
+      name: Test OSD daemon deployment with all-available-devices enabled.

--- a/fragments/install/cephadm/test_cephadm_add_rgw_using_labels.yaml
+++ b/fragments/install/cephadm/test_cephadm_add_rgw_using_labels.yaml
@@ -1,0 +1,17 @@
+# The purpose of this test is to deploy a RGW daemon using cephadm with help of labels.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          placement:
+            label: rgw
+        command: apply
+        pos_args:
+          - rgw.1
+        service: rgw
+      desc: Test deploying of RGW daemon using CephAdm with label
+      destroy-cluster: false
+      module: test_rgw.py
+      name: Test RGW daemon deployment with labels.

--- a/fragments/install/cephadm/test_cephadm_deploy_2_mds.yaml
+++ b/fragments/install/cephadm/test_cephadm_deploy_2_mds.yaml
@@ -1,0 +1,30 @@
+# The purpose of this test case is to deploy active - active MDS daemons on the cluster.
+# This involves creating a CephFS volume with name fsvol001 with 2 MDS.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - ceph fs volume create fsvol001 --placement='4 label:mds'
+          - ceph fs set fsvol001 max_mds 2
+      desc: Create and configure a volume with 2 MDS limit
+      destroy-cluster: false
+      module: exec.py
+      name: Test CephFS volume with 2 MDS configured
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          placement:
+            label: mds
+        command: apply
+        pos_args:
+          - fsvol001
+        service: mds
+      desc: Test deploying MDS daemons on hosts with label mds.
+      destroy-cluster: false
+      module: test_mds.py
+      name: Test OSD daemon deployment with all-available-devices enabled.

--- a/fragments/install/cephadm/test_cephadm_initial_bootstrap.yaml
+++ b/fragments/install/cephadm/test_cephadm_initial_bootstrap.yaml
@@ -1,0 +1,15 @@
+# The purpose of this test case is to verify the initial bootstrap of the cluster
+# using CephAdm.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          mon-ip: node1
+        command: bootstrap
+        service: cephadm
+      desc: Bootstrap the cluster with minimal configuration.
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: Test cephadm minimal bootstrap

--- a/fragments/setup/test_setup_configure_system.yaml
+++ b/fragments/setup/test_setup_configure_system.yaml
@@ -1,0 +1,9 @@
+# A test setup workflow that configures the system with the minimal required
+# packages. Ironically, this is not a test case but a workflow.
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for RHCS cluster deployment.
+      module: install_prereq.py
+      name: test setup install cluster prerequisites

--- a/pipeline/rhcs_delete.groovy
+++ b/pipeline/rhcs_delete.groovy
@@ -1,0 +1,49 @@
+/*
+    Script to remove an existing cluster via UMB message.
+*/
+def sharedLib
+
+node("centos-7") {
+
+    timeout(unit: "MINUTES", time: 30) {
+        stage("Prepare env") {
+            if (env.WORKSPACE) {
+                sh (script: "sudo rm -rf *")
+            }
+
+            checkout ([
+                $class: 'GitSCM',
+                branches: [[name: 'origin/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'CloneOption',
+                    shallow: true,
+                    noTags: true,
+                    reference: '',
+                    depth: 0
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
+            ])
+
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+            sharedLib.prepareNode()
+        }
+    }
+
+    stage("Remove cluster") {
+        def ciMap = sharedLib.getCIMessageMap()
+
+        def cmd = ".venv/bin/python run.py --log-level debug"
+        cmd += " --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
+        cmd += " --cleanup ${ciMap['instances-name']}"
+
+        println ("Command: ${cmd}")
+
+        sh (script: cmd)
+        println "Successfully removed the cluster."
+    }
+
+}

--- a/pipeline/rhcs_deploy.groovy
+++ b/pipeline/rhcs_deploy.groovy
@@ -1,0 +1,144 @@
+/*
+    The primary objective of this script is to deploy a RHCS cluster to be used as a
+    external application by integrating applications.
+*/
+def rhcsVersionMap = [ "4": "nautilus", "5": "pacific" ]
+def ciMap = [:]
+
+def baseInventoryPath = "conf/inventory"
+def baseGlobalConfPath = "conf"
+def baseSuitePath = "suites"
+def sharedLib
+def vmPrefix
+
+// Defaults
+def inventory = "rhel-8.4-server-x86_64-medlarge.yaml"
+def globalConf = "integrations/7_node_ceph.yaml"
+def testSuite = "integrations/ocs/"
+
+node ("centos-7") {
+
+    timeout(unit: "MINUTES", time: 30) {
+        stage("Prepare env") {
+            if (env.WORKSPACE) {
+                sh (script: "sudo rm -rf *")
+            }
+
+            checkout ([
+                $class: 'GitSCM',
+                branches: [[name: 'origin/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'CloneOption',
+                    shallow: true,
+                    noTags: true,
+                    reference: '',
+                    depth: 0
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
+            ])
+
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+            sharedLib.prepareNode()
+        }
+    }
+
+    stage("Deploy") {
+        def cliArgs = "--v2"
+        ciMap = sharedLib.getCIMessageMap()
+
+        majorVersion = ciMap.build.substring(0,1)
+        upstreamName = rhcsVersionMap[majorVersion]
+
+        if (ciMap.containsKey("inventory")) {
+            inventory = ciMap.inventory
+        }
+
+        if (ciMap.containsKey("testsuite")) {
+            testSuite = ciMap.testsuite
+        }
+
+        if (ciMap.containsKey("global-conf")) {
+            globalConf = ciMap["global-conf"]
+        }
+
+        // determine the platform
+        def osName = sh (
+            script: "cat ${baseInventoryPath}/${inventory} | grep -e '^id:' | cut -d ':' -f 2",
+            returnStdout: true
+        ).trim()
+        def osMajorVersion = sh (
+            script: "cat ${baseInventoryPath}/${inventory} | grep -e '^version_id:' | cut -d ':' -f 2 | cut -d '.' -f 1",
+            returnStdout: true
+        ).trim()
+        def platform = "${osName}-${osMajorVersion}"
+
+        // Prepare the CLI arguments
+        cliArgs += " --rhbuild ${ciMap.build}"
+        cliArgs += " --platform ${platform}"
+        cliArgs += " --build tier-0"
+        cliArgs += " --inventory ${baseInventoryPath}/${inventory}"
+        cliArgs += " --global-conf ${baseGlobalConfPath}/${upstreamName}/${globalConf}"
+        cliArgs += " --suite ${baseSuitePath}/${upstreamName}/${testSuite}"
+
+        println "Debug: ${cliArgs}"
+
+        returnStatus = sharedLib.executeTestSuite(cliArgs, false)
+        if ( returnStatus.result == "FAIL") {
+            error "Deployment failed."
+        }
+
+        vmPrefix = returnStatus["instances-name"]
+    }
+
+    stage('Publish') {
+        def sutInfo = readYaml file: "sut.yaml"
+        sutInfo["instances-name"] = vmPrefix
+
+        def msgMap = [
+            "artifact": [
+                "type": "product-build",
+                "name": "Red Hat Ceph Storage",
+                "nvr": "RHCEPH-${ciMap.build}",
+                "phase": "integration",
+            ],
+            "extra": sutInfo,
+            "contact": [
+                "name": "Downstream Ceph QE",
+                "email": "cephci@redhat.com",
+            ],
+            "system": [
+                "os": "centos-7",
+                "label": "centos-7",
+                "provider": "openstack",
+            ],
+            "pipeline": [
+                "name": "rhceph-deploy-cluster",
+                "id": currentBuild.number,
+            ],
+            "run": [
+                "url": env.BUILD_URL,
+                "log": "${env.BUILD_URL}console",
+            ],
+            "test": [
+                "type": "integration",
+                "category": "system",
+                "result": currentBuild.currentResult,
+            ],
+            "generated_at": env.BUILD_ID,
+            "version": "1.1.0"
+        ]
+
+        def msg = writeJSON returnText: true, json: msgMap
+        println msg
+
+        sharedLib.SendUMBMessage(
+            msg,
+            "VirtualTopic.qe.ci.rhcs.deploy.complete",
+            "ProductBuildInStaging"
+        )
+    }
+}

--- a/run.py
+++ b/run.py
@@ -1055,12 +1055,17 @@ def store_cluster_state(ceph_cluster_object, ceph_clusters_file_name):
 
 def collect_recipe(ceph_cluster):
     """
-    Collects the podman version/Docker Version and ceph version installed and writes to version_info.json file
+    Gather the system under test details.
+
+    At present, the following information are gathered
+        container (podman/docker)   version
+        ceph                        Deployed Ceph version
+
     Args:
-        ceph_cluster:
+        ceph_cluster:   Cluster participating in the test.
 
     Returns:
-
+        None
     """
     version_datails = {}
     installer_node = ceph_cluster.get_ceph_objects("installer")
@@ -1080,12 +1085,15 @@ def collect_recipe(ceph_cluster):
     if output:
         log.info(f"Docker Version {output}")
         version_datails["DOCKER"] = output
-    out, rc = client_node[0].exec_command(
-        sudo=True, cmd="ceph --version | awk '{print $3}'", check_ec=False
-    )
-    output = out.read().decode().rstrip()
-    log.info(f"ceph Version {output}")
-    version_datails["CEPH"] = output
+
+    if client_node:
+        out, rc = client_node[0].exec_command(
+            sudo=True, cmd="ceph --version | awk '{print $3}'", check_ec=False
+        )
+        output = out.read().decode().rstrip()
+        log.info(f"ceph Version {output}")
+        version_datails["CEPH"] = output
+
     version_detail = open("version_info.json", "w+")
     json.dump(version_datails, version_detail)
     version_detail.close()

--- a/suites/nautilus/integrations/ocs/001_suite_setup.yaml
+++ b/suites/nautilus/integrations/ocs/001_suite_setup.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/setup/test_setup_configure_system.yaml

--- a/suites/nautilus/integrations/ocs/002_deploy_cluster.yaml
+++ b/suites/nautilus/integrations/ocs/002_deploy_cluster.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/install/ansible/test_ceph_ansible_deploy_cluster_mds_override.yaml

--- a/suites/nautilus/integrations/ocs/003_write_sut_info.yaml
+++ b/suites/nautilus/integrations/ocs/003_write_sut_info.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/generic/gather_system_info.yaml

--- a/suites/pacific/integrations/ocs/001_suite_setup.yaml
+++ b/suites/pacific/integrations/ocs/001_suite_setup.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/setup/test_setup_configure_system.yaml

--- a/suites/pacific/integrations/ocs/002_bootstrap_cluster.yaml
+++ b/suites/pacific/integrations/ocs/002_bootstrap_cluster.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/install/cephadm/test_cephadm_initial_bootstrap.yaml

--- a/suites/pacific/integrations/ocs/003_add_nodes_to_cluster.yaml
+++ b/suites/pacific/integrations/ocs/003_add_nodes_to_cluster.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/install/cephadm/test_cephadm_add_hosts_with_labels.yaml

--- a/suites/pacific/integrations/ocs/004_deploy_configure_rgw.yaml
+++ b/suites/pacific/integrations/ocs/004_deploy_configure_rgw.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/install/cephadm/test_cephadm_add_rgw_using_labels.yaml

--- a/suites/pacific/integrations/ocs/005_deploy_configure_mds.yaml
+++ b/suites/pacific/integrations/ocs/005_deploy_configure_mds.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/install/cephadm/test_cephadm_deploy_2_mds.yaml

--- a/suites/pacific/integrations/ocs/006_write_sut_info.yaml
+++ b/suites/pacific/integrations/ocs/006_write_sut_info.yaml
@@ -1,0 +1,1 @@
+../../../../fragments/generic/gather_system_info.yaml

--- a/tests/misc_env/gather_cluster_info.py
+++ b/tests/misc_env/gather_cluster_info.py
@@ -1,0 +1,79 @@
+"""Retrieves the information of the system under test."""
+import binascii
+import os
+from json import loads
+from logging import getLogger
+
+import yaml
+
+LOG = getLogger(__name__)
+
+
+def run(ceph_cluster, ceph_nodes, config, **kwargs) -> int:
+    """
+    Entry point to this module.
+
+    In this method, the Ceph cluster information is gathered along with the creation
+    of RGW user. All this information is then written to sut.yaml file.
+
+    Args:
+        ceph_cluster:       Instance of Ceph
+        ceph_nodes (list):  List of nodes participating in the cluster.
+        config (dict):
+
+    Returns:
+        0 -> on success
+        1 -> on failure
+
+    Raises:
+        CommandError
+    """
+    LOG.info("Gathering details about the system under test.")
+    rhbuild = config["rhbuild"]
+
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    base_cmd = "sudo cephadm shell --"
+    if rhbuild.startswith("4"):
+        base_cmd = "sudo"
+
+    # Get admin key
+    cmd = f"{base_cmd} ceph auth get client.admin --format json"
+    out, err = installer.exec_command(cmd=cmd)
+    cmd_resp = loads(out.read().decode())
+    admin_key = cmd_resp[0]["key"]
+
+    # Create rgw-admin-ops-user
+    uid = binascii.hexlify(os.urandom(16)).decode()
+    cmd = f"{base_cmd} radosgw-admin user create --uid={uid}"
+    cmd += " --display_name='rgw-admin-ops-user'"
+    cmd += " --email rgw-admin-ops-user@foo.bar"
+
+    out, err = installer.exec_command(cmd=cmd)
+    cmd_resp = loads(out.read().decode())
+    access_key = cmd_resp["keys"][0]["access_key"]
+    secret_key = cmd_resp["keys"][0]["secret_key"]
+
+    sut_details = dict(
+        {
+            "access_key_rgw-admin-ops-user": access_key,
+            "secret_key_rgw-admin-ops-user": secret_key,
+            "login": {"username": "root", "password": ceph_nodes[0].root_passwd},
+            "admin_keyring": {"key": admin_key},
+            "external_cluster_node_roles": list(),
+        }
+    )
+    for node in ceph_nodes:
+        node_info = dict(
+            {
+                "hostname": node.vmname,
+                "ip_address": node.ip_address,
+                "roles": list(set(node.role.role_list)),
+            }
+        )
+        sut_details["external_cluster_node_roles"].append(node_info)
+
+    with open("sut.yaml", "w") as fh:
+        yaml.dump(sut_details, fh)
+
+    LOG.info("Successfully written the system details.")
+    return 0


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we are adding support for deploying a Ceph cluster using UMB messages. This would be helpful for integration testing.

[RFE:](https://docs.google.com/document/d/1XcCJ1_gDSv-3q2AD3Hizr-kcjqNhvmzXR0_rFFORXgI/edit#)

__Logs__
Deploy: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/rhceph-deploy-cluster/14/console
Cleanup: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/rhceph-delete-cluster/3/console

__UMB__
https://datagrepper.engineering.redhat.com/id?id=ID:ceph-downstream-jenkins-csb-storage-44811-1637019131754-2721:1:1:1:1&is_raw=true&size=extra-large