### PR TITLE
Fix for Issue_1112

### DIFF
--- a/init_suite.py
+++ b/init_suite.py
@@ -267,16 +267,16 @@ def load_suites(test_suites):
 
     test_suite_catalogue = []
 
-    log.info(f"List of test suites: \n{test_suites}")
+    log.info(f"List of test suites provided: \n{test_suites}")
 
     for test_suite in test_suites:
         if os.path.isdir(test_suite):
-            log.info("suite is directory")
+            log.info("Provided suite is a directory")
             fragments = Directory(test_suite).fragments
             log.debug(f"got fragments: \n{fragments}")
             test_suite_catalogue.extend(fragments)
         else:
-            log.info("suite is file")
+            log.info("Provided suite is a file")
             test_suite_catalogue.append(test_suite)
 
     return Suite(test_suite_catalogue).suites

--- a/run.py
+++ b/run.py
@@ -479,7 +479,7 @@ def run(args):
     # load config, suite and inventory yaml files
     conf = load_file(glb_file)
     suite = init_suite.load_suites(suite_files)
-    log.info(f"Found the following valid test suites: {suite['tests']}")
+    log.debug(f"Found the following valid test suites: {suite['tests']}")
     if suite["nan"] and not suite["tests"]:
         raise Exception("Please provide valid test suite name")
 

--- a/run.py
+++ b/run.py
@@ -479,6 +479,9 @@ def run(args):
     # load config, suite and inventory yaml files
     conf = load_file(glb_file)
     suite = init_suite.load_suites(suite_files)
+    log.info(f"Found the following valid test suites: {suite['tests']}")
+    if suite["nan"] and not suite["tests"]:
+        raise Exception("Please provide valid test suite name")
 
     cli_arguments = f"{sys.executable} {' '.join(sys.argv)}"
     log.info(f"The CLI for the current run :\n{cli_arguments}\n")


### PR DESCRIPTION
# Description

Giving a more descriptive message when provided suite-name as a part of --suite argument while running run.py doesn't exist.
This is a fix for #1112 
Signed-off-by: Chebrolu Harika hchebrol@redhat.com

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
