### PR TITLE
Remove testsuites with pattern "psi-only" from IBM-Tier-X job

### DIFF
--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -68,6 +68,7 @@ node(nodeName) {
     }
 
     // Running the test suites in batches of 5
+    testStages.removeAll { it.contains("psi-only") }
     (testStages.keySet() as List).collate(5).each{
         def stages = testStages.subMap(it)
         parallel stages


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Remove/Ignore testsuites with pattern "psi-only" from IBM-Tier-X job

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
