### PR TITLE
Introduce failure alert notifications in listener jobs

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -11,90 +11,111 @@ def remoteName= "ibm-cos"
 
 node(nodeName) {
 
-    timeout(unit: "MINUTES", time: 30) {
-        stage('prepareJenkinsAgent') {
-            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
-            checkout([
-                $class: 'GitSCM',
-                branches: [[name: 'origin/master']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                    [
-                        $class: 'CloneOption',
-                        shallow: true,
-                        noTags: true,
-                        reference: '',
-                        depth: 1
+    try {
+        timeout(unit: "MINUTES", time: 30) {
+            stage('prepareJenkinsAgent') {
+                if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: 'origin/master']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [
+                            $class: 'CloneOption',
+                            shallow: true,
+                            noTags: true,
+                            reference: '',
+                            depth: 1
+                        ],
+                        [$class: 'CleanBeforeCheckout'],
                     ],
-                    [$class: 'CleanBeforeCheckout'],
-                ],
-                submoduleCfg: [],
-                userRemoteConfigs: [[
-                    url: 'https://github.com/red-hat-storage/cephci.git'
-                ]]
-            ])
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/red-hat-storage/cephci.git'
+                    ]]
+                ])
 
-            // prepare the node
-            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
-            sharedLib.prepareNode()
-        }
-    }
-
-    stage('configureReportPortalWorkDir') {
-        (rpPreprocDir, credsRpProc) = sharedLib.configureRpPreProc()
-    }
-
-    stage('uploadTestResult') {
-        def msgMap = sharedLib.getCIMessageMap()
-        def composeInfo = msgMap["recipe"]
-
-        def resultDir = msgMap["test"]["object-prefix"]
-        println("Test results are available at ${resultDir}")
-
-        def tmpDir = sh(returnStdout: true, script: "mktemp -d").trim()
-        sh script: "rclone sync ${remoteName}://${reportBucket} ${tmpDir} --progress --create-empty-src-dirs"
-
-        def metaData = readYaml file: "${tmpDir}/${resultDir}/metadata.yaml"
-        def copyFiles = "cp -a ${tmpDir}/${resultDir}/results ${rpPreprocDir}/payload/"
-        def rmTmpDir = "rm -rf ${tmpDir}"
-
-        // Modifications to reuse methods
-        metaData["ceph_version"] = metaData["ceph-version"]
-        if ( metaData["stage"] == "latest" ) { metaData["stage"] = "Tier-0" }
-
-        sh script: "${copyFiles} && ${rmTmpDir}"
-
-        if ( composeInfo ){
-            metaData["buildArtifacts"] = composeInfo
-        }
-        sharedLib.sendEmail(metaData["results"], metaData, metaData["stage"])
-        sharedLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData)
-
-        //Remove the sync results folder
-        sh script: "rclone purge ${remoteName}:${reportBucket}/${resultDir}"
-
-        // Update RH recipe file
-        def testStatus = msgMap["test"]["result"]
-
-        if ( composeInfo != null && testStatus == "SUCCESS" ){
-            def tierLevel = msgMap["pipeline"]["name"]
-            def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
-            majorVersion = rhcsVersion["major_version"]
-            minorVersion = rhcsVersion["minor_version"]
-
-            def latestContent = sharedLib.readFromReleaseFile(
-                    majorVersion, minorVersion
-                )
-
-            if ( latestContent.containsKey(tierLevel) ) {
-                latestContent[tierLevel] = composeInfo
+                // prepare the node
+                sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+                sharedLib.prepareNode()
             }
-            else {
-                def updateContent = ["${tierLevel}": composeInfo]
-                latestContent += updateContent
+        }
+
+        stage('configureReportPortalWorkDir') {
+            (rpPreprocDir, credsRpProc) = sharedLib.configureRpPreProc()
+        }
+
+        stage('uploadTestResult') {
+            def msgMap = sharedLib.getCIMessageMap()
+            def composeInfo = msgMap["recipe"]
+
+            def resultDir = msgMap["test"]["object-prefix"]
+            println("Test results are available at ${resultDir}")
+
+            def tmpDir = sh(returnStdout: true, script: "mktemp -d").trim()
+            sh script: "rclone sync ${remoteName}://${reportBucket} ${tmpDir} --progress --create-empty-src-dirs"
+
+            def metaData = readYaml file: "${tmpDir}/${resultDir}/metadata.yaml"
+            def copyFiles = "cp -a ${tmpDir}/${resultDir}/results ${rpPreprocDir}/payload/"
+            def rmTmpDir = "rm -rf ${tmpDir}"
+
+            // Modifications to reuse methods
+            metaData["ceph_version"] = metaData["ceph-version"]
+            if ( metaData["stage"] == "latest" ) { metaData["stage"] = "Tier-0" }
+
+            sh script: "${copyFiles} && ${rmTmpDir}"
+
+            if ( composeInfo ){
+                metaData["buildArtifacts"] = composeInfo
             }
-            sharedLib.writeToReleaseFile(majorVersion, minorVersion, latestContent)
+            sharedLib.sendEmail(metaData["results"], metaData, metaData["stage"])
+            sharedLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData)
+
+            //Remove the sync results folder
+            sh script: "rclone purge ${remoteName}:${reportBucket}/${resultDir}"
+
+            // Update RH recipe file
+            def testStatus = msgMap["test"]["result"]
+
+            if ( composeInfo != null && testStatus == "SUCCESS" ){
+                def tierLevel = msgMap["pipeline"]["name"]
+                def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
+                majorVersion = rhcsVersion["major_version"]
+                minorVersion = rhcsVersion["minor_version"]
+
+                def latestContent = sharedLib.readFromReleaseFile(
+                        majorVersion, minorVersion
+                    )
+
+                if ( latestContent.containsKey(tierLevel) ) {
+                    latestContent[tierLevel] = composeInfo
+                }
+                else {
+                    def updateContent = ["${tierLevel}": composeInfo]
+                    latestContent += updateContent
+                }
+                sharedLib.writeToReleaseFile(majorVersion, minorVersion, latestContent)
+            }
+        }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
+
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
         }
     }
