### PR TITLE
Added upgrade suite for 4.x to 5.x with RGW tests

### DIFF
--- a/conf/pacific/rgw/5-node-with-iscsi-role.yaml
+++ b/conf/pacific/rgw/5-node-with-iscsi-role.yaml
@@ -1,0 +1,42 @@
+######################################################
+# This conf file is for RGW tests with upgrade scenario
+######################################################
+
+globals:
+  - ceph-cluster:
+     name: ceph
+     node1:
+       role:
+         - _admin
+         - mon
+         - mgr
+         - osd
+         - installer
+       no-of-volumes: 1
+       disk-size: 40
+     node2:
+       role:
+         - mon
+         - mgr
+         - osd
+         - grafana
+       no-of-volumes: 1
+       disk-size: 40
+     node3:
+       role:
+         - mon
+         - mgr
+         - osd
+         - mds
+       no-of-volumes: 1
+       disk-size: 40
+     node4:
+       role:
+         - rgw
+         - iscsi-gw
+
+     node5:
+       role:
+         - rgw
+         - iscsi-gw
+         - client

--- a/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
@@ -1,0 +1,405 @@
+#############################################################################
+# - Automation support for upgrade from RHCS4 to RHCS5 cluster with RGW tests
+#
+# Test steps:
+# ---------------------------------------------------------------------
+# - Deploy bare-metal Nautilus Ceph cluster using CDN RPMS with lvm osd scenario
+# - Run RGW tests
+# - Convert the cluster to containerized using ceph-ansible
+# - Upgrade to Pacific using ceph-ansible
+# - Run RGW tests after upgrade
+#
+#############################################################################
+tests:
+- test:
+    name: install ceph pre-requisites
+    module: install_prereq.py
+    abort-on-fail: true
+
+- test:
+    name: ceph ansible install rhcs 4.x from cdn
+    polarion-id: CEPH-83573588
+    module: test_ansible.py
+    config:
+      use_cdn: true
+      build: '4.x'
+      ansi_config:
+        ceph_origin: repository
+        ceph_repository: rhcs
+        osd_scenario: lvm
+        osd_auto_discovery: false
+        ceph_stable_rh_storage: true
+        ceph_docker_image: "rhceph/rhceph-4-rhel8"
+        ceph_docker_image_tag: "latest"
+        ceph_docker_registry: "registry.redhat.io"
+        copy_admin_key: true
+        radosgw_num_instances: 2
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+    desc: deploy ceph containerized 4.x cdn setup using ceph-ansible
+    destroy-cluster: false
+    abort-on-fail: true
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      commands:
+        - "ceph -s"
+        - "ceph versions"
+      sudo: true
+    desc: check for ceph status and version
+
+
+# Basic Bucket Operation Tests
+
+- test:
+    name: Mbuckets
+    desc: test to create "M" no of buckets
+    polarion-id: CEPH-9789
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects
+    desc: test to create "M" no of buckets and "N" no of objects
+    polarion-id: CEPH-9789
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects
+    desc: test to create "M" no of buckets and "N" no of objects with encryption
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects_delete
+    desc: test to create "M" no of buckets and "N" no of objects with delete
+    module: sanity_rgw.py
+    polarion-id: CEPH-14237
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects_download
+    desc: test to create "M" no of buckets and "N" no of objects with download
+    module: sanity_rgw.py
+    polarion-id: CEPH-14237
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects with sharing enabled
+    desc: test to perform bucket ops with sharding operations
+    module: sanity_rgw.py
+    polarion-id: CEPH-9245
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
+      timeout: 300
+
+
+# Bucket Listing Tests
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of bucket with top level objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_flat_ordered.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of versionsed bucket with top level objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for unordered listing of bucket with top level objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_flat_unordered.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of bucket with pseudo directories and objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_pseudo_ordered.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of bucket with pseudo directories only
+    polarion-id: CEPH-83573651
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+      timeout: 300
+
+# Swift basic operation
+
+- test:
+    name: Swift based tests
+    desc: RGW lifecycle operations using swift
+    polarion-id: CEPH-11019
+    module: sanity_rgw.py
+    config:
+      script-name: test_swift_basic_ops.py
+      config-file-name: test_swift_basic_ops.yaml
+      timeout: 300
+
+- test:
+    name: swift versioning copy tests
+    desc: restore versioned object in swift
+    polarion-id: CEPH-10646
+    module: sanity_rgw.py
+    config:
+      script-name: test_swift_basic_ops.py
+      config-file-name: test_swift_version_copy_op.yaml
+      timeout: 500
+
+- test:
+    name: Swift based tests
+    desc: Swift bulk delete operation
+    polarion-id: CEPH-9753
+    module: sanity_rgw.py
+    config:
+      script-name: test_swift_bulk_delete.py
+      config-file-name: test_swift_bulk_delete.yaml
+      timeout: 300
+
+# resharding tests
+- test:
+    name: Resharding tests
+    desc: Reshading test - manual
+    polarion-id: CEPH-83571740
+    module: sanity_rgw.py
+    config:
+      script-name: test_dynamic_bucket_resharding.py
+      config-file-name: test_manual_resharding.yaml
+      timeout: 500
+- test:
+    name: Resharding tests
+    desc: Reshading test - dynamic
+    polarion-id: CEPH-83571740
+    module: sanity_rgw.py
+    config:
+      script-name: test_dynamic_bucket_resharding.py
+      config-file-name: test_dynamic_resharding.yaml
+      timeout: 500
+
+
+# switch from rpm to container
+- test:
+    name: switch-from-non-containerized-to-containerized-ceph-daemons
+    polarion-id: CEPH-83573510
+    module: switch_rpm_to_container.py
+    abort-on-fail: true
+
+- test:
+    name: Upgrade containerized ceph to 5.x latest
+    polarion-id: CEPH-83573679
+    module: test_ansible_upgrade.py
+    config:
+      ansi_config:
+        ceph_origin: distro
+        ceph_repository: rhcs
+        ceph_rhcs_version: 5
+        osd_scenario: lvm
+        osd_auto_discovery: false
+        fetch_directory: ~/fetch
+        radosgw_num_instances: 2
+        copy_admin_key: true
+        containerized_deployment: true
+        upgrade_ceph_packages: true
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+    desc: Test upgrade from 4.x cdn -> 5.x latest
+    abort-on-fail: true
+
+# Basic Bucket Operation Tests
+
+- test:
+    name: Mbuckets
+    desc: test to create "M" no of buckets
+    polarion-id: CEPH-9789
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects
+    desc: test to create "M" no of buckets and "N" no of objects
+    polarion-id: CEPH-9789
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects
+    desc: test to create "M" no of buckets and "N" no of objects with encryption
+    module: sanity_rgw.py
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects_delete
+    desc: test to create "M" no of buckets and "N" no of objects with delete
+    module: sanity_rgw.py
+    polarion-id: CEPH-14237
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects_download
+    desc: test to create "M" no of buckets and "N" no of objects with download
+    module: sanity_rgw.py
+    polarion-id: CEPH-14237
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+      timeout: 300
+- test:
+    name: Mbuckets_with_Nobjects with sharing enabled
+    desc: test to perform bucket ops with sharding operations
+    module: sanity_rgw.py
+    polarion-id: CEPH-9245
+    config:
+      script-name: test_Mbuckets_with_Nobjects.py
+      config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
+      timeout: 300
+
+# Bucket Listing Tests
+
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of bucket with top level objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_flat_ordered.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of versionsed bucket with top level objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for unordered listing of bucket with top level objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_flat_unordered.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of bucket with pseudo directories and objects
+    polarion-id: CEPH-83573545
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_pseudo_ordered.yaml
+      timeout: 300
+- test:
+    name: Bucket Listing tests
+    desc: measure execution time for ordered listing of bucket with pseudo directories only
+    polarion-id: CEPH-83573651
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+      timeout: 300
+
+# Swift basic operation
+
+- test:
+    name: Swift based tests
+    desc: RGW lifecycle operations using swift
+    polarion-id: CEPH-11019
+    module: sanity_rgw.py
+    config:
+      script-name: test_swift_basic_ops.py
+      config-file-name: test_swift_basic_ops.yaml
+      timeout: 300
+
+- test:
+    name: swift versioning copy tests
+    desc: restore versioned object in swift
+    polarion-id: CEPH-10646
+    module: sanity_rgw.py
+    config:
+      script-name: test_swift_basic_ops.py
+      config-file-name: test_swift_version_copy_op.yaml
+      timeout: 500
+
+- test:
+    name: Swift based tests
+    desc: Swift bulk delete operation
+    polarion-id: CEPH-9753
+    module: sanity_rgw.py
+    config:
+      script-name: test_swift_bulk_delete.py
+      config-file-name: test_swift_bulk_delete.yaml
+      timeout: 300
+
+# resharding tests
+- test:
+    name: Resharding tests
+    desc: Reshading test - manual
+    polarion-id: CEPH-83571740
+    module: sanity_rgw.py
+    config:
+      script-name: test_dynamic_bucket_resharding.py
+      config-file-name: test_manual_resharding.yaml
+      timeout: 500
+- test:
+    name: Resharding tests
+    desc: Reshading test - dynamic
+    polarion-id: CEPH-83571740
+    module: sanity_rgw.py
+    config:
+      script-name: test_dynamic_bucket_resharding.py
+      config-file-name: test_dynamic_resharding.yaml
+      timeout: 500


### PR DESCRIPTION
Added upgrade suite for 4.x to 5.x with RGW tests

# Test steps:
# ---------------------------------------------------------------------
# - Deploy Nautilus Ceph cluster using CDN RPMS with lvm osd scenario
# - Run RGW tests
# - Convert the cluster to containerized using ceph-ansible
# - Upgrade to Pacific using ceph-ansible
# - Run RGW tests after upgrade

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ON34F0/

The following ticket is created to triage test failures: https://issues.redhat.com/browse/RHCEPHQE-1950
