### PR TITLE
Adding multifs test cases for cephfs

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
@@ -1,0 +1,126 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_multifs.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# Test-Case Covered:
+#   CEPH-83573878 - Verify the option to enable/disable multiFS support
+#   CEPH-83573873 - Try creating 2 Filesystem using same Pool(negative)
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        args:
+          - ceph
+          - fs
+          - set
+          - cephfs
+          - max_mds
+          - "2"
+        command: shell
+      desc: "Add Active Active configuration of MDS for cephfs"
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Add Active Active configuration of MDS"
+      polarion-id: CEPH-11344
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: multifs flag
+      module: multifs.multifs_flag.py
+      polarion-id: CEPH-83573878
+      desc: Tests the multifs flag functionality
+      abort-on-fail: false
+  - test:
+        name: multifs same pool
+        module: multifs.multifs_same_pool.py
+        polarion-id: CEPH-83573873
+        desc: Tests the file system with same pools
+        abort-on-fail: false

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -93,6 +93,21 @@ class FsUtils(object):
                 output_dict["data_pool_name"] = fs["data_pools"][0]
         return output_dict
 
+    def get_fs_details(self, client, **kwargs):
+        """
+        Gets all filesystems information
+        Args:
+            client:
+        Returns:
+            json object with all fs
+        """
+        fs_details_cmd = "ceph fs ls --format json"
+        if kwargs.get("extra_params"):
+            fs_details_cmd += f"{kwargs.get('extra_params')}"
+        out, rc = client.exec_command(sudo=True, cmd=fs_details_cmd)
+        all_fs_info = json.loads(out.read().decode())
+        return all_fs_info
+
     def auth_list(self, clients, **kwargs):
         """
         Creates ceph.client.<hostname>.keyring file for the given clients

--- a/tests/cephfs/multifs/multifs_flag.py
+++ b/tests/cephfs/multifs/multifs_flag.py
@@ -1,0 +1,68 @@
+import logging
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+
+log = logging.getLogger(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573878   Verify the option to enable/disable multiFS support
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. check the enable_multiple flag value
+    2. Get total number of filesystems present
+    3. Disable enable_multiple if enabled and try creating filesystem
+    4. Enable enable_multiple and try creating filesystem
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        client1 = clients[0]
+        total_fs = fs_util.get_fs_details(client1)
+        if len(total_fs) == 1:
+            client1.exec_command(
+                sudo=True, cmd="ceph fs flag set enable_multiple false"
+            )
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
+        )
+        if rc == 0:
+            raise CommandFailed(
+                "We are able to create multipe filesystems even after setting enable_multiple to false"
+            )
+        log.info(
+            "We are not able to create multipe filesystems after setting enable_multiple to false as expected"
+        )
+        client1.exec_command(sudo=True, cmd="ceph fs flag set enable_multiple true")
+        client1.exec_command(sudo=True, cmd="ceph fs volume create cephfs_new")
+        log.info(
+            "We are able to create multipe filesystems after setting enable_multiple to True as expected"
+        )
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        commands = [
+            "ceph config set mon mon_allow_pool_delete true",
+            "ceph fs volume rm cephfs_new --yes-i-really-mean-it",
+        ]
+        for command in commands:
+            client1.exec_command(sudo=True, cmd=command)

--- a/tests/cephfs/multifs/multifs_same_pool.py
+++ b/tests/cephfs/multifs/multifs_same_pool.py
@@ -1,0 +1,53 @@
+import logging
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+
+log = logging.getLogger(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573873   Try creating 2 Filesystem using same Pool(negative)
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. Check if cephfs filesystem is present, if not create cephfs
+    2. collect data pool and meta datapool info of cephfs
+    3. try creating cephfs1 with data pool and meta datapool of cephfs
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        client1 = clients[0]
+        fs_details = fs_util.get_fs_info(client1)
+        if not fs_details:
+            fs_util.create_fs(client1, "cephfs")
+        fs_details = fs_util.get_fs_info(client1)
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs new cephfs1 {fs_details['metadata_pool_name']} {fs_details['data_pool_name']}",
+            check_ec=False,
+        )
+        if rc == 0:
+            raise CommandFailed(
+                "We are able to create filesystems with same pool used by other filesystem"
+            )
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1


### PR DESCRIPTION
Adding multifs test cases for cephfs

Test cases Covered:
CEPH-83573878 - Verify the option to enable/disable multiFS support	
CEPH-83573873 - Try creating 2 Filesystem using the same Pool(negative)

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
