### PR TITLE
Fix interop failures in RHEL 8.6

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -761,6 +761,7 @@ class Ceph(object):
         ubuntu_repo,
         build=None,
         cloud_type="openstack",
+        exclude_ansible=False,
     ):
         """
         Setup packages required for ceph-ansible istallation
@@ -770,6 +771,8 @@ class Ceph(object):
             installer_url (str): installer url
             ubuntu_repo (str): deb repo url
             build (str):  ansible_config.build or rhbuild cli argument
+            cloud_type (str): IaaS provider - defaults to OpenStack.
+            exclude_ansible (bool): Excludes the ansible package from being upgraded
         """
         if not build:
             build = self.rhcs_version
@@ -841,12 +844,18 @@ class Ceph(object):
                     node.exec_command(
                         sudo=True, cmd="yum update metadata", check_ec=False
                     )
+
+                    cmd = "yum update -y"
+                    if exclude_ansible:
+                        cmd += " --exclude=ansible*"
+
                     p.spawn(
                         node.exec_command,
                         sudo=True,
-                        cmd="yum update -y",
+                        cmd=cmd,
                         long_running=True,
                     )
+
                 sleep(10)
 
     def create_rbd_pool(self, k_and_m, cluster_name=None):

--- a/conf/inventory/rhel-8.6-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.6-server-x86_64.yaml
@@ -1,0 +1,42 @@
+---
+version_id: 8.6
+id: rhel
+instance:
+  create:
+    image-name: RHEL-8.6.0-x86_64-nightly-latest
+    vm-size: ci.m1.medium
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: True
+
+    groups:
+        - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4eHmz10szeHNS3dNejKokW85ksB+iR4HGOFsmQM11Ni68Nm5aqEKvkOZU8TpY92vpCQL0A68GlrXB845cACdyk6HUJYyNNNMC43l1FYWOwjMqQBSdj8W3VQDTA6eiG60mt5fgI8fyR38rKzIA1MnTBkSSjuh5kQVJ9bdEp3GuY5oc8vxDNBlGJ6LYnyEWt/pqL2J+mpjqnOjsC+EbE2exhP9O+mvzpQiyo/+dEN1COwX3//pNRXGfOSeOczHNsJE8Eu+j/n/BlW57++sJyFMkzS7bUxMSGM6quvjQZ7RT1c5JM6vLEiQyzQxoRgzY93h1yKlOstBi0NamtpqHQZGP kdreyer@redhat.com
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser:pass123
+      expire: False
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - curl -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
+      - update-ca-trust
+      - sudo yum clean metadata
+      - sudo yum clean all
+      - touch /ceph-qa-ready
+
+    final_message: "Ready for ceph qa testing"

--- a/pipeline/scripts/4/interop/test-cephfs-core-features.sh
+++ b/pipeline/scripts/4/interop/test-cephfs-core-features.sh
@@ -63,6 +63,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build rc \

--- a/pipeline/scripts/4/interop/test-rbd-core-features.sh
+++ b/pipeline/scripts/4/interop/test-rbd-core-features.sh
@@ -63,6 +63,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build rc \

--- a/pipeline/scripts/4/interop/test-rgw-core-features.sh
+++ b/pipeline/scripts/4/interop/test-rgw-core-features.sh
@@ -63,6 +63,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build rc \

--- a/pipeline/scripts/4/interop/test-rhceph-image-on-rhel-8.sh
+++ b/pipeline/scripts/4/interop/test-rhceph-image-on-rhel-8.sh
@@ -63,6 +63,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build rc \

--- a/pipeline/scripts/4/interop/test-rhceph-rhel-8-rpm.sh
+++ b/pipeline/scripts/4/interop/test-rhceph-rhel-8-rpm.sh
@@ -63,6 +63,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build rc \

--- a/tests/ceph_installer/test_ansible.py
+++ b/tests/ceph_installer/test_ansible.py
@@ -21,6 +21,10 @@ def run(ceph_cluster, **kw):
     test_data = kw.get("test_data")
     cloud_type = config.get("cloud-type", "openstack")
 
+    # In case of Interop, we would like to avoid updating the packages... mainly, the
+    # ansible package.
+    exclude_ansible = config.get("skip_enabling_rhel_rpms", False)
+
     ubuntu_repo = config.get("ubuntu_repo", None)
     base_url = config.get("base_url", None)
     installer_url = config.get("installer_url", None)
@@ -88,7 +92,13 @@ def run(ceph_cluster, **kw):
     ceph_cluster.setup_ssh_keys()
 
     ceph_cluster.setup_packages(
-        base_url, hotfix_repo, installer_url, ubuntu_repo, build, cloud_type
+        base_url,
+        hotfix_repo,
+        installer_url,
+        ubuntu_repo,
+        build,
+        cloud_type,
+        exclude_ansible,
     )
 
     ceph_installer.install_ceph_ansible(build)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Adding support for RHEL 8.6 Interop testing. In the PR, the following changes are made

- Adding inventory file for RHEL 8.6
- Adding `skip-subscription` to the suites
- Installing `ansible-2.9` from EPEL instead of subscription
- Fix CLI positional arguments for `subscription-manager` 

__Logs__
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5ZYJB9