-
 }

--- a/pipeline/rhos_scripts/Jenkinsfile-cleanup-env.groovy
+++ b/pipeline/rhos_scripts/Jenkinsfile-cleanup-env.groovy
@@ -7,34 +7,56 @@ def nodeName = "centos-7"
 def sharedLib
 
 node(nodeName){
-    stage('Install prereq') {
-        checkout([
-            $class: 'GitSCM',
-            branches: [[name: '*/master']],
-            doGenerateSubmoduleConfigurations: false,
-            extensions: [[
-                $class: 'SubmoduleOption',
-                disableSubmodules: false,
-                parentCredentials: false,
-                recursiveSubmodules: true,
-                reference: '',
-                trackingSubmodules: false
-            ]],
-            submoduleCfg: [],
-            userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
-        ])
-        sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
-        sharedLib.prepareNode()
-    }
-    stage('Scrub RHOS-Ring') {
-        echo "Cleanup environment and Send Email to respective user"
-        cmd = "${env.WORKSPACE}/.venv/bin/python ${env.WORKSPACE}/cleanup_env.py --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
-        echo cmd
-        rc = sh(script: "${cmd}", returnStatus: true)
-        if (rc != 0)
-        {
-            sh "echo \"stage failed with exit code : ${rc}\""
-            currentBuild.result = 'FAILURE'
+    try {
+        stage('Install prereq') {
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'SubmoduleOption',
+                    disableSubmodules: false,
+                    parentCredentials: false,
+                    recursiveSubmodules: true,
+                    reference: '',
+                    trackingSubmodules: false
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
+            ])
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
+            sharedLib.prepareNode()
+        }
+        stage('Scrub RHOS-Ring') {
+            echo "Cleanup environment and Send Email to respective user"
+            cmd = "${env.WORKSPACE}/.venv/bin/python ${env.WORKSPACE}/cleanup_env.py --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
+            echo cmd
+            rc = sh(script: "${cmd}", returnStatus: true)
+            if (rc != 0)
+            {
+                sh "echo \"stage failed with exit code : ${rc}\""
+                currentBuild.result = 'FAILURE'
+            }
+        }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
+
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
         }
     }
 }

--- a/pipeline/rhos_scripts/Jenkinsfile-quota.groovy
+++ b/pipeline/rhos_scripts/Jenkinsfile-quota.groovy
@@ -7,34 +7,56 @@ def nodeName = "centos-7"
 def sharedLib
 
 node(nodeName){
-    stage('Install prereq') {
-        checkout([
-            $class: 'GitSCM',
-            branches: [[name: '*/master']],
-            doGenerateSubmoduleConfigurations: false,
-            extensions: [[
-                $class: 'SubmoduleOption',
-                disableSubmodules: false,
-                parentCredentials: false,
-                recursiveSubmodules: true,
-                reference: '',
-                trackingSubmodules: false
-            ]],
-            submoduleCfg: [],
-            userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
-        ])
-        sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
-        sharedLib.prepareNode()
-    }
-    stage('Fetch quota and Send Email') {
-        echo "Fetch quota and Send Email"
-        cmd = "source ${env.WORKSPACE}/.venv/bin/activate;${env.WORKSPACE}/.venv/bin/python ${env.WORKSPACE}/rhos_quota.py --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
-        echo cmd
-        rc = sh(script: "${cmd}", returnStatus: true)
-        if (rc != 0)
-        {
-            sh "echo \"stage failed with exit code : ${rc}\""
-            currentBuild.result = 'FAILURE'
+    try {
+        stage('Install prereq') {
+            checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                doGenerateSubmoduleConfigurations: false,
+                extensions: [[
+                    $class: 'SubmoduleOption',
+                    disableSubmodules: false,
+                    parentCredentials: false,
+                    recursiveSubmodules: true,
+                    reference: '',
+                    trackingSubmodules: false
+                ]],
+                submoduleCfg: [],
+                userRemoteConfigs: [[url: 'https://github.com/red-hat-storage/cephci.git']]
+            ])
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/common.groovy")
+            sharedLib.prepareNode()
+        }
+        stage('Fetch quota and Send Email') {
+            echo "Fetch quota and Send Email"
+            cmd = "source ${env.WORKSPACE}/.venv/bin/activate;${env.WORKSPACE}/.venv/bin/python ${env.WORKSPACE}/rhos_quota.py --osp-cred ${env.HOME}/osp-cred-ci-2.yaml"
+            echo cmd
+            rc = sh(script: "${cmd}", returnStatus: true)
+            if (rc != 0)
+            {
+                sh "echo \"stage failed with exit code : ${rc}\""
+                currentBuild.result = 'FAILURE'
+            }
+        }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
+
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
         }
     }
 }

