### PR TITLE
launch test run in report-portal for IBM test run results

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -1,0 +1,61 @@
+/*
+    Pipeline script for uploading IBM test run results to report portal.
+*/
+
+def nodeName = "centos-7"
+def credsRpProc = [:]
+def sharedLib
+def rpPreprocDir
+def reportBucket = "qe-ci-reports"
+def remoteName= "ibm-cos"
+
+node(nodeName) {
+
+    timeout(unit: "MINUTES", time: 30) {
+        stage('Install prereq') {
+            if (env.WORKSPACE) {
+                sh script: "sudo rm -rf *"
+            }
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: 'origin/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [
+                    [
+                        $class: 'CloneOption',
+                        shallow: true,
+                        noTags: true,
+                        reference: '',
+                        depth: 1
+                    ],
+                    [$class: 'CleanBeforeCheckout'],
+                ],
+                submoduleCfg: [],
+                userRemoteConfigs: [[
+                    url: 'https://github.com/red-hat-storage/cephci.git'
+                ]]
+            ])
+
+            // prepare the node
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+            sharedLib.prepareNode()
+        }
+    }
+
+    stage('Configure RP_PreProc'){
+        (rpPreprocDir, credsRpProc) = sharedLib.configureRpPreProc()
+    }
+
+    stage('Upload xml to report-portal'){
+        def configFile = sh(script: "rclone config file", returnStdout: true )
+        def listFiles = sh(
+            script: "rclone lsf ${remoteName}:${reportBucket} -R --files-only",
+            returnStdout: true
+        )
+        def fileNames = listFiles.split("\\n")
+        for (fName in fileNames){
+            println("Upload ${fName} to report-portal.......")
+            sharedLib.uploadXunitXml(fName, credsRpProc, rpPreprocDir)
+        }
+    }
+}

--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -6,6 +6,8 @@
 
 echo "Initialize Node"
 sudo yum install -y git-core
+sudo yum install -y zip unzip
+sudo yum install -y p7zip
 
 # Workaround: Disable IPv6 to have quicker downloads
 sudo sysctl -w net.ipv6.conf.eth0.disable_ipv6=1
@@ -31,6 +33,12 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
+.venv/bin/pip install git+https://gitlab.cee.redhat.com/ccit/reportportal/rp_preproc.git@rpv5
 deactivate
+
+# Install rclone
+curl https://rclone.org/install.sh | sudo bash || echo 0
+mkdir -p ~/.config/rclone
+wget http://magna002.ceph.redhat.com/cephci-jenkins/.ibm-cos.conf -O ~/.config/rclone/rclone.conf
 
 echo "Done bootstrapping the Jenkins node."


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Upload IBM test run results results to report portal.
    - Create test launch using JSON/Yaml test run properties.
    - use XML file to update test launch with test cases and other properties.
- Configure `rp_preproc` to access report portal.
- Delete that file object from COS post upgrade.

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/rhceph-post-results/35/console
