### PR TITLE
RGW MutiSite upgrade test suite from 4.x to 5 latest

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
@@ -1,0 +1,301 @@
+# Polarion ID: CEPH-83574664
+# Objective: Testing Multisite upgrade from RHCS 4 GA to RHCS 5 latest development build.
+# conf: rgw_multisite.yaml
+# platform: rhel-8
+---
+tests:
+
+  - test:
+      abort-on-fail: true
+      desc: install ceph pre requisites
+      module: install_prereq.py
+      name: install vm pre-requsites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            primary_node: ceph-pri
+            use_cdn: true
+            build: "4.x"
+            ansi_config:
+              ceph_origin: repository
+              ceph_repository: rhcs
+              ceph_repository_type: cdn
+              ceph_rhcs_version: 4
+              osd_scenario: lvm
+              osd_auto_discovery: false
+              containerized_deployment: true
+              ceph_docker_image: rhceph/rhceph-4-rhel8
+              ceph_docker_image_tag: latest
+              ceph_docker_registry: registry.redhat.io
+              copy_admin_key: true
+              dashboard_enabled: false
+              rgw_multisite: true
+              rgw_zone: US_EAST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: true
+              rgw_zonesecondary: false
+              rgw_zonegroupmaster: true
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              rgw_multisite_proto: "http"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+        ceph-sec:
+          config:
+            primary_node: ceph-pri
+            use_cdn: true
+            build: "4.x"
+            ansi_config:
+              ceph_origin: repository
+              ceph_repository: rhcs
+              ceph_repository_type: cdn
+              ceph_rhcs_version: 4
+              osd_scenario: lvm
+              osd_auto_discovery: false
+              containerized_deployment: true
+              ceph_docker_image: rhceph/rhceph-4-rhel8
+              ceph_docker_image_tag: latest
+              ceph_docker_registry: registry.redhat.io
+              copy_admin_key: true
+              dashboard_enabled: false
+              rgw_multisite: true
+              rgw_zone: US_WEST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: false
+              rgw_zonesecondary: true
+              rgw_zonegroupmaster: false
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              rgw_multisite_proto: "http"
+              rgw_pull_proto: http
+              rgw_pull_port: 8080
+      desc: Deploying Ceph multisite RGW cluster using ceph-ansible
+      module: test_ansible.py
+      name: deploy ceph multisite cluster from cdn
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create user
+
+  # Baseline testing
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects.yaml
+            timeout: 300
+      desc: test to create "M" no of buckets and "N" no of objects
+      module: sanity_rgw_multisite.py
+      name: Test M buckets with N objects
+      polarion-id: CEPH-9789
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+            timeout: 300
+      desc: test to create "M" buckets and "N" objects with multipart upload
+      module: sanity_rgw_multisite.py
+      name: Test multipart upload of M buckets with N objects
+      polarion-id: CEPH-9801
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_swift_basic_ops.py
+            config-file-name: test_swift_basic_ops.yaml
+            timeout: 300
+      desc: Test object operations with swift
+      module: sanity_rgw_multisite.py
+      name: Swift based tests
+      polarion-id: CEPH-11019
+
+  # Bucket Listing Tests
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered.yaml
+            timeout: 300
+      desc: test duration for ordered listing of bucket with top level objects
+      module: sanity_rgw_multisite.py
+      name: test ordered listing of buckets
+      polarion-id: CEPH-83573545
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+      desc: test duration for unordered listing of buckets with top level objects
+      module: sanity_rgw_multisite.py
+      name: test unordered listing of buckets
+      polarion-id: CEPH-83573545
+
+  # Performing cluster upgrade
+
+  - test:
+      name: ceph multisite upgrade
+      module: test_ansible_upgrade.py
+      clusters:
+        ceph-pri:
+          config:
+            primary_node: ceph-pri
+            build: "5.x"
+            ansi_config:
+              ceph_origin: distro
+              ceph_repository: rhcs
+              ceph_rhcs_version: 5
+              osd_scenario: lvm
+              osd_auto_discovery: false
+              containerized_deployment: true
+              copy_admin_key: true
+              dashboard_enabled: false
+              rgw_multisite: true
+              rgw_zone: US_EAST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: true
+              rgw_zonesecondary: false
+              rgw_zonegroupmaster: true
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              rgw_multisite_proto: "http"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              upgrade_ceph_packages: true
+        ceph-sec:
+          config:
+            primary_node: ceph-pri
+            build: "5.x"
+            ansi_config:
+              ceph_origin: distro
+              ceph_repository: rhcs
+              ceph_rhcs_version: 5
+              osd_scenario: lvm
+              osd_auto_discovery: false
+              containerized_deployment: true
+              copy_admin_key: true
+              dashboard_enabled: false
+              rgw_multisite: true
+              rgw_zone: US_WEST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: false
+              rgw_zonesecondary: true
+              rgw_zonegroupmaster: false
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              rgw_multisite_proto: "http"
+              rgw_pullhost: "{node_ip:ceph-pri#node5}"
+              rgw_pull_proto: http
+              rgw_pull_port: 8080
+              upgrade_ceph_packages: true
+      desc: Upgrading the clusters to the specified build.
+      abort-on-fail: true
+      polarion-id: CEPH-83574664
+
+  # Test cluster post upgrade
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+            timeout: 300
+      desc: test to create "M" no of buckets and "N" no of objects with delete
+      module: sanity_rgw_multisite.py
+      name: Test delete using M buckets with N objects
+      polarion-id: CEPH-14237
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            timeout: 300
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      module: sanity_rgw_multisite.py
+      name: Test download with M buckets with N objects
+      polarion-id: CEPH-14237
+
+  # Basic swift based tests
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_swift_basic_ops.py
+            config-file-name: test_swift_version_copy_op.yaml
+            timeout: 500
+      desc: test restoring of versioned objects in swift
+      module: sanity_rgw_multisite.py
+      name: test swift versioning copy
+      polarion-id: CEPH-10646
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_swift_basic_ops.py
+            config-file-name: test_swift_object_expire_op.yaml
+            timeout: 500
+      desc: test object expiration with swift
+      module: sanity_rgw_multisite.py
+      name: test swift object expiration
+      polarion-id: CEPH-9718
+
+  # Listing
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+      desc: test the duration for ordered listing of versioned buckets
+      module: sanity_rgw_multisite.py
+      name: Bucket Listing tests
+      polarion-id: CEPH-83573545
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+      desc: test duration for unordered listing of buckets
+      module: sanity_rgw_multisite.py
+      name: test unordered listing of buckets
+      polarion-id: CEPH-83573545

--- a/tests/ceph_installer/test_ansible.py
+++ b/tests/ceph_installer/test_ansible.py
@@ -52,7 +52,7 @@ def run(ceph_cluster, **kw):
         for key in ("rgw_multisite", "rgw_zonesecondary")
     ):
         ceph_cluster_dict = kw.get("ceph_cluster_dict")
-        primary_node = "ceph-rgw1"
+        primary_node = config.get("primary_node", "ceph-rgw1")
         primary_rgw_node = (
             ceph_cluster_dict.get(primary_node).get_ceph_object("rgw").node
         )


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR adds a suite file for testing RGW multisite upgrade from 4.x to 5.x -  development build. - CEPH-83574664

<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/51_ms/upgrade/