### PR TITLE
move indexless tests down the order

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -578,20 +578,6 @@ tests:
         config-file-name: test_bucket_link_unlink.yaml
         timeout: 500
 
-  # Index-less buckets
-
-  - test:
-      name: Indexless buckets
-      desc: Indexless (blind) buckets
-      comments: Known issue BZ-2043366
-      polarion-id: CEPH-10354, CEPH-10357
-      module: sanity_rgw.py
-      config:
-        test-version: v2
-        script-name: test_indexless_buckets.py
-        config-file-name: test_indexless_buckets_s3.yaml
-        timeout: 500
-
   # Multifactor Authentication tests
   - test:
       name: MFA deletes
@@ -669,3 +655,18 @@ tests:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
         timeout: 300
+
+  # Index-less buckets
+
+  - test:
+      name: Indexless buckets
+      desc: Indexless (blind) buckets
+      comments: Known issue BZ-2043366
+      polarion-id: CEPH-10354, CEPH-10357
+      module: sanity_rgw.py
+      config:
+        test-version: v2
+        script-name: test_indexless_buckets.py
+        config-file-name: test_indexless_buckets_s3.yaml
+        timeout: 500
+


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Moving the indexless tests down the order to avoid subsequent test failures due to indexless placement-targets

[logs]( https://159.23.92.24/job/tier-x/808/artifact/logs/e39yq-808/)


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
