### PR TITLE
Fail create_pool if pool creation fails

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -73,7 +73,9 @@ class Rbd:
     def create_pool(self, poolname):
         if self.ceph_version > 2 and self.k_m:
             self.create_ecpool(profile=self.ec_profile, poolname=self.datapool)
-        self.exec_cmd(cmd="ceph osd pool create {} 64 64".format(poolname))
+        if not self.exec_cmd(cmd="ceph osd pool create {} 64 64".format(poolname)):
+            log.error("Pool creation failed")
+            return False
         if not self.check_pool_exists(pool_name=poolname):
             log.error("Pool not created")
             return False


### PR DESCRIPTION
create_pool method should return false as soon as pool creation fails
As of now unhandled TypeError is occurring as pool doesn't exist

Signed-off-by: Vasishta <vashastr@redhat.com>