### PR TITLE
Adding Multi FS test cases in CephFS

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
@@ -8,6 +8,8 @@
 #   CEPH-83573873 - Try creating 2 Filesystem using same Pool(negative)
 #   CEPH-83573872 - Tests the file system with fstab entries with multiple file systems and reboots with kernel mounts
 #   CEPH-83573871 - Tests the file system with fstab entries with multiple file systems and reboots with fuse mounts
+#   CEPH-83573870 - Create 2 Filesystem with default values on different MDS daemons
+#   CEPH-83573867 - Create 4-5 Filesystem randomly on different MDS daemons
 #=======================================================================================================================
 tests:
   -
@@ -137,4 +139,16 @@ tests:
       module: multifs.multifs_fusemounts.py
       polarion-id: CEPH-83573871
       desc: Tests the file system with fstab entries with multiple file systems and reboots using fuse mount
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems wtih different MDS daemons
+      module: multifs.multifs_default_values.py
+      polarion-id: CEPH-83573870
+      desc: Create 2 Filesystem with default values on different MDS daemons
+      abort-on-fail: false
+  - test:
+      name: creation of multiple file systems
+      module: multifs.multifs_multiplefs.py
+      polarion-id: CEPH-83573867
+      desc: Create 4-5 Filesystem randomly on different MDS daemons
       abort-on-fail: false

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -215,6 +215,31 @@ class FsUtils(object):
         args = parser.parse_args(str_args.split())
         return args
 
