### PR TITLE
Adapting rhceph-test-executor script to remove --v2 tag

### DIFF
--- a/pipeline/test_executor.groovy
+++ b/pipeline/test_executor.groovy
@@ -17,7 +17,6 @@ def getCLI(){
     def cli = "--rhbuild ${params.RHCS_Build}"
     cli += " --platform ${params.Platform}"
     cli += " --build ${params.Build}"
-    cli += " --v2"
     cli += " --global-conf conf/${cephVersion}/${params.Group}/${params.Conf}.yaml"
     cli += " --inventory conf/inventory/${params.Inventory}.yaml"
     cli += " --suite suites/${cephVersion}/${params.Group}/${params.Suite}.yaml"


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description
Adapting rhceph-test-executor script to remove --v2 tag


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