--- a/pipeline/signed-compose-listener.groovy
+++ b/pipeline/signed-compose-listener.groovy
@@ -9,109 +9,130 @@ def platform
 
 // Pipeline script entry point
 node(nodeName) {
-
-    timeout(unit: "MINUTES", time: 30) {
-        stage('Preparing') {
-            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
-            checkout([
-                $class: 'GitSCM',
-                branches: [[name: 'origin/master']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                    [
-                        $class: 'CloneOption',
-                        shallow: true,
-                        noTags: true,
-                        reference: '',
-                        depth: 1
+    try {
+        timeout(unit: "MINUTES", time: 30) {
+            stage('Preparing') {
+                if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: 'origin/master']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [
+                            $class: 'CloneOption',
+                            shallow: true,
+                            noTags: true,
+                            reference: '',
+                            depth: 1
+                        ],
+                        [$class: 'CleanBeforeCheckout'],
                     ],
-                    [$class: 'CleanBeforeCheckout'],
-                ],
-                submoduleCfg: [],
-                userRemoteConfigs: [[
-                    url: 'https://github.com/red-hat-storage/cephci.git'
-                ]]
-            ])
-            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
-            sharedLib.prepareNode()
-        }
-    }
-
-    stage("Updating") {
-        versions = sharedLib.fetchMajorMinorOSVersion("signed-compose")
-        def majorVersion = versions.major_version
-        def minorVersion = versions.minor_version
-        platform = versions.platform
-
-        def cimsg = sharedLib.getCIMessageMap()
-        composeUrl = cimsg["compose-path"].replace(
-            "/mnt/redhat/", "http://download-node-02.eng.bos.redhat.com/"
-        )
-        cephVersion = sharedLib.fetchCephVersion(composeUrl)
-
-        def releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
-        if ( releaseMap.isEmpty() ) {
-            sharedLib.unSetLock(majorVersion, minorVersion)
-            currentBuild.result = "ABORTED"
-            error "No release information was found."
-        }
-
-        if ( releaseMap?.rc?."ceph-version" ) {
-            def currentCephVersion = releaseMap.rc."ceph-version"
-            def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
-            if (compare == -1) {
-                sharedLib.unSetLock(majorVersion, minorVersion)
-                println "Existing Ceph Version: ${currentCephVersion}"
-                println "Found Ceph Version: ${cephVersion}"
-
-                currentBuild.result = "ABORTED"
-                error "Abort: New version is lower than existing ceph version."
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/red-hat-storage/cephci.git'
+                    ]]
+                ])
+                sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+                sharedLib.prepareNode()
             }
         }
 
