### PR TITLE
Adding multifs fuse mount test case with Fstab entry

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
@@ -6,7 +6,8 @@
 # Test-Case Covered:
 #   CEPH-83573878 - Verify the option to enable/disable multiFS support
 #   CEPH-83573873 - Try creating 2 Filesystem using same Pool(negative)
-#   CEPH-83573872 - Tests the file system with fstab entries with multiple file systems and reboots
+#   CEPH-83573872 - Tests the file system with fstab entries with multiple file systems and reboots with kernel mounts
+#   CEPH-83573871 - Tests the file system with fstab entries with multiple file systems and reboots with fuse mounts
 #=======================================================================================================================
 tests:
   -
@@ -129,5 +130,11 @@ tests:
         name: multifs reboot with fstab
         module: multifs.multifs_kernelmounts.py
         polarion-id: CEPH-83573872
-        desc: Tests the file system with fstab entries with multiple file systems and reboots
+        desc: Tests the file system with fstab entries with multiple file systems and reboots using kernel mount
         abort-on-fail: false
+  - test:
+      name: multifs reboot with fstab fuse
+      module: multifs.multifs_fusemounts.py
+      polarion-id: CEPH-83573871
+      desc: Tests the file system with fstab entries with multiple file systems and reboots using fuse mount
+      abort-on-fail: false

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -4,6 +4,7 @@ It contains all the re-useable functions related to cephfs
 It installs all the pre-requisites on client nodes
 
 """
+import argparse
 import datetime
 import json
 import random
@@ -171,11 +172,69 @@ class FsUtils(object):
             if kwargs.get("extra_params"):
                 fuse_cmd += f"{kwargs.get('extra_params')}"
             client.exec_command(sudo=True, cmd=fuse_cmd, long_running=True)
-            out, rc = client.exec_command(cmd="mount")
+            self.wait_until_mount_succeeds(client, mount_point)
+            if kwargs.get("fstab"):
+                mon_node_ips = self.get_mon_node_ips()
+                mon_node_ip = ",".join(mon_node_ips)
+                try:
+                    client.exec_command(sudo=True, cmd="ls -lrt /etc/fstab.backup")
+                except CommandFailed:
+                    client.exec_command(
+                        sudo=True, cmd="cp /etc/fstab /etc/fstab.backup"
+                    )
+                fstab = client.remote_file(
+                    sudo=True, file_name="/etc/fstab", file_mode="a+"
+                )
+                fstab_entry = (
+                    f"{mon_node_ip}    {mount_point}    fuse.ceph    "
+                    f"ceph.name=client.{kwargs.get('new_client_hostname', client.node.hostname)},"
+                )
+                if kwargs.get("extra_params"):
+                    arguments = self.convert_string_args(kwargs.get("extra_params"))
+                    if arguments.client_fs:
+                        fstab_entry += f"ceph.client_fs={arguments.client_fs},"
+                    if arguments.r:
+                        fstab_entry += f"ceph.client_mountpoint={arguments.r},"
+                    if arguments.id:
+                        fstab_entry += f"ceph.id={arguments.id},"
+                fstab_entry += "_netdev,defaults      0       0"
+                fstab.write(fstab_entry + "\n")
+                fstab.flush()
+                fstab.close()
+
+    def convert_string_args(self, str_args):
+        """
+        This is support fucntion for adding fstab entry for fuse mounts.
+        it takes extra params given to fuse mount command and
+        returns it as Namespace where we can access then as variable
+        """
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("--client_fs")
+        parser.add_argument("-r")
+        parser.add_argument("--id")
+        args = parser.parse_args(str_args.split())
+        return args
+
+    def wait_until_mount_succeeds(self, client, mount_point, timeout=180, interval=5):
+        """
+        Checks for the mount point and returns the status based on mount command
+        :param client:
+        :param mount_point:
+        :param timeout:
+        :param interval:
+        :return: boolean
+        """
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+        log.info("Wait for the mount to appear")
+        while end_time > datetime.datetime.now():
+            out, rc = client.exec_command(sudo=True, cmd="mount", check_ec=False)
             mount_output = out.read().decode().rstrip("\n")
             mount_output = mount_output.split()
             log.info("Validate Fuse Mount:")
-            assert mount_point.rstrip("/") in mount_output, "Fuse mount failed"
+            if mount_point.rstrip("/") in mount_output:
+                return True
+            sleep(interval)
+        return False
 
     def kernel_mount(self, kernel_clients, mount_point, mon_node_ip, **kwargs):
         """
@@ -218,12 +277,11 @@ class FsUtils(object):
             mount_output = out.read().decode()
             mount_output = mount_output.split()
             log.info("validate kernel mount:")
-            assert mount_point.rstrip("/") in mount_output, "Kernel mount failed"
+            self.wait_until_mount_succeeds(client, mount_point)
             if kwargs.get("fstab"):
-                out, rc = client.exec_command(
-                    sudo=True, cmd="ls -lrt /etc/fstab.backup", check_ec=False
-                )
-                if not rc == 0:
+                try:
+                    client.exec_command(sudo=True, cmd="ls -lrt /etc/fstab.backup")
+                except CommandFailed:
                     client.exec_command(
                         sudo=True, cmd="cp /etc/fstab /etc/fstab.backup"
                     )

--- a/tests/cephfs/multifs/multifs_fusemounts.py
+++ b/tests/cephfs/multifs/multifs_fusemounts.py
@@ -1,0 +1,130 @@
+import random
+import string
+import traceback
+
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573871   Explore ceph-fuse mount of more than 2 Filesystem on same client.
+                    Also verify persistent mounts upon reboots.
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. Create 2 file systems if not present
+    2. mount both the file systems and using fuse mount and fstab entry
+    3. reboot the node
+    4. validate if the mount points are still present
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        client1 = clients[0]
+        client1.exec_command(
+            sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
+        )
+        total_fs = fs_util.get_fs_details(client1)
+        if len(total_fs) < 2:
+            log.error(
+                "We can't proceed with the test case as we are not able to create 2 filesystems"
+            )
+
+        fs_names = [fs["name"] for fs in total_fs]
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        fuse_mounting_dir_1 = f"/mnt/cephfs_fuse{mounting_dir}_1/"
+        fuse_mounting_dir_2 = f"/mnt/cephfs_fuse{mounting_dir}_2/"
+
+        fs_util.fuse_mount(
+            [clients[0]],
+            fuse_mounting_dir_1,
+            extra_params=f"--client_fs {fs_names[0]}",
+            fstab=True,
+        )
+        fs_util.fuse_mount(
+            [clients[0]],
+            fuse_mounting_dir_2,
+            extra_params=f"--client_fs {fs_names[1]}",
+            fstab=True,
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
+            f"--files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+            f"{fuse_mounting_dir_1}",
+            long_running=True,
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
+            f"--files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+            f"{fuse_mounting_dir_2}",
+            long_running=True,
+        )
+        fs_util.reboot_node(client1)
+        out, rc = client1.exec_command(cmd="mount")
+        mount_output = out.read().decode()
+        mount_output = mount_output.split()
+        log.info("validate fuse mount:")
+        assert fuse_mounting_dir_1.rstrip("/") in mount_output, "fuse mount failed"
+        assert fuse_mounting_dir_2.rstrip("/") in mount_output, "fuse mount failed"
+        client1.exec_command(
+            sudo=True, cmd=f"mkdir -p {fuse_mounting_dir_1}/io_after_reboot"
+        )
+        client1.exec_command(
+            sudo=True, cmd=f"mkdir -p {fuse_mounting_dir_2}/io_after_reboot"
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
+            f"--files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+            f"{fuse_mounting_dir_1}/io_after_reboot",
+            long_running=True,
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
+            f"--files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+            f"{fuse_mounting_dir_2}/io_after_reboot",
+            long_running=True,
+        )
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        fs_util.client_clean_up(
+            "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_1
+        )
+        fs_util.client_clean_up(
+            "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_2
+        )
+        commands = [
+            "ceph config set mon mon_allow_pool_delete true",
+            "ceph fs volume rm cephfs_new --yes-i-really-mean-it",
+        ]
+        for command in commands:
+            client1.exec_command(sudo=True, cmd=command)
+        client1.exec_command(
+            sudo=True, cmd="cp /etc/fstab.backup /etc/fstab", check_ec=False
+        )
+        client1.exec_command(sudo=True, cmd="rm -f /etc/fstab.backup", check_ec=False)

--- a/tests/cephfs/multifs/multifs_kernelmounts.py
+++ b/tests/cephfs/multifs/multifs_kernelmounts.py
@@ -80,6 +80,17 @@ def run(ceph_cluster, **kw):
         log.info(traceback.format_exc())
         return 1
     finally:
+        fs_util.client_clean_up(
+            "umount",
+            kernel_clients=[clients[0]],
+            mounting_dir=kernel_mounting_dir_1,
+        )
+        fs_util.client_clean_up(
+            "umount",
+            kernel_clients=[clients[0]],
+            mounting_dir=kernel_mounting_dir_2,
+        )
+
         commands = [
             "ceph config set mon mon_allow_pool_delete true",
             "ceph fs volume rm cephfs_new --yes-i-really-mean-it",


### PR DESCRIPTION
Adding multifs fuse mount test case with Fstab entry
CEPH-83573871 - Tests the file system with fstab entries with multiple file systems and reboots with fuse mounts

Logs 5.1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZCYYGG/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
