### PR TITLE
Abort signed container image build if yum_repourls tag is not present in ci msg

### DIFF
--- a/pipeline/signed-container-image-listener.groovy
+++ b/pipeline/signed-container-image-listener.groovy
@@ -59,6 +59,11 @@ node(nodeName) {
 
             containerImage = repoDetails.index.pull.find({ x -> !(x.contains("sha")) })
 
+            if(! repoDetails.containsKey("yum_repourls")){
+                sharedLib.unSetLock(majorVersion, minorVersion)
+                currentBuild.result = "ABORTED"
+                error "Unable to retrieve compose url."
+            }
             def repoUrl = repoDetails.yum_repourls.find({ x -> x.contains("Tools") })
             composeUrl = repoUrl.split("work").find({
                 x -> x.contains("RHCEPH-${majorVersion}.${minorVersion}")


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description

https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/job/rhceph-signed-container-image-listener/75 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
