### PR TITLE
Supporting S3-style subdomains for self signed certificates

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -371,8 +371,6 @@ class GenerateServiceSpec:
         if node_names:
             spec["placement"]["hosts"] = self.get_hostnames(node_names)
 
-        # ToDo: This works for only one host. Not sure, how cephadm handles SSL
-        #       certificate for multiple hosts.
         if spec["spec"].get("rgw_frontend_ssl_certificate") == "create-cert":
             subject = {
                 "common_name": spec["placement"]["hosts"][0],

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -168,8 +168,7 @@ def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> in
         tests = "s3tests"
 
         if build.startswith("5"):
-            extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!fails_on_aws"
-            extra_args += ",!lifecycle_expiration"
+            extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616"
 
             if not encryption:
                 extra_args += ",!encryption"

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1001,15 +1001,19 @@ def generate_self_signed_certificate(subject: Dict) -> Tuple:
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(365 * 24 * 60 * 60)
 
+    san_list = [
+        f"DNS:*.{subject['common_name']}",
+        f"DNS:{subject['common_name']}",
+        f"IP:{subject['ip_address']}",
+    ]
+    sans = ", ".join(san_list)
     extensions = [
         crypto.X509Extension(
             b"keyUsage", False, b"Digital Signature, Non Repudiation, Key Encipherment"
         ),
         crypto.X509Extension(b"basicConstraints", False, b"CA:FALSE"),
         crypto.X509Extension(b"extendedKeyUsage", False, b"serverAuth, clientAuth"),
-        crypto.X509Extension(
-            b"subjectAltName", False, f"IP:{subject['ip_address']}".encode()
-        ),
+        crypto.X509Extension(b"subjectAltName", False, sans.encode()),
     ]
     cert.add_extensions(extensions)
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we are adding support for using wildcards in the subject alternate name field of the self signed certificate. This enables support for S3-style subdomains.

Removing the ToDo as `cephadm` supports only one certificate chain.

Adding support for `S3 bucket lifecycle tests`

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3/acl/5.1/execute_s3tests_0.log

```
[cephuser@ceph-prag00-8mb4vr-node6 ~]$ ceph config-key get rgw/cert/rgw.rgw.ssl | openssl x509 -noout -text
Certificate:
    Data:
        ...
        Validity
            Not Before: Dec 28 09:15:38 2021 GMT
            Not After : Dec 28 09:15:38 2022 GMT
        Subject: C = IN, ST = Karnataka, L = Bangalore, O = Red Hat Inc, OU = Storage, CN = ceph-prag00-8mb4vr-node5
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                RSA Public-Key: (2048 bit)
                Modulus:
    ...
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: 
                Digital Signature, Non Repudiation, Key Encipherment
            X509v3 Basic Constraints: 
                CA:FALSE
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Subject Alternative Name: 
                DNS:*.ceph-prag00-8mb4vr-node5, DNS:ceph-prag00-8mb4vr-node5, IP Address:xxxx
    Signature Algorithm: sha256WithRSAEncryption
...
```

