### PR TITLE
add radoslist test

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_image_test-bucket-lifecycle-and-listing.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_image_test-bucket-lifecycle-and-listing.yaml
@@ -209,3 +209,14 @@ tests:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
         timeout: 300
+
+  - test:
+      name: Bucket radoslist 
+      desc: radoslist on all buckets
+      polarion-id: CEPH-83574480
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -436,6 +436,16 @@ tests:
         config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
         timeout: 300
 
+  - test:
+      name: Bucket radoslist 
+      desc: radoslist on all buckets
+      polarion-id: CEPH-83574480
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+        
   # Bucket Request Payer tests
 
   - test:


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Add radoslist test to both nautilus and pacific suites.
logs: 
http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/fix_radoslist/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
