### PR TITLE
Adding support for RHEL-9 platform

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -748,20 +748,21 @@ def config_ntp(ceph_node, cloud_type="openstack"):
     """
     distro_info = ceph_node.distro_info
     distro_ver = distro_info["VERSION_ID"]
+    key = "7" if distro_ver.split(".")[0] == "7" else "all"
 
     ntp_config = {
         "7": [
             "sed -i '/server*/d' /etc/ntp.conf",
             "echo 'server clock.corp.redhat.com iburst' | tee -a /etc/ntp.conf",
         ],
-        "8": [
+        "all": [
             "sed -i '/pool*/d;/server*/d' /etc/chrony.conf",
             "sed -i '1i server clock.corp.redhat.com iburst' /etc/chrony.conf",
         ],
     }
     if cloud_type not in ["ibmc", "baremetal"]:
         # IBM-Cloud hosted environments are configured via the DHCP client.
-        commands = ntp_config[distro_ver.split(".")[0]]
+        commands = ntp_config[key]
         for cmd in commands:
             ceph_node.exec_command(sudo=True, cmd=cmd, long_running=True)
 
@@ -773,14 +774,14 @@ def config_ntp(ceph_node, cloud_type="openstack"):
             "ntpq -p",
             "ntpstat",
         ],
-        "8": [
+        "all": [
             "systemctl stop chronyd.service",
             "systemctl start chronyd.service",
             "chronyc makestep",
             "chronyc sources",
         ],
     }
-    commands = ntp_run[distro_ver.split(".")[0]]
+    commands = ntp_run[key]
 
     for cmd in commands:
         ceph_node.exec_command(sudo=True, cmd=cmd, long_running=True)

--- a/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
+++ b/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
@@ -26,8 +26,8 @@ instance:
 
     chpasswd:
       list: |
-        root: passwd
-        cephuser: pass123
+        root:passwd
+        cephuser:pass123
       expire: False
 
     runcmd:

--- a/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.4-minimal-amd64-1.yaml
@@ -26,8 +26,8 @@ instance:
 
     chpasswd:
       list: |
-        root: passwd
-        cephuser: pass123
+        root:passwd
+        cephuser:pass123
       expire: False
 
     runcmd:

--- a/conf/inventory/ibm-vpc-rhel-8.5-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.5-minimal-amd64-1.yaml
@@ -26,8 +26,8 @@ instance:
 
     chpasswd:
       list: |
-        root: passwd
-        cephuser: pass123
+        root:passwd
+        cephuser:pass123
       expire: False
 
     runcmd:

--- a/conf/inventory/rhel-8.5-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.5-server-x86_64.yaml
@@ -26,7 +26,7 @@ instance:
     chpasswd:
       list: |
         root:passwd
-        cephuser: pass123
+        cephuser:pass123
       expire: False
 
     runcmd:

--- a/conf/inventory/rhel-9-latest.yaml
+++ b/conf/inventory/rhel-9-latest.yaml
@@ -1,1 +1,1 @@
-RHEL-9.0.0-x86_64-latest.yaml
+rhel-9.0-server-x86_64.yaml

--- a/conf/inventory/rhel-9.0-server-x86_64.yaml
+++ b/conf/inventory/rhel-9.0-server-x86_64.yaml
@@ -9,6 +9,7 @@ instance:
     #cloud-config
 
     ssh_pwauth: True
+    disable_root: false
 
     groups:
         - cephuser
@@ -20,17 +21,19 @@ instance:
         shell: /bin/bash
         ssh-authorized-keys:
            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4eHmz10szeHNS3dNejKokW85ksB+iR4HGOFsmQM11Ni68Nm5aqEKvkOZU8TpY92vpCQL0A68GlrXB845cACdyk6HUJYyNNNMC43l1FYWOwjMqQBSdj8W3VQDTA6eiG60mt5fgI8fyR38rKzIA1MnTBkSSjuh5kQVJ9bdEp3GuY5oc8vxDNBlGJ6LYnyEWt/pqL2J+mpjqnOjsC+EbE2exhP9O+mvzpQiyo/+dEN1COwX3//pNRXGfOSeOczHNsJE8Eu+j/n/BlW57++sJyFMkzS7bUxMSGM6quvjQZ7RT1c5JM6vLEiQyzQxoRgzY93h1yKlOstBi0NamtpqHQZGP kdreyer@redhat.com
-           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDI0tHxJQ7n+uMiLpsoR6CKAVd0xatgVQuqp/gmnGpZU0kE54a29vPNnEt7/aLitbfyhc57rrbHOT09H3ov74GZKkoVBSbMJUSsK3drbN+58wcuk+HK0htRewmwCfcfi9AkrVbyw6pbPXW/pbjxnxLep52fKmpJJnImZ5eHRV5le9OSAcLA1LHYR4y9R3IOrTp7jgpE205UxZi5OopAx7gkyTsmfydvmq4MjaSwbVOJ7aW/Fdt5FVxNJP3Zl/OrvDoo/1WovoRIDbVQH8JFpLikMSnCqtBVIHDeW6imAKl6dpn9Gf4FxD94+OcurhXo2p0pvSzC4Strg4d2Sxqh4wph jenkins-build@jenkins
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
 
     chpasswd:
       list: |
         root:passwd
-        cephuser: pass123
+        cephuser:pass123
       expire: False
 
     runcmd:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - sudo systemctl restart sshd
       - sudo yum clean metadata
       - sudo yum clean all
       - touch /ceph-qa-ready

--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -14,26 +14,27 @@ log = Log(__name__)
 
 
 rpm_packages = {
-    "py2": [
+    "7": [
         "wget",
-        "git",
+        "git-core",
         "python-virtualenv",
         "python-nose",
         "ntp",
         "python2-pip",
         "chrony",
     ],
-    "py3": [
+    "all": [
         "wget",
-        "git",
-        "python3-virtualenv",
-        "python3-nose",
-        "python3-pip",
+        "git-core",
+        "python3-devel",
         "chrony",
         "yum-utils",
+        "net-tools",
+        "lvm2",
+        "podman",
     ],
 }
-deb_packages = ["wget", "git", "python-virtualenv", "lsb-release", "ntp"]
+deb_packages = ["wget", "git-core", "python-virtualenv", "lsb-release", "ntp"]
 deb_all_packages = " ".join(deb_packages)
 
 
@@ -128,23 +129,21 @@ def install_prereq(
                     enable_rhel_rpms(ceph, distro_ver)
             else:
                 log.info("Skipped enabling the RHEL RPM's provided by Subscription")
+
         if repo:
             setup_addition_repo(ceph, repo)
-        # TODO enable only python3 rpms on both rhel7 &rhel8 once all component
-        #  suites(rhcs3,4) are compatible
-        if distro_ver.startswith("8"):
-            rpm_all_packages = rpm_packages.get("py3") + ["net-tools"]
-            if rhbuild[0] > "4":
-                rpm_all_packages = rpm_packages.get("py3") + ["lvm2", "podman"]
-            rpm_all_packages = " ".join(rpm_all_packages)
-        else:
-            rpm_all_packages = " ".join(rpm_packages.get("py2"))
+
+        rpm_all_packages = " ".join(rpm_packages.get("all"))
+        if distro_ver.startswith("7"):
+            rpm_all_packages = " ".join(rpm_packages.get("7"))
+
         ceph.exec_command(
-            cmd="sudo yum install -y " + rpm_all_packages, long_running=True
+            cmd=f"sudo yum install -y {rpm_all_packages}", long_running=True
         )
         if ceph.role == "client":
-            ceph.exec_command(cmd="sudo yum install -y attr", long_running=True)
+            ceph.exec_command(cmd="sudo yum install -y attr gcc", long_running=True)
             ceph.exec_command(cmd="sudo pip install crefi", long_running=True)
+
         ceph.exec_command(cmd="sudo yum clean metadata")
         config_ntp(ceph, cloud_type)
 
@@ -258,6 +257,7 @@ def enable_rhel_rpms(ceph, distro_ver):
     repos = {
         "7": ["rhel-7-server-rpms", "rhel-7-server-extras-rpms"],
         "8": ["rhel-8-for-x86_64-appstream-rpms", "rhel-8-for-x86_64-baseos-rpms"],
+        "9": ["rhel-9-for-x86_64-appstream-rpms", "rhel-9-for-x86_64-baseos-rpms"],
     }
 
     for repo in repos.get(distro_ver[0]):
@@ -323,9 +323,9 @@ def registry_login(ceph, distro_ver):
 
     In this method, docker or podman is installed based on OS.
     """
