### PR TITLE
Added workaround for grafana deployment for 5.1 test runs

### DIFF
--- a/pipeline/cron-pipeline-test-executor.groovy
+++ b/pipeline/cron-pipeline-test-executor.groovy
@@ -67,8 +67,18 @@ node(nodeName) {
                 error "Required Prameters are not provided.."
             }
 
+            /*
+                Temporary work-around to set grafana_image and will be removed as soon
+                as beta is available.
+                Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2062627
+            */
+            def cliArgs = "--build latest --xunit-results "
+            if ( rhcephVersion == "5.1" ){
+                cliArgs += "--custom-config grafana_image=registry-proxy.engineering.redhat.com/rh-osbs/grafana:ceph-5.1-rhel-8-containers-candidate-30294-20220307225425"
+            }
+
             testStages = sharedLib.fetchStages(
-                "--build latest --xunit-results",
+                cliArgs,
                 buildType,
                 testResults,
                 rhcephVersion,

--- a/pipeline/ibm-tier-0.groovy
+++ b/pipeline/ibm-tier-0.groovy
@@ -64,8 +64,18 @@ node(nodeName) {
             error "Required Prameters are not provided.."
         }
 
+        /*
+            Temporary work-around to set grafana_image and will be removed as soon
+            as beta is available.
+            Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2062627
+        */
+        def cliArgs = "--build ${buildType} --cloud ibmc --xunit-results "
+        if ( rhcephVersion == "5.1" ){
+            cliArgs += "--custom-config grafana_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/grafana:ceph-5.1-rhel-8-containers-candidate-30294-20220307225425"
+        }
+
         testStages = sharedLib.fetchStages(
-            "--build ${buildType} --cloud ibmc --xunit-results",
+            cliArgs,
             buildPhase,
             testResults,
             rhcephVersion

--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -79,12 +79,22 @@ node(nodeName) {
         buildPhase = buildPhaseValue[1].toInteger()+1
         buildPhase = buildPhaseValue[0]+"-"+buildPhase
 
+        /*
+            Temporary work-around to set grafana_image and will be removed as soon
+            as beta is available.
+            Ref: https://bugzilla.redhat.com/show_bug.cgi?id=2062627
+        */
+        def cliArgs = "--build tier-0 --cloud ibmc --xunit-results "
+        if ( rhcephVersion == "5.1" ){
+            cliArgs += "--custom-config grafana_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/grafana:ceph-5.1-rhel-8-containers-candidate-30294-20220307225425"
+        }
+
         // Till the pipeline matures, using the build that has passed tier-0 suite.
         testStages = sharedLib.fetchStages(
-            "--build tier-0 --cloud ibmc --xunit-results",
-             buildPhase,
-             testResults,
-             rhcephversion
+            cliArgs,
+            buildPhase,
+            testResults,
+            rhcephversion
         )
 
         // Removing suites that are meant to be executed only in RH network.


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Workaround is to deploy grafana with currently available development container image.
- This PR needs to be reverted when beta-image is available.

**Issue:**
```
$ podman pull registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest
Trying to pull registry.redhat.io/rhceph-beta/rhceph-5-dashboard-rhel8:latest...
Error: Source image rejected: None of the signatures were accepted, reasons: Invalid GPG signature:
```