### PR TITLE
Updated cli args in pipeline for upgrade with tags

### DIFF
--- a/pipeline/scripts/4/3/tier-2/test-upgrade-with-tags.sh
+++ b/pipeline/scripts/4/3/tier-2/test-upgrade-with-tags.sh
@@ -28,6 +28,7 @@ $WORKSPACE/.venv/bin/python run.py \
     --suite $test_suite \
     --inventory $test_inventory \
     --log-level DEBUG \
+    --skip-version-compare \
     $CLI_ARGS
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Updated cli args in pipeline for upgrade with tags to include `--skip-version-compare` 

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-R3ZOF8/