### PR TITLE
Changing the count of nodes to scale down NFS to 1, since there was a mismatch between count and placement of nodes

### DIFF
--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
@@ -572,7 +572,7 @@ tests:
           placement:
             nodes:
               - node10
-            limit: 2
+            limit: 1
             sep: ";"
       destroy-cluster: False
       abort-on-fail: True


### PR DESCRIPTION
Changing the count of nodes to scale down NFS to 1, since there was a mismatch between count and placement of nodes

Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
