### PR TITLE
Retrieve correct number of available devices

### DIFF
--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -56,12 +56,14 @@ class OSD(ApplyMixin, Orch):
             if not node.get("devices"):
                 continue
 
-            devices = list()
+            devices = {"available": [], "unavailable": []}
             for device in node.get("devices"):
                 if device["available"]:
-                    devices.append(device["path"])
+                    devices["available"].append(device["path"])
+                    continue
+                devices["unavailable"].append(device["path"])
 
-            if devices:
+            if devices["available"]:
                 node_device_dict.update({node["addr"]: devices})
 
         if not node_device_dict:
@@ -94,11 +96,13 @@ class OSD(ApplyMixin, Orch):
                     if dmn["hostname"] == node and dmn["status_desc"] == "running":
                         count += 1
 
+                count = count - len(devices["unavailable"])
+
                 LOG.info(
                     "%s %s/%s osd daemon(s) up... Retries: %s"
-                    % (node, count, len(devices), checks)
+                    % (node, count, len(devices["available"]), checks)
                 )
-                if count == len(devices):
+                if count == len(devices["available"]):
                     deployed += 1
 
             if deployed == len(node_device_dict):


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

Comparison of available device count was not matched perfectly to the number of deployed OSD daemons.
If one OSD is already depoyed it returns out `6/5`.
**Issue:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-02S3ER/Apply_OSD,_MDS,_RGW_Service_deployment_0.log
```
2021-12-03 22:57:16,449 - root - INFO - ceph-ci-7uux1-02s3er-node1-installer 6/6 osd daemon(s) up... Retries: 0.0
2021-12-03 22:57:16,449 - root - INFO - ceph-ci-7uux1-02s3er-node2 6/6 osd daemon(s) up... Retries: 0.0
2021-12-03 22:57:16,449 - root - INFO - ceph-ci-7uux1-02s3er-node3 6/5 osd daemon(s) up... Retries: 0.0
2021-12-03 22:57:21,450 - root - ERROR - OSDs are not up and running in hosts
Traceback (most recent call last):
  File "/home/jenkins-build/workspace/rhceph-tier-x/tests/ceph_installer/test_cephadm.py", line 128, in run
    func(cfg)
  File "/home/jenkins-build/workspace/rhceph-tier-x/ceph/ceph_admin/osd.py", line 109, in apply
    raise OSDServiceFailure("OSDs are not up and running in hosts")
ceph.ceph_admin.osd.OSDServiceFailure: OSDs are not up and running in hosts
2021-12-03 22:57:21,452 - ceph.ceph - INFO - Running command cephadm -v shell -- ceph status on 10.0.210.58
```
**Solution:**
Consider unavailable devices to fix this issue.