### PR TITLE
Fix for build_type is released

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -179,7 +179,7 @@ class BootstrapMixin:
         args = config.get("args")
         custom_repo = args.pop("custom_repo", "")
         custom_image = args.pop("custom_image", True)
-        build_type = config.get("build_type")
+        build_type = self.config.get("build_type")
 
         if build_type == "released" or custom_repo.lower() == "cdn":
             custom_image = False


### PR DESCRIPTION
Fix for build_type is released

We have added self.config.
Earlier we used to get cfg of steps present in suites.yaml file instead of config from the arguments

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