-        if ( !releaseMap.containsKey("rc") ) {
-            releaseMap.rc = [:]
-            releaseMap.rc.composes = [:]
+        stage("Updating") {
+            versions = sharedLib.fetchMajorMinorOSVersion("signed-compose")
+            def majorVersion = versions.major_version
+            def minorVersion = versions.minor_version
+            platform = versions.platform
+
+            def cimsg = sharedLib.getCIMessageMap()
+            composeUrl = cimsg["compose-path"].replace(
+                "/mnt/redhat/", "http://download-node-02.eng.bos.redhat.com/"
+            )
+            cephVersion = sharedLib.fetchCephVersion(composeUrl)
+
+            def releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
+            if ( releaseMap.isEmpty() ) {
+                sharedLib.unSetLock(majorVersion, minorVersion)
+                currentBuild.result = "ABORTED"
+                error "No release information was found."
+            }
+
+            if ( releaseMap?.rc?."ceph-version" ) {
+                def currentCephVersion = releaseMap.rc."ceph-version"
+                def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
+                if (compare == -1) {
+                    sharedLib.unSetLock(majorVersion, minorVersion)
+                    println "Existing Ceph Version: ${currentCephVersion}"
+                    println "Found Ceph Version: ${cephVersion}"
+
+                    currentBuild.result = "ABORTED"
+                    error "Abort: New version is lower than existing ceph version."
+                }
+            }
+
+            if ( !releaseMap.containsKey("rc") ) {
+                releaseMap.rc = [:]
+                releaseMap.rc.composes = [:]
+            }
+
+            releaseMap.rc."ceph-version" = cephVersion
+            releaseMap.rc."compose-label" = cimsg["compose-label"]
+            releaseMap.rc.composes["${platform}"] = composeUrl
+            sharedLib.writeToReleaseFile(majorVersion, minorVersion, releaseMap)
+
+            def bucket = "ceph-${majorVersion}.${minorVersion}-${platform}"
+            sharedLib.uploadCompose(bucket, cephVersion, composeUrl)
+
         }
 
-        releaseMap.rc."ceph-version" = cephVersion
-        releaseMap.rc."compose-label" = cimsg["compose-label"]
-        releaseMap.rc.composes["${platform}"] = composeUrl
-        sharedLib.writeToReleaseFile(majorVersion, minorVersion, releaseMap)
+        stage('Messaging') {
+            def contentMap = [
+                "artifact": [
+                    "build_action": "rc",
+                    "name": "Red Hat Ceph Storage",
+                    "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
+                    "phase": "rc",
+                    "type": "product-build",
+                    "version": cephVersion
+                ],
+                "build": [
+                    "platform": platform,
+                    "compose-url": composeUrl
+                ],
+                "contact": [
+                    "email": "ceph-qe@redhat.com",
+                    "name": "Downstream Ceph QE"
+                ],
+                "run": [
+                    "log": "${env.BUILD_URL}console",
+                    "url": env.BUILD_URL
+                ],
+                "version": "1.0.0"
+            ]
+            def msgContent = writeJSON returnText: true, json: contentMap
+            def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.update.complete"
 
-        def bucket = "ceph-${majorVersion}.${minorVersion}-${platform}"
-        sharedLib.uploadCompose(bucket, cephVersion, composeUrl)
+            sharedLib.SendUMBMessage(msgContent, overrideTopic, "ProductBuildDone")
+            println "Updated UMB Message Successfully"
+        }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
 
-    }
-
-    stage('Messaging') {
-        def contentMap = [
-            "artifact": [
-                "build_action": "rc",
-                "name": "Red Hat Ceph Storage",
-                "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
-                "phase": "rc",
-                "type": "product-build",
-                "version": cephVersion
-            ],
-            "build": [
-                "platform": platform,
-                "compose-url": composeUrl
-            ],
-            "contact": [
-                "email": "ceph-qe@redhat.com",
-                "name": "Downstream Ceph QE"
-            ],
-            "run": [
-                "log": "${env.BUILD_URL}console",
-                "url": env.BUILD_URL
-            ],
-            "version": "1.0.0"
-        ]
-        def msgContent = writeJSON returnText: true, json: contentMap
-        def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.update.complete"
-
-        sharedLib.SendUMBMessage(msgContent, overrideTopic, "ProductBuildDone")
-        println "Updated UMB Message Successfully"
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
+        }
     }
 }

