### PR TITLE
log-dir option to not use dynamic dir if custom name provided

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -479,18 +479,17 @@ def create_run_dir(run_id, log_dir=""):
         if not os.path.isabs(log_dir):
             base_dir = os.path.join(os.getcwd(), log_dir)
     elif not os.path.isdir(base_dir):
-        base_dir = "/tmp"
-
-    run_dir = os.path.join(base_dir, dir_name)
-    print(f"log directory - {run_dir}")
-
+        base_dir = f"/tmp/{dir_name}"
+    else:
+        base_dir = os.path.join(base_dir, dir_name)
+    print(f"log directory - {base_dir}")
     try:
-        os.makedirs(run_dir)
+        os.makedirs(base_dir)
     except OSError:
         if "jenkins" in getpass.getuser():
             raise
 
-    return run_dir
+    return base_dir
 
 
 def close_and_remove_filehandlers(logger=logging.getLogger()):


### PR DESCRIPTION
- log-dir option to not use dynamic dir if custom name provided
`previous: custom-dir-provided/dynamic-run-dir-created/`
`now: custom-dir-provided/`

**Custom directory provided**
```  
 python3 run.py --v2 --osp-cred ~/osp-cred-ci-2.yaml --rhbuild 4.2 --platform rhel-8 --instances-name sunil-4-2z4-rhel-8-5 --global-conf conf/nautilus/ansible/tier-0_deploy.yaml --suite suites/nautilus/ansible/tier-0_deploy_rpm_ceph.yaml --inventory conf/inventory/rhel-8-latest.yaml --log-level INFO --build released --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag 4-69.1638383142 --reuse rerun/sunil-4-2z4-rhel-8-5-CPFQD5 --log-dir test-run1

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /home/sunnagar/Sunil/cephci/test-run1
```
**Custom directory not provided, and nfs path accessible**
```
python3 run.py --v2 --osp-cred ~/osp-cred-ci-2.yaml --rhbuild 4.2 --platform rhel-8 --instances-name sunil-4-2z4-rhel-8-5 --global-conf conf/nautilus/ansible/tier-0_deploy.yaml --suite suites/nautilus/ansible/tier-0_deploy_rpm_ceph.yaml --inventory conf/inventory/rhel-8-latest.yaml --log-level INFO --build released --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag 4-69.1638383142 --reuse rerun/sunil-4-2z4-rhel-8-5-CPFQD5

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /ceph/cephci-jenkins/cephci-run-525QA6
```
**Custom directory not provided, and nfs path not accessible**
```
python3 run.py --v2 --osp-cred ~/osp-cred-ci-2.yaml --rhbuild 4.2 --platform rhel-8 --instances-name sunil-4-2z4-rhel-8-5 --global-conf conf/nautilus/ansible/tier-0_deploy.yaml --suite suites/nautilus/ansible/tier-0_deploy_rpm_ceph.yaml --inventory conf/inventory/rhel-8-latest.yaml --log-level INFO --build released --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag 4-69.1638383142 --reuse rerun/sunil-4-2z4-rhel-8-5-CPFQD5                   

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /tmp/cephci-run-EIYIYY
```


Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>
