### PR TITLE
Adding support for specifying root CA location

### DIFF
--- a/cephci.yaml.template
+++ b/cephci.yaml.template
@@ -51,3 +51,6 @@
 
 # URI to be used for retrieving the RHCS build details
 # build-url: <URI to fileserver>
+
+# Web based location to retrieve root CA key and cert
+root-ca-location: <URL to base location of rootCA cert>

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -960,7 +960,11 @@ def generate_node_name(cluster_name, instance_name, run_id, node, role):
 
 def get_cephqe_ca() -> Optional[Tuple]:
     """Retrieve CephCI QE CA certificate and key."""
-    base_uri = "http://magna002.ceph.redhat.com/cephci-jenkins"
+    base_uri = (
+        get_cephci_config()
+        .get("root-ca-location", "http://magna002.ceph.redhat.com/cephci-jenkins")
+        .rstrip("/")
+    )
     ca_cert = None
     ca_key = None
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
This PR enables support for specifying the location to retrieve the root CA certificate and key. This is helpful when the tests are being executed in multiple environments.

The name of the key and cert is still static though.

It fixes the failure seen with RHCS 5.x SSL based Multisite test scenario

__Logs__
https://159.23.92.24/job/Custom%20Test%20Run/4/console