### PR TITLE
Fixes 4.3 Tier-1 upgrade failure due to failing RGW sanity test

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -128,14 +128,14 @@ def run(ceph_cluster, **kw):
         if ceph_cluster.rhcs_version.version[0] == 5:
             setup_cluster_access(ceph_cluster, rgw_node)
             rgw_node.exec_command(
-                sudo=True, cmd="yum install -y ceph-radosgw --nogpgcheck"
+                sudo=True, cmd="yum install -y ceph-common --nogpgcheck"
             )
 
         if ceph_cluster.rhcs_version.version[0] in [3, 4]:
             if ceph_cluster.containerized:
-                # install ceph-radosgw on the host hosting the container
+                # install ceph-common on the host hosting the container
                 rgw_node.exec_command(
-                    sudo=True, cmd="yum install -y ceph-radosgw --nogpgcheck"
+                    sudo=True, cmd="yum install -y ceph-common --nogpgcheck"
                 )
 
     script_name = config.get("script-name")


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

At the time of installing `ceph-radosgw` package it has been noticed that the container of RGW is stopping causing the entire test suite to fail. The RGW tests have a dependency on `ceph-common` package hence switching to install only that package.

__Analysis__
[Console output](https://privatebin-it-iso.int.open.paas.redhat.com/?74e0da82890bdbef#43rdhVfvhqd9hAgcygm6qKfbDCFHAt1t2NxJsm8WV9y3)

__Error__
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Z18RHA

__Logs__
4.x container upgrade: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_tier_1/4.3/upgrade/
5.0 tier-0 : http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rgw_tier_0/5.0/