### PR TITLE
Fix container name in case of FQDN

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1991,7 +1991,7 @@ class CephDemon(CephObject):
     def container_name(self):
         return (
             (
-                "ceph-{role}-{host}".format(role=self.role, host=self.node.hostname)
+                "ceph-{role}-{host}".format(role=self.role, host=self.node.shortname)
                 if not self.__custom_container_name
                 else self.__custom_container_name
             )

--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -123,3 +123,8 @@ class CephBaremetalNode:
     def role(self, roles: list) -> None:
         """Set the roles for the VM."""
         self._roles = deepcopy(roles)
+
+    @property
+    def shortname(self) -> str:
+        """Return the shortform of the hostname."""
+        return self.hostname.split(".")[0]


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

The container name uses FQDN instead of the shortname which leads to the below error. This PR moves the formulation of the container name to use the shortname.

__Error__
https://159.23.92.24/job/psathyan_custom/8/console