### PR TITLE
Scale up and scale down cluster after upgrade

### DIFF
--- a/conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml
+++ b/conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml
@@ -1,0 +1,72 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+          - osd
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+        no-of-volumes: 4
+        disk-size: 15
+      node2:
+        role:
+          - osd
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - alertmanager
+          - crash
+          - rgw
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - mon
+          - osd
+          - node-exporter
+          - crash
+          - rgw
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - client
+      node5:
+        role:
+          - pool
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - pool
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role:
+          - pool
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role:
+          - pool
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - pool
+        no-of-volumes: 4
+        disk-size: 15
+      node10:
+        role:
+          - pool
+        no-of-volumes: 4
+        disk-size: 15

--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
@@ -1,0 +1,585 @@
+#############################################################################
+# Tier-level: 2
+# Test-Suite: tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
+# Test-Case: Test elasticity of cluster after upgrade from prev released version to current latest build
+#
+# Cluster configuration: (conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml)
+# --------------------------------------------------------------------------
+# Nodes:
+#    10-Node cluster(RHEL-8.3 and above)
+#    Initial cluster config - 3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
+#     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
+#     Node3 - Mon, OSD, MDS, RGW, node-exporter
+#     Node4 - Client
+#    Post upgrade
+#    Scale up cluster to 5 MONS, 5 MGRS, 4 RGWs, 4 MDSs, 2 NFSs, 2 ISCSIs and 10 OSD nodes
+#    Scale down cluster to initial configuration
+#
+# Test steps:
+# ---------------------------------------------------------------------
+# - Deploy containerised Nautilus Ceph cluster using CDN RPMS
+# - Run some I/O's
+# - Upgrade to Pacific using ceph-ansible and parallel run I/O's
+# - adopt to cephadm using ceph-adopt playbook
+# - Run some I/O's
+# - Scale up the cluster to 5 MONS, 5 MGRS, 4 RGWs, 4 MDSs, 2 NFSs, 2 ISCSIs and 10 OSD nodes
+# - Run some I/O's
+# - Scale down the cluster to its initial configuration
+# - Run some I/O's
+#
+#############################################################################
+tests:
+- test:
+    name: install ceph pre-requisites
+    module: install_prereq.py
+    config:
+      is_production: True
+    abort-on-fail: True
+
+- test:
+    name: ceph ansible install containerized rhcs 4.x from cdn
+    module: test_ansible.py
+    config:
+      use_cdn: True
+      build: '4.x'
+      ansi_config:
+        ceph_origin: repository
+        ceph_repository: rhcs
+        ceph_repository_type: cdn
+        ceph_rhcs_version: 4
+        osd_scenario: lvm
+        osd_auto_discovery: False
+        ceph_stable_rh_storage: True
+        containerized_deployment: True
+        ceph_docker_image: "rhceph/rhceph-4-rhel8"
+        ceph_docker_image_tag: "latest"
+        ceph_docker_registry: "registry.redhat.io"
+        copy_admin_key: True
+        dashboard_enabled: True
+        dashboard_admin_user: admin
+        dashboard_admin_password: p@ssw0rd
+        grafana_admin_user: admin
+        grafana_admin_password: p@ssw0rd
+        node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+        grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+        prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+        alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+    desc: deploy ceph containerized 4.x cdn setup using ceph-ansible
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      commands:
+        - ceph -s
+        - ceph versions
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: Parallel run
+    module: test_parallel.py
+    parallel:
+     - test:
+         name: rados_bench_test
+         module: radosbench.py
+         config:
+           pg_num: '128'
+           pool_type: 'normal'
+         desc: run rados bench for 360 - normal profile
+     - test:
+         name: rbd-io
+         module: rbd_faster_exports.py
+         config:
+           io-total: 100M
+           cleanup: False
+         desc: Perform export during read/write,resizing,flattening,lock operations
+     - test:
+         name: Upgrade containerized ceph to 5.x latest
+         module: test_ansible_upgrade.py
+         config:
+           build: '5.x'
+           ansi_config:
+             ceph_origin: distro
+             ceph_repository: rhcs
+             ceph_rhcs_version: 5
+             osd_scenario: lvm
+             osd_auto_discovery: False
+             fetch_directory: ~/fetch
+             copy_admin_key: True
+             containerized_deployment: True
+             upgrade_ceph_packages: True
+             dashboard_enabled: True
+             dashboard_admin_user: admin
+             dashboard_admin_password: p@ssw0rd
+             grafana_admin_user: admin
+             grafana_admin_password: p@ssw0rd
+             node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+             grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
+             prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+             alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
+         desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest -> cephadm adopt
+         abort-on-fail: True
+    desc: Running upgrade and i/o's parallelly
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      commands:
+        - ceph -s
+        - ceph versions
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: rbd-io
+    module: rbd_faster_exports.py
+    config:
+        io-total: 100M
+    desc: Perform export during read/write,resizing,flattening,lock operations
+
+- test:
+    name: rgw sanity tests
+    module: sanity_rgw.py
+    config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+    desc: Perform rgw tests
+
+- test:
+    name: Add new nodes to the cluster
+    module: test_add_node.py
+    config:
+      command: add_node
+      base_cmd_args:
+        verbose: True
+      args:
+        role: pool
+    desc: Perform pre req on all nodes with given role to add them to the cluster
+
+- test:
+    name: Add hosts to ceph cluster
+    desc: Add host node(s) with IP address and labels
+    module: test_host.py
+    config:
+      service: host
+      command: add_hosts
+      args:
+        nodes:
+          - node5
+          - node6
+          - node7
+          - node8
+          - node9
+          - node10
+        attach_ip_address: True
+        labels: apply-all-labels
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale up Monitor with placement
+    desc: Scale up monitor nodes to 5 with placement
+    module: test_mon.py
+    abort-on-fail: True
+    config:
+      command: apply
+      service: mon
+      base_cmd_args:
+        verbose: True
+      args:
+        placement:
+          nodes:
+              - node1
+              - node2
+              - node3
+              - node5
+              - node6
+          sep: ";"    # separator to be used for placements
+
+- test:
+    name: Scale up Manager service
+    desc: Scale up manager nodes to 5 with placement option
+    module: test_mgr.py
+    config:
+      command: apply
+      service: mgr
+      base_cmd_args:
+        verbose: True
+      args:
+        placement:
+          nodes:
+              - node1
+              - node2
+              - node3
+              - node5
+              - node6
+          sep: " "
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale up RGW Service
+    desc: Scale up RGW service to 4 nodes
+    module: test_rgw.py
+    config:
+      command: apply
+      service: rgw
+      base_cmd_args:          # arguments to ceph orch
+        verbose: True
+      pos_args:               # positional arguments
+        - myrgw                 # service id
+      args:
+        placement:
+          nodes:              # A list of strings that would looked up
+              - node7
+              - node8
+              - node9
+              - node10
+          limit: 4            # no of daemons
+          sep: ";"            # separator to be used for placements
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale up MDS Service
+    desc: Scale up MDS service to 4 nodes
+    module: test_mds.py
+    config:
+      command: apply
+      service: mds
+      base_cmd_args:          # arguments to ceph orch
+        verbose: True
+      pos_args:
+        - cephfs              # name of the filesystem
+      args:
+        placement:
+          nodes:
+            - node7
+            - node8
+            - node9
+            - node10
+          limit: 4            # no of daemons
+          sep: " "            # separator to be used for placements
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Create replicated pool for NFS
+    desc: Add pool for NFS Ganesha service
+    module: test_bootstrap.py
+    config:
+      command: shell
+      args:                     # command arguments
+        - ceph
+        - osd
+        - pool
+        - create
+        - nfs-ganesha-pool
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Enable rgw application on nfs-ganesha pool
+    desc: enable rgw on nfs-ganesha pool
+    module: test_bootstrap.py
+    config:
+      command: shell
+      args:             # command arguments
+        - ceph
+        - osd
+        - pool
+        - application
+        - enable
+        - nfs-ganesha-pool
+        - rgw
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Apply NFS Service
+    desc: Apply NFS-Ganesha service on role nodes
+    module: test_nfs.py
+    config:
+      command: apply
+      service: nfs
+      base_cmd_args:
+          verbose: True
+      pos_args:
+        - mynfs                         # nfs service ID
+        - nfs-ganesha-pool              # name of the pool
+      args:
+        placement:
+          nodes:
+            - node9
+            - node10
+          limit: 2
+          sep: ";"
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Create replicated pool
+    desc: Add pool for ISCSI service
+    module: test_bootstrap.py
+    config:
+      command: shell
+      args: # command arguments
+        - ceph
+        - osd
+        - pool
+        - create
+        - iscsi
+        - "3"
+        - "3"
+        - replicated
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Enable rbd application on pool
+    desc: enable rbd on iscsi pool
+    module: test_bootstrap.py
+    config:
+      command: shell
+      args: # command arguments
+        - ceph
+        - osd
+        - pool
+        - application
+        - enable
+        - iscsi
+        - rbd
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Apply ISCSI Service
+    desc: Apply ISCSI target service on iscsi role nodes
+    module: test_iscsi.py
+    config:
+      command: apply
+      service: iscsi
+      base_cmd_args:            # arguments to ceph orch
+        verbose: True
+      pos_args:
+        - iscsi                 # name of the pool
+        - api_user              # name of the API user
+        - api_pass              # password of the api_user.
+      args:
+        placement:
+          nodes:
+            - node7
+            - node8 # either label or node.
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      commands:
+        - ceph -s
+        - ceph versions
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: rbd-io
+    module: rbd_faster_exports.py
+    config:
+      io-total: 100M
+    desc: Perform export during read/write,resizing,flattening,lock operations
+
+- test:
+    name: rgw sanity tests
+    module: sanity_rgw.py
+    config:
+      script-name: test_multitenant_user_access.py
+      config-file-name: test_multitenant_access.yaml
+      timeout: 300
+    desc: Perform rgw tests
+
+- test:
+    name: Scale down Monitor with placement
+    desc: Scale down monitor nodes to 3 with placement
+    module: test_mon.py
+    abort-on-fail: True
+    config:
+      command: apply
+      service: mon
+      base_cmd_args:
+        verbose: True
+      args:
+        placement:
+          nodes:
+            - node1
+            - node5
+            - node6
+          sep: ";"    # separator to be used for placements
+
+- test:
+    name: Scale down Manager service
+    desc: Scale down manager nodes to 3 with placement option
+    module: test_mgr.py
+    config:
+      command: apply
+      service: mgr
+      base_cmd_args:
+        verbose: True
+      args:
+        placement:
+          nodes:
+            - node1
+            - node5
+            - node6
+          sep: " "
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale down RGW Service
+    desc: Scale down RGW service to 2 nodes
+    module: test_rgw.py
+    config:
+      command: apply
+      service: rgw
+      base_cmd_args: # arguments to ceph orch
+        verbose: True
+      pos_args: # positional arguments
+        - myrgw                 # service id
+      args:
+        placement:
+          nodes: # A list of strings that would looked up
+            - node9
+            - node10
+          limit: 2            # no of daemons
+          sep: ";"            # separator to be used for placements
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale down MDS Service
+    desc: Scale down MDS service to 2 nodes
+    module: test_mds.py
+    config:
+      command: apply
+      service: mds
+      base_cmd_args: # arguments to ceph orch
+        verbose: True
+      pos_args:
+        - cephfs              # name of the filesystem
+      args:
+        placement:
+          nodes:
+            - node7
+            - node8
+          limit: 2            # no of daemons
+          sep: " "            # separator to be used for placements
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale down NFS Service
+    desc: Scale down NFS-Ganesha service to 1 node
+    module: test_nfs.py
+    config:
+      command: apply
+      service: nfs
+      base_cmd_args:
+        verbose: True
+      pos_args:
+        - mynfs                         # nfs service ID
+        - nfs-ganesha-pool              # name of the pool
+      args:
+        placement:
+          nodes:
+            - node10
+          limit: 1
+          sep: ";"
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: Scale down ISCSI Service
+    desc: Scale down ISCSI target service to 1 node
+    module: test_iscsi.py
+    polarion-id: CEPH-83574776
+    config:
+      command: apply
+      service: iscsi
+      base_cmd_args: # arguments to ceph orch
+        verbose: True
+      pos_args:
+        - iscsi                 # name of the pool
+        - api_user              # name of the API user
+        - api_pass              # password of the api_user.
+      args:
+        placement:
+          nodes:
+            - node7
+    destroy-cluster: False
+    abort-on-fail: True
+
+- test:
+    name: check-ceph-health
+    module: exec.py
+    config:
+      commands:
+        - ceph -s
+        - ceph versions
+      sudo: True
+    desc: Check for ceph health debug info
+
+- test:
+    name: rados_bench_test
+    module: radosbench.py
+    config:
+      pg_num: '128'
+      pool_type: 'normal'
+    desc: run rados bench for 360 - normal profile
+
+- test:
+    name: rbd-io
+    module: rbd_faster_exports.py
+    config:
+      io-total: 100M
+    desc: Perform export during read/write,resizing,flattening,lock operations
+
+- test:
+    name: rgw sanity tests
+    module: sanity_rgw.py
+    config:
+      script-name: test_multitenant_user_access.py
+      config-file-name: test_multitenant_access.yaml
+      timeout: 300
+    desc: Perform rgw tests

