### PR TITLE
Fix failure in verify keyfile method

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -519,6 +519,7 @@ def get_host_osd_map(cls):
     for obj in osd_obj["nodes"]:
         if obj["type"] == "host":
             osd_dict[obj["name"]] = obj["children"]
+
     return osd_dict
 
 
@@ -541,6 +542,7 @@ def get_host_daemon_map(cls):
             daemon_dict[daemon["hostname"]].append(daemon_name)
         else:
             daemon_dict[daemon["hostname"]] = [daemon_name]
+
     return daemon_dict
 
 
@@ -558,6 +560,7 @@ def get_hosts_deployed(cls):
     host_obj = json.loads(out)
     for host in host_obj:
         hosts.append(host["hostname"])
+
     return hosts
 
 
@@ -573,11 +576,12 @@ def file_or_path_exists(node, file_or_path):
     """
     try:
         out, _ = node.exec_command(cmd=f"ls -l {file_or_path}", sudo=True)
-        LOG.info("Output : %s" % out.read().decode())
+        LOG.info(f"Output : {out.read().decode()}")
+        return True
     except CommandFailed as err:
-        LOG.error("Error: %s" % err)
-        return False
-    return True
+        LOG.error(f"Error: {err}")
+
+    return False
 
 
 def monitoring_file_existence(node, file_or_path, file_exist=True, timeout=120):
@@ -644,4 +648,5 @@ def validate_log_file_after_enable(cls):
         except CommandFailed as err:
             LOG.error("Error: %s" % err)
             return False
+
     return True

--- a/ceph/ceph_admin/host.py
+++ b/ceph/ceph_admin/host.py
@@ -120,10 +120,11 @@ class Host(MaintenanceMixin, Orch):
 
         if _labels:
             if "_admin" in _labels:
-                logger.info("Ceph keyring - default: %s" % DEFAULT_KEYRING_PATH)
-                if not monitoring_file_existence(node, DEFAULT_KEYRING_PATH):
+                if not monitoring_file_existence(ceph_node, DEFAULT_KEYRING_PATH):
                     raise HostOpFailure("Ceph keyring not found")
+
                 logger.info("Ceph Keyring found")
+
             assert sorted(self.fetch_labels_by_hostname(ceph_node.shortname)) == sorted(
                 _labels
             )


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes the below error message seen during cluster deployment

__Error__
```
2022-01-23 07:57:08,448 - root - ERROR - 'str' object has no attribute 'exec_command'
Traceback (most recent call last):
  File "/data/workspace/tier-0/tests/ceph_installer/test_cephadm.py", line 129, in run
    func(cfg)
  File "/data/workspace/tier-0/ceph/ceph_admin/host.py", line 166, in add_hosts
    self.add(cfg)
  File "/data/workspace/tier-0/ceph/ceph_admin/host.py", line 124, in add
    if not monitoring_file_existence(node, DEFAULT_KEYRING_PATH):
  File "/data/workspace/tier-0/ceph/ceph_admin/helper.py", line 597, in monitoring_file_existence
    if file_exist == file_or_path_exists(node, file_or_path):
  File "/data/workspace/tier-0/ceph/ceph_admin/helper.py", line 575, in file_or_path_exists
    out, _ = node.exec_command(cmd=f"ls -l {file_or_path}", sudo=True)
AttributeError: 'str' object has no attribute 'exec_command'
```

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/default_file/