### PR TITLE
4.x deployment can fail when reuse option is used

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -384,7 +384,7 @@ class Ceph(object):
         """
         devs = []
         devchar = 98
-        if node.vm_node.node_type == "baremetal":
+        if hasattr(node, "vm_node") and node.vm_node.node_type == "baremetal":
             devs = [x.path for x in node.get_allocated_volumes()]
         else:
             devices = len(node.get_allocated_volumes())


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR address #978 where-in deployment fails when we attempt to execute the test suite that has cluster configuration/deployment as part of its workflow.

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/reuse/