### PR TITLE
Validating logging mechanism on IBM-C

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ flake8
 tox
 python-openstackclient
 yamllint
+logdna

--- a/run.py
+++ b/run.py
@@ -20,6 +20,7 @@ import traceback
 from getpass import getuser
 from typing import Optional
 
+import logdna
 import requests
 import yaml
 from docopt import docopt
@@ -393,6 +394,19 @@ def run(args):
 
         server = f"tcp://{host}:{port}"
         log._logger.debug(f"Log events are also pushed to {server}")
+
+    log_dna_config = get_cephci_config().get("log-dna", {})
+
+    if log_dna_config:
+        options = {
+            "hostname": "Cephci",
+            "url": log_dna_config.get("url"),
+            "index_meta": True,
+            "tags": run_id,
+        }
+        apiKey = log_dna_config.get("api-key")
+        logdna_handler = logdna.LogDNAHandler(apiKey, options)
+        root.addHandler(logdna_handler)
 
     startup_log = os.path.join(run_dir, "startup.log")
 


### PR DESCRIPTION
Validating logging mechanism on IBM-C
Added logstash details to validate logging

for adding log-dna handler. we need to add lg-dna details to .cephci.yaml in below format

**log-dna:
  url: https://logs.au-syd.logging.cloud.ibm.com/logs/ingest
  api-key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx**


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
