### PR TITLE
Add support to install rgw with ssl

### DIFF
--- a/suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -1,0 +1,267 @@
+#
+# Objective: Test rgw with ssl configured using ceph-ansible and upgrade
+# ceph_cluster: single site baremetal
+# ceph_conf_overrides:
+#       - rgw_override_bucket_index_max_shards = 17
+#
+---
+tests:
+#  - test:
+#      name: install ceph pre-requisities
+#      module: install_prereq.py
+#      abort-on-fail: true
+
+  - test:
+      name: ceph ansible
+      module: test_ansible.py
+      config:
+        use_cdn: true
+        build: "4.x"
+        ansi_config:
+          ceph_origin: repository
+          ceph_repository_type: cdn
+          ceph_rhcs_version: 4
+          ceph_repository: rhcs
+          osd_scenario: lvm
+          osd_auto_discovery: false
+          fetch_directory: ~/fetch
+          copy_admin_key: true
+          dashboard_enabled: false
+          radosgw_frontend_ssl_certificate: "/etc/ceph/server.pem"
+          radosgw_frontend_port: 443
+          ceph_conf_overrides:
+              client:
+                rgw_override_bucket_index_max_shards: 17
+      desc: test cluster setup using ceph-ansible
+      polarion-id: CEPH-83574750
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        commands:
+           - "ceph -s"
+           - "ceph versions"
+        sudo: True
+      desc: check for ceph status and version
+
+  # Swift basic operation
+
+  - test:
+      name: swift upload large object tests
+      desc: upload large object in swift
+      polarion-id: CEPH-9808
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_large_upload.yaml
+        timeout: 300
+  - test:
+      name: swift download large object tests
+      desc: download large object in swift
+      polarion-id: CEPH-9809
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_large_download.yaml
+        timeout: 300
+
+  #versioning tests
+  - test:
+      name: Versioning Tests
+      desc: Versioning with copy objects
+      polarion-id: CEPH-9221
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_copy_objects.py
+        config-file-name: test_versioning_copy_objects.yaml
+        timeout: 300
+
+  - test:
+      name: Test deletion of object versions
+      desc: test to delete versioning objects
+      polarion-id: CEPH-14262
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_with_objects.py
+        config-file-name: test_versioning_objects_delete.yaml
+        timeout: 300
+
+  #resharding tests
+  - test:
+      name: Resharding tests
+      desc: Reshading test - manual
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_manual_resharding.yaml
+        timeout: 500
+  - test:
+      name: Dynamic Resharding tests
+      desc: Reshading test - dynamic
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_dynamic_resharding.yaml
+        timeout: 500
+
+  - test:
+      name: Dynamic Resharding tests
+      desc: Reshading test on versioned buckets - dynamic
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_dynamic_resharding_with_version.yaml
+        timeout: 500
+
+  #lifecycle tests
+  - test:
+      name: Bucket Lifecycle Object_expiration_tests
+      desc: Test object expiration for Prefix and tag based filter and for more than one days
+      polarion-id: CEPH-11179, CEPH-11180
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_rule_prefix_and_tag.yaml
+        timeout: 300
+
+  - test:
+      name: Bucket Lifecycle Object_expiration_tests
+      desc: Test object expiration for non current version expiration
+      polarion-id: CEPH-11190
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_rule_prefix_non_current_days.yaml
+        timeout: 300
+
+  #upgrade ceph cluster
+  - test:
+      name: Upgrade ceph cluster to 4.x latest
+      polarion-id: CEPH-83574678
+      module: test_ansible_upgrade.py
+      config:
+        ansi_config:
+          ceph_origin: distro
+          ceph_repository: rhcs
+          ceph_rhcs_version: 4
+          osd_scenario: lvm
+          osd_auto_discovery: false
+          copy_admin_key: true
+          radosgw_frontend_ssl_certificate: "/etc/ceph/server.pem"
+          radosgw_frontend_port: 443
+          upgrade_ceph_packages: true
+          dashboard_enabled: false
+          ceph_conf_overrides:
+              client:
+                rgw_override_bucket_index_max_shards: 17
+      desc: Test Ceph-Ansible rolling update 4.x cdn -> 4.x latest
+      abort-on-fail: true
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        commands:
+           - "ceph -s"
+           - "ceph versions"
+        sudo: True
+      desc: check for ceph health debug info
+
+
+  # Swift basic operation
+
+  - test:
+       name: Swift based tests
+       desc: Swift bulk delete operation
+       polarion-id: CEPH-9753
+       module: sanity_rgw.py
+       config:
+           script-name: test_swift_bulk_delete.py
+           config-file-name: test_swift_bulk_delete.yaml
+           timeout: 300
+  - test:
+      name: swift upload large object tests
+      desc: upload large object in swift
+      polarion-id: CEPH-9808
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_large_upload.yaml
+        timeout: 300
+  - test:
+      name: swift download large object tests
+      desc: download large object in swift
+      polarion-id: CEPH-9809
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_large_download.yaml
+        timeout: 300
+
+  # versioning tests
+  - test:
+      name: Versioning Tests
+      desc: Versioning with copy objects
+      polarion-id: CEPH-9221
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_copy_objects.py
+        config-file-name: test_versioning_copy_objects.yaml
+        timeout: 300
+
+  - test:
+      name: Test deletion of object versions
+      desc: test to delete versioning objects
+      polarion-id: CEPH-14262
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_with_objects.py
+        config-file-name: test_versioning_objects_delete.yaml
+        timeout: 300
+
+  #resharding tests
+  - test:
+      name: Resharding tests
+      desc: Reshading test - manual
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_manual_resharding.yaml
+        timeout: 500
+  - test:
+      name: Dynamic Resharding tests
+      desc: Reshading test - dynamic
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_dynamic_resharding.yaml
+        timeout: 500
+
+  #lifecycle tests
+  - test:
+      name: Bucket Lifecycle Object_expiration_tests
+      desc: Test object expiration for Prefix and tag based filter and for more than one days
+      polarion-id: CEPH-11179, CEPH-11180
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_rule_prefix_and_tag.yaml
+        timeout: 300
+  - test:
+      name: Bucket Lifecycle Object_expiration_tests
+      desc: Test object expiration for non current version expiration
+      polarion-id: CEPH-11190
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_rule_prefix_non_current_days.yaml
+        timeout: 300
+