--- a/pipeline/signed-container-image-listener.groovy
+++ b/pipeline/signed-container-image-listener.groovy
@@ -11,101 +11,124 @@ def releaseMap = [:]
 // Pipeline script entry point
 node(nodeName) {
 
-    timeout(unit: "MINUTES", time: 30) {
-        stage('Preparing') {
-            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
-            checkout([
-                $class: 'GitSCM',
-                branches: [[name: 'origin/master']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                    [
-                        $class: 'CloneOption',
-                        shallow: true,
-                        noTags: true,
-                        reference: '',
-                        depth: 1
+    try {
+
+        timeout(unit: "MINUTES", time: 30) {
+            stage('Preparing') {
+                if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: 'origin/master']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [
+                            $class: 'CloneOption',
+                            shallow: true,
+                            noTags: true,
+                            reference: '',
+                            depth: 1
+                        ],
+                        [$class: 'CleanBeforeCheckout'],
                     ],
-                    [$class: 'CleanBeforeCheckout'],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/red-hat-storage/cephci.git'
+                    ]]
+                ])
+                sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+                sharedLib.prepareNode(1)
+            }
+        }
+
+        stage("Updating") {
+            versions = sharedLib.fetchMajorMinorOSVersion("signed-container-image")
+            def majorVersion = versions.major_version
+            def minorVersion = versions.minor_version
+
+            def cimsg = sharedLib.getCIMessageMap()
+            def repoDetails = cimsg.build.extra.image
+
+            containerImage = repoDetails.index.pull.find({ x -> !(x.contains("sha")) })
+
+            def repoUrl = repoDetails.yum_repourls.find({ x -> x.contains("Tools") })
+            composeUrl = repoUrl.split("work").find({
+                x -> x.contains("RHCEPH-${majorVersion}.${minorVersion}")
+            })
+            println "repo url : ${composeUrl}"
+
+            cephVersion = sharedLib.fetchCephVersion(composeUrl)
+            releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
+
+            if ( releaseMap.isEmpty() || !releaseMap?.rc?."ceph-version" ) {
+                sharedLib.unSetLock(majorVersion, minorVersion)
+                currentBuild.result = "ABORTED"
+                error "Unable to retrieve release build recipes."
+            }
+
+            def currentCephVersion = releaseMap.rc."ceph-version"
+            def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
+            if ( compare != 0 ) {
+                sharedLib.unSetLock(majorVersion, minorVersion)
+                println "Current Ceph Version : ${currentCephVersion}"
+                println "New Ceph Version : ${cephVersion}"
+            }
+
+            releaseMap.rc.repository = containerImage
+            sharedLib.writeToReleaseFile(majorVersion, minorVersion, releaseMap)
+
+            println "Success: Updated below information \n ${releaseMap}"
+        }
+
+        stage('Publishing') {
+            def contentMap = [
+                "artifact": [
+                    "build_action": "rc",
+                    "name": "Red Hat Ceph Storage",
+                    "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
+                    "phase": "rc",
+                    "type": "product-build",
+                    "version": cephVersion
                 ],
-                submoduleCfg: [],
-                userRemoteConfigs: [[
-                    url: 'https://github.com/red-hat-storage/cephci.git'
-                ]]
-            ])
-            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
-            sharedLib.prepareNode(1)
+                "build": [
+                    "repository": containerImage,
+                    "version": cephVersion,
+                    "composes": releaseMap.rc.composes
+                ],
+                "contact": [
+                    "email": "ceph-qe@redhat.com",
+                    "name": "Downstream Ceph QE"
+                ],
+                "run": [
+                    "log": "${env.BUILD_URL}console",
+                    "url": env.BUILD_URL
+                ],
+                "version": "1.0.0"
+            ]
+            def msgContent = writeJSON returnText: true, json: contentMap
+            def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
+
+            sharedLib.SendUMBMessage(msgContent, overrideTopic, "ProductBuildDone")
+            println "Updated UMB Message Successfully"
         }
-    }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
 
-    stage("Updating") {
-        versions = sharedLib.fetchMajorMinorOSVersion("signed-container-image")
-        def majorVersion = versions.major_version
-        def minorVersion = versions.minor_version
-
-        def cimsg = sharedLib.getCIMessageMap()
-        def repoDetails = cimsg.build.extra.image
-
-        containerImage = repoDetails.index.pull.find({ x -> !(x.contains("sha")) })
-
-        def repoUrl = repoDetails.yum_repourls.find({ x -> x.contains("Tools") })
-        composeUrl = repoUrl.split("work").find({
-            x -> x.contains("RHCEPH-${majorVersion}.${minorVersion}")
-        })
-        println "repo url : ${composeUrl}"
-
-        cephVersion = sharedLib.fetchCephVersion(composeUrl)
-        releaseMap = sharedLib.readFromReleaseFile(majorVersion, minorVersion)
-
-        if ( releaseMap.isEmpty() || !releaseMap?.rc?."ceph-version" ) {
-            sharedLib.unSetLock(majorVersion, minorVersion)
-            currentBuild.result = "ABORTED"
-            error "Unable to retrieve release build recipes."
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
         }
-
-        def currentCephVersion = releaseMap.rc."ceph-version"
-        def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
-        if ( compare != 0 ) {
-            sharedLib.unSetLock(majorVersion, minorVersion)
-            println "Current Ceph Version : ${currentCephVersion}"
-            println "New Ceph Version : ${cephVersion}"
-        }
-
-        releaseMap.rc.repository = containerImage
-        sharedLib.writeToReleaseFile(majorVersion, minorVersion, releaseMap)
-
-        println "Success: Updated below information \n ${releaseMap}"
-    }
-
-    stage('Publishing') {
-        def contentMap = [
-            "artifact": [
-                "build_action": "rc",
-                "name": "Red Hat Ceph Storage",
-                "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
-                "phase": "rc",
-                "type": "product-build",
-                "version": cephVersion
-            ],
-            "build": [
-                "repository": containerImage,
-                "version": cephVersion,
-                "composes": releaseMap.rc.composes
-            ],
-            "contact": [
-                "email": "ceph-qe@redhat.com",
-                "name": "Downstream Ceph QE"
-            ],
-            "run": [
-                "log": "${env.BUILD_URL}console",
-                "url": env.BUILD_URL
-            ],
-            "version": "1.0.0"
-        ]
-        def msgContent = writeJSON returnText: true, json: contentMap
-        def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
-
-        sharedLib.SendUMBMessage(msgContent, overrideTopic, "ProductBuildDone")
-        println "Updated UMB Message Successfully"
     }
 }

