### PR TITLE
Fix 943 - Fixes an issue with create_xunit_results method

### DIFF
--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -18,7 +18,8 @@ def create_xunit_results(suite_name, test_cases, run_dir):
 
     Returns: None
     """
-    xml_file = f"{run_dir}/{suite_name}.xml"
+    _file = suite_name.split("/")[-1]
+    xml_file = f"{run_dir}/{_file}.xml"
 
     log.info(f"Creating xUnit result file for test suite: {suite_name}")
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR closes #943 wherein we are unable to create the xunit results. The regression is caused by the value being passed to the method. The change splits the path into filename instead of using the full path.

__Log__
```
All test logs located here: /tmp/cephci-run-KEFFZK
2021-11-24 12:21:21,077 - utility.xunit - INFO - Creating xUnit result file for test suite: suites/nautilus/cephfs/tier-0_fs.yaml
2021-11-24 12:21:21,097 - utility.xunit - INFO - xUnit result file created: /tmp/cephci-run-KEFFZK/tier-0_fs.yaml.xml

All test logs located here: /tmp/cephci-run-KEFFZK

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:06:38.809386                   Pass                             
ceph ansible                     test cluster setup using ceph-ansible                          0:21:50.689094                   Pass                             
recreate cephfs with ec pools    Creates ec pools and Creates Filesystem using ec pools         0:02:20.235452                   Pass                             
cephfs-basics                    cephfs basic operations                                        0:07:54.519269                   Pass                             
2021-11-24 12:21:21,256 - __main__ - INFO - final rc of test run 0
```