### PR TITLE
Support image overrides via custom-config

### DIFF
--- a/run.py
+++ b/run.py
@@ -93,7 +93,6 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--xunit-results]
         [--enable-eus]
         [--skip-enabling-rhel-rpms]
-        [--grafana-image <image-name>]
   run.py --cleanup=name --osp-cred <file> [--cloud <str>]
         [--log-level <LEVEL>]
 
@@ -154,9 +153,6 @@ Options:
                                     [default: false]
   --skip-enabling-rhel-rpms         skip adding rpms from subscription if using beta
                                     rhel images for Interop runs
-  --grafana-image <image_name>      Development purpose - provide custom grafana image
-                                    in conjunction with --skip-monitoring-stack during
-                                    cluster bootstrap via CephADM
 """
 log = Log(__name__)
 root = logging.getLogger()
@@ -562,7 +558,6 @@ def run(args):
     kernel_repo = args.get("--kernel-repo", None)
 
     docker_insecure_registry = args.get("--insecure-registry", False)
-    custom_grafana_image = args.get("--grafana-image", None)
 
     post_results = args.get("--post-results")
     skip_setup = args.get("--skip-cluster", False)
@@ -913,9 +908,6 @@ def run(args):
 
             if osp_cred:
                 config["osp_cred"] = osp_cred
-
-            if custom_grafana_image:
-                config["grafana_image"] = custom_grafana_image
 
             # if Kernel Repo is defined in ENV then set the value in config
             if os.environ.get("KERNEL-REPO-URL") is not None:

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -113,6 +113,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     """
     LOG.info("Starting Ceph cluster deployment.")
     config = kwargs["config"]
+    config["overrides"] = kwargs.get("test_data", {}).get("custom-config")
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     try:
         steps = config.get("steps", [])

--- a/tests/cephadm/test_bootstrap.py
+++ b/tests/cephadm/test_bootstrap.py
@@ -548,6 +548,7 @@ def run(ceph_cluster, **kw):
     config = kw.get("config")
     build = config.get("build", config.get("rhbuild"))
     ceph_cluster.rhcs_version = build
+    config["overrides"] = kw.get("test_data", {}).get("custom-config")
 
     # Manage Ceph using ceph-admin orchestration
     command = config.pop("command")

--- a/tests/cephadm/test_cephadm_upgrade.py
+++ b/tests/cephadm/test_cephadm_upgrade.py
@@ -39,6 +39,7 @@ def run(ceph_cluster, **kwargs) -> int:
     """
     LOG.info("Upgrade Ceph cluster...")
     config = kwargs["config"]
+    config["overrides"] = kwargs.get("test_data", {}).get("custom-config")
     orch = Orch(cluster=ceph_cluster, **config)
 
     client = ceph_cluster.get_nodes(role="client")[0]

--- a/tests/cephadm/test_monitoring.py
+++ b/tests/cephadm/test_monitoring.py
@@ -29,6 +29,7 @@ def run(ceph_cluster, **kw):
     """
     log.info("Running Ceph-admin Provisioning test")
     config = kw.get("config")
+    config["overrides"] = kw.get("test_data", {}).get("custom-config")
 
     build = config.get("build", config.get("rhbuild"))
     ceph_cluster.rhcs_version = build


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Adds support for providing custom image overrides during bootstrap. In this PR, we are extending `--custom-config` CLI argument support to RHCS 5.x deployments also.

__Example__
```
>  python run.py --rhbuild 5.1 \
       --v2 \
       --platform rhel-8 \
       --build tier-0
       --global-conf cluster.yaml \
       --osp-cred cred.yaml  \
       --inventory conf/inventory/rhel-8.4-server-x86_64.yaml \
       --suite suites/pacific/rgw/tier-0_rgw.yaml \
       --custom-config grafana_image=redhat.registry.io/myGrafanaImage \
       --custom-config keepalived_image=redhat.registry.io/myKeepAliveD
```

Closes #1002 

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/custom_config/

```
[cephuser@ceph-prag01-dm7kn9-node1-installer ~]$ sudo cephadm shell -- ceph config dump
Inferring fsid fd6498f4-7363-11ec-a854-fa163e1b128b
Using recent ceph image registry-proxy.engineering.redhat.com/rh-osbs/rhceph@sha256:e145926e677431810030ef8d40960775935212d197514b05e260320beaea6ea7
WHO     MASK  LEVEL     OPTION                                  VALUE                                                                                                                         RO
global        basic     container_image                         registry-proxy.engineering.redhat.com/rh-osbs/rhceph@sha256:a8e81e44c60a77dd1e5eeeb33c66550e3fd613a9f22df5eac6eb589da4aa66fb  * 
  mon         advanced  auth_allow_insecure_global_id_reclaim   false                                                                                                                           
  mon         advanced  public_network                          10.0.208.0/22                                                                                                                 * 
  mgr         advanced  mgr/cephadm/container_image_keepalived  registry-proxy.engineering.redhat.com/rh-osbs/keepalived:2.1.5-1                                                              * 
  mgr         advanced  mgr/cephadm/container_init              True                                                                                                                          * 
  mgr         advanced  mgr/cephadm/migration_current           3                                                                                                                             * 
  mgr         advanced  mgr/cephadm/registry_password           MTQj5t3n5K86p3gH                                                                                                              * 
  mgr         advanced  mgr/cephadm/registry_url                registry.redhat.io                                                                                                            * 
  mgr         advanced  mgr/cephadm/registry_username           qa@redhat.com                                                                                                                 * 
  mgr         advanced  mgr/dashboard/GRAFANA_API_SSL_VERIFY    false                                                                                                                         * 
  mgr         advanced  mgr/dashboard/ssl_server_port           8443                                                                                                                          * 
  mgr         advanced  mgr/orchestrator/orchestrator           cephadm                                                                                                                         
  mgr         advanced  mgr/pg_autoscaler/autoscale_profile     scale-up                                                                                                                        
[cephuser@ceph-prag01-dm7kn9-node1-installer ~]$
```