### PR TITLE
Fix cdn issue: default empty string to custom_repo

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -177,7 +177,7 @@ class BootstrapMixin:
         """
         self.cluster.setup_ssh_keys()
         args = config.get("args")
-        custom_repo = args.pop("custom_repo", None)
+        custom_repo = args.pop("custom_repo", "")
         custom_image = args.pop("custom_image", True)
         build_type = config.get("build_type")
 


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-58HY3F
**Failure:**

```2021-11-23 07:31:33,570 - root - ERROR - 'NoneType' object has no attribute 'lower'

Traceback (most recent call last):

  File "/home/jenkins-build/workspace/rhceph-tier-0/tests/ceph_installer/test_cephadm.py", line 128, in run

    func(cfg)

  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph_admin/bootstrap.py", line 184, in bootstrap

    if build_type == "released" or custom_repo.lower() == "cdn":

AttributeError: 'NoneType' object has no attribute 'lower'

2021-11-23 07:31:33,572 - ceph.ceph - INFO - Running command cephadm -v shell -- ceph status on 10.0.210.125

2021-11-23 07:31:33,596 - ceph.ceph - ERROR - Error 127 during cmd, timeout 300

2021-11-23 07:31:33,603 - utility.utils - WARNING - Encountered an error during report portal operation.

2021-11-23 07:31:33,603 - __main__ - ERROR - Traceback (most recent call last):

  File "run.py", line 956, in run

    clients=clients,

  File "/home/jenkins-build/workspace/rhceph-tier-0/tests/ceph_installer/test_cephadm.py", line 145, in run

    get_cluster_state(cephadm)

  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph_admin/helper.py", line 471, in get_cluster_state

    out, err = cls.shell(args=[cmd])

  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph_admin/shell.py", line 48, in shell

    check_ec=check_status,

  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph.py", line 1948, in exec_command

    return self.node.exec_command(cmd=cmd, **kw)

  File "/home/jenkins-build/workspace/rhceph-tier-0/ceph/ceph.py", line 1455, in exec_command

    + str(self.ip_address)

ceph.ceph.CommandFailed: cephadm -v shell -- ceph status Error:  bash: cephadm: command not found

```

**Solution:**
```
>>> 
>>> v = str()
>>> v.lower()
''
>>> if not v: print("Nothing...")
... 
Nothing...
>>> 
```