### PR TITLE
Fixing logging when error/exception occurs

### DIFF
--- a/utility/log.py
+++ b/utility/log.py
@@ -148,7 +148,6 @@ class Log:
     def error(
         self,
         message: Any,
-        exc_info: bool = True,
         *args,
         **kwargs,
     ) -> None:
@@ -163,13 +162,12 @@ class Log:
         Returns:
             None
         """
-        kwargs["exc_info"] = exc_info
+        kwargs["exc_info"] = kwargs.get("exc_info", True)
         self._log("error", message, *args, **kwargs)
 
     def exception(
         self,
         message: Any,
-        exc_info: bool = True,
         *args,
         **kwargs,
     ) -> None:
@@ -183,5 +181,5 @@ class Log:
         Returns:
             None
         """
-        kwargs["exc_info"] = exc_info
+        kwargs["exc_info"] = kwargs.get("exc_info", True)
         self._log("exception", message, *args, **kwargs)


### PR DESCRIPTION
Fixing logging when error/exception occurs
We were seeing logging error when there is cmd failure.
we had log statement 
**logger.error("Error %s during cmd, timeout %d", exit_status, timeout)**
In Log.py(wrapper class) we had exec_info argument which getting substituted with exit_status.
To avoid this we have modified wrapper class and removed exec_info as extra_param

Cephfs _ Logs : [http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4Z0X1J/](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4Z0X1J/
)
rgw Logs 2 : [http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6GOPVE/](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6GOPVE/)
Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
