### PR TITLE
Add properties in xunit-xml file and cos_cli file manage object

### DIFF
--- a/pipeline/scripts/ci/cos_cli.py
+++ b/pipeline/scripts/ci/cos_cli.py
@@ -1,0 +1,138 @@
+"""This script is to update report artifacts on IBM
+
+- Upload test result files to "qe-ci-reports" bucket
+- Executes bucket file options like upload, download, delete and list
+"""
+
+import logging
+import sys
+
+from docopt import docopt
+
+from storage.ibm_cos import CloudObjectStorage
+
+LOG = logging.getLogger(__name__)
+
+usage = """
+This script helps to update reports in IBM.
+
+Usage:
+  cos_cli.py upload <SOURCE_FILE> <OBJ_KEYNAME> <bucket_name>
+  cos_cli.py download <OBJ_KEYNAME> <bucket_name> <DESTINATION_FILE>
+  cos_cli.py delete <OBJ_KEYNAME> <bucket_name>
+  cos_cli.py list <bucket_name>
+  cos_cli.py -h | --help
+
+    action              upload | download | delete | list
+    bucket_name         bucket name
+
+Example:
+    python cos_cli.py upload test.xml test-run-1 qe-ci-reports-bucket
+    python cos_cli.py download test-run-1 qe-ci-reports test.xml
+    python cos_cli.py delete test-run-1 qe-ci-reports
+    python cos_cli.py list qe-ci-reports
+
+Options:
+    -h --help                       Show this screen
+"""
+cos = CloudObjectStorage()
+
+
+def upload_objfile(bucket: str, local_file: str, obj_key: str):
+    """Upload file as file object.
+
+    Args:
+        bucket: bucket name
+        local_file: local file path
+        obj_key: object name to store file
+
+    """
+    with open(local_file, "rb") as in_file:
+        cos.resource.Bucket(bucket).upload_fileobj(in_file, obj_key)
+    LOG.info(f"Uploaded successfully object({obj_key}) using file({local_file})")
+
+
+def download_objfile(bucket: str, local_file: str, obj_key: str):
+    """Download file object as file.
+
+    Args:
+        bucket: bucket name
+        local_file: local file path
+        obj_key: object name to store file
+
+    """
+    with open(local_file, "wb") as out_file:
+        cos.resource.Bucket(bucket).download_fileobj(obj_key, out_file)
+    LOG.info(
+        f"Downloaded successfully using KeyName({obj_key}) into file({local_file})"
+    )
+
+
+def delete_objfile(bucket: str, obj_key: str):
+    """Delete file object.
+
+    Args:
+        bucket: bucket name
+        obj_key: object name to store file
+    """
+    obj = cos.resource.Bucket(bucket).Object(obj_key)
+    obj.delete()
+    obj.wait_until_not_exists()
+    LOG.info(f"Deleted successfully the file object({obj_key})")
+
+
+def list_objects(bucket: str):
+    """List file objects from bucket.
+
+    Args:
+        bucket: bucket name
+    Returns:
+        list
+    """
+    _objs = cos.client.list_objects(Bucket=bucket)
+    print([i["Key"] for i in _objs.get("Contents")])
+
+
+OPS = {
+    "upload": upload_objfile,
+    "download": download_objfile,
+    "delete": delete_objfile,
+    "list": list_objects,
+}
+
+if __name__ == "__main__":
+
+    _args = docopt(usage, help=True, version=None, options_first=False)
+    logging.basicConfig(
+        handlers=[logging.StreamHandler(sys.stdout)],
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s",
+    )
+
+    try:
+        _def = None
+        for key, value in OPS.items():
+            if _args[key]:
+                _def = value
+                break
+        else:
+            raise Exception("please provide right action")
+
+        bucket_name = _args["<bucket_name>"]
+        args = [bucket_name]
+
+        file_path = _args.get("<SOURCE_FILE>", None) or _args.get(
+            "<DESTINATION_FILE>", None
+        )
+
+        if file_path:
+            args.append(file_path)
+
+        obj_keyname = _args.get("<OBJ_KEYNAME>", None)
+        if obj_keyname:
+            args.append(obj_keyname)
+
+        _def(*args)
+    except BaseException as be:
+        LOG.error(be)
+        print(usage)

