### PR TITLE
Fix string replacement in log location

### DIFF
--- a/run.py
+++ b/run.py
@@ -614,7 +614,7 @@ def run(args):
         suite_file_name = suite_name.split("::")[0].split("/")[-1]
         suite_file_name = suite_file_name.strip(".yaml")
         suite_file_name = " ".join(suite_file_name.split("_"))
-        _log = run_dir.replace("/ceph", "http://magna002.ceph.redhat.com")
+        _log = run_dir.replace("/ceph/", "http://magna002.ceph.redhat.com/")
 
         launch_name = f"RHCS {rhbuild} - {suite_file_name}"
         launch_desc = textwrap.dedent(


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes the issue where all patterns of the location string is being replaced with the file server name.

__Error__
```
ceph version: 16.2.6-36.el8cp
ceph-ansible version: 6.0.19-1.el8cp.noarch
compose-id: RHCEPH-5.1-RHEL-8-20211123.ci.2 
invoked-by: jenkins-build 
log-location: http://magna002.ceph.redhat.comhttp://magna002.ceph.redhat.comci-jenkinshttp://magna002.ceph.redhat.comci-run-59SBAW 
docker registry: registry-proxy.engineering.redhat.com 
docker image: rh-osbs/rhceph 
docker tag: ceph-5.1-rhel-8-containers-candidate-25012-20211123070231 invoked-by: jenkins-buil
```

__Log__
```
>>> x = '/ceph/cephci-jenkins/ceph-ci-run-59SBW'
>>> x.replace('/ceph', 'http://magna002.ceph.redhat.com')
'http://magna002.ceph.redhat.comhttp://magna002.ceph.redhat.comci-jenkinshttp://magna002.ceph.redhat.com-ci-run-59SBW'
>>> x.replace('/ceph/', 'http://magna002.ceph.redhat.com')
'http://magna002.ceph.redhat.comcephci-jenkins/ceph-ci-run-59SBW'
>>> x.replace('/ceph/', 'http://magna002.ceph.redhat.com/')
'http://magna002.ceph.redhat.com/cephci-jenkins/ceph-ci-run-59SBW'
>>> 
```