### PR TITLE
Fixing log Dna issue buffer size

### DIFF
--- a/run.py
+++ b/run.py
@@ -399,12 +399,16 @@ def run(args):
 
     if log_dna_config:
         options = {
-            "hostname": "Cephci",
+            "hostname": f"Cephci-{run_id}",
             "url": log_dna_config.get("url"),
             "index_meta": True,
             "tags": run_id,
+            "buf_retention_limit": 419430400,
+            "flush_limit": 2 * 1024 * 1024 * 100,
+            "max_retry_attempts": 10,
         }
         apiKey = log_dna_config.get("api-key")
+
         logdna_handler = logdna.LogDNAHandler(apiKey, options)
         root.addHandler(logdna_handler)
 

--- a/utility/log.py
+++ b/utility/log.py
@@ -93,6 +93,11 @@ class Log:
         }
         extra = deepcopy(self.metadata)
         extra.update(kwargs.get("metadata", {}))
+        message = str(message)
+        if len(message.encode("utf-8")) > 16000:
+            chunks = [message[i : i + 16000] for i in range(0, len(message), 16000)]
+            for i in chunks:
+                log[level](i, *args, extra=extra, **kwargs)
         log[level](message, *args, extra=extra, **kwargs)
 
     def info(self, message: Any, *args, **kwargs) -> None:


### PR DESCRIPTION
Fixing log Dna issue buffer size

Problem : 

- Buffer limit is getting exceeded beyond limit and script is getting stuck.
- Log buffer getting flushed because of message size > 16 KB

Soultion:

- Increased the BUffer size to 419430400
- We have chunked the message in to 16KB and pushed the logs

Logs : 
https://159.23.92.24/job/custom_run_amk/22/console 
https://159.23.92.24/job/custom_run_amk/21/console 

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarin Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