--- a/run.py
+++ b/run.py
@@ -131,7 +131,7 @@ Options:
   --report-portal                   Post results to report portal. Requires config file,
                                     see README.
   --log-level <LEVEL>               Set logging level
-  --log-dir <LEVEL>                 Set log directory [default: /tmp]
+  --log-dir <LEVEL>                 Set log directory
   --instances-name <name>           Name that will be used for instances creation
   --osp-image <image>               Image for osp instances, default value is taken from
                                     conf file
@@ -371,7 +371,7 @@ def run(args):
 
     # Set log directory and get absolute path
     console_log_level = args.get("--log-level")
-    log_directory = args.get("--log-dir", "/tmp")
+    log_directory = args.get("--log-dir")
 
     run_id = generate_unique_id(length=6)
     run_dir = create_run_dir(run_id, log_directory)

--- a/run.py
+++ b/run.py
@@ -1058,11 +1058,25 @@ def run(args):
     log.info("\nAll test logs located here: {base}".format(base=url_base))
     close_and_remove_filehandlers()
 
+    test_run_metadata = {
+        "polarion-project-id": "CEPH",
+        "suite-name": suite_name,
+        "distro": distro,
+        "ceph-version": ceph_version,
+        "ceph-ansible-version": ceph_ansible_version,
+        "base_url": base_url,
+        "container-registry": docker_registry,
+        "container-image": docker_image,
+        "container-tag": docker_tag,
+        "compose-id": compose_id,
+        "log-dir": run_dir,
+    }
+
     if post_to_report_portal:
         rp_logger.finish_launch()
 
     if xunit_results:
-        create_xunit_results(suite_name, tcs, run_dir)
+        create_xunit_results(suite_name, tcs, run_dir, test_run_metadata)
 
     print("\nAll test logs located here: {base}".format(base=url_base))
     print_results(tcs)

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -456,13 +456,13 @@ def configure_logger(test_name, run_dir, level=logging.INFO):
     return log_url
 
 
-def create_run_dir(run_id, log_dir="/tmp"):
+def create_run_dir(run_id, log_dir=""):
     """
     Create the directory where test logs will be placed.
 
     Args:
         run_id: id of the test run. used to name the directory
-        log_dir: log directory. default: "/tmp"
+        log_dir: log directory name.
     Returns:
         Full path of the created directory
     """
@@ -473,11 +473,17 @@ def create_run_dir(run_id, log_dir="/tmp"):
     print(msg)
     dir_name = "cephci-run-{run_id}".format(run_id=run_id)
     base_dir = "/ceph/cephci-jenkins"
-    if not os.path.isdir(base_dir):
-        if not os.path.isabs(log_dir):
-            log_dir = os.path.join(os.getcwd(), log_dir)
+
+    if log_dir:
         base_dir = log_dir
+        if not os.path.isabs(log_dir):
+            base_dir = os.path.join(os.getcwd(), log_dir)
+    elif not os.path.isdir(base_dir):
+        base_dir = "/tmp"
+
     run_dir = os.path.join(base_dir, dir_name)
+    print(f"log directory - {run_dir}")
+
     try:
         os.makedirs(run_dir)
     except OSError:

--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -7,7 +7,7 @@ from junitparser import Failure, JUnitXml, TestCase, TestSuite
 log = logging.getLogger(__name__)
 
 
-def create_xunit_results(suite_name, test_cases, run_dir):
+def create_xunit_results(suite_name, test_cases, run_dir, test_run_metadata):
     """
     Create an xUnit result file for the test suite's executed test cases.
 
@@ -15,6 +15,7 @@ def create_xunit_results(suite_name, test_cases, run_dir):
         suite_name: the test suite name
         test_cases: the test cases objects
         run_dir: the run directory to store xUnit result files
+        test_run_metadata: test run meta information in dict
 
     Returns: None
     """
