### PR TITLE
Yaml inventory support for rhel9 nodes

### DIFF
--- a/conf/inventory/RHEL-9.0.0-x86_64-latest.yaml
+++ b/conf/inventory/RHEL-9.0.0-x86_64-latest.yaml
@@ -1,0 +1,39 @@
+version_id: 9.0
+id: rhel
+instance:
+  create:
+    image-name: RHEL-9.0.0-x86_64-nightly-latest
+    vm-size: ci.m1.medium
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: True
+
+    groups:
+        - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4eHmz10szeHNS3dNejKokW85ksB+iR4HGOFsmQM11Ni68Nm5aqEKvkOZU8TpY92vpCQL0A68GlrXB845cACdyk6HUJYyNNNMC43l1FYWOwjMqQBSdj8W3VQDTA6eiG60mt5fgI8fyR38rKzIA1MnTBkSSjuh5kQVJ9bdEp3GuY5oc8vxDNBlGJ6LYnyEWt/pqL2J+mpjqnOjsC+EbE2exhP9O+mvzpQiyo/+dEN1COwX3//pNRXGfOSeOczHNsJE8Eu+j/n/BlW57++sJyFMkzS7bUxMSGM6quvjQZ7RT1c5JM6vLEiQyzQxoRgzY93h1yKlOstBi0NamtpqHQZGP kdreyer@redhat.com
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDI0tHxJQ7n+uMiLpsoR6CKAVd0xatgVQuqp/gmnGpZU0kE54a29vPNnEt7/aLitbfyhc57rrbHOT09H3ov74GZKkoVBSbMJUSsK3drbN+58wcuk+HK0htRewmwCfcfi9AkrVbyw6pbPXW/pbjxnxLep52fKmpJJnImZ5eHRV5le9OSAcLA1LHYR4y9R3IOrTp7jgpE205UxZi5OopAx7gkyTsmfydvmq4MjaSwbVOJ7aW/Fdt5FVxNJP3Zl/OrvDoo/1WovoRIDbVQH8JFpLikMSnCqtBVIHDeW6imAKl6dpn9Gf4FxD94+OcurhXo2p0pvSzC4Strg4d2Sxqh4wph jenkins-build@jenkins
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser: pass123
+      expire: False
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - sudo yum clean metadata
+      - sudo yum clean all
+      - touch /ceph-qa-ready
+
+
+    final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rhel-9-latest.yaml
+++ b/conf/inventory/rhel-9-latest.yaml
@@ -1,0 +1,1 @@
+RHEL-9.0.0-x86_64-latest.yaml


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Added yaml inventory file for RHEL9 to support in cephci.
Fixes [RHCEPHQE-285](https://issues.redhat.com/browse/RHCEPHQE-285)

CLI used 
`python run.py --osp-cred osp/osp-cred-ci-2.yaml --global-conf conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml --suite suites/pacific/cephadm/tier-1_skip_dashboard.yaml --inventory conf/inventory/rhel-9-latest.yaml --rhs-ceph-repo http://download.eng.bos.redhat.com/rhel-9/composes/raw/ceph-5.1-rhel-9/latest-RHCEPH-5-RHEL-9/ --ignore-latest-container --docker-registry registry-proxy.engineering.redhat.com --docker-image rh-osbs/rhceph --docker-tag ceph-5.1-rhel-8-containers-candidate-52253-20220215213225 --insecure-registry --rhbuild 5.1 --platform rhel-9 --build latest --log-level debug`

RHEL 9 nodes got created in rhos-d
![RHEL9 node](https://user-images.githubusercontent.com/22169979/155084668-ed7daa87-664e-40c5-9cf7-3b6475d2b3a3.png)



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
