### PR TITLE
Adding logic for bootstrap with config file

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -9,7 +9,7 @@ from ceph.ceph_admin.cephadm_ansible import CephadmAnsible
 from utility.utils import get_cephci_config
 
 from .common import config_dict_to_string
-from .helper import GenerateServiceSpec
+from .helper import GenerateServiceSpec, create_ceph_config_file
 from .typing_ import CephAdmProtocol
 
 logger = logging.getLogger(__name__)
@@ -259,6 +259,11 @@ class BootstrapMixin:
                 node=self.installer, cluster=self.cluster, specs=specs
             )
             args["apply-spec"] = spec_cls.create_spec_file()
+
+        # config
+        conf = args.get("config")
+        if conf:
+            args["config"] = create_ceph_config_file(node=self.installer, config=conf)
 
         cmd += config_dict_to_string(args)
         out, err = self.installer.exec_command(

--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -440,6 +440,32 @@ class GenerateServiceSpec:
         return temp_file.name
 
 
+def create_ceph_config_file(node, config):
+    """
+    Create config file based on config options and return file name
+
+    Returns:
+        temp_filename (Str)
+
+    """
+    path = dirname(__file__) + "/jinja_templates/config.jinja"
+    with open(path) as fd:
+        template = fd.read()
+
+    conf_content = Template(template).render(config=config)
+
+    LOG.info(f"Conf yaml file content:\n{conf_content}")
+    # Create conf yaml file
+    temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
+    conf_file = node.node.remote_file(
+        sudo=True, file_name=temp_file.name, file_mode="w"
+    )
+    conf_file.write(conf_content)
+    conf_file.flush()
+
+    return temp_file.name
+
+
 def get_cluster_state(cls, commands=[]):
     """
     fetch cluster state using commands provided along

--- a/ceph/ceph_admin/jinja_templates/config.jinja
+++ b/ceph/ceph_admin/jinja_templates/config.jinja
@@ -1,0 +1,6 @@
+{%- set nlt = "\n  " -%}
+{%+ for conf, dict in config.items() %}
+[{{ conf }}]
+{%+ for key, value in dict.items() %}{{ key }} = {{ value }}
+{%+ endfor %}
+{%+ endfor %}

--- a/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
+++ b/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
@@ -28,6 +28,7 @@
 #       - registry-json: <registry-URL>
 #       - fsid: <cluster-fsid>
 #       - mon-ip: <monitor IP address: Required>
+#       - config: <ceph config options to be set during bootstrap>
 #   (2) Copy SSH keys to nodes.
 #   (3) Add nodes to cluster with address and role labels attached to it using Host spec yaml file.
 #   (4) Deploy services using apply spec option, (" ceph orch apply -i <spec_file>)
@@ -54,7 +55,7 @@ tests:
       name: Cephadm Bootstrap
       desc: cephadm cluster bootstrap
       module: test_bootstrap.py
-      polarion-id:
+      polarion-id: CEPH-83574725
       config:
         command: bootstrap
         base_cmd_args:
@@ -66,13 +67,19 @@ tests:
           custom_image: true
           mon-ip: node1
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
+          config:
+            mgr:
+              mgr/cephadm/container_image_grafana: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5-27
+              mgr/cephadm/container_image_alertmanager: openshift4/ose-prometheus-alertmanager:v4.9.0-202110182323.p0.git.579e3c6.assembly.stream
+              mgr/cephadm/container_image_prometheus: registry.redhat.io/openshift4/ose-prometheus:v4.9.0-202110182323.p0.git.3197fa7.assembly.stream
+              mgr/cephadm/container_image_node_exporter: openshift4/ose-prometheus-node-exporter:v4.6.0-202107070256.p0.git.c63b8f3
       destroy-cluster: false
       abort-on-fail: true
   - test:
       name: Host addition with spec file
       desc: add hosts using spec file.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574726
       config:
         steps:
         - config:
@@ -105,7 +112,7 @@ tests:
       name: Service deployment with spec
       desc: Add services using spec file.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574727
       config:
         steps:
         - config:
@@ -156,7 +163,7 @@ tests:
       name: MDS Service deployment with spec
       desc: Add MDS services using spec file
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574728
       config:
         steps:
           - config:
@@ -184,7 +191,7 @@ tests:
       name: NFS Service deployment with spec
       desc: Add NFS services using spec file
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574729
       config:
         steps:
           - config:


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description
This change is to allow specifying any config options to be set during bootstrap. As a start I have set monitoring services to be used in the config options, we could use the same suite args to set any config options during bootstrap of a node.

Success test run - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VIKBFZ/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