+    def wait_for_mds_process(
+        self, client, process_name, timeout=180, interval=5, ispresent=True
+    ):
+        """
+        Checks for the proccess and returns the status based on ispresent
+        :param client:
+        :param process_name:
+        :param timeout:
+        :param interval:
+        :param ispresent:
+        :return:
+        """
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+        log.info("Wait for the process to start or stop")
+        while end_time > datetime.datetime.now():
+            client.exec_command(
+                sudo=True, cmd=f"ceph orch ps | grep {process_name}", check_ec=False
+            )
+            if client.node.exit_status == 0 and ispresent:
+                return True
+            if client.node.exit_status == 1 and not ispresent:
+                return True
+            sleep(interval)
+        return False
+
     def wait_until_mount_succeeds(self, client, mount_point, timeout=180, interval=5):
         """
         Checks for the mount point and returns the status based on mount command

--- a/tests/cephfs/multifs/multifs_default_values.py
+++ b/tests/cephfs/multifs/multifs_default_values.py
@@ -1,0 +1,129 @@
+import json
+import random
+import string
+import traceback
+
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def validate_mds_placements(fs_name, daemon_ls_after, host_list, daemon_count):
+    i = 0
+    for daemon in daemon_ls_after:
+        if daemon.get("daemon_id").startswith(fs_name):
+            i += 1
+            if daemon.get("hostname") not in host_list:
+                return 1
+    if i != daemon_count:
+        return 1
+    return 0
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573870 - Create 2 Filesystem with default values on different MDS daemons
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. Create 2 file systems with placement arguments
+    2. validate the mds came on the specified placements
+    3. mount both the file systems and using fuse mount
+    4. Run IOs on the FS
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        client1 = clients[0]
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
+        )
+        daemon_ls_before = json.loads(out.read().decode())
+        daemon_count_before = len(daemon_ls_before)
+        host_list = [
+            client1.node.hostname.replace("node7", "node2"),
+            client1.node.hostname.replace("node7", "node3"),
+        ]
+        hosts = " ".join(host_list)
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs volume create cephfs_new --placement='2 {hosts}'",
+            check_ec=False,
+        )
+        fs_util.wait_for_mds_process(client1, "cephfs_new")
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
+        )
+        daemon_ls_after = json.loads(out.read().decode())
+        daemon_count_after = len(daemon_ls_after)
+        assert daemon_count_after > daemon_count_before, (
+            "daemon count is reduced after creating FS. "
+            "Expectation is MDS daemons whould be more"
+        )
+
+        total_fs = fs_util.get_fs_details(client1)
+        if len(total_fs) < 2:
+            log.error(
+                "We can't proceed with the test case as we are not able to create 2 filesystems"
+            )
+        fs_names = [fs["name"] for fs in total_fs]
+        validate_mds_placements("cephfs_new", daemon_ls_after, hosts, 2)
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        fuse_mounting_dir_1 = f"/mnt/cephfs_fuse{mounting_dir}_1/"
+        fuse_mounting_dir_2 = f"/mnt/cephfs_fuse{mounting_dir}_2/"
+
+        fs_util.fuse_mount(
+            [clients[0]], fuse_mounting_dir_1, extra_params=f"--client_fs {fs_names[0]}"
+        )
+        fs_util.fuse_mount(
+            [clients[0]], fuse_mounting_dir_2, extra_params=f"--client_fs {fs_names[1]}"
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
+            f"--files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+            f"{fuse_mounting_dir_1}",
+            long_running=True,
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
+            f"--files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+            f"{fuse_mounting_dir_2}",
+            long_running=True,
+        )
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        fs_util.client_clean_up(
+            "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_1
+        )
+        fs_util.client_clean_up(
+            "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_2
+        )
+        commands = [
+            "ceph config set mon mon_allow_pool_delete true",
+        ]
+        for command in commands:
+            client1.exec_command(sudo=True, cmd=command)
+        fs_util.remove_fs(client1, "cephfs_new")

--- a/tests/cephfs/multifs/multifs_multiplefs.py
+++ b/tests/cephfs/multifs/multifs_multiplefs.py
@@ -1,0 +1,95 @@
+import json
+import random
+import string
+import traceback
+
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573867 - Create 4-5 Filesystem randomly on different MDS daemons
+
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. Create 5 file systems with default values
+    2. Validate the mds counts and the file systems counts
+    3. mount all the file systems and using fuse mount
+    4. Run IOs on the FSs
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        client1 = clients[0]
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        for i in range(1, 5):
+            out, rc = client1.exec_command(
+                sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
+            )
+            daemon_ls_before = json.loads(out.read().decode())
+            daemon_count_before = len(daemon_ls_before)
+            client1.exec_command(
+                sudo=True,
+                cmd=f"ceph fs volume create cephfs_{i}",
+                check_ec=False,
+            )
+            fs_util.wait_for_mds_process(client1, f"cephfs_{i}")
+            out_after, rc = client1.exec_command(
+                sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
+            )
+            daemon_ls_after = json.loads(out_after.read().decode())
+            daemon_count_after = len(daemon_ls_after)
+            assert daemon_count_after > daemon_count_before, (
+                f"daemon count is reduced after creating FS. Demons count before : {daemon_count_before} ;"
+                f"after:{daemon_count_after}"
+                "Expectation is MDS daemons whould be more"
+            )
+            fuse_mounting_dir = f"/mnt/cephfs_fuse{mounting_dir}_{i}/"
+            fs_util.fuse_mount(
+                [clients[0]], fuse_mounting_dir, extra_params=f"--client_fs cephfs_{i}"
+            )
+            client1.exec_command(
+                sudo=True,
+                cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400"
+                f" --files 100 --files-per-dir 10 --dirs-per-dir 1 --top "
+                f"{fuse_mounting_dir}",
+                long_running=True,
+            )
+        return 0
+
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+
+    finally:
+        for i in range(1, 5):
+            fs_util.client_clean_up(
+                "umount",
+                fuse_clients=[clients[0]],
+                mounting_dir=f"/mnt/cephfs_fuse{mounting_dir}_{i}/",
+            )
+        client1.exec_command(
+            sudo=True, cmd="ceph config set mon mon_allow_pool_delete true"
+        )
+        [fs_util.remove_fs(client1, f"cephfs_{i}") for i in range(1, 5)]


### PR DESCRIPTION
Adding Multi FS test cases in CephFS
CEPH-83573870 - Create 2 Filesystem with default values on different MDS daemons
CEPH-83573867 - Create 4-5 Filesystem randomly on different MDS daemons

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