-    container = "docker"
-    if distro_ver.startswith("8"):
-        container = "podman"
+    container = "podman"
+    if distro_ver.startswith("7"):
+        container = "docker"
 
     ceph.exec_command(
         cmd="sudo yum install -y {c}".format(c=container), long_running=True

--- a/tests/misc_env/sosreport.py
+++ b/tests/misc_env/sosreport.py
@@ -1,4 +1,4 @@
-""" Collecting logs using sosreport from all nodes in cluster Except Client Node"""
+""" Collecting logs using sosreport from all nodes in cluster Except Client Node."""
 
 import re
 
@@ -9,22 +9,27 @@ log = Log(__name__)
 
 
 def run(**kw):
-    """
+    """Entry point for execution used by cephci framework.
+
     :param kw:
        - ceph_nodes: ceph node list representing a cluster
+
     :return: 0 on success, 1 for failures
     """
     log.info(f"MetaData Information {log.metadata} in {__name__}")
     ceph_nodes = kw.get("ceph_nodes")
     results = dict()
+
     log.info("Running sosreport test")
     with parallel() as p:
         for cnode in ceph_nodes:
             if cnode.role != "client":
                 p.spawn(generate_sosreport, cnode, results)
+
     log.info(results)
     if all(results.values()):
         return 0
+
     return 1
 
 
@@ -33,32 +38,27 @@ def generate_sosreport(cnode, results):
     Generate sosreport to the given node and validate for the ceph
     :param:
        - ceph_nodes: ceph node list representing a cluster
-       - results: Dictionary to store cnode and result of this function as boolean. True for Success False otherwise
+       - results: Dictionary to store cnode and result of this function as boolean.
+                  True for Success False otherwise
     """
     node = cnode.hostname
     try:
         results.update({node: True})
-        out, err = cnode.exec_command(
-            sudo=True, cmd="yum -y install sos", long_running=True
-        )
-        if err:
-            results[node] = False
-            return
+        cnode.exec_command(cmd="sudo yum -y install sos", check_ec=False)
+
         out, err = cnode.exec_command(
             sudo=True, cmd="sosreport -a --all-logs -e ceph --batch", long_running=True
         )
         sosreport = re.search(r"/var/tmp/sosreport-.*.tar.xz", out)
         if err and not sosreport:
+            log.error(err)
             results[node] = False
             return
+
         log.info(f"Generated sosreport is :{sosreport.group()}")
-        out, err = cnode.exec_command(
-            sudo=True,
-            cmd=f"tar -tvf {sosreport.group()} '*ceph*' | wc -l",
-            long_running=True,
+        cnode.exec_command(
+            sudo=True, cmd=f"tar -tvf {sosreport.group()} '*ceph*' | wc -l"
         )
-        if err or int(out) < 1:
-            results[node] = False
-            return
-    except Exception:
+    except BaseException as be:  # noqa
+        log.exception(be)
         results[node] = False


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
The necessary changes to support RHEL-9 platform is carried out in this PR.

- The gathering of ceph-common and ceph-ansible versions is refactored so that we avoid any `NoneType` errors encountered when the packages are not found in the known paths.
- A change is also done as an enabler for `ibmc-baremetal`.
- sos report installation is modified due to warnings messages being displayed.

__cli__
```
/home/psathyan/venv/cephci.venv/bin/python run.py \
  --log-level debug \
  --instances-name prag01 \
  --osp-cred /home/psathyan/.osp-core.yaml \
  --rhbuild 5.1 \
  --platform rhel-9 \
  --build latest \
  --global-conf conf/pacific/rgw/tier-0_rgw.yaml \
  --inventory conf/inventory/rhel-9-latest.yaml \
  --suite suites/pacific/rgw/tier-0_rgw.yaml \
  --reuse rerun/prag01-5ON35E \
  --skip-subscription \
  --add-repo http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/repofile.repo \
  --skip-sos-report
```

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/rhel-9/
RHEL-7: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/test_r/