### PR TITLE
Added crash ls TC into nautilus and pacific MS suite

### DIFF
--- a/suites/nautilus/rgw/tier-1-extn_rgw_multisite-primary-to-secondary.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw_multisite-primary-to-secondary.yaml
@@ -183,3 +183,25 @@ tests:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
+  - test:
+      name: crash ls command
+      desc: Create bucket on primary required for crash check
+      polarion-id: CEPH-83574706
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name:  test_Mbuckets_with_Nobjects.py
+            config-file-name:  test_bucket_sync_cmd_crash.yaml
+            timeout: 300
+  - test:
+      name: crash ls command
+      desc: Execute bucket sync command to check command is not crashing on secondary
+      polarion-id: CEPH-83574706
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw2:
+          config:
+            script-name:  test_Mbuckets_with_Nobjects.py
+            config-file-name:  test_bucket_sync_cmd_crash.yaml
+            timeout: 300

--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-primary-to-secondary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-primary-to-secondary.yaml
@@ -273,3 +273,25 @@ tests:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
+  - test:
+      name: crash ls command
+      desc: Create bucket on primary required for crash check
+      polarion-id: CEPH-83574706
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name:  test_Mbuckets_with_Nobjects.py
+            config-file-name:  test_bucket_sync_cmd_crash.yaml
+            timeout: 300
+  - test:
+      name: crash ls command
+      desc: Execute bucket sync command to check command is not crashing on secondary
+      polarion-id: CEPH-83574706
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name:  test_Mbuckets_with_Nobjects.py
+            config-file-name:  test_bucket_sync_cmd_crash.yaml
+            timeout: 300


### PR DESCRIPTION
Added crash ls TC into nautilus and pacific MS suite

Following is the link of successful run:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2ZIMRU/

Signed-off-by: udaysk23 <ukurundw@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarin Test with Automation script details and update automation fields
- [x] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
