### PR TITLE
Add ceph dump commands to debug the failures

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -461,6 +461,8 @@ def get_cluster_state(cls, commands=[]):
         "ceph orch ls -f yaml",
         "ceph orch ps -f json-pretty",
         "ceph health detail -f yaml",
+        "ceph mgr dump",  # https://bugzilla.redhat.com/show_bug.cgi?id=2033165#c2
+        "ceph mon stat",
     ]
 
     __CLUSTER_STATE_COMMANDS.extend(commands)

--- a/tests/cephadm/test_cephadm_upgrade.py
+++ b/tests/cephadm/test_cephadm_upgrade.py
@@ -83,6 +83,8 @@ def run(ceph_cluster, **kwargs) -> int:
                 "ceph orch ps -f yaml",
                 "ceph orch ls -f yaml",
                 "ceph orch upgrade status",
+                "ceph mgr dump",  # https://bugzilla.redhat.com/show_bug.cgi?id=2033165#c2
+                "ceph mon stat",
             ]
         )
     return 0


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Get ceph MON/MGR state for debugging the failures.