### PR TITLE
Fix for Issue_1096

### DIFF
--- a/run.py
+++ b/run.py
@@ -467,6 +467,8 @@ def run(args):
 
             if rhbuild in composes:
                 base_url = composes[rhbuild or "latest"]["base_url"]
+            else:
+                raise Exception("\nERROR: Require --v2 as one of argument, run exited.")
 
         # Get ubuntu-repo
         if not ubuntu_repo and rhbuild.startswith("3"):


### PR DESCRIPTION
# Description

This is a fix for Issue_1096. Fix is inclusion of exception handling when there is no proper rhbuild version found in rhbuild.yaml file.
Signed-off-by: Chebrolu Harika hchebrol@redhat.com

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
