### PR TITLE
Provide an argument to disable SOSreport collection on Failure

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -1004,7 +1004,7 @@ def get_node_by_id(cluster, node_name):
         node instance (CephVMNode)
     """
     for node in cluster.get_nodes():
-        searches = re.findall(fr"{node_name}?\d*", node.shortname)
+        searches = re.findall(rf"{node_name}?\d*", node.shortname)
         for ele in searches:
             if ele == node_name:
                 return node

--- a/run.py
+++ b/run.py
@@ -966,7 +966,7 @@ def run(args):
             cluster_name = cluster.get("ceph-cluster").get("name", "ceph")
             installer = ceph_cluster_dict[cluster_name].get_nodes(role="installer")[0]
             sosreport.run(installer.ip_address, "cephuser", "cephuser", run_dir)
-        log.info(f"Generated sosreports location : {url_base}/sosreports")
+        log.info(f"Generated sosreports location : {url_base}/sosreports\n")
 
     return jenkins_rc
 

--- a/run.py
+++ b/run.py
@@ -91,6 +91,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--xunit-results]
         [--enable-eus]
         [--skip-enabling-rhel-rpms]
+        [--skip-sos-report]
   run.py --cleanup=name --osp-cred <file> [--cloud <str>]
         [--log-level <LEVEL>]
 
@@ -149,6 +150,8 @@ Options:
                                     [default: false]
   --skip-enabling-rhel-rpms         skip adding rpms from subscription if using beta
                                     rhel images for Interop runs
+  --skip-sos-report                 Enables to collect sos-report on test suite failures
+                                    [default: false]
 """
 log = Log(__name__)
 root = logging.getLogger()
@@ -476,6 +479,7 @@ def run(args):
 
     enable_eus = args.get("--enable-eus", False)
     skip_enabling_rhel_rpms = args.get("--skip-enabling-rhel-rpms", False)
+    skip_sos_report = args.get("--skip-sos-report", False)
 
     # load config, suite and inventory yaml files
     conf = load_file(glb_file)
@@ -954,12 +958,14 @@ def run(args):
 
     email_results(test_result=test_res)
 
-    if jenkins_rc:
+    if jenkins_rc and not skip_sos_report:
         log.info(
             "\n\nGenerating sosreports for all the nodes due to failures in testcase"
         )
-        installer_node = ceph_cluster_dict["ceph"].get_nodes(role="installer")[0]
-        sosreport.run(installer_node.ip_address, "cephuser", "cephuser", run_dir)
+        for cluster in conf.get("globals"):
+            cluster_name = cluster.get("ceph-cluster").get("name", "ceph")
+            installer = ceph_cluster_dict[cluster_name].get_nodes(role="installer")[0]
+            sosreport.run(installer.ip_address, "cephuser", "cephuser", run_dir)
         log.info(f"Generated sosreports location : {url_base}/sosreports")
 
     return jenkins_rc


### PR DESCRIPTION

Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
At present, SOS report is generated whenever there is a failure. This could cause inconvenience during dev test.
Providing this option allows developers to skip this step during evaluation by way of passing a CLI argument.
Add `--skip-sos-report` or an appropriate one to run.py
--skip-sos-report set to true : https://159.23.92.24/job/Custom%20Test%20Run/7/console
--skip-sos-report set to false(default) : https://159.23.92.24/job/Custom%20Test%20Run/8/console

<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