--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
@@ -1,0 +1,633 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
+# Test-Case: Test elasticity of cluster after upgrade from Build-to-Build (B2B)
+#
+# Cluster Configuration:
+#    conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml
+#
+# Nodes:
+#    10-Node cluster(RHEL-8.3 and above)
+#    Initial cluster config - 3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
+#     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
+#     Node3 - Mon, OSD, MDS, RGW, node-exporter
+#     Node4 - Client
+#    Post upgrade
+#    Scale up cluster to 5 MONS, 5 MGRS, 4 RGWs, 4 MDSs, 2 NFSs, 2 ISCSIs and 10 OSD nodes
+#    Scale down cluster to initial configuration
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - custom_repo: "cdn"
+#       - skip-monitoring stack
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Deploy services using apply option,
+#       - 3 Mon on node1, node2, Node3
+#       - addition of OSD's using "all-available-devices" option.
+#       - RGW on node2, node3 with india.south(realm.zone) using label.
+#       - MDS on node2, node3 with host placements.
+#   (4) Upgrade to distro build(N) by provided Ceph image version.
+#   (5) Scale up cluster to 5 MONS, 5 MGRS, 4 RGWs, 4 MDSs, 2 NFSs, 2 ISCSIs and 10 OSD nodes
+#   (6) Run some I/O's
+#   (7) Scale down the cluster to its initial configuration
+#   (8) Run some I/O's
+#
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      config:
+        is_production: True
+      abort-on-fail: True
+  - test:
+      name: Cluster deployment
+      desc: Cluster deployment
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: True
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: True
+              args:
+                fsid: f64f341c-655d-11eb-8778-fa163e914bcc
+                custom_repo: "cdn"
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                skip-monitoring-stack: True
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                nodes:
+                  - node2
+                  - node3
+                  - node5
+                  - node6
+                  - node7
+                  - node8
+                attach_ip_address: True
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  nodes:
+                    - node1
+                    - node2
+                    - node3
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  nodes:
+                    - node1
+                    - node2
+                    - node3
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: True
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args: # arguments to ceph orch
+                verbose: True
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node7
+                    - node8
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+          - config:
+              command: apply
+              service: prometheus
+              args:
+                placement:
+                  nodes:
+                    - node1
+                  limit: 1
+                  sep: ";"
+          - config:
+              command: apply
+              service: grafana
+              args:
+                placement:
+                  nodes:
+                    - node1
+                  limit: 1
+                  sep: ";"
+          - config:
+              command: apply
+              service: alertmanager
+              args:
+                placement:
+                  nodes:
+                    - node1
+          - config:
+              command: apply
+              service: node-exporter
+              args:
+                placement:
+                  nodes: "*"
+          - config:
+              command: apply
+              service: crash
+              base_cmd_args:
+                verbose: True
+              args:
+                placement:
+                  nodes: "*"
+          - config:
+              command: apply
+              service: rgw
+              base_cmd_args: # arguments to ceph orch
+                verbose: True
+              pos_args: # positional arguments
+                - myrgw                 # service id
+              args:
+                placement:
+                  nodes: # A list of strings that would looked up
+                    - node7
+                    - node8
+                  limit: 2            # no of daemons
+                  sep: ";"            # separator to be used for placements
+      destroy-cluster: False
+      abort-on-fail: True
+  - test:
+      name: Configure client
+      desc: Configure client with admin keyring.
+      module: test_client.py
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>) --> /etc/ceph/ceph.{id}.keyring
+        node: node4                       # client node
+        copy_admin_keyring: True          # Copy admin keyring to node
+        store-keyring: /etc/ceph/ceph.client.1.keyring  # local copy at the installer
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      destroy-cluster: False
+      abort-on-fail: True
+  - test:
+      name: Parallel run
+      module: test_parallel.py
+      parallel:
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects.yaml
+              timeout: 300
+            desc: test to create "M" no of buckets and "N" no of objects
+            module: sanity_rgw.py
+            name: Test M buckets with N objects
+        - test:
+            name: rbd-io
+            module: rbd_faster_exports.py
+            config:
+              io-total: 100M
+            desc: Perform export during read/write,resizing,flattening,lock operations
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: test_cephadm_upgrade.py
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: True
+              benchmark:
+                type: rados                      # future-use
+                pool_per_client: True
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: True
+            destroy-cluster: False
+            abort-on-fail: True
+      desc: Running upgrade and i/o's parallelly
+  - test:
+      name: Add hosts to ceph cluster
+      desc: Add host node(s) with IP address and labels
+      module: test_host.py
+      config:
+        service: host
+        command: add_hosts
+        args:
+          nodes:
+            - node5
+            - node6
+            - node9
+            - node10
+          attach_ip_address: True
+          labels: apply-all-labels
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale up Monitor with placement
+      desc: Scale up monitor nodes to 5 with placement
+      module: test_mon.py
+      abort-on-fail: True
+      config:
+        command: apply
+        service: mon
+        base_cmd_args:
+          verbose: True
+        args:
+          placement:
+            nodes:
+                - node1
+                - node2
+                - node3
+                - node5
+                - node6
+            sep: ";"    # separator to be used for placements
+
+  - test:
+      name: Scale up Manager service
+      desc: Scale up manager nodes to 5 with placement option
+      module: test_mgr.py
+      config:
+        command: apply
+        service: mgr
+        base_cmd_args:
+          verbose: True
+        args:
+          placement:
+            nodes:
+                - node1
+                - node2
+                - node3
+                - node5
+                - node6
+            sep: " "
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale up RGW Service
+      desc: Scale up RGW service to 4 nodes
+      module: test_rgw.py
+      config:
+        command: apply
+        service: rgw
+        base_cmd_args:          # arguments to ceph orch
+          verbose: True
+        pos_args:               # positional arguments
+          - myrgw                 # service id
+        args:
+          placement:
+            nodes:              # A list of strings that would looked up
+                - node7
+                - node8
+                - node9
+                - node10
+            limit: 4            # no of daemons
+            sep: ";"            # separator to be used for placements
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale up MDS Service
+      desc: Scale up MDS service to 4 nodes
+      module: test_mds.py
+      config:
+        command: apply
+        service: mds
+        base_cmd_args:          # arguments to ceph orch
+          verbose: True
+        pos_args:
+          - cephfs              # name of the filesystem
+        args:
+          placement:
+            nodes:
+              - node7
+              - node8
+              - node9
+              - node10
+            limit: 4            # no of daemons
+            sep: " "            # separator to be used for placements
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Create replicated pool for NFS
+      desc: Add pool for NFS Ganesha service
+      module: test_bootstrap.py
+      config:
+        command: shell
+        args:                     # command arguments
+          - ceph
+          - osd
+          - pool
+          - create
+          - nfs-ganesha-pool
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Enable rgw application on nfs-ganesha pool
+      desc: enable rgw on nfs-ganesha pool
+      module: test_bootstrap.py
+      config:
+        command: shell
+        args:             # command arguments
+          - ceph
+          - osd
+          - pool
+          - application
+          - enable
+          - nfs-ganesha-pool
+          - rgw
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Apply NFS Service
+      desc: Apply NFS-Ganesha service on role nodes
+      module: test_nfs.py
+      config:
+        command: apply
+        service: nfs
+        base_cmd_args:
+            verbose: True
+        pos_args:
+          - mynfs                         # nfs service ID
+          - nfs-ganesha-pool              # name of the pool
+        args:
+          placement:
+            nodes:
+              - node9
+              - node10
+            limit: 2
+            sep: ";"
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Create replicated pool
+      desc: Add pool for ISCSI service
+      module: test_bootstrap.py
+      config:
+        command: shell
+        args: # command arguments
+          - ceph
+          - osd
+          - pool
+          - create
+          - iscsi
+          - "3"
+          - "3"
+          - replicated
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Enable rbd application on pool
+      desc: enable rbd on iscsi pool
+      module: test_bootstrap.py
+      config:
+        command: shell
+        args: # command arguments
+          - ceph
+          - osd
+          - pool
+          - application
+          - enable
+          - iscsi
+          - rbd
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Apply ISCSI Service
+      desc: Apply ISCSI target service on iscsi role nodes
+      module: test_iscsi.py
+      config:
+        command: apply
+        service: iscsi
+        base_cmd_args:            # arguments to ceph orch
+          verbose: True
+        pos_args:
+          - iscsi                 # name of the pool
+          - api_user              # name of the API user
+          - api_pass              # password of the api_user.
+        args:
+          placement:
+            nodes:
+              - node7
+              - node8 # either label or node.
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        commands:
+          - ceph -s
+          - ceph versions
+        sudo: True
+      desc: Check for ceph health debug info
+
+  - test:
+      name: rados_bench_test
+      module: radosbench.py
+      config:
+        pg_num: '128'
+        pool_type: 'normal'
+      desc: run rados bench for 360 - normal profile
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      name: Scale down Monitor with placement
+      desc: Scale down monitor nodes to 3 with placement
+      module: test_mon.py
+      abort-on-fail: True
+      config:
+        command: apply
+        service: mon
+        base_cmd_args:
+          verbose: True
+        args:
+          placement:
+            nodes:
+              - node1
+              - node5
+              - node6
+            sep: ";"    # separator to be used for placements
+
+  - test:
+      name: Scale down Manager service
+      desc: Scale down manager nodes to 3 with placement option
+      module: test_mgr.py
+      config:
+        command: apply
+        service: mgr
+        base_cmd_args:
+          verbose: True
+        args:
+          placement:
+            nodes:
+              - node1
+              - node5
+              - node6
+            sep: " "
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale down RGW Service
+      desc: Scale down RGW service to 2 nodes
+      module: test_rgw.py
+      config:
+        command: apply
+        service: rgw
+        base_cmd_args: # arguments to ceph orch
+          verbose: True
+        pos_args: # positional arguments
+          - myrgw                 # service id
+        args:
+          placement:
+            nodes: # A list of strings that would looked up
+              - node9
+              - node10
+            limit: 2            # no of daemons
+            sep: ";"            # separator to be used for placements
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale down MDS Service
+      desc: Scale down MDS service to 2 nodes
+      module: test_mds.py
+      config:
+        command: apply
+        service: mds
+        base_cmd_args: # arguments to ceph orch
+          verbose: True
+        pos_args:
+          - cephfs              # name of the filesystem
+        args:
+          placement:
+            nodes:
+              - node7
+              - node8
+            limit: 2            # no of daemons
+            sep: " "            # separator to be used for placements
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale down NFS Service
+      desc: Scale down NFS-Ganesha service to 1 node
+      module: test_nfs.py
+      config:
+        command: apply
+        service: nfs
+        base_cmd_args:
+          verbose: True
+        pos_args:
+          - mynfs                         # nfs service ID
+          - nfs-ganesha-pool              # name of the pool
+        args:
+          placement:
+            nodes:
+              - node10
+            limit: 2
+            sep: ";"
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: Scale down ISCSI Service
+      desc: Scale down ISCSI target service to 1 node
+      module: test_iscsi.py
+      polarion-id: CEPH-83574777
+      config:
+        command: apply
+        service: iscsi
+        base_cmd_args: # arguments to ceph orch
+          verbose: True
+        pos_args:
+          - iscsi                 # name of the pool
+          - api_user              # name of the API user
+          - api_pass              # password of the api_user.
+        args:
+          placement:
+            nodes:
+              - node7
+      destroy-cluster: False
+      abort-on-fail: True
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        commands:
+          - ceph -s
+          - ceph versions
+        sudo: True
+      desc: Check for ceph health debug info
+
+  - test:
+      name: rados_bench_test
+      module: radosbench.py
+      config:
+        pg_num: '128'
+        pool_type: 'normal'
+      desc: run rados bench for 360 - normal profile
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests

