### PR TITLE
Rados tier-2 test suite changes

### DIFF
--- a/suites/pacific/rados/tier_2_rados.yaml
+++ b/suites/pacific/rados/tier_2_rados.yaml
@@ -167,7 +167,7 @@ tests:
         replicated_pool:
           create: true
           pool_name: test_re_pool
-          pg_num: 64
+          pg_num: 16
           size: 2
           disable_pg_autoscale: true
           rados_write_duration: 50
@@ -185,34 +185,6 @@ tests:
       desc: Create replicated pools and run IO
 
   - test:
-      name: LRC EC pool LC
-      module: rados_prep.py
-      polarion-id: CEPH-83571632
-      config:
-        ec_pool:
-          create: true
-          pool_name: test_ec_pool
-          pg_num: 64
-          k: 4
-          m: 2
-          l: 3
-          plugin: lrc
-          disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
-        set_pool_configs:
-          pool_name: test_ec_pool
-          configurations:
-            pg_num: 32
-            pgp_num: 32
-            pg_autoscale_mode: 'on'
-            compression_mode: force
-            compression_algorithm: snappy
-        delete_pools:
-          - test_ec_pool
-      desc: Create LRC EC pools and run IO
-
-  - test:
       name: EC pool with Overwrites
       module: rados_prep.py
       polarion-id: CEPH-83571730
@@ -221,6 +193,7 @@ tests:
           create: true
           pool_name: ec_pool_overwrite
           app_name: rbd
+          pg_num: 32
           erasure_code_use_overwrites: "true"
           k: 3
           m: 2
@@ -239,13 +212,14 @@ tests:
   - test:
       name: EC Pool Recovery Improvement
       module: pool_tests.py
-      polarion-id: CEPH-83573852
+      polarion-id: CEPH-83573852, CEPH-83571632
       config:
         ec_pool_recovery_improvement:
           create: true
           pool_name: ec_pool_recovery
           k: 3
           m: 2
+          pg_num: 32
           plugin: jerasure
           rados_write_duration: 200
           rados_read_duration: 50
@@ -260,9 +234,10 @@ tests:
       module: stretch_cluster.py
       polarion-id: CEPH-83573621
       config:
-        site1: site-blr
-        site2: site-pune
+        site1: site-A
+        site2: site-B
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      abort-on-fail: true
 
   - test:
       name: Compression algorithms
@@ -272,6 +247,7 @@ tests:
         replicated_pool:
           create: true
           pool_name: re_pool_compress
+          pg_num: 32
           rados_write_duration: 10
           rados_read_duration: 10
         enable_compression:
@@ -325,8 +301,9 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 10
-          rados_read_duration: 10
+          rados_write_duration: 100
+          rados_read_duration: 50
+          pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
           mon_target_pg_per_osd: 128


### PR DESCRIPTION
1. Removed LRC EC pool test cases, as LRC profile not supported downstream
2. Reduced the number of PG's on each pool.
3. Sometimes, stretch fails to deploy as there might be some stray pools,
 other than default rule. Added steps to find and delete them.

Also fixes the issues with long running tests found in report portal for the run : " suites/pacific/rados/tier_2_rados.yaml (rhel-8.4.0-x86_64-released)#18 "

The failures were as cluster was in bad state( OSD's moved out of default root crush map ), after Stretch mode deployment failed. added flag ` abort-on-fail: true ` after stretch mode tests so that execution ends and further tests won't be attempted.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

