### PR TITLE
Automation of CEPH-9230:snap&clone of an imported image

### DIFF
--- a/suites/nautilus/rbd/tier-2_rbd_regression.yaml
+++ b/suites/nautilus/rbd/tier-2_rbd_regression.yaml
@@ -1,0 +1,42 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing
+# functionality of Ceph RBD component.
+#
+# Conf file - conf/nautilus/rbd/tier-0_rbd.yaml
+#
+# The following tests are covered
+#   - CEPH-9230 - verification snap and clone on an imported image
+#
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: "install ceph pre-requisites"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        ansi_config:
+          ceph_conf_overrides:
+            mon:
+              mon_allow_pool_delete: true
+          ceph_origin: distro
+          ceph_repository: rhcs
+          copy_admin_key: true
+          dashboard_enabled: false
+          fetch_directory: ~/fetch
+          osd_auto_discovery: false
+          osd_scenario: lvm
+      desc: "setup four node cluster using ceph ansible"
+      destroy-cluster: false
+      module: test_ansible.py
+      name: "ceph ansible"
+  -
+    test:
+      desc: "snap and clone operations on imported image"
+      module: rbd_snap_clone_imported_image.py
+      name: "snap and clone on imported image"
+      polarion-id: CEPH-9230

--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -1,0 +1,81 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component.
+#
+# Conf File - conf/pacific/rbd/tier-0_rbd.yaml
+#
+# The following tests are covered
+#   - CEPH-9230 - verification snap and clone on an imported image
+
+tests:
+
+  # Setup the cluster
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  # Test cases to be executed
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      desc: snap and clone operations on imported image
+      destroy-cluster: false
+      module: rbd_snap_clone_imported_image.py
+      name: snap and clone on imported image
+      polarion-id: CEPH-9230

--- a/tests/rbd/exceptions.py
+++ b/tests/rbd/exceptions.py
@@ -1,0 +1,34 @@
+class RbdBaseException(Exception):
+    """Base exception for all RBD modules"""
+
+    pass
+
+
+class CreateFileError(RbdBaseException):
+    """Raised when create_file_to_import function call fails"""
+
+    pass
+
+
+class ImportFileError(RbdBaseException):
+    """Raised when import_file function call fails"""
+
+    pass
+
+
+class SnapCreateError(RbdBaseException):
+    """Raised when rbd snap create fails"""
+
+    pass
+
+
+class ProtectSnapError(RbdBaseException):
+    """Raised when protecting a snap fails"""
+
+    pass
+
+
+class CreateCloneError(RbdBaseException):
+    """Raised when Creating a clone fails"""
+
+    pass

--- a/tests/rbd/rbd_snap_clone_imported_image.py
+++ b/tests/rbd/rbd_snap_clone_imported_image.py
@@ -1,0 +1,59 @@
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd.rbd_utils import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """Verification of snap and clone on an imported image.
+
+    This module verifies snapshot and cloning operations on an imported image
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9230 - verification snap and clone on an imported image
+    Pre-requisites :
+    1. Cluster must be up and running with capacity to create pool
+       (At least with 64 pgs)
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+
+    Test Case Flow:
+    1. Create a pool
+    2. Create a dummy file, import it as an image
+    3. Create snapshot of it and protect the snapshot
+    4. Create a clone
+    """
+    log.info("Running snap and clone operations on imported image")
+    rbd = Rbd(**kw)
+    pool = rbd.random_string()
+    image = rbd.random_string()
+    snap = rbd.random_string()
+    dir_name = rbd.random_string()
+    clone = rbd.random_string()
+
+    rbd.exec_cmd(cmd="mkdir {}".format(dir_name))
+    try:
+        if not rbd.create_pool(poolname=pool):
+            # create pool does not catch exceptions, it returns true/false.
+            # so we are returning 1 instead of raising exception
+            return 1
+
+        rbd.create_file_to_import(filename="dummy_file")
+        rbd.import_file("dummy_file", pool, image)
+        rbd.snap_create(pool, image, snap)
+        snap_name = f"{pool}/{image}@{snap}"
+        rbd.protect_snapshot(snap_name)
+        rbd.create_clone(snap_name, pool, clone)
+    except RbdBaseException as error:
+        print(error.message)
+
+    finally:
+        rbd.clean_up(pools=[pool])
+        return rbd.flag


### PR DESCRIPTION
Automated CEPH-9230 - RBD-import/export:Import an rbd image and create snaps and clones
and addted it to new suite

new file:   suites/nautilus/rbd/tier-2_rbd_regression.yaml
new file:   tests/rbd/rbd_snap_clone_imported_image.py
new file:   suites/pacific/rbd/tier-2_rbd_regression.yaml
new file:   tests/rbd/exceptions.py
modified:   tests/rbd/rbd_utils.py

Updates:
Feb 7 - Addressed optimisation suggestions to python f strings
        and exception handling using userdefined exceptions

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
