### PR TITLE
Add Bucket Lifecycle test support on multi-site

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
@@ -38,12 +38,6 @@ tests:
               rgw_multisite_proto: "http"
               system_access_key: 86nBoQOGpQgKxh4BLMyq
               system_secret_key: NTnkbmkMuzPjgwsBpJ6o
-              ceph_conf_overrides:
-                global:
-                  osd_pool_default_pg_num: 64
-                  osd_default_pool_size: 2
-                  osd_pool_default_pgp_num: 64
-                  mon_max_pg_per_osd: 1024
         ceph-rgw2:
           config:
             ansi_config:

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
@@ -1,0 +1,116 @@
+# Below are the multi-site test scenarios run on the secondary and verified the sync/io on the primary
+# ceph-rgw1 is master/primary site
+# ceph-rgw2 is slave/secondary site
+
+tests:
+  - test:
+      name: pre-req
+      module: install_prereq.py
+      abort-on-fail: true
+      desc: install ceph pre requisites
+  - test:
+      name: ceph ansible
+      module: test_ansible.py
+      clusters:
+        ceph-rgw1:
+          config:
+            ansi_config:
+              ceph_test: True
+              ceph_origin: distro
+              ceph_repository: rhcs
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              dashboard_enabled: False
+              rgw_multisite: true
+              rgw_zone: US_EAST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: true
+              rgw_zonesecondary: false
+              rgw_zonegroupmaster: true
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              rgw_multisite_proto: "http"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+        ceph-rgw2:
+          config:
+            ansi_config:
+              ceph_test: True
+              ceph_origin: distro
+              ceph_repository: rhcs
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              dashboard_enabled: False
+              rgw_multisite: true
+              rgw_zone: US_WEST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: false
+              rgw_zonesecondary: true
+              rgw_zonegroupmaster: false
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              rgw_multisite_proto: "http"
+              rgw_pull_proto: http
+              rgw_pull_port: 8080
+      desc: setup multisite cluster using ceph-ansible
+      abort-on-fail: true
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-rgw1:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-rgw2
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create user
+
+  - test:
+      clusters:
+        ceph-rgw1:
+          config:
+            config-file-name: test_lc_rule_prefix_and_tag.yaml
+            script-name: test_bucket_lifecycle_object_expiration.py
+            timeout: 300
+            verify-io-on-site: [ "ceph-rgw2" ]
+      desc: test_lifecycle  on secondary with AND rule filter
+      module: sanity_rgw_multisite.py
+      polarion-id: CEPH-11179, CEPH-11180
+      name: m buckets with n objects
+  - test:
+      name: Buckets and Objects test
+      desc: test_lifecycle  on secondary
+      polarion-id: CEPH-11190
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration.py
+            verify-io-on-site: ["ceph-rgw2"]
+            config-file-name: test_lc_rule_prefix_non_current_days.yaml
+            timeout: 300

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
@@ -38,12 +38,6 @@ tests:
               rgw_multisite_proto: "http"
               system_access_key: 86nBoQOGpQgKxh4BLMyq
               system_secret_key: NTnkbmkMuzPjgwsBpJ6o
-              ceph_conf_overrides:
-                global:
-                  osd_pool_default_pg_num: 64
-                  osd_default_pool_size: 2
-                  osd_pool_default_pgp_num: 64
-                  mon_max_pg_per_osd: 1024
         ceph-rgw2:
           config:
             ansi_config:

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
@@ -1,0 +1,116 @@
+# Below are the multi-site test scenarios run on the secondary and verified the sync/io on the primary
+# ceph-rgw1 is master/primary site
+# ceph-rgw2 is slave/secondary site
+
+tests:
+  - test:
+      name: pre-req
+      module: install_prereq.py
+      abort-on-fail: true
+      desc: install ceph pre requisites
+  - test:
+      name: ceph ansible
+      module: test_ansible.py
+      clusters:
+        ceph-rgw1:
+          config:
+            ansi_config:
+              ceph_test: True
+              ceph_origin: distro
+              ceph_repository: rhcs
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              dashboard_enabled: False
+              rgw_multisite: true
+              rgw_zone: US_EAST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: true
+              rgw_zonesecondary: false
+              rgw_zonegroupmaster: true
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              rgw_multisite_proto: "http"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              ceph_conf_overrides:
+                global:
+                  osd_pool_default_pg_num: 64
+                  osd_default_pool_size: 2
+                  osd_pool_default_pgp_num: 64
+                  mon_max_pg_per_osd: 1024
+        ceph-rgw2:
+          config:
+            ansi_config:
+              ceph_test: True
+              ceph_origin: distro
+              ceph_repository: rhcs
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              dashboard_enabled: False
+              rgw_multisite: true
+              rgw_zone: US_WEST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: false
+              rgw_zonesecondary: true
+              rgw_zonegroupmaster: false
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              rgw_multisite_proto: "http"
+              rgw_pull_proto: http
+              rgw_pull_port: 8080
+      desc: setup multisite cluster using ceph-ansible
+      abort-on-fail: true
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-rgw1:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-rgw2
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create user
+
+  - test:
+      clusters:
+        ceph-rgw2:
+          config:
+            config-file-name: test_lc_rule_prefix_and_tag.yaml
+            script-name: test_bucket_lifecycle_object_expiration.py
+            timeout: 300
+            verify-io-on-site: [ "ceph-rgw1" ]
+      desc: test_lifecycle  on secondary with AND rule filter
+      module: sanity_rgw_multisite.py
+      polarion-id: CEPH-11179, CEPH-11180
+      name: m buckets with n objects
+  - test:
+      name: Buckets and Objects test
+      desc: test_lifecycle  on secondary
+      polarion-id: CEPH-11190
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw2:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration.py
+            verify-io-on-site: ["ceph-rgw1"]
+            config-file-name: test_lc_rule_prefix_non_current_days.yaml
+            timeout: 300


### PR DESCRIPTION
Signed-off-by: viduship <vimishra@redhat.com>
Fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=2044176
Support lifecycle tests on multi-site.
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
