### PR TITLE
Not send UMB message on error

### DIFF
--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -546,8 +546,8 @@ def uploadResults(def objKey, def dirName, def bucketName="qe-ci-reports") {
 
         sh script: "${cpFile} && ${cmd} ${scriptFile} ${args}"
     } catch(Exception exc) {
-        println "Encountered a failure during uploading of results."
         println exc
+        error "Encountered a failure during uploading of results."
     }
 }
 


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Downstream listener job should not send UMB message on exception.