### PR TITLE
resize/expand the rbd image in local cluster

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -443,6 +443,11 @@ class RbdMirror:
                 long_running=True,
             )
 
+    def resize_image(self, **kw):
+        self.exec_cmd(cmd=f"rbd resize --size 5G {kw.get('imagespec')}")
+        cmd = self.exec_cmd(cmd=f"rbd info {kw.get('imagespec')} --format=json")
+        log.info(cmd)
+
     def create_pool(self, **kw):
         if self.ceph_version > 2 and self.k_m:
             self.create_ecpool(profile=self.ec_profile, poolname=self.datapool)

--- a/tests/rbd_mirror/test_rbd_mirror.py
+++ b/tests/rbd_mirror/test_rbd_mirror.py
@@ -32,6 +32,7 @@ def run(**kw):
         mirror1.config_mirror(mirror2, poolname=poolname, mode="pool")
         mirror2.wait_for_status(poolname=poolname, images_pattern=1)
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+        mirror1.resize_image(imagespec=imagespec, size=config.get("imagesize"))
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)


### PR DESCRIPTION
Signed-off-by: Gopi-Patta <gpatta@redhat.com>

resize/expand the rbd image in local cluster after running some io and resizing should be successful.

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