--- a/tests/ceph_installer/test_ansible.py
+++ b/tests/ceph_installer/test_ansible.py
@@ -1,7 +1,7 @@
 import datetime
 
 from ceph.utils import get_public_network, set_container_info
-from utility.utils import Log
+from utility.utils import Log, generate_self_signed_cert_on_rgw
 
 LOG = Log(__name__)
 
@@ -64,6 +64,15 @@ def run(ceph_cluster, **kw):
 
     build = config.get("build", config.get("rhbuild"))
     ceph_cluster.rhcs_version = build
+
+    # create ssl certificate
+    if (
+        config.get("ansi_config").get("radosgw_frontend_ssl_certificate")
+        == "/etc/ceph/server.pem"
+    ):
+        LOG.info("install self signed certificate on rgw node")
+        rgw_node = ceph_nodes.get_ceph_object("rgw").node
+        generate_self_signed_cert_on_rgw(rgw_node)
 
     if config.get("skip_setup") is True:
         LOG.info("Skipping setup of ceph cluster")

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1273,3 +1273,29 @@ def method_should_succeed(function, *args, **kwargs):
     log.debug(f"The {function} return status is {rc}")
     if not rc:
         raise AssertionError(f"Execution failed at function {function}")
+
+
+def generate_self_signed_cert_on_rgw(rgw_node):
+    """
+    generate self signed certifcate on given rgw node
+    """
+    SSL_CERT_PATH = "/etc/ceph/"
+    PEM_FILE_NAME = "server.pem"
+    #    rgw_node = ceph_nodes.get_ceph_object("rgw").node
+    subject = {
+        "common_name": rgw_node.hostname,
+        "ip_address": rgw_node.ip_address,
+    }
+    key, cert, ca = generate_self_signed_certificate(subject=subject)
+    pem = key + cert + ca
+    rgw_node.exec_command(
+        sudo=True,
+        cmd="mkdir /etc/ceph; chown 755 /etc/ceph; touch /etc/ceph/server.pem",
+    )
+    PEM_FILE_PATH = os.path.join(SSL_CERT_PATH, PEM_FILE_NAME)
+    server_pem_file = rgw_node.remote_file(
+        sudo=True, file_name=PEM_FILE_PATH, file_mode="w+"
+    )
+    server_pem_file.write(pem)
+    server_pem_file.flush()
+    log.info(pem)


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

Add support to deploy rgw with ssl frontend 
logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3N90JR/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
