### PR TITLE
On event of failure in any test suite support pulling of sosreport

### DIFF
--- a/run.py
+++ b/run.py
@@ -35,6 +35,7 @@ from ceph.utils import (
     create_ceph_nodes,
     create_ibmc_ceph_nodes,
 )
+from utility import sosreport
 from utility.polarion import post_to_polarion
 from utility.retry import retry
 from utility.utils import (
@@ -902,6 +903,7 @@ def run(args):
         else run_dir
     )
     log.info("\nAll test logs located here: {base}".format(base=url_base))
+
     close_and_remove_filehandlers()
 
     test_run_metadata = {
@@ -948,6 +950,14 @@ def run(args):
     }
 
     email_results(test_result=test_res)
+
+    if jenkins_rc:
+        log.info(
+            "\n\nGenerating sosreports for all the nodes due to failures in testcase"
+        )
+        installer_node = ceph_cluster_dict["ceph"].get_nodes(role="installer")[0]
+        sosreport.run(installer_node.ip_address, "cephuser", "cephuser", run_dir)
+        log.info(f"Generated sosreports location : {url_base}/sosreports")
 
     return jenkins_rc
 

--- a/utility/sosreport.py
+++ b/utility/sosreport.py
@@ -1,0 +1,128 @@
+"""Standard script to collect all the logs from ceph cluster through and place it in directory provided
+
+Through installer node get all other nodes in the cluster, generate sosreport for all the nodes obtained.
+then upload all the collected logs to magna/directory(run_dir) provided
+
+  Typical usage example:
+
+  python sosreport.py --ip x.x.x.x --username abc --password abcd --directory /tmp/cephci-run-ysfyu
+  python sosreport.py -h
+"""
+import os
+import re
+import sys
+
+import paramiko
+from docopt import docopt
+
+doc = """
+Standard script to collect all the logs from ceph cluster
+
+    Usage:
+        sosreport.py --ip <str> --username <str> --password <str> --directory <str>
+        sosreport.py (-h | --help)
+
+    Options:
+        -h --help          Shows the command usage
+        --ip <str>         IP address of Installer node.
+        --username <str>   Username to be used to access the system other than root
+        --password <str>   password of given username
+        --directory <str>  directory/folder
+"""
+
+
+def generate_sosreport_in_node(
+    nodeip: str, uname: str, pword: str, directory: str, results: list
+) -> None:
+    """Generate sosreport in the given node and copy report to directory provided
+
+    Args:
+       nodeip              host Ip address
+       uname               Username for accessing host
+       pword               password for accessing host through given user
+       directory           directory to store all the logs
+       results             host IP address for which this operation are failed
+
+    Returns:
+        None
+    """
+    print(f"Connecting {nodeip} to generate sosreport")
+    try:
+        ssh_d = paramiko.SSHClient()
+        ssh_d.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh_d.connect(nodeip, username=uname, password=pword)
+        ssh_d.exec_command("sudo yum -y install sos")
+        stdin, stdout, stderr = ssh_d.exec_command(
+            "sudo sosreport -a --all-logs -e ceph --batch"
+        )
+        rc = stdout.channel.recv_exit_status()
+        sosreport = re.search(r"sosreport-.*.tar.xz", stdout.read().decode())
+        if rc and not sosreport:
+            print(f"Failed to generate sosreport {nodeip}")
+            results.append(nodeip)
+            return
+        source_file = f"/var/tmp/{sosreport.group()}"
+        ssh_d.exec_command(f"sudo chown {uname} {source_file}")
+        directory_path = os.path.join(directory, "sosreports")
+        dir_exist = os.path.exists(directory_path)
+        if not dir_exist:
+            os.makedirs(directory_path)
+        ftp_client = ssh_d.open_sftp()
+        ftp_client.get(f"{source_file}", f"{directory_path}/{sosreport.group()}")
+        ftp_client.close()
+        print(
+            f"Successfully generated sosreport for node {nodeip} :{sosreport.group()}"
+        )
+        ssh_d.exec_command(f"sudo rm -rf {source_file}")
+        ssh_d.close()
+    except Exception:
+        results.append(nodeip)
+
+
+def run(installer_ip: str, uname: str, pword: str, directory: str) -> int:
+    """Standard script to collect all the logs from ceph cluster
+
+    Through installer node get all other nodes in the cluster, generate sosreport for all the nodes obtained.
+    then upload all the collected logs to given directory
+
+    Args:
+       installer_ip   installer IP address
+       uname          username to be used to access the system other than root
+       pword          password for installer node
+       directory      directory/folder name ex:
+
+    Returns:
+        0 on success or 1 for failures
+
+    Raises:
+        AssertionError: An error occurred if given IP is not of Installer node
+    """
+    results = []
+
+    ssh_install = paramiko.SSHClient()
+    ssh_install.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_install.connect(installer_ip, username=uname, password=pword)
+    stdin, stdout, stderr = ssh_install.exec_command("hostname")
+    if "installer" not in stdout.read().decode():
+        raise AssertionError("Please provide installer node details")
+    stdin, stdout, stderr = ssh_install.exec_command(
+        "cut -f 1 /etc/hosts | cut -d ' ' -f 3"
+    )
+    nodes = stdout.read().decode().split("\n")
+
+    print(f"Host that are obtained from given host: {nodes}")
+    for nodeip in nodes:
+        if nodeip:
+            generate_sosreport_in_node(nodeip, uname, pword, directory, results)
+    print(f"\n\nFailed to collect logs from nodes :{results}")
+    return 1 if results else 0
+
+
+if __name__ == "__main__":
+    arguments = docopt(doc)
+    installer_ip = arguments["--ip"]
+    username = arguments["--username"]
+    password = arguments["--password"]
+    directory = arguments["--directory"]
+    rc = run(installer_ip, username, password, directory)
+    sys.exit(rc)


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Improvement - on event of failure in any test suite support pulling of sosreport
5.1
    log: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/157/console
    magna: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8YXAHU/sosreports/
4.2
    console:
        https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/185/console
        https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/186/console

IBM cloud: 
5.0: https://159.23.92.24/job/Custom%20Test%20Run/3/console
4.2: https://159.23.92.24/job/Custom%20Test%20Run/4/console


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