--- a/pipeline/unsigned-compose-listener.groovy
+++ b/pipeline/unsigned-compose-listener.groovy
@@ -10,104 +10,124 @@ def platform
 
 // Pipeline script entry point
 node(nodeName) {
-
-    timeout(unit: "MINUTES", time: 30) {
-        stage('Preparing') {
-            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
-            checkout([
-                $class: 'GitSCM',
-                branches: [[name: 'origin/master']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                    [
-                        $class: 'CloneOption',
-                        shallow: true,
-                        noTags: true,
-                        reference: '',
-                        depth: 1
+    try {
+        timeout(unit: "MINUTES", time: 30) {
+            stage('Preparing') {
+                if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: 'origin/master']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [
+                            $class: 'CloneOption',
+                            shallow: true,
+                            noTags: true,
+                            reference: '',
+                            depth: 1
+                        ],
+                        [$class: 'CleanBeforeCheckout'],
                     ],
-                    [$class: 'CleanBeforeCheckout'],
-                ],
-                submoduleCfg: [],
-                userRemoteConfigs: [[
-                    url: 'https://github.com/red-hat-storage/cephci.git'
-                ]]
-            ])
-            sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
-            sharedLib.prepareNode()
-        }
-    }
-
-    stage('Updating') {
-        echo "${params.CI_MESSAGE}"
-
-        ciMsg = sharedLib.getCIMessageMap()
-        composeUrl = ciMsg["compose_url"]
-
-        cephVersion = sharedLib.fetchCephVersion(composeUrl)
-        versionInfo = sharedLib.fetchMajorMinorOSVersion("unsigned-compose")
-
-        majorVer = versionInfo['major_version']
-        minorVer = versionInfo['minor_version']
-        platform = versionInfo['platform']
-
-        releaseContent = sharedLib.readFromReleaseFile(majorVer, minorVer)
-        if ( releaseContent?.latest?."ceph-version") {
-            currentCephVersion = releaseContent["latest"]["ceph-version"]
-            def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
-
-            if (compare == -1) {
-                sharedLib.unSetLock(majorVer, minorVer)
-                currentBuild.result = "ABORTED"
-                println "Build Ceph Version: ${cephVersion}"
-                println "Found Ceph Version: ${currentCephVersion}"
-                error("The latest ceph version is lower than existing one.")
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/red-hat-storage/cephci.git'
+                    ]]
+                ])
+                sharedLib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+                sharedLib.prepareNode()
             }
         }
 
-        if ( !releaseContent.containsKey("latest") ) {
-            releaseContent.latest = [:]
-            releaseContent.latest.composes = [:]
+        stage('Updating') {
+            echo "${params.CI_MESSAGE}"
+
+            ciMsg = sharedLib.getCIMessageMap()
+            composeUrl = ciMsg["compose_url"]
+
+            cephVersion = sharedLib.fetchCephVersion(composeUrl)
+            versionInfo = sharedLib.fetchMajorMinorOSVersion("unsigned-compose")
+
+            majorVer = versionInfo['major_version']
+            minorVer = versionInfo['minor_version']
+            platform = versionInfo['platform']
+
+            releaseContent = sharedLib.readFromReleaseFile(majorVer, minorVer)
+            if ( releaseContent?.latest?."ceph-version") {
+                currentCephVersion = releaseContent["latest"]["ceph-version"]
+                def compare = sharedLib.compareCephVersion(currentCephVersion, cephVersion)
+
+                if (compare == -1) {
+                    sharedLib.unSetLock(majorVer, minorVer)
+                    currentBuild.result = "ABORTED"
+                    println "Build Ceph Version: ${cephVersion}"
+                    println "Found Ceph Version: ${currentCephVersion}"
+                    error("The latest ceph version is lower than existing one.")
+                }
+            }
+
+            if ( !releaseContent.containsKey("latest") ) {
+                releaseContent.latest = [:]
+                releaseContent.latest.composes = [:]
+            }
+
+            releaseContent["latest"]["ceph-version"] = cephVersion
+            releaseContent["latest"]["composes"]["${platform}"] = composeUrl
+            sharedLib.writeToReleaseFile(majorVer, minorVer, releaseContent)
+
+            def bucket = "ceph-${majorVer}.${minorVer}-${platform}"
+            sharedLib.uploadCompose(bucket, cephVersion, composeUrl)
+
         }
 
-        releaseContent["latest"]["ceph-version"] = cephVersion
-        releaseContent["latest"]["composes"]["${platform}"] = composeUrl
-        sharedLib.writeToReleaseFile(majorVer, minorVer, releaseContent)
+        stage('Messaging') {
 
-        def bucket = "ceph-${majorVer}.${minorVer}-${platform}"
-        sharedLib.uploadCompose(bucket, cephVersion, composeUrl)
+            def msgMap = [
+                "artifact": [
+                    "type" : "product-build",
+                    "name": "Red Hat Ceph Storage",
+                    "version": cephVersion,
+                    "nvr": "RHCEPH-${majorVer}.${minorVer}",
+                    "build_action": "latest",
+                    "phase": "tier-0"
+                ],
+                "contact":[
+                    "name": "Downstream Ceph QE",
+                    "email": "ceph-qe@redhat.com"
+                ],
+                "build": [
+                    "platform": platform,
+                    "compose-url": composeUrl
+                ],
+                "run": [
+                    "url": env.BUILD_URL,
+                    "log": "${env.BUILD_URL}console"
+                ],
+                "version": "1.0.0"
+            ]
+            def topic = 'VirtualTopic.qe.ci.rhcephqe.product-build.update.complete'
 
+            //send UMB message notifying that a new build has arrived
+            sharedLib.SendUMBMessage(msgMap, topic, 'ProductBuildDone')
+        }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
+
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
+        }
     }
