### PR TITLE
Adds support of environment variables in rgw script

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -24,6 +24,9 @@ Below configs are needed in order to run the tests
                             max: 15M
         run_io_verify (optional):
                     true or false
+        env-vars (optional):
+                    - cleanup=False
+                    - objects_count: 500
         extra-pkgs (optional):
                     Packages to install
                     example:
@@ -157,8 +160,10 @@ def run(ceph_cluster, **kw):
         remote_fp = rgw_node.remote_file(file_name=f_name, file_mode="w")
         remote_fp.write(yaml.dump(test_config, default_flow_style=False))
 
+    cmd_env = " ".join(config.get("env-vars", []))
     out, err = rgw_node.exec_command(
-        cmd=f"sudo {python_cmd} "
+        cmd=cmd_env
+        + f"sudo {python_cmd} "
         + test_folder_path
         + script_dir
         + script_name

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -26,6 +26,9 @@ Below configs are needed in order to run the tests
                                 max: 15M
             verify-io-on-site (optional):
                         Primary node> or Secondary node
+            env-vars (optional):
+                        - cleanup=False
+                        - objects_count: 500
             extra-pkgs (optional):
                         Packages to install
                         example:
@@ -110,8 +113,10 @@ def run(**kw):
         )
         remote_fp.write(yaml.dump(test_config, default_flow_style=False))
 
+    cmd_env = " ".join(config.get("env-vars", []))
     out, err = test_site_node.exec_command(
-        cmd="sudo python3 "
+        cmd=cmd_env
+        + "sudo python3 "
         + test_folder_path
         + script_dir
         + script_name


### PR DESCRIPTION
Adds support of environment variables in rgw script

Following is the log link where it is appending env-variables to command:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DFUPDH

Note: (In above run, I haven't ran an entire suite since env variable is still not supported in ceph-qe-script)
Signed-off-by: udaysk23 <ukurundw@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
