### PR TITLE
Adding nfs (rgw) to upgrade confs

### DIFF
--- a/conf/pacific/upgrades/5-0_upgrades.yaml
+++ b/conf/pacific/upgrades/5-0_upgrades.yaml
@@ -32,7 +32,6 @@ globals:
        role:
          - osd
          - rgw
-         - nfs
        no-of-volumes: 3
        disk-size: 20
      node7:
@@ -44,3 +43,4 @@ globals:
        disk-size: 20
      node8:
        role: client
+# This conf doesn't have nfs as its not supported till 5.1 

--- a/conf/pacific/upgrades/upgrade_small-cluster.yaml
+++ b/conf/pacific/upgrades/upgrade_small-cluster.yaml
@@ -1,0 +1,45 @@
+# This conf to have a minimal handy conf which can be used for executions to get an upgraded cluster within short amount of time and resources
+# This conf is not to be used in jenkins runs as it would cause failure of some TCs because of lesser OSDs
+
+globals:
+  - ceph-cluster:
+     name: ceph
+     node1:
+       role:
+         - _admin
+         - mon
+         - mgr
+         - osd
+         - installer
+       no-of-volumes: 1
+       disk-size: 40  
+     node2:
+       role:
+         - mon
+         - mgr
+         - osd
+         - grafana
+       no-of-volumes: 1
+       disk-size: 40
+     node3:
+       role:
+         - mon
+         - mgr
+         - osd
+         - mds
+       no-of-volumes: 1
+       disk-size: 40
+     node4:
+       role:
+         - rgw
+         - iscsi-gw
+
+     node5:
+       role:
+         - rgw
+         - iscsi-gw
+         - client
+
+     node6:
+       role:
+         - nfs

--- a/pipeline/scripts/5/0/tier-1/test-upgrade-4x-container-to-5x-container.sh
+++ b/pipeline/scripts/5/0/tier-1/test-upgrade-4x-container-to-5x-container.sh
@@ -6,7 +6,7 @@ instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml"
-test_conf="conf/pacific/upgrades/upgrades.yaml"
+test_conf="conf/pacific/upgrades/5-0_upgrades.yaml"
 test_inventory="conf/inventory/rhel-8-latest.yaml"
 return_code=0
 

--- a/pipeline/scripts/5/0/tier-1/test-upgrade-4x-rpm-to-5x-container.sh
+++ b/pipeline/scripts/5/0/tier-1/test-upgrade-4x-rpm-to-5x-container.sh
@@ -6,7 +6,7 @@ instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.0"
 test_suite="suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml"
-test_conf="conf/pacific/upgrades/upgrades.yaml"
+test_conf="conf/pacific/upgrades/5-0_upgrades.yaml"
 test_inventory="conf/inventory/rhel-8-latest.yaml"
 return_code=0
 


### PR DESCRIPTION
Signed-off-by: VasishtaShastry <vipin.indiasmg@gmail.com>

# Description
Upgrade of 4.x clusters with nfs+RGW was blocked because of which nfs (rgw) were now included in configs of upgrades.
With 1) https://bugzilla.redhat.com/show_bug.cgi?id=2017508 and 2) https://github.com/ceph/ceph-ansible/commit/a752edbd29bf9fa1915446cf4f668ab92711cca7 
Adding nfs (RGW) back to configs

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
