### PR TITLE
fix issue with ssh-user

### DIFF
--- a/suites/pacific/rbd/tier-0_rbd.yaml
+++ b/suites/pacific/rbd/tier-0_rbd.yaml
@@ -29,6 +29,8 @@ tests:
           verbose: true
         args:
           ssh-user: cephuser
+          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide with ssh-user
+          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
           registry-json: registry.redhat.io
           custom_image: true
           mon-ip: node1


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

With custom ssh-user need to pass its ssh-key arguments.

**Issue:** 
```
entrypoint ceph ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/rhceph@sha256:d42c0d99ddeaa001570dce4eb90b71699e0401fe449966b935f669ffad22bd01 orch host add ceph-ci-56zmw-css0kh-node2 10.245.4.204 mgr mon
Error EINVAL: Failed to connect to ceph-ci-56zmw-css0kh-node2 (10.245.4.204).
Please make sure that the host is reachable and accepts connections using the cephadm SSH key

To add the cephadm SSH key to the host:
> ceph cephadm get-pub-key > ~/ceph.pub
> ssh-copy-id -f -i ~/ceph.pub cephuser@10.245.4.204

To check that the host is reachable:
> ceph cephadm get-ssh-config > ssh_config
> ceph config-key get mgr/cephadm/ssh_identity_key > ~/cephadm_private_key
> chmod 0600 ~/cephadm_private_key
> ssh -F ssh_config -i ~/cephadm_private_key cephuser@10.245.4.204
 10.245.4.201
Traceback (most recent call last):
  File "/data/workspace/tier-0/tests/ceph_installer/test_cephadm.py", line 128, in run
    func(cfg)
  File "/data/workspace/tier-0/ceph/ceph_admin/host.py", line 168, in add_hosts
    self.add(cfg)
  File "/data/workspace/tier-0/ceph/ceph_admin/host.py", line 108, in add
    self.shell(args=cmd)
  File "/data/workspace/tier-0/ceph/ceph_admin/shell.py", line 49, in shell
    check_ec=check_status,
  File "/data/workspace/tier-0/ceph/ceph.py", line 1963, in exec_command
    return self.node.exec_command(cmd=cmd, **kw)
  File "/data/workspace/tier-0/ceph/ceph.py", line 1470, in exec_command
    + str(self.ip_address)
ceph.ceph.CommandFailed: cephadm -v shell -- ceph orch host add ceph-ci-56zmw-css0kh-node2 10.245.4.204 mgr mon Error:  Running command: /usr/bin/podman --version
```
**Test results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-T6O4WL/?C=M;O=A