### PR TITLE
Fix publishing issue with Tier-2 stage

### DIFF
--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -89,7 +89,9 @@ node(nodeName) {
 
         // Adding metadata information
         def recipeMap = sharedLib.readFromRecipeFile(rhcephVersion)
-        def content = recipeMap[buildType]
+
+        // Using only Tier-0 as pipeline progresses even if intermediate stages fail.
+        def content = recipeMap["tier-0"]
         content["product"] = "Red Hat Ceph Storage"
         content["version"] = rhcephVersion
         content["date"] = sh(returnStdout: true, script: "date")


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
```
java.lang.NullPointerException: Cannot set property 'product' on null object
	at org.codehaus.groovy.runtime.NullObject.setProperty(NullObject.java:80)
	at org.codehaus.groovy.runtime.InvokerHelper.setProperty(InvokerHelper.java:197)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.putAt(DefaultGroovyMethods.java:272)
	at org.codehaus.groovy.runtime.dgm$509.doMethodInvoke(Unknown Source)
```
This PR fixes the above error that we see when running jobs above Tier-1 stage. The issue occurs as we try to pick the build information of Tier-(x-1). There are instances when there is no build information as the content is updated only when that stage passes. 

These stages are triggered only when Tier-0 has passed hence moving to use only `tier-0` build details to match the test execution.