--- a/tests/cephadm/test_add_node.py
+++ b/tests/cephadm/test_add_node.py
@@ -1,0 +1,74 @@
+import tempfile
+
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def create_cephadm_pub_key_file(cls):
+    """
+    Creates the cephadm pub key file for the cluster
+    Args:
+        cls: cephadm instance object
+
+    Returns:
+        str: filename of the key file generated
+    """
+    ceph_pub_key, _ = cls.shell(args=["ceph", "cephadm", "get-pub-key"])
+    node = cls.installer
+    temp_file = tempfile.NamedTemporaryFile(suffix=".pub")
+    pub_key_file = node.node.remote_file(
+        sudo=True, file_name=temp_file.name, file_mode="w"
+    )
+    pub_key_file.write(ceph_pub_key)
+    pub_key_file.flush()
+
+    return temp_file.name
+
+
+def run(ceph_cluster, **kw):
+    """
+    Add node to the cluster
+
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): Ceph cluster object
+        kw: test data
+
+    - Perform all pre requisites necessary to add a node with role pool to the cluster
+
+        Example::
+            config:
+                command: add_node
+                base_cmd_args:
+                    verbose: true
+                args:
+                    role: <roles to be considered>
+                    ssh-user: <user>
+                    ssh-public-key: <full path to the ssh public key file>
+                    ssh-private-key: <full path to the ssh private key file>
+    """
+    config = kw.get("config")
+
+    # Manage Ceph using ceph-admin orchestration
+    command = config.pop("command")
+    log.info("Executing %s" % command)
+
+    instance = CephAdmin(cluster=ceph_cluster, **config)
+    log.info("Fetching pub key file")
+    pub_key_file = create_cephadm_pub_key_file(instance)
+    config["args"]["ssh-public-key"] = pub_key_file
+    log.info("Fetching nodes")
+    args = config["args"]
+    nodes = []
+    if args.get("role"):
+        nodes = instance.cluster.get_nodes(role=args["role"])
+
+    log.info("Distributing ceph pub key")
+
+    instance.distribute_cephadm_gen_pub_key(
+        ssh_key_path=args.get("output-pub-ssh-key") or args.get("ssh-public-key"),
+        nodes=nodes,
+    )
+    log.info("pub key distribution success")
+    return 0


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Adding test suites to scale up and scale down different daemons in the cluster after 4x to 5x and 5x to 5x+1 upgrade.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IUPLB2 


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
