### PR TITLE
Changing the job trigger to UMB messaging

### DIFF
--- a/pipeline/ibm-tier-0.groovy
+++ b/pipeline/ibm-tier-0.groovy
@@ -1,6 +1,4 @@
-/*
-    Pipeline script for executing Tier 0 test suites for RH Ceph Storage in IBM cloud.
-*/
+/* Pipeline script for executing Tier 0 test suites for RH Ceph Storage in IBM cloud. */
 
 def nodeName = "agent-01"
 def testStages = [:]
@@ -14,10 +12,8 @@ def sharedLib
 node(nodeName) {
 
     timeout(unit: "MINUTES", time: 30) {
-        stage('Install prereq') {
-            if (env.WORKSPACE) {
-                sh script: "sudo rm -rf *"
-            }
+        stage('prepareNode') {
+            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
             checkout([
                 $class: 'GitSCM',
                 branches: [[name: 'origin/master']],
@@ -44,11 +40,11 @@ node(nodeName) {
         }
     }
 
-    stage('Prepare-Stages') {
+    stage('prepareTestStages') {
         /* Prepare pipeline stages using RHCEPH version */
         rhcephVersion = "${params.rhcephVersion}" ?: ""
         buildType = "${params.buildType}" ?: ""
-        if ((! rhcephVersion?.trim()) && (! buildType?.trim())) {
+        if ( (! rhcephVersion?.trim()) && (! buildType?.trim()) ) {
             error "Required Prameters are not provided.."
         }
 
@@ -56,26 +52,98 @@ node(nodeName) {
             "--build ${buildType} --cloud ibmc --xunit-results",
             buildPhase,
             testResults,
-            rhcephversion
+            rhcephVersion
         )
 
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."
         }
-        currentBuild.description = "${params.rhcephVersion}"
+        currentBuild.description = "${params.rhcephVersion} - ${buildPhase}"
     }
 
     parallel testStages
 
-    stage('upload xUnit-xml to COS'){
+    stage('publishTestResult') {
+        // Copy all the results into one folder before upload
         def dirName = "ibm_${currentBuild.projectName}_${currentBuild.number}"
-        testResults.each{key,dict->
-            sharedLib.uploadObject(key, dirName, dict["log-dir"])
+        def targetDir = "${env.WORKSPACE}/${dirName}/results"
+        sh(script: "mkdir -p ${targetDir}")
+        testResults.each { key, value ->
+            sh(script: "cp ${value['log-dir']}/xunit.xml ${targetDir}/${key}.xml")
         }
+
+        // Adding metadata information
+        def recipeMap = sharedLib.readFromRecipeFile(rhcephVersion)
+        def content = recipeMap[buildType]
+        content["product"] = "Red Hat Ceph Storage"
+        content["version"] = rhcephVersion
+        content["date"] = sh(returnStdout: true, script: "date")
+        content["log"] = env.RUN_DISPLAY_URL
+        content["stage"] = buildType
+        content["results"] = testResults
+
+        writeYaml file: "${env.WORKSPACE}/${dirName}/metadata.yaml", data: content
+        sharedLib.uploadResults(dirName, "${env.WORKSPACE}/${dirName}")
+
+        // Send UMB message
+        def rpmType = "unsigned"
+        if ( buildType == "rc" ) { rpmType = "signed" }
+
+        def msgMap = [
+            "artifact": [
+                "type": "product-build",
+                "name": "Red Hat Ceph Storage",
+                "version": content["ceph-version"],
+                "nvr": rhcephVersion,
+                "phase": "testing",
+                "build": rpmType,
+            ],
+            "contact": [
+                "name": "Downstream Ceph QE",
+                "email": "cephci@redhat.com",
+            ],
+            "system": [
+                "os": "centos-7",
+                "label": "agent-01",
+                "provider": "IBM-Cloud",
+            ],
+            "pipeline": [
+                "name": "tier-0",
+                "id": currentBuild.number,
+            ],
+            "run": [
+                "url": env.RUN_DISPLAY_URL,
+                "additional_urls": [
+                    "doc": "https://docs.engineering.redhat.com/display/rhcsqe/RHCS+QE+Pipeline",
+                    "repo": "https://github.com/red-hat-storage/cephci",
+                    "report": "https://reportportal-rhcephqe.apps.ocp4.prod.psi.redhat.com/",
+                    "tcms": "https://polarion.engineering.redhat.com/polarion/",
+                ],
+            ],
+            "test": [
+                "type": buildPhase,
+                "category": "functional",
+                "result": currentBuild.currentResult,
+                "object-prefix": dirName,
+            ],
+            "generated_at": env.BUILD_ID,
+            "version": "1.1.0",
+        ]
+
+        sharedLib.SendUMBMessage(
+            msgMap,
+            "VirtualTopic.qe.ci.rhcephqe.product-build.test.complete",
+            "Tier0TestingDone",
+        )
+
     }
 
-    stage('Update Results and Execute Tier-X suite') {
+    stage('postBuildAction') {
+        // Archive the logs
+        archiveArtifacts artifacts: "${env.WORKSPACE}/logs/*.log"
+        junit "${env.WORKSPACE}/logs/**/xunit.xml"
+
         // Update result to recipe file and execute post tier based on run execution
         if ("FAIL" in sharedLib.fetchStageStatus(testResults)) {
             currentBuild.result = "FAILED"

--- a/pipeline/scripts/ci/cos_cli.py
+++ b/pipeline/scripts/ci/cos_cli.py
@@ -18,6 +18,7 @@ This script helps to update reports in IBM.
 
 Usage:
   cos_cli.py upload <SOURCE_FILE> <OBJ_KEYNAME> <bucket_name>
+  cos_cli.py upload_directory <SOURCE_FILE> <OBJ_KEYNAME> <bucket_name>
   cos_cli.py download <OBJ_KEYNAME> <bucket_name> <DESTINATION_FILE>
   cos_cli.py delete <OBJ_KEYNAME> <bucket_name>
   cos_cli.py list <bucket_name>
@@ -28,6 +29,7 @@ Usage:
 
 Example:
     python cos_cli.py upload test.xml test-run-1 qe-ci-reports-bucket
+    python cos_cli.py upload_directory results test-run-1 qe-ci-reports
     python cos_cli.py download test-run-1 qe-ci-reports test.xml
     python cos_cli.py delete test-run-1 qe-ci-reports
     python cos_cli.py list qe-ci-reports
@@ -81,6 +83,19 @@ def delete_objfile(bucket: str, obj_key: str):
     LOG.info(f"Deleted successfully the file object({obj_key})")
 
 
+def upload_directory(bucket: str, local_dir: str, prefix: str) -> None:
+    """
+    Uploads the given file to the provided bucket with the mentioned name.
+
+    Args:
+        bucket (str):       The name of container to which file has to be uploaded
+        local_dir (str):    Complete path to the file that needs to be uploaded
+        prefix (str):       The name to be used for the uploaded object
+    """
+    cos.upload_directory(local_dir, prefix, bucket)
+    LOG.info("Successfully upload the object to IBM COS !!!")
+
+
 def list_objects(bucket: str):
     """List file objects from bucket.
 
@@ -98,6 +113,7 @@ OPS = {
     "download": download_objfile,
     "delete": delete_objfile,
     "list": list_objects,
+    "upload_directory": upload_directory,
 }
 
 if __name__ == "__main__":

--- a/pipeline/unsigned-container-image-listener.groovy
+++ b/pipeline/unsigned-container-image-listener.groovy
@@ -110,14 +110,4 @@ node(nodeName) {
         lib.SendUMBMessage(msgContent, overrideTopic, msgType)
     }
 
-    stage("Push Ceph Recipe") {
-        def recipeMap = [
-            "ceph-version": cephVersion,
-            "repository": compose.repository.tokenize(":")[-1],
-            "RHCephVersion": "RHCEPH-${versions.major_version}.${versions.minor_version}",
-            "platforms": releaseDetails.latest.composes.keySet().collect()
-        ]
-        lib.uploadBuildRecipe(recipeMap)
-    }
-
 }

--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -33,12 +33,12 @@ python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt
-.venv/bin/pip install git+https://gitlab.cee.redhat.com/ccit/reportportal/rp_preproc.git@rpv5
+python -m pip install git+https://gitlab.cee.redhat.com/ccit/reportportal/rp_preproc.git@rpv5
 deactivate
 
 # Install rclone
 curl https://rclone.org/install.sh | sudo bash || echo 0
-mkdir -p ~/.config/rclone
-wget http://magna002.ceph.redhat.com/cephci-jenkins/.ibm-cos.conf -O ~/.config/rclone/rclone.conf
+mkdir -p ${HOME}/.config/rclone
+wget http://magna002.ceph.redhat.com/cephci-jenkins/.ibm-cos.conf -O ${HOME}/.config/rclone/rclone.conf
 
 echo "Done bootstrapping the Jenkins node."


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, the following changes are carried out for IBM-C jobs

- Trigger based on UMB message event
- Modified log directory
- Archiving the logs
- Post UMB message on completion

In addition to the above changes, the post results job is also modified 
- Trigger based on UMB message event
- Synchronous directory instead of files
- Report portal now merges all the launches
- Adds metadata information to the launch

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-post-results/301/console
https://datagrepper.engineering.redhat.com/id?id=ID:eb84bae189a1-39477-1640936858376-115:1:1:1:1&is_raw=true&size=extra-large