-
-    stage('Messaging') {
-
-        def msgMap = [
-            "artifact": [
-                "type" : "product-build",
-                "name": "Red Hat Ceph Storage",
-                "version": cephVersion,
-                "nvr": "RHCEPH-${majorVer}.${minorVer}",
-                "build_action": "latest",
-                "phase": "tier-0"
-            ],
-            "contact":[
-                "name": "Downstream Ceph QE",
-                "email": "ceph-qe@redhat.com"
-            ],
-            "build": [
-                "platform": platform,
-                "compose-url": composeUrl
-            ],
-            "run": [
-                "url": env.BUILD_URL,
-                "log": "${env.BUILD_URL}console"
-            ],
-            "version": "1.0.0"
-        ]
-        def topic = 'VirtualTopic.qe.ci.rhcephqe.product-build.update.complete'
-
-        //send UMB message notifying that a new build has arrived
-        sharedLib.SendUMBMessage(msgMap, topic, 'ProductBuildDone')
-    }
-
 }

--- a/pipeline/unsigned-container-image-listener.groovy
+++ b/pipeline/unsigned-container-image-listener.groovy
@@ -13,104 +13,125 @@ def releaseDetails = [:]
 
 node(nodeName) {
 
-    timeout(unit: "MINUTES", time: 30) {
-        stage('Preparing') {
-            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
-            checkout([
-                $class: 'GitSCM',
-                branches: [[name: 'origin/master']],
-                doGenerateSubmoduleConfigurations: false,
-                extensions: [
-                    [
-                        $class: 'CloneOption',
-                        shallow: true,
-                        noTags: true,
-                        reference: '',
-                        depth: 1
+    try {
+        timeout(unit: "MINUTES", time: 30) {
+            stage('Preparing') {
+                if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: 'origin/master']],
+                    doGenerateSubmoduleConfigurations: false,
+                    extensions: [
+                        [
+                            $class: 'CloneOption',
+                            shallow: true,
+                            noTags: true,
+                            reference: '',
+                            depth: 1
+                        ],
+                        [$class: 'CleanBeforeCheckout'],
                     ],
-                    [$class: 'CleanBeforeCheckout'],
+                    submoduleCfg: [],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/red-hat-storage/cephci.git'
+                    ]]
+                ])
+
+                // prepare the node
+                lib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
+                lib.prepareNode(1)
+            }
+        }
+
+        stage('Updating') {
+            println "msg = ${params.CI_MESSAGE}"
+
+            compose = lib.getCIMessageMap()
+            versions = lib.fetchMajorMinorOSVersion('unsigned-container-image')
+            cephVersion = lib.fetchCephVersion(compose.compose_url)
+
+            releaseDetails = lib.readFromReleaseFile(
+                versions.major_version, versions.minor_version,
+            )
+            if ( !releaseDetails?.latest?."ceph-version") {
+                lib.unSetLock(versions.major_version, versions.minor_version)
+                currentBuild.results = "ABORTED"
+                error("Unable to retrieve release information")
+            }
+
+            def currentCephVersion = releaseDetails.latest."ceph-version"
+            def compare = lib.compareCephVersion(currentCephVersion, cephVersion)
+
+            if (compare != 0) {
+                lib.unSetLock(versions.major_version, versions.minor_version)
+                currentBuild.result = "ABORTED"
+                println "Build Ceph Version: ${cephVersion}"
+                println "Found Ceph Version: ${currentCephVersion}"
+                error("The ceph versions do not match.")
+            }
+            releaseDetails.latest.repository = compose.repository
+            lib.writeToReleaseFile(
+                versions.major_version, versions.minor_version, releaseDetails
+            )
+
+        }
+
+        stage('Messaging') {
+            def artifactsMap = [
+                "artifact": [
+                    "type": "product-build",
+                    "name": "Red Hat Ceph Storage",
+                    "version": cephVersion,
+                    "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
+                    "phase": "tier-0",
+                    "build_action": "latest"
                 ],
-                submoduleCfg: [],
-                userRemoteConfigs: [[
-                    url: 'https://github.com/red-hat-storage/cephci.git'
-                ]]
-            ])
+                "contact": [
+                    "name": "Downstream Ceph QE",
+                    "email": "ceph-qe@redhat.com"
+                ],
+                "build": [
+                    "repository": compose.repository,
+                    "composes": releaseDetails.latest.composes,
+                    "version": cephVersion
+                ],
+                "test": [
+                    "phase": "tier-0"
+                ],
+                "run": [
+                    "url": env.BUILD_URL,
+                    "log": "${env.BUILD_URL}console"
+                ],
+                "version": "1.0.0"
+            ]
 
-            // prepare the node
-            lib = load("${env.WORKSPACE}/pipeline/vars/lib.groovy")
-            lib.prepareNode(1)
+            def msgContent = writeJSON returnText: true, json: artifactsMap
+            println "${msgContent}"
+
+            def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
+            def msgType = "ProductBuildDone"
+
+            lib.SendUMBMessage(msgContent, overrideTopic, msgType)
+        }
+    } catch(Exception err) {
+        if (currentBuild.result != "ABORTED") {
+            // notify about failure
+            currentBuild.result = "FAILURE"
+            def failureReason = err.getMessage()
+            def subject =  "[CEPHCI-PIPELINE-ALERT] [JOB-FAILURE] - ${env.JOB_NAME}/${env.BUILD_NUMBER}"
+            def body = "<body><h3><u>Job Failure</u></h3></p>"
+            body += "<dl><dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd>"
+            body += "<dt>Failure Reason:</dt><dd>${failureReason}</dd></dl></body>"
+
+            emailext (
+                mimeType: 'text/html',
+                subject: "${subject}",
+                body: "${body}",
+                from: "cephci@redhat.com",
+                to: "ceph-qe@redhat.com"
+            )
+            subject += "\n Jenkins URL: ${env.BUILD_URL}"
+            googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
         }
     }