@@ -24,9 +25,13 @@ def create_xunit_results(suite_name, test_cases, run_dir):
     log.info(f"Creating xUnit result file for test suite: {suite_name}")
 
     suite = TestSuite(suite_name)
+    for k, v in test_run_metadata.items():
+        suite.add_property(k, v if v else "--NA--")
 
     for tc in test_cases:
         case = TestCase(tc["name"])
+        case.time = tc.get("duration", 0)
+
         if tc["status"] != "Pass":
             case.result = Failure("test failed")
         suite.add_testcase(case)


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- add test run properties to xunit-xml.
- cos_cli script to handle report files.
```
$ python3 pipeline/scripts/ci/cos_cli.py upload ~/test.xml  test-run-check-1 qe-ci-reports       
2021-12-09 14:08:45,902 - INFO - cos_cli.py:53 - Uploaded successfully object(test-run-check-1) using file(/home/sunnagar/test.xml)

$ python3 pipeline/scripts/ci/cos_cli.py download test-run-check-1 qe-ci-reports ~/downloaded_xml.xml
2021-12-09 14:09:57,249 - INFO - cos_cli.py:68 - Downloaded successfully using KeyName(test-run-check-1) into file(/home/sunnagar/downloaded_xml.xml)

ls /home/sunnagar/downloaded_xml.xml                    ─╯
/home/sunnagar/downloaded_xml.xml

$ python3 pipeline/scripts/ci/cos_cli.py list qe-ci-reports
['test-run-1', 'test-run-3', 'test-run-4', 'test-run-check-1', 'test-trun-1']

$ python3 pipeline/scripts/ci/cos_cli.py delete test-run-check-1 qe-ci-reports 
2021-12-09 14:11:21,078 - INFO - cos_cli.py:82 - Deleted successfully the file object(test-run-check-1)
```
- Modify custom log directory method.
*With `/ceph` mount point*
```
$ python3 run.py --v2 --osp-cred ~/osp-cred-ci-2.yaml --rhbuild 4.2 --platform rhel-8 --instances-name sunil-4-2z4-rhel-8-5 --global-conf conf/nautilus/ansible/tier-0_deploy.yaml --suite suites/nautilus/ansible/tier-0_deploy_rpm_ceph.yaml --inventory conf/inventory/rhel-8-latest.yaml --log-level INFO --build released --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag 4-69.1638383142 --reuse rerun/sunil-4-2z4-rhel-8-5-CPFQD5 

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /ceph/cephci-jenkins/cephci-run-XG3WAL
```
*Without `/ceph` mount point*
```
$ python3 run.py --v2 --osp-cred ~/osp-cred-ci-2.yaml --rhbuild 4.2 --platform rhel-8 --instances-name sunil-4-2z4-rhel-8-5 --global-conf conf/nautilus/ansible/tier-0_deploy.yaml --suite suites/nautilus/ansible/tier-0_deploy_rpm_ceph.yaml --inventory conf/inventory/rhel-8-latest.yaml --log-level INFO --build released --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag 4-69.1638383142 --reuse rerun/sunil-4-2z4-rhel-8-5-CPFQD5

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /tmp/cephci-run-EFXBEQ
```

*With custom log-dir*

```
$ python3 run.py --v2 --osp-cred ~/osp-cred-ci-2.yaml --rhbuild 4.2 --platform rhel-8 --instances-name sunil-4-2z4-rhel-8-5 --global-conf conf/nautilus/ansible/tier-0_deploy.yaml --suite suites/nautilus/ansible/tier-0_deploy_rpm_ceph.yaml --inventory conf/inventory/rhel-8-latest.yaml --log-level INFO --build released --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag 4-69.1638383142 --reuse rerun/sunil-4-2z4-rhel-8-5-CPFQD5 --log-dir test-run1

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /home/sunnagar/Sunil/cephci/test-run1/cephci-run-G4XGDB
```


Please review, but we can merge once we have successful run with code changes(added DNM for same reason).