### PR TITLE
Fix yaml parser error

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml
@@ -163,7 +163,7 @@ tests:
       polarion-id: CEPH-83574164
       desc: subvolumegroup creation with desired data pool_layout
       abort-on-fail: true
-- test:
+  - test:
       name: Subvolume Resize
       module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
       polarion-id: CEPH-83574193
@@ -175,4 +175,3 @@ tests:
       polarion-id: CEPH-83574166
       desc: subvolumegroup creation with uid and gid
       abort-on-fail: true
-


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

Fix yaml parser error
```
yaml.parser.ParserError: while parsing a block mapping
  in "/home/sunnagar/Sunil/recipe/cephci/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml", line 12, column 1
expected <block end>, but found '-'
  in "/home/sunnagar/Sunil/recipe/cephci/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml", line 166, column 1

```