### PR TITLE
Upgrade from 5.x cdn bits to latest distro

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -133,11 +133,12 @@ class CephAdmin(BootstrapMixin, ShellMixin):
 
     def set_cdn_tool_repo(self):
         """
-        Enable the cdn Tools repo on Cephadm node.
+        Enable the cdn Tools repo on all ceph node.
         """
         cdn_repo = "rhceph-5-tools-for-rhel-8-x86_64-rpms"
         cmd = f"subscription-manager repos --enable={cdn_repo}"
-        self.installer.exec_command(sudo=True, cmd=cmd)
+        for node in self.cluster.get_nodes():
+            node.exec_command(sudo=True, cmd=cmd)
 
     def install(self, **kwargs: Dict) -> None:
         """

--- a/suites/pacific/cephadm/tier-1_cephadm_upgrade.yaml
+++ b/suites/pacific/cephadm/tier-1_cephadm_upgrade.yaml
@@ -14,7 +14,8 @@
 #     Node4 - Client
 
 # Test Steps:
-#   (1) Bootstrap cluster using N-1 (currently alpha) ceph image version with below options,
+#   (1) (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - custom_repo: "cdn"
 #       - skip-monitoring stack
 #       - registry-url: <registry-URL>
 #       - mon-ip: <monitor address, Required>
@@ -24,7 +25,7 @@
 #       - addition of OSD's using "all-available-devices" option.
 #       - RGW on node2, node3 with india.south(realm.zone) using label.
 #       - MDS on node2, node3 with host placements.
-#   (4) Upgrade to latest provided(N) Ceph image version.
+#   (4) Upgrade to distro build(N) by provided Ceph image version.
 #===============================================================================================
 tests:
   - test:
@@ -34,9 +35,9 @@ tests:
       abort-on-fail: true
   - test:
       name: Cluster deployment
-      desc: Cluster deployment with alpha version 16.2.0-8
+      desc: Cluster deployment with latest released version of 5.x
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83573791
       config:
         verify_cluster_health: true
         steps:
@@ -45,9 +46,8 @@ tests:
               service: cephadm
               base_cmd_args:
                 verbose: true
-              args:       # https://bugzilla.redhat.com/show_bug.cgi?id=1944978
-                custom_repo: "ftp://partners.redhat.com/d960e6f2052ade028fa16dfc24a827f5/rhel-8/Tools/x86_64/os/"
-                custom_image: false     # pick default image from cephadm source code.
+              args:
+                custom_repo: "cdn"
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 skip-monitoring-stack: true
@@ -163,7 +163,7 @@ tests:
       name: Upgrade ceph
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
-      polarion-id:
+      polarion-id: CEPH-83573791
       config:
         command: start
         service: upgrade


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Modified the upgrade suite as per the recent changes related to CDN bits.
Test Results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-577CSZ/
Upgraded successfully from 5.x cdn version 16.2.0-143.el8cp to 5.1 ditro version 16.2.6-36.el8cp
