### PR TITLE
[post-results-job] fix null value issue before updating recipe files

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -71,7 +71,7 @@ node(nodeName) {
         def testStatus = msgMap["test"]["result"]
         def composeInfo = msgMap["recipe"]
 
-        if ( composeInfo && testStatus == "SUCCESS" ){
+        if ( composeInfo != null && testStatus == "SUCCESS" ){
             def tierLevel = msgMap["pipeline"]["name"]
             def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
             majorVersion = rhcsVersion["major_version"]

--- a/pipeline/signed-container-image-listener.groovy
+++ b/pipeline/signed-container-image-listener.groovy
@@ -6,6 +6,7 @@ def versions
 def cephVersion
 def composeUrl
 def containerImage
+def releaseMap = [:]
 
 // Pipeline script entry point
 node(nodeName) {
@@ -54,7 +55,7 @@ node(nodeName) {
         println "repo url : ${composeUrl}"
 
         cephVersion = sharedLib.fetchCephVersion(composeUrl)
-        def releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
+        releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
 
         if ( releaseMap.isEmpty() || !releaseMap?.rc?."ceph-version" ) {
             sharedLib.unSetLock(majorVersion, minorVersion)
@@ -87,7 +88,9 @@ node(nodeName) {
                 "version": cephVersion
             ],
             "build": [
-                "repository": containerImage
+                "repository": containerImage,
+                "version": cephVersion,
+                "composes": releaseMap.rc.composes
             ],
             "contact": [
                 "email": "ceph-qe@redhat.com",


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Handle null value in post-results job while writing recipe information to recipe file.
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-post-results/426/console
```
java.lang.IllegalArgumentException: data parameter has invalid content (no-basic classes)
	at org.jenkinsci.plugins.pipeline.utility.steps.conf.WriteYamlStep.setData(WriteYamlStep.java:109)
Caused: java.lang.reflect.InvocationTargetException
```
- update build and repository details in signed-image-listener job.