-
-    stage('Updating') {
-        println "msg = ${params.CI_MESSAGE}"
-
-        compose = lib.getCIMessageMap()
-        versions = lib.fetchMajorMinorOSVersion('unsigned-container-image')
-        cephVersion = lib.fetchCephVersion(compose.compose_url)
-
-        releaseDetails = lib.readFromReleaseFile(
-            versions.major_version, versions.minor_version,
-        )
-        if ( !releaseDetails?.latest?."ceph-version") {
-            lib.unSetLock(versions.major_version, versions.minor_version)
-            currentBuild.results = "ABORTED"
-            error("Unable to retrieve release information")
-        }
-
-        def currentCephVersion = releaseDetails.latest."ceph-version"
-        def compare = lib.compareCephVersion(currentCephVersion, cephVersion)
-
-        if (compare != 0) {
-            lib.unSetLock(versions.major_version, versions.minor_version)
-            currentBuild.result = "ABORTED"
-            println "Build Ceph Version: ${cephVersion}"
-            println "Found Ceph Version: ${currentCephVersion}"
-            error("The ceph versions do not match.")
-        }
-        releaseDetails.latest.repository = compose.repository
-        lib.writeToReleaseFile(
-            versions.major_version, versions.minor_version, releaseDetails
-        )
-
-    }
-
-    stage('Messaging') {
-        def artifactsMap = [
-            "artifact": [
-                "type": "product-build",
-                "name": "Red Hat Ceph Storage",
-                "version": cephVersion,
-                "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
-                "phase": "tier-0",
-                "build_action": "latest"
-            ],
-            "contact": [
-                "name": "Downstream Ceph QE",
-                "email": "ceph-qe@redhat.com"
-            ],
-            "build": [
-                "repository": compose.repository,
-                "composes": releaseDetails.latest.composes,
-                "version": cephVersion
-            ],
-            "test": [
-                "phase": "tier-0"
-            ],
-            "run": [
-                "url": env.BUILD_URL,
-                "log": "${env.BUILD_URL}console"
-            ],
-            "version": "1.0.0"
-        ]
-
-        def msgContent = writeJSON returnText: true, json: artifactsMap
-        println "${msgContent}"
-
-        def overrideTopic = "VirtualTopic.qe.ci.rhcephqe.product-build.promote.complete"
-        def msgType = "ProductBuildDone"
-
-        lib.SendUMBMessage(msgContent, overrideTopic, msgType)
-    }
-
 }


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Failure email and chat notification, in listener jobs fails.

**Test Simulation results:**

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/test-post-result-notifications/10/console

**_Email notification:_**
![image](https://user-images.githubusercontent.com/31158377/152785903-073ee1f7-c150-49f6-b5c1-929c9d5dc6cb.png)


**_Chat notification:_**

> [ CEPHCI-PIPELINE-ALERT ] test-post-result-notifications/10 failed..
>  Jenkins URL: https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/test-post-result-notifications/10/
> 
> 
 