### PR TITLE
removeAll method is not support for linkedHashMap

### DIFF
--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -60,6 +60,9 @@ node(nodeName) {
              rhcephversion
         )
 
+        // Removing suites that are meant to be executed only in RH network.
+        testStages = testStages.findAll { ! it.key.contains("psi-only") }
+
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
             error "No test stages found.."
@@ -67,9 +70,7 @@ node(nodeName) {
         currentBuild.description = "${params.rhcephVersion} - ${buildPhase}"
     }
 
-    // Running the test suites in batches of 5
-    testStages.removeAll { it.contains("psi-only") }
-    (testStages.keySet() as List).collate(5).each{
+    (testStages.keySet() as List).collate(5).each {
         def stages = testStages.subMap(it)
         parallel stages
     }


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

```
hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: java.util.LinkedHashMap.removeAll() is applicable for argument types: (org.jenkinsci.plugins.workflow.cps.CpsClosure2) values: [org.jenkinsci.plugins.workflow.cps.CpsClosure2@6a6d6679]
Possible solutions: remove(java.lang.Object), remove(java.lang.Object), remove(java.lang.Object, java.lang.Object), replaceAll(java.util.function.BiFunction), replaceAll(java.util.function.BiFunction)
```

This PR attempts to fix the above failure by using `findAll` instead of `removeAll`

__Logs__
https://159.23.92.24/job/tier-x/99/console