### PR TITLE
Introduced sleep time to avoid rbd-mirror failure

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -202,6 +202,8 @@ class RbdMirror:
     def wait_for_status(self, **kw):
         tout = datetime.timedelta(seconds=600)
         starttime = datetime.datetime.now()
+        # Waiting for cluster to be aware of new event
+        time.sleep(20)
         while True:
             if kw.get("poolname", False):
                 if kw.get("health_pattern"):


### PR DESCRIPTION
Introducing sleep time before get the image status on peer clusters to avoid the failures.

https://159.23.92.24/job/Custom%20Test%20Run/27/console

Signed-off-by: Gopi-Patta

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
