### PR TITLE
move ceph build selection to test modules

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -1125,3 +1125,29 @@ def translate_to_ip(clusters, cluster_name: str, string: str) -> str:
         replaced_string = re.sub(replacement_pattern, node_ip, replaced_string)
 
     return replaced_string
+
+
+def set_container_info(ceph_cluster, config, use_cdn, containerized):
+    """
+    Set container information in ansible configuration
+    Args:
+        ceph_cluster: ceph cluster object
+        use_cdn: boolean to check CDN
+        config: test config
+        containerized: boolean indicates containerized build.
+    Returns:
+        ansi_config
+    """
+    ansi_config = dict()
+
+    if use_cdn:
+        ceph_cluster.use_cdn = True
+        config["use_cdn"] = True
+        ansi_config["ceph_origin"] = "repository"
+        ansi_config["ceph_repository_type"] = "cdn"
+    else:
+        if containerized:
+            ansi_config["ceph_docker_registry"] = config.get("ceph_docker_registry")
+            ansi_config["ceph_docker_image"] = config.get("ceph_docker_image")
+            ansi_config["ceph_docker_image_tag"] = config.get("ceph_docker_image_tag")
+    return ansi_config

--- a/run.py
+++ b/run.py
@@ -862,83 +862,14 @@ def run(args):
                 docker_image,
                 docker_tag,
             )
-            # For cdn container installation provide GAed container parameters
-            # in test suite file as below, In case cdn is not enabled the latest
-            # container details will be considered.
-            #
-            # config:
-            #     use_cdn: True
-            #     ansi_config:
-            #       ceph_repository_type: cdn
-            #       ceph_docker_image: "rhceph/rhceph-4-rhel8"
-            #       ceph_docker_image_tag: "latest"
-            #       ceph_docker_registry: "registry.redhat.io"
 
-            if (
-                config
-                and config.get("ansi_config")
-                and config.get("ansi_config").get("ceph_repository_type") != "cdn"
-            ):
-                if docker_registry:
-                    config.get("ansi_config")["ceph_docker_registry"] = str(
-                        docker_registry
-                    )
+            config["ceph_docker_registry"] = docker_registry
+            report_portal_description += f"docker registry: {docker_registry}"
+            config["ceph_docker_image"] = docker_image
+            report_portal_description += f"docker image: {docker_image}"
+            config["ceph_docker_image_tag"] = docker_tag
+            report_portal_description += f"docker registry: {docker_registry}"
 
-                if docker_image:
-                    config.get("ansi_config")["ceph_docker_image"] = str(docker_image)
-
-                if docker_tag:
-                    config.get("ansi_config")["ceph_docker_image_tag"] = str(docker_tag)
-                cluster_docker_registry = config.get("ansi_config").get(
-                    "ceph_docker_registry"
-                )
-                cluster_docker_image = config.get("ansi_config").get(
-                    "ceph_docker_image"
-                )
-                cluster_docker_tag = config.get("ansi_config").get(
-                    "ceph_docker_image_tag"
-                )
-
-                if cluster_docker_registry:
-                    cluster_docker_registry = config.get("ansi_config").get(
-                        "ceph_docker_registry"
-                    )
-                    report_portal_description = (
-                        report_portal_description
-                        + "\ndocker registry: {docker_registry}".format(
-                            docker_registry=cluster_docker_registry
-                        )
-                    )
-
-                if cluster_docker_image:
-                    cluster_docker_image = config.get("ansi_config").get(
-                        "ceph_docker_image"
-                    )
-                    report_portal_description = (
-                        report_portal_description
-                        + "\ndocker image: {docker_image}".format(
-                            docker_image=cluster_docker_image
-                        )
-                    )
-
-                if cluster_docker_tag:
-                    cluster_docker_tag = config.get("ansi_config").get(
-                        "ceph_docker_image_tag"
-                    )
-                    report_portal_description = (
-                        report_portal_description
-                        + "\ndocker tag: {docker_tag}".format(
-                            docker_tag=cluster_docker_tag
-                        )
-                    )
-                if cluster_docker_image and cluster_docker_registry:
-                    tc["docker-containers-list"].append(
-                        "{docker_registry}/{docker_image}:{docker_tag}".format(
-                            docker_registry=cluster_docker_registry,
-                            docker_image=cluster_docker_image,
-                            docker_tag=cluster_docker_tag,
-                        )
-                    )
             if filestore:
                 config["filestore"] = filestore
 

--- a/tests/ceph_ansible/test_ansible_upgrade.py
+++ b/tests/ceph_ansible/test_ansible_upgrade.py
@@ -3,7 +3,12 @@ import logging
 import yaml
 
 from ceph.ceph_admin.common import config_dict_to_string
-from ceph.utils import get_ceph_versions, get_public_network, translate_to_ip
+from ceph.utils import (
+    get_ceph_versions,
+    get_public_network,
+    set_container_info,
+    translate_to_ip,
+)
 from utility.utils import get_latest_container_image_tag
 
 log = logging.getLogger(__name__)
@@ -33,6 +38,10 @@ def run(ceph_cluster, **kw):
     ceph_cluster.custom_config = test_data.get("custom-config")
     ceph_cluster.custom_config_file = test_data.get("custom-config-file")
     ceph_cluster.use_cdn = config.get("use_cdn")
+
+    config["ansi_config"].update(
+        set_container_info(ceph_cluster, config, ceph_cluster.use_cdn, containerized)
+    )
 
     # Translate RGW node to ip address for Multisite
     rgw_pull_host = config["ansi_config"].get("rgw_pullhost")


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

**Fix issue:** 
RHceph compose and container image should be moved away from run.py
https://github.com/red-hat-storage/cephci/issues/980

**Test Results:**
**_4x-5x container upgrade_**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZG6IP9
**_4x-rpm-5x-container upgrade_**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CWNITQ
**_4.3 deployment_**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-70MJZ3/
**_3.x to 4x_upgrade_**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K6090C