### PR TITLE
Enable monitoring stack when skip-dashboard used in bootstrap

### DIFF
--- a/suites/pacific/cephadm/tier-1_skip_dashboard.yaml
+++ b/suites/pacific/cephadm/tier-1_skip_dashboard.yaml
@@ -246,3 +246,39 @@ tests:
           password: admin@123
       destroy-cluster: false
       abort-on-fail: true
+  - test:
+      name: Enable the alertmanager
+      desc: Enables alertmanager monitoring stack
+      module: test_dashboard.py
+      polarion-id: CEPH-83574783
+      config:
+        command: enable_alertmanager
+        args:
+          alertmanager-port: "9093"
+          alertmanager_ssl_set: False
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Enable the prometheus
+      desc: Enables prometheus monitoring stack
+      module: test_dashboard.py
+      polarion-id: CEPH-83574782
+      config:
+        command: enable_prometheus
+        args:
+          prometheus-port: "9095"
+          prmoetheus-ssl-set: False
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Enable the grafana
+      desc: Enables grafana monitoring stack
+      module: test_dashboard.py
+      polarion-id: CEPH-83574784
+      config:
+        command: enable_grafana
+        args:
+          grafana-port: "3000"
+          grafana-ssl-set: False
+      destroy-cluster: false
+      abort-on-fail: true


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Fixes [RHCEPHQE-880](https://issues.redhat.com/browse/RHCEPHQE-880)
Enabling the monitoring stack like Prometheus, alert-manager, and grafana when skip-dashboard used in bootstrap

Test Results: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W6UV1Y

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
