### PR TITLE
Avoid failure of run if testname is a number

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -564,7 +564,7 @@ def create_unique_test_name(test_name, name_list):
     Returns:
         unique name for the test case
     """
-    base = "_".join(test_name.split())
+    base = "_".join(str(test_name).split())
     num = 0
     while "{base}_{num}".format(base=base, num=num) in name_list:
         num += 1


### PR DESCRIPTION
This fix avoids failure of run if test name is just a number.
This fix gives free-hand to formulate temporary suite files with test names as per users's convinience

modified:   utility/utils.py

Unhandled traceback without this commit -
Traceback (most recent call last):
  File "run.py", line 1045, in <module>
    rc = run(args)
  File "run.py", line 758, in run
    unique_test_name = create_unique_test_name(tc["name"], test_names)
  File "/home/vasishta/cephci/utility/utils.py", line 567, in create_unique_test_name
    base = "_".join(test_name.split())
AttributeError: 'int' object has no attribute 'split'

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
