### PR TITLE
Validation of service created using a spec file 

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -124,5 +124,5 @@ class ApplyMixin:
         if not verify_service:
             return
 
-        if not self.check_service_exists(service_name=service_name):
+        if not self.check_service_exists(service_type=service_name):
             raise OrchApplyServiceFailure(self.SERVICE_NAME)

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -60,7 +60,7 @@ class Orch(
         return [node for node in loads(out) if label in node.get("labels")]
 
     def check_service_exists(
-        self, service_name: str, timeout: int = 300, interval: int = 5
+        self, service_type: str, timeout: int = 300, interval: int = 5
     ) -> bool:
         """
         Verify the provided service is running for the given list of ids.
@@ -77,7 +77,7 @@ class Orch(
         end_time = datetime.now() + timedelta(seconds=timeout)
         check_status_dict = {
             "base_cmd_args": {"format": "json"},
-            "args": {"service_name": service_name, "refresh": True},
+            "args": {"service_type": service_type, "refresh": True},
         }
 
         while end_time > datetime.now():
@@ -87,7 +87,7 @@ class Orch(
             running = out["status"]["running"]
             count = out["status"]["size"]
 
-            LOG.info("%s/%s %s daemon(s) up... retrying", running, count, service_name)
+            LOG.info("%s/%s %s daemon(s) up... retrying", running, count, service_type)
 
             if count == running:
                 return True
@@ -95,7 +95,7 @@ class Orch(
         # Identify the failure
         out, err = self.ls(check_status_dict)
         out = loads(out)
-        LOG.error(f"{service_name} failed with \n{out[0]['events']}")
+        LOG.error(f"{service_type} failed with \n{out[0]['events']}")
 
         return False
 
@@ -204,8 +204,10 @@ class Orch(
         # todo: add verification part
 
         # validate services
-        if config["validate-spec-services"]:
+        validate_spec_services = config.get("validate-spec-services")
+        if validate_spec_services:
             self.validate_spec_services(specs=specs)
+            LOG.info("Validation of service created using a spec file is completed")
 
     def op(self, op, config):
         """
@@ -301,8 +303,8 @@ class Orch(
             return True
         return False
 
-    def validate_spec_services(self, specs) -> bool:
+    def validate_spec_services(self, specs) -> None:
         LOG.info("Validating spec services")
         for spec in specs:
-            self.check_service_exists(service_name=spec["service_type"])
+            self.check_service_exists(service_type=spec["service_type"])
         return False

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -187,9 +187,10 @@ class Orch(
             base_cmd.append(base_cmd_args_str)
 
         base_cmd.append("apply -i")
+        specs = config["specs"]
 
         spec_cls = GenerateServiceSpec(
-            node=self.installer, cluster=self.cluster, specs=config["specs"]
+            node=self.installer, cluster=self.cluster, specs=specs
         )
         spec_filename = spec_cls.create_spec_file()
         base_cmd.append(spec_filename)
@@ -201,6 +202,10 @@ class Orch(
 
         LOG.info(f"apply-spec command response :\n{out}")
         # todo: add verification part
+
+        # validate services
+        if config["validate-spec-services"]:
+            self.validate_spec_services(specs=specs)
 
     def op(self, op, config):
         """
@@ -294,4 +299,10 @@ class Orch(
         elif op == "resume" and not loads(out)["paused"]:
             LOG.info("The orch operations are resumed")
             return True
+        return False
+
+    def validate_spec_services(self, specs) -> bool:
+        LOG.info("Validating spec services")
+        for spec in specs:
+            self.check_service_exists(service_name=spec["service_type"])
         return False

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -56,7 +56,7 @@ class OrchProtocol(CephAdmProtocol, Protocol):
         ...
 
     def check_service_exists(
-        self, service_name: str, timeout: int = 300, interval: int = 5
+        self, service_type: str, timeout: int = 300, interval: int = 5
     ) -> bool:
         ...
 
@@ -75,7 +75,7 @@ class OrchProtocol(CephAdmProtocol, Protocol):
     def verify_status(self, op: str) -> None:
         ...
 
-    def validate_spec_services(self, steps) -> bool:
+    def validate_spec_services(self, steps):
         ...
 
 

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -75,6 +75,9 @@ class OrchProtocol(CephAdmProtocol, Protocol):
     def verify_status(self, op: str) -> None:
         ...
 
+    def validate_spec_services(self, steps) -> bool:
+        ...
+
 
 class DaemonProtocol(OrchProtocol, Protocol):
     """Daemon protocol object for supporting static duck typing hints."""

--- a/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
+++ b/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
@@ -69,10 +69,14 @@ tests:
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
           config:
             mgr:
-              mgr/cephadm/container_image_grafana: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5-27
-              mgr/cephadm/container_image_alertmanager: openshift4/ose-prometheus-alertmanager:v4.9.0-202110182323.p0.git.579e3c6.assembly.stream
-              mgr/cephadm/container_image_prometheus: registry.redhat.io/openshift4/ose-prometheus:v4.9.0-202110182323.p0.git.3197fa7.assembly.stream
-              mgr/cephadm/container_image_node_exporter: openshift4/ose-prometheus-node-exporter:v4.6.0-202107070256.p0.git.c63b8f3
+              mgr/cephadm/container_image_grafana:
+                registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5-27
+              mgr/cephadm/container_image_alertmanager:
+                openshift4/ose-prometheus-alertmanager:v4.9.0-202110182323.p0.git.579e3c6.assembly.stream
+              mgr/cephadm/container_image_prometheus:
+                registry.redhat.io/openshift4/ose-prometheus:v4.9.0-202110182323.p0.git.3197fa7.assembly.stream
+              mgr/cephadm/container_image_node_exporter:
+                openshift4/ose-prometheus-node-exporter:v4.6.0-202107070256.p0.git.c63b8f3
       destroy-cluster: false
       abort-on-fail: true
   - test:
@@ -82,32 +86,32 @@ tests:
       polarion-id: CEPH-83574726
       config:
         steps:
-        - config:
-            service: host
-            command: set_address
-            args:
-              node: node1
-        - config:
-            service: host
-            command: label_add
-            args:
-              node: node1
-              labels: apply-all-labels
-        - config:
-            command: apply_spec
-            service: orch
-            specs:
-             - service_type: host
-               address: true
-               labels: apply-all-labels
-               nodes:
-                 - node2
-                 - node3
-             - service_type: host
-               address: true
-               labels: apply-all-labels
-               nodes:
-                 - node4
+          - config:
+              service: host
+              command: set_address
+              args:
+                node: node1
+          - config:
+              service: host
+              command: label_add
+              args:
+                node: node1
+                labels: apply-all-labels
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: host
+                  address: true
+                  labels: apply-all-labels
+                  nodes:
+                    - node2
+                    - node3
+                - service_type: host
+                  address: true
+                  labels: apply-all-labels
+                  nodes:
+                    - node4
   - test:
       name: Service deployment with spec
       desc: Add services using spec file.
@@ -115,50 +119,51 @@ tests:
       polarion-id: CEPH-83573746,CEPH-83574727
       config:
         steps:
-        - config:
-            command: apply_spec
-            service: orch
-            specs:
-            - service_type: mon
-              placement:
-                nodes:
-                - node1
-                - node2
-                - node3
-            - service_type: mgr
-              placement:
-                label: mgr
-            - service_type: prometheus
-              placement:
-                count: 1
-                nodes:
-                  - node1
-            - service_type: grafana
-              placement:
-                nodes:
-                  - node1
-            - service_type: alertmanager
-              placement:
-                count: 2
-                label: alertmanager
-            - service_type: node-exporter
-              placement:
-                host_pattern: "*"
-            - service_type: crash
-              placement:
-                host_pattern: "*"
-            - service_type: osd
-              service_id: all-available-devices
-              encrypted: "true"                     # boolean as string
-              placement:
-                host_pattern: "*"
-              data_devices:
-                all: "true"                         # boolean as string
-        - config:
-            command: shell
-            args:                 # sleep to get all services deployed
-              - sleep
-              - "300"
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mon
+                  placement:
+                    nodes:
+                      - node1
+                      - node2
+                      - node3
+                - service_type: mgr
+                  placement:
+                    label: mgr
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 2
+                    label: alertmanager
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
+                - service_type: osd
+                  service_id: all-available-devices
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    host_pattern: "*"
+                  data_devices:
+                    all: "true"                         # boolean as string
+          - config:
+              command: shell
+              args:                 # sleep to get all services deployed
+                - sleep
+                - "300"
   - test:
       name: MDS Service deployment with spec
       desc: Add MDS services using spec file
@@ -292,4 +297,4 @@ tests:
         sudo: True
         check_status: True
         commands:
-        - "ceph status"
+          - "ceph status"

--- a/unittests/ceph/ceph_admin/test_apply.py
+++ b/unittests/ceph/ceph_admin/test_apply.py
@@ -12,7 +12,7 @@ class MockApplyMixinTestWithShellOutput(ApplyMixin):
     def shell(self, args):
         return "Scheduled rgw update", 0
 
-    def check_service_exists(self, service_name="rgw"):
+    def check_service_exists(self, service_type="rgw"):
         return True
 
 
@@ -24,7 +24,7 @@ class MockApplyMixinTestWithOutShellOutput(ApplyMixin):
     def shell(self, args):
         return 0, 0
 
-    def check_service_exists(self, service_name="rgw"):
+    def check_service_exists(self, service_type="rgw"):
         return True
 
 
@@ -36,7 +36,7 @@ class MockApplyMixinTestWithOutServiceOutput(ApplyMixin):
     def shell(self, args):
         return 0, 0
 
-    def check_service_exists(self, service_name="rgw"):
+    def check_service_exists(self, service_type="rgw"):
         return False
 
 


### PR DESCRIPTION
# Description
Added validation of services when created using a spec file. 
Also modified check_services_exists to use service type instead of service_name as in case of osd when we use `all-available-devices` the ` "service_name": "osd.all-available-devices" `


#ceph orch  --format json-pretty ls  --service_type osd

"placement": {
      "host_pattern": "*"
    },
    "service_id": "all-available-devices",
    "service_name": "osd.all-available-devices",
    "service_type": "osd",
    "spec": {
      "data_devices": {
        "all": true
      },
      "encrypted": true,
      "filter_logic": "AND",
      "objectstore": "bluestore"
    },
    "status": {
      "created": "2022-02-22T13:43:12.688559Z",
      "last_refresh": "2022-02-23T04:44:11.293054Z",
      "running": 17,
      "size": 21


The log has a failure due to bz "OSD count mismatched with ceph orch commands "

Bz: https://bugzilla.redhat.com/show_bug.cgi?id=1959508
Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HIN5A0/