### PR TITLE
parallel-upgrades: avoid RBD cleanup during parallel upgrade runs

### DIFF
--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
@@ -92,6 +92,7 @@ tests:
            module: rbd_faster_exports.py
            config:
              io-total: 100M
+             cleanup: false
            desc: Perform export during read/write,resizing,flattening,lock operations
        - test:
            name: Upgrade containerized ceph to 5.x latest

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
@@ -114,6 +114,7 @@ tests:
           module: rbd_faster_exports.py
           config:
             io-total: 100M
+            cleanup: false
           desc: Perform export during read/write,resizing,flattening,lock operations
       - test:
           name: Upgrade containerized ceph to 5.x latest

--- a/tests/rbd/rbd_faster_exports.py
+++ b/tests/rbd/rbd_faster_exports.py
@@ -91,7 +91,7 @@ def run(**kw):
             rbd.exec_cmd,
             cmd="rbd resize -s {} --allow-shrink {}/{}".format("8G", pool, image),
         )
-
-    rbd.clean_up(dir_name=dir_name, pools=[pool])
+    if config.get("cleanup", True):
+        rbd.clean_up(dir_name=dir_name, pools=[pool])
 
     return rbd.flag


### PR DESCRIPTION
Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>
