### PR TITLE
Fix ssl has no attribute TLSVersion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "junitparser==1.4.0",
         "jinja_markdown",
         "htmllistparse==0.5.2",
+        "ibm-cloud-sdk-core==3.15.0",
         "ibm-cos-sdk",
         "ibm-cos-sdk-core",
         "ibm-cos-sdk-s3transfer",


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we fixing the `ibm-cloud-sdk-core == 3.15.0` due to the below error

```
[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-52)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-53)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-54)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-55)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-56)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-57)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-58)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-59)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-60)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-61)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-62)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-63)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-64)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-65)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-66)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-67)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-68)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-69)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-70)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-71)[](https://159.23.92.24/blue/organizations/jenkins/tier-0/detail/tier-0/27/pipeline/54/#step-74-log-72)log directory - /tmp/cephci-run-0VE2ML

2022-03-21 13:52:15,466 - __main__ - INFO - Startup log location: /tmp/cephci-run-0VE2ML/startup.log

Traceback (most recent call last):

  File "run.py", line 1019, in <module>

    rc = run(args)

  File "run.py", line 420, in run

    cleanup_ibmc_ceph_nodes(osp_cred, cleanup_name)

  File "/data/jenkins/workspace/tier-0/ceph/utils.py", line 43, in cleanup_ibmc_ceph_nodes

    access_key=ibmc["access-key"], service_url=ibmc["service-url"]

  File "/data/jenkins/workspace/tier-0/compute/ibm_vpc.py", line 37, in get_ibm_service

    service = VpcV1(authenticator=authenticator)

  File "/data/jenkins/workspace/tier-0/.venv/lib64/python3.6/site-packages/ibm_vpc/vpc_v1.py", line 98, in __init__

    authenticator=authenticator)

  File "/data/jenkins/workspace/tier-0/.venv/lib64/python3.6/site-packages/ibm_cloud_sdk_core/base_service.py", line 97, in __init__

    self.http_adapter = SSLHTTPAdapter()

  File "/data/jenkins/workspace/tier-0/.venv/lib64/python3.6/site-packages/ibm_cloud_sdk_core/utils.py", line 35, in __init__

    super().__init__(*args, **kwargs)

  File "/data/jenkins/workspace/tier-0/.venv/lib64/python3.6/site-packages/requests/adapters.py", line 130, in __init__

    self.init_poolmanager(pool_connections, pool_maxsize, block=pool_block)

  File "/data/jenkins/workspace/tier-0/.venv/lib64/python3.6/site-packages/ibm_cloud_sdk_core/utils.py", line 42, in init_poolmanager

    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2

AttributeError: module 'ssl' has no attribute 'TLSVersion'
```

__Logs__
```
(venv) [cephuser@ceph-qe-jump-01 cephci]$ python run.py --log-level debug --osp-cred ~/.iaas.yaml --cleanup -ci- --cloud ibmc

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /tmp/cephci-run-63S2N6
2022-03-21 15:15:53,607 - __main__ - INFO - Startup log location: /tmp/cephci-run-63S2N6/startup.log
2022-03-21 15:15:56,881 - ceph.utils - INFO - Done cleaning up nodes with pattern -ci-
2022-03-21 15:15:56,882 - __main__ - INFO - final rc of test run 0
(venv) [cephuser@ceph-qe-jump-01 cephci]$
```