### PR TITLE
discard comma in def args in sendEmail

### DIFF
--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -286,7 +286,7 @@ def sendEmail(
     def testResults,
     def artifactDetails,
     def tierLevel,
-    def toList="ceph-qe-list@redhat.com",
+    def toList="ceph-qe-list@redhat.com"
     ) {
     /*
         Send an Email


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

fix issue in method definition by discarding comma in def args in sendEmail

```
org.jenkinsci.plugins.workflow.cps.CpsCompilationErrorsException: startup failed:
Script1.groovy: 290: unexpected token: ) @ line 290, column 5.
       ) {
       ^
```
