### PR TITLE
fix issue in install pre-req to install pkgs consideration

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -134,7 +134,7 @@ def install_prereq(
         #  suites(rhcs3,4) are compatible
         if distro_ver.startswith("8"):
             rpm_all_packages = rpm_packages.get("py3") + ["net-tools"]
-            if rhbuild[0] > "5":
+            if rhbuild[0] > "4":
                 rpm_all_packages = rpm_packages.get("py3") + ["lvm2", "podman"]
             rpm_all_packages = " ".join(rpm_all_packages)
         else:


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

`rhbuild[0] > "5":` should be `rhbuild[0] > "4":` for 5x pkgs.