### PR TITLE
Enabling --skip-subscription for interop 5.x scripts

### DIFF
--- a/pipeline/scripts/5/interop/test-cephfs-core-features.sh
+++ b/pipeline/scripts/5/interop/test-cephfs-core-features.sh
@@ -62,6 +62,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build ${BUILD_TYPE} \

--- a/pipeline/scripts/5/interop/test-rbd-core-features.sh
+++ b/pipeline/scripts/5/interop/test-rbd-core-features.sh
@@ -62,6 +62,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build ${BUILD_TYPE} \

--- a/pipeline/scripts/5/interop/test-rgw-core-features.sh
+++ b/pipeline/scripts/5/interop/test-rgw-core-features.sh
@@ -62,6 +62,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build ${BUILD_TYPE} \

--- a/pipeline/scripts/5/interop/test-rhceph-deployment-features.sh
+++ b/pipeline/scripts/5/interop/test-rhceph-deployment-features.sh
@@ -62,6 +62,7 @@ ${PY_CMD} run.py \
     --log-level DEBUG \
     --xunit-results \
     --skip-enabling-rhel-rpms \
+    --skip-subscription \
     --rhbuild ${RHCS_VERSION} \
     --platform ${CEPH_PLATFORM} \
     --build ${BUILD_TYPE} \


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Enabling --skip-subscription for interop 5.x scripts.

logs: http://magna002.ceph.redhat.com/ceph-qe-logs/tmathew/cephci-run-FN5U92/