### PR TITLE
method_should_succeed moved to utility/utils

### DIFF
--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -14,21 +14,6 @@ from ceph.ceph_admin.osd import OSD
 log = logging.getLogger(__name__)
 
 
-def method_should_succeed(function, *args, **kwargs):
-    """
-    Checks return status of command execution
-    and raise assertion on failure
-    Args:
-        function: name of the function
-        args: arg list
-        kwargs: arg dict
-    """
-    if function(*args, **kwargs):
-        pass
-    else:
-        raise AssertionError(f"Execution failed at function {function}")
-
-
 def set_osd_devices_unamanged(ceph_cluster, unmanaged):
     """
     Sets osd device unmanaged as true/false

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -7,6 +7,7 @@ from ceph.ceph_admin import CephAdmin
 from ceph.rados import utils
 from ceph.rados.core_workflows import RadosOrchestrator
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.utils import method_should_succeed
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ def run(ceph_cluster, **kw):
     log.info("Running create pool test case")
     if config.get("create_pool"):
         pool = config.get("create_pool")
-        utils.method_should_succeed(
+        method_should_succeed(
             rados_obj.create_pool, pool_name=pool["pool_name"], pg_num=pool["pg_num"]
         )
         rados_obj.change_recover_threads(config=pool, action="set")
@@ -73,24 +74,20 @@ def run(ceph_cluster, **kw):
             f"device path  : {dev_path}, osd_id : {osd_id}, host.hostname : {host.hostname}"
         )
         utils.set_osd_devices_unamanged(ceph_cluster, unmanaged=True)
-        utils.method_should_succeed(rados_obj.bench_write, **pool)
-        utils.method_should_succeed(utils.set_osd_out, ceph_cluster, osd_id)
-        utils.method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        method_should_succeed(rados_obj.bench_write, **pool)
+        method_should_succeed(utils.set_osd_out, ceph_cluster, osd_id)
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
         utils.osd_remove(ceph_cluster, osd_id)
-        utils.method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        utils.method_should_succeed(
-            utils.zap_device, ceph_cluster, host.hostname, dev_path
-        )
-        utils.method_should_succeed(
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        method_should_succeed(utils.zap_device, ceph_cluster, host.hostname, dev_path)
+        method_should_succeed(
             wait_for_device, host, container_id, osd_id, action="remove"
         )
         utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
-        utils.method_should_succeed(
-            wait_for_device, host, container_id, osd_id, action="add"
-        )
-        utils.method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        utils.method_should_succeed(rados_obj.bench_write, **pool)
-        utils.method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        method_should_succeed(wait_for_device, host, container_id, osd_id, action="add")
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        method_should_succeed(rados_obj.bench_write, **pool)
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
         utils.set_osd_devices_unamanged(ceph_cluster, unmanaged=False)
         rados_obj.change_recover_threads(config=pool, action="rm")
     return 0

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1222,3 +1222,24 @@ def install_start_kafka(rgw_node, cloud_type):
 
     # wait for kafka service to start
     time.sleep(30)
+
+
+def method_should_succeed(function, *args, **kwargs):
+    """
+    Wrapper function to verify the return value of executed method.
+
+    This function will raise Assertion if return value is false, empty, or 0.
+    Args:
+        function: name of the function
+        args: arg list
+        kwargs: arg dict
+    Usage:
+        Basic usage is pass a function and it's list and/or dict arguments
+        ex:     method_should_succeed(set_osd_out, ceph_cluster, osd_id)
+                method_should_succeed(bench_write, **pool)
+    """
+    rc = function(*args, **kwargs)
+
+    log.debug(f"The {function} return status is {rc}")
+    if not rc:
+        raise AssertionError(f"Execution failed at function {function}")


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Moved method_should_succeed() to utility/utils.

Logs:
[Robust_rebalancing_-_osd_replacement_0.log](https://github.com/red-hat-storage/cephci/files/7819920/Robust_rebalancing_-_osd_replacement_0.log)
[startup.log](https://github.com/red-hat-storage/cephci/files/7819922/startup.log)


