### PR TITLE
[ceph/ceph.py] Fix RHCS version issue at verify_cluster_health

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -634,7 +634,7 @@ class Ceph(object):
         if cluster_name is not None:
             cmd += f" --cluster {cluster_name}"
 
-        if rhbuild and rhbuild.startswith("5"):
+        if rhbuild and rhbuild.split(".")[0] >= "5":
             cmd = f"cephadm shell -- {cmd}"
 
         out, err = client.exec_command(cmd=cmd, sudo=True)
@@ -675,7 +675,7 @@ class Ceph(object):
         Returns:
            int: return 0 when ceph is in healthy state, else 1
         """
-        pacific = True if (rhbuild and rhbuild.startswith("5")) else False
+        pacific = True if (rhbuild and rhbuild.split(".")[0] >= "5") else False
         if not client:
             client = (
                 self.get_ceph_object("client")


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

**Issue:**  The verify_cluster_health was enabling cephadm shell execution by using RHCEPH version 5.x(pacific), Now with quincy 6.0 hit the below failure.
```
2022-03-16 11:33:37,322 - ceph.ceph - INFO - Running command ceph -s on 10.0.211.29
2022-03-16 11:33:38,277 - ceph.ceph - ERROR - Error 127 during cmd, timeout 120
NoneType: None
2022-03-16 11:33:38,301 - test_cephadm - ERROR - ceph -s Error:  bash: ceph: command not found
 10.0.211.29
Traceback (most recent call last):
  File "/home/sunnagar/Sunil/cephci/tests/ceph_installer/test_cephadm.py", line 134, in run
    rhbuild=config.get("rhbuild"), client=cephadm.installer
  File "/home/sunnagar/Sunil/cephci/ceph/ceph.py", line 699, in check_health
    out, err = client.exec_command(cmd=cmd, sudo=True)
  File "/home/sunnagar/Sunil/cephci/ceph/ceph.py", line 1972, in exec_command
    return self.node.exec_command(cmd=cmd, **kw)
  File "/home/sunnagar/Sunil/cephci/ceph/ceph.py", line 1479, in exec_command
    + str(self.ip_address)
ceph.ceph.CommandFailed: ceph -s Error:  bash: ceph: command not found
```
**Fix:** `True if RHCEPH-version >= "5"`

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AUDZ5C (failure)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X8IL34 (Test case fixed here) 
