### PR TITLE
Fix syntax error in groovy script

### DIFF
--- a/pipeline/ibm-tier-0.groovy
+++ b/pipeline/ibm-tier-0.groovy
@@ -167,7 +167,7 @@ node(nodeName) {
         sharedLib.writeToRecipeFile(buildType, rhcephVersion, buildPhase)
         latestContent = sharedLib.readFromRecipeFile(rhcephVersion)
         println "Recipe file content is: ${latestContent}"
-        buildArtifacts = writeJSON returnText: true json: buildArtifacts
+        buildArtifacts = writeJSON returnText: true, json: buildArtifacts
         if (buildType == 'latest') {
             build ([
                 wait: false,

--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -172,7 +172,7 @@ node(nodeName) {
             skipPublishingChecks: true ,
             allowEmptyResults: true
         )
-        buildArtifacts = writeJSON returnText: true json: buildArtifacts
+        buildArtifacts = writeJSON returnText: true, json: buildArtifacts
         // Update result to recipe file and execute post tier based on run execution
         build ([
             wait: false,


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

```
WorkflowScript: 170: expecting '}', found ':' @ line 170, column 57.
   riteJSON returnText: true json: buildArt
```

This PR fixes the syntax issue seen with the groovy file.

__Logs__
https://159.23.92.24/job/tier-0/9/console