### PR TITLE
5.x cdn related changes

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -131,6 +131,14 @@ class CephAdmin(BootstrapMixin, ShellMixin):
             for node in self.cluster.get_nodes():
                 node.exec_command(sudo=True, cmd=cmd)
 
+    def set_cdn_tool_repo(self):
+        """
+        Enable the cdn Tools repo on Cephadm node.
+        """
+        cdn_repo = "rhceph-5-tools-for-rhel-8-x86_64-rpms"
+        cmd = f"subscription-manager repos --enable={cdn_repo}"
+        self.installer.exec_command(sudo=True, cmd=cmd)
+
     def install(self, **kwargs: Dict) -> None:
         """
         Install the cephadm package in the installer node.

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -179,8 +179,12 @@ class BootstrapMixin:
         args = config.get("args")
         custom_repo = args.pop("custom_repo", None)
         custom_image = args.pop("custom_image", True)
+        build_type = config.get("build_type")
 
-        if custom_repo:
+        if build_type == "released" or custom_repo.lower() == "cdn":
+            custom_image = False
+            self.set_cdn_tool_repo()
+        elif custom_repo:
             self.set_tool_repo(repo=custom_repo)
         else:
             self.set_tool_repo()

--- a/run.py
+++ b/run.py
@@ -819,6 +819,7 @@ def run(args):
                 if repo.startswith("http"):
                     config["add-repo"] = repo
 
+            config["build_type"] = build
             config["enable_eus"] = enable_eus
             config["skip_enabling_rhel_rpms"] = skip_enabling_rhel_rpms
             config["docker-insecure-registry"] = docker_insecure_registry

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -47,6 +47,10 @@ def run(**kw):
     rhbuild = config.get("rhbuild")
     skip_enabling_rhel_rpms = config.get("skip_enabling_rhel_rpms", False)
     is_production = config.get("is_production", False)
+    build_type = config.get("build_type", None)
+    # when build set to released subscribing nodes with CDN credentials
+    if build_type == "released":
+        is_production = True
     cloud_type = config.get("cloud-type", "openstack")
     with parallel() as p:
         for ceph in ceph_nodes:


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Fixes **RHCEPHQE-1006**
Enabled tools repo "rhceph-5-tools-for-rhel-8-x86_64-rpms" for GA versions
To deploy ceph 5.x on released GA bits using `--build` as **released** in CLI
e.g `python run.py --v2 --osp-cred osp/osp-cred-ci-2.yaml --rhbuild 5.0 --platform rhel-8 --build released --global-conf conf/pacific/cephadm/tier1_3node_cephadm_bootstrap.yaml --suite suites/pacific/cephadm/tier_0_cephadm.yaml --inventory conf/inventory/rhel-8.4-server-x86_64.yaml --log-level DEBUG`
Test result: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2TPP2U
Deployed 5.x cdn ceph with version "16.2.0-143.el8cp"

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
