### PR TITLE
fix typo in cloud-typo

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -81,7 +81,7 @@ def run(ceph_cluster, **kw):
     run_io_verify = config.get("run_io_verify", False)
     extra_pkgs = config.get("extra-pkgs")
     install_start_kafka_broker = config.get("install_start_kafka")
-    cloud_type = config.get("cloud_type")
+    cloud_type = config.get("cloud-type")
     test_config = {"config": config.get("test-config", {})}
     rgw_node = rgw_ceph_object.node
     distro_version_id = rgw_node.distro_info["VERSION_ID"]


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Fix typo in cloud_type. 
fixes the pipeline failures - https://159.23.92.24/job/tier-x/54/artifact/logs/ogtxe-54/bucket_notification_with_kafka_endpoint_0.log 
2022-01-11 18:18:20,588 ERROR: cmd execution failed
2022-01-11 18:18:20,588 ERROR: error: sudo: /usr/local/kafka/bin/kafka-console-consumer.sh: command not found returncode: 1

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
