### PR TITLE
Add check to verify sync on secondary after user create

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -51,7 +51,7 @@ import time
 
 import yaml
 
-from utility.utils import setup_cluster_access, sync_status_on_primary
+from utility.utils import setup_cluster_access, verify_sync_status
 
 log = logging.getLogger(__name__)
 
@@ -138,6 +138,7 @@ def run(**kw):
         copy_file_from_node_to_node(
             user_details_file, test_site_node, copy_user_to_site_node, user_details_file
         )
+        verify_sync_status(copy_user_to_site_node)
 
     verify_io_on_sites = config.get("verify-io-on-site", [])
     if verify_io_on_sites:
@@ -145,7 +146,7 @@ def run(**kw):
         for site in verify_io_on_sites:
             verify_io_on_site_node = clusters.get(site).get_ceph_object("rgw").node
             log.info(f"Check sync status on {site}")
-            sync_status_on_primary(verify_io_on_site_node)
+            verify_sync_status(verify_io_on_site_node)
             # adding sleep for 60 seconds before verification of data starts
             time.sleep(60)
             log.info(f"verification IO on {site}")

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -131,7 +131,7 @@ def fuse_mount(fuse_clients, mounting_dir):
         log.error(e)
 
 
-def sync_status_on_primary(verify_io_on_site_node, retry=10, delay=60):
+def verify_sync_status(verify_io_on_site_node, retry=10, delay=60):
     """
     verify multisite sync status on primary
     """
@@ -156,7 +156,7 @@ def sync_status_on_primary(verify_io_on_site_node, retry=10, delay=60):
     )
     if "behind" in check_sync_status or "recovering" in check_sync_status:
         log.info("sync is in progress")
-        log.info("sleep of 60 secs for sync to complete")
+        log.info(f"sleep of {delay}secs for sync to complete")
         for retry_count in range(retry):
             time.sleep(delay)
             check_sync_status, err = verify_io_on_site_node.exec_command(


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Add a check to verify sync status after user create 
snippet:
2022-01-13 17:27:32,116 - ceph.ceph - INFO - Running command sudo radosgw-admin sync status on 10.0.211.0
2022-01-13 17:27:33,358 - ceph.ceph - INFO - Command completed successfully
2022-01-13 17:27:33,358 - utility.utils - INFO - No errors or failures in sync status
2022-01-13 17:27:33,358 - utility.utils - INFO - check if sync is in progress, if sync is in progress retry 10 times with 60secs of sleep
2022-01-13 17:27:33,358 - utility.utils - INFO - sync is in progress
2022-01-13 17:27:33,358 - utility.utils - INFO - sleep of 60secs for sync to complete
2022-01-13 17:28:33,359 - ceph.ceph - INFO - Running command sudo radosgw-admin sync status on 10.0.211.0
2022-01-13 17:28:34,559 - ceph.ceph - INFO - Command completed successfully
2022-01-13 17:28:34,559 - utility.utils - INFO - sync completed
2022-01-13 17:28:34,560 - utility.utils - INFO - metadata is caught up
2022-01-13 17:28:34,560 - utility.utils - INFO - sync status complete

[logs:](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BS60Z4/create_user_0.log) 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
