### PR TITLE
Reducing the config to decrease the runtime for tier-1

### DIFF
--- a/suites/pacific/cephfs/tier-1_fs.yaml
+++ b/suites/pacific/cephfs/tier-1_fs.yaml
@@ -200,7 +200,7 @@ tests:
       name: cephfs-mdsfailover-pinning-io
       module: dir_pinning.py
       config:
-        num_of_dirs: 1000
+        num_of_dirs: 200
       polarion-id: CEPH-11227
       desc: MDSfailover on active-active mdss,performing client IOs with no pinning at the first,later pin 10 dirs with IOs
       abort-on-fail: false


### PR DESCRIPTION
Reducing the config to decrease the runtime for tier-1

Logs : [http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3RLKR9/](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3RLKR9/)

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
