### PR TITLE
Pushing the Logs to IBM-COS

### DIFF
--- a/compute/ibm_vpc.py
+++ b/compute/ibm_vpc.py
@@ -291,7 +291,7 @@ class CephVMNodeIBM:
             )
 
             # Construct a dict representation of a ImageIdentityById model
-            images = self.service.list_images()
+            images = self.service.list_images(name=image_name)
             image_id = get_resource_id(image_name, images.get_result())
             image_identity_model = dict({"id": image_id})
 

--- a/pipeline/ibm-tier-0.groovy
+++ b/pipeline/ibm-tier-0.groovy
@@ -94,12 +94,28 @@ node(nodeName) {
         // Copy all the results into one folder before upload
         def dirName = "ibm_${currentBuild.projectName}_${currentBuild.number}"
         def targetDir = "${env.WORKSPACE}/${dirName}/results"
+        def attachDir = "${env.WORKSPACE}/${dirName}/attachments"
         sh(script: "mkdir -p ${targetDir}")
         testResults.each { key, value ->
             sh(
                 script: "cp ${value['log-dir']}/xunit.xml ${targetDir}/${key}.xml",
                 returnStatus: true
             )
+        }
+        testResults.each { key, value ->
+            sh(
+                script: "mkdir -p ${attachDir}/${key} && tar -zcvf ${value['log-dir']}/${key}.tar.gz ${value['log-dir']}/*.log && cp ${value['log-dir']}/${key}.tar.gz ${attachDir}/${key}/",
+                returnStatus: true
+            )
+            def scriptFiles = sh (returnStdout: true, script: "ls ${value['log-dir']}/*.err | cat")
+            if (scriptFiles){
+                def fileNames = scriptFiles.split("\\n")
+                for (filePath in fileNames) {
+                sh(
+                    script: "mkdir -p ${attachDir}/${key} && cp ${filePath} ${attachDir}/${key}/"
+                )
+                }
+            }
         }
 
         // Adding metadata information


### PR DESCRIPTION
Pushing the Logs to Report portal
As part of this we are creating a folder with name Attachements
Zipping all the *.logs and copying them to Attachements.

This can be viewed in attachment section of Report portal  run

Please find the jenkins run :
https://159.23.92.24/job/amk_tier0/19/console

For the file structure details i have downloaded the logs collected in IBM-COS to manga
http://magna002.ceph.redhat.com/ceph-qe-logs/amar/ibm_amk_tier0_19/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
