### PR TITLE
Correction to email notification for psi-only-executor job

### DIFF
--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -73,6 +73,7 @@ node(nodeName) {
         // Till the pipeline matures, using the build that has passed tier-0 suite.
         testStages = sharedLib.fetchStages(cliArgs, tierLevel, testResults)
         testStages = testStages.findAll { it.key.contains("psi-only")}
+        testResults = testResults.findAll { it.key.contains("psi-only")}
 
         if ( testStages.isEmpty() ) {
             currentBuild.result = "ABORTED"
@@ -95,7 +96,8 @@ node(nodeName) {
         sharedLib.sendEmail(
             testResults,
             sharedLib.buildArtifactsDetails(releaseContent, ciMap, "tier-0"),
-            tierLevel.capitalize()
+            tierLevel.capitalize(),
+            "ceph-qe@redhat.com"
         )
     }
 


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Raising this PR to correct the email being sent for rhceph-execute-psi-only-suites job. The email body will now contain only the test results for the stages executed as part of this job and the email will be sent to ceph-qe@redhat.com

Related Jira ticket - https://issues.redhat.com/browse/RHCEPHQE-1683 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
