### PR TITLE
Add rhceph build in upgrade test cases

### DIFF
--- a/suites/nautilus/upgrades/tier-1_upgrade_container.yaml
+++ b/suites/nautilus/upgrades/tier-1_upgrade_container.yaml
@@ -91,6 +91,7 @@ tests:
     polarion-id: CEPH-83573588
     module: test_ansible_upgrade.py
     config:
+      build: '4.x'
       ansi_config:
         ceph_origin: distro
         ceph_stable_release: nautilus

--- a/suites/nautilus/upgrades/tier-1_upgrade_rpm.yaml
+++ b/suites/nautilus/upgrades/tier-1_upgrade_rpm.yaml
@@ -63,6 +63,7 @@ tests:
       polarion-id: CEPH-83573508
       module: test_ansible_upgrade.py
       config:
+        build: '4.x'
         ansi_config:
           ceph_origin: distro
           ceph_stable_release: nautilus

--- a/suites/nautilus/upgrades/tier-2_okr_bz_1994827.yaml
+++ b/suites/nautilus/upgrades/tier-2_okr_bz_1994827.yaml
@@ -99,6 +99,7 @@ tests:
     polarion-id: CEPH-83574481
     module: test_ansible_upgrade.py
     config:
+      build: '4.x'
       ansi_cli_args:
         skip-tags: "wait_all_osds_up"
       ansi_config:

--- a/suites/nautilus/upgrades/tier-2_upgrade_okr-bz-1876447-rpm.yaml
+++ b/suites/nautilus/upgrades/tier-2_upgrade_okr-bz-1876447-rpm.yaml
@@ -45,6 +45,7 @@ tests:
     polarion-id: CEPH-83573508
     module: test_ansible_upgrade.py
     config:
+      build: '4.x'
       ansi_config:
         ceph_origin: distro
         cluster: custom_ceph

--- a/suites/nautilus/upgrades/tier-2_upgrade_test-disk-scenarios-container.yaml
+++ b/suites/nautilus/upgrades/tier-2_upgrade_test-disk-scenarios-container.yaml
@@ -65,6 +65,7 @@ tests:
             polarion-id: CEPH-83574033
             module: test_ansible_upgrade.py
             config:
+              build: '4.x'
               ansi_config:
                 ceph_origin: distro
                 ceph_stable_release: nautilus

--- a/suites/nautilus/upgrades/tier-2_upgrade_test-disk-scenarios-rpm.yaml
+++ b/suites/nautilus/upgrades/tier-2_upgrade_test-disk-scenarios-rpm.yaml
@@ -41,6 +41,7 @@ tests:
     polarion-id: CEPH-11110
     module: test_ansible_upgrade.py
     config:
+      build: '4.x'
       ansi_config:
         ceph_origin: distro
         ceph_stable_release: nautilus

--- a/suites/nautilus/upgrades/tier-2_upgrade_test-filestore-to-bluestore.yaml
+++ b/suites/nautilus/upgrades/tier-2_upgrade_test-filestore-to-bluestore.yaml
@@ -46,6 +46,7 @@ tests:
     polarion-id: CEPH-11110
     module: test_ansible_upgrade.py
     config:
+      build: '4.x'
       ansi_config:
         ceph_origin: distro
         osd_objectstore: filestore

--- a/suites/nautilus/upgrades/tier-2_upgrade_test-rpm-to-container-lvm.yaml
+++ b/suites/nautilus/upgrades/tier-2_upgrade_test-rpm-to-container-lvm.yaml
@@ -42,6 +42,7 @@ tests:
     polarion-id: CEPH-11110
     module: test_ansible_upgrade.py
     config:
+      build: '4.x'
       ansi_config:
         ceph_origin: distro
         ceph_stable_release: nautilus

--- a/suites/nautilus/upgrades/upgrade_rgw_test.yaml
+++ b/suites/nautilus/upgrades/upgrade_rgw_test.yaml
@@ -368,6 +368,7 @@ tests:
        polarion-id: CEPH-11110
        module: test_ansible_upgrade.py
        config:
+         build: '4.x'
          ansi_config:
            ceph_origin: distro
            ceph_stable_release: nautilus

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal_without_dashboard.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5_x_baremetal_without_dashboard.yaml
@@ -99,6 +99,7 @@ tests:
     polarion-id: CEPH-83573679
     module: test_ansible_upgrade.py
     config:
+      build: '5.x'
       ansi_config:
         ceph_origin: distro
         ceph_stable_release: pacific

--- a/suites/pacific/upgrades/tier-1-upgrade_4x_to_5x_multisite.yaml
+++ b/suites/pacific/upgrades/tier-1-upgrade_4x_to_5x_multisite.yaml
@@ -139,6 +139,7 @@ tests:
       clusters:
         ceph-rgw1:
           config:
+            build: '5.x'
             ansi_config:
               ceph_origin: distro
               ceph_repository: rhcs
@@ -174,6 +175,7 @@ tests:
                     testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         ceph-rgw2:
           config:
+            build: '5.x'
             ansi_config:
               ceph_origin: distro
               ceph_repository: rhcs

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
@@ -98,6 +98,7 @@ tests:
            polarion-id: CEPH-83573680
            module: test_ansible_upgrade.py
            config:
+             build: '5.x'
              ansi_config:
                ceph_origin: distro
                ceph_stable_release: pacific

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
@@ -120,28 +120,29 @@ tests:
           polarion-id: CEPH-83573679
           module: test_ansible_upgrade.py
           config:
-             ansi_config:
-               ceph_origin: distro
-               ceph_stable_release: pacific
-               ceph_repository: rhcs
-               ceph_rhcs_version: 5
-               osd_scenario: lvm
-               osd_auto_discovery: False
-               ceph_stable: True
-               ceph_stable_rh_storage: True
-               fetch_directory: ~/fetch
-               radosgw_num_instances: 2
-               copy_admin_key: true
-               containerized_deployment: true
-               upgrade_ceph_packages: True
-               dashboard_admin_user: admin
-               dashboard_admin_password: p@ssw0rd
-               grafana_admin_user: admin
-               grafana_admin_password: p@ssw0rd
-               node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
-               grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
-               prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
-               alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+            build: '5.x'
+            ansi_config:
+              ceph_origin: distro
+              ceph_stable_release: pacific
+              ceph_repository: rhcs
+              ceph_rhcs_version: 5
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              radosgw_num_instances: 2
+              copy_admin_key: true
+              containerized_deployment: true
+              upgrade_ceph_packages: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest -> cephadm adopt
           abort-on-fail: True
     desc: Running upgrade and i/o's parallelly


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Add RHCeph build value in upgrade test cases which avoids enabling wrong environment(Repositories and other configuration).