### PR TITLE
Test single site conversion to multi-site

### DIFF
--- a/pipeline/scripts/4/3/test-rgw_singlesite_to_multisite-tier-2.sh
+++ b/pipeline/scripts/4/3/test-rgw_singlesite_to_multisite-tier-2.sh
@@ -1,0 +1,48 @@
+#! /bin/sh
+echo "Beginning Ceph RGW Multisite primary site verification testing."
+
+random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)
+instance_name="ci-${random_string}"
+platform="rhel-8"
+rhbuild="4.3"
+test_suite="suites/nautilus/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
+test_conf="conf/nautilus/rgw/tier-1_rgw_multisite.yaml"
+test_inventory="conf/inventory/rhel-8-latest.yaml"
+return_code=0
+
+# Process the CLI arguments for IBM-C environment
+CLI_ARGS=$@
+cloud="ibmc"
+if [ -z "${CLI_ARGS##*$cloud*}" ] ; then
+    test_inventory="conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+else
+    CLI_ARGS="$CLI_ARGS --post-results --report-portal"
+fi
+
+$WORKSPACE/.venv/bin/python run.py \
+    --osp-cred $HOME/osp-cred-ci-2.yaml \
+    --rhbuild $rhbuild \
+    --platform $platform \
+    --instances-name $instance_name \
+    --global-conf $test_conf \
+    --suite $test_suite \
+    --inventory $test_inventory \
+    --log-level DEBUG \
+    $CLI_ARGS
+
+if [ $? -ne 0 ]; then
+    return_code=1
+fi
+
+CLEANUP_ARGS="--log-level debug --osp-cred $HOME/osp-cred-ci-2.yaml"
+if [ -z "${CLI_ARGS##*$cloud*}" ] ; then
+    CLEANUP_ARGS="$CLEANUP_ARGS --cloud ibmc"
+fi
+
+$WORKSPACE/.venv/bin/python run.py --cleanup $instance_name $CLEANUP_ARGS
+
+if [ $? -ne 0 ]; then
+    echo "cleanup instance failed for instance $instance_name"
+fi
+
+exit ${return_code}

--- a/suites/nautilus/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -1,0 +1,272 @@
+# Below are the multi-site test scenarios run on the master and verified the sync/io on the slave
+# The test  will create a primary site 'ceph-rgw1', write IOs on the first site, indeuce delay of 10ms on firat site and second site, and then convert it to a multisite and test sync.
+# ceph-rgw1 is master/primary site
+# ceph-rgw2 is slave/secondary site
+
+tests:
+  - test:
+      name: pre-req
+      module: install_prereq.py
+      abort-on-fail: true
+      desc: install ceph pre requisites
+
+  - test:
+      name: ceph ansible
+      module: test_ansible.py
+      clusters:
+        ceph-rgw1:
+          config:
+            ansi_config:
+              ceph_test: True
+              ceph_origin: distro
+              ceph_repository: rhcs
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              dashboard_enabled: False
+              rgw_multisite: true
+              rgw_zone: US_EAST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: true
+              rgw_zonesecondary: false
+              rgw_zonegroupmaster: true
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              rgw_multisite_proto: "http"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+      desc: setup single site with USA realm using ceph-ansible
+      abort-on-fail: true
+  - test:
+      name: create user
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects on primary(single site)
+      polarion-id: CEPH-9789
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_compression on primary(single site)
+      polarion-id: CEPH-11350
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_aws4 on primary(single site)
+      polarion-id: CEPH-9637
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_delete on primary(single site)
+      polarion-id: CEPH-14237
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_download on primary(single site)
+      polarion-id: CEPH-14237
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_enc on primary(single site)
+      polarion-id: CEPH-11358,CEPH-11361
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_multipart on primary(single site)
+      polarion-id: CEPH-9801
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on primary(single site)
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_unordered.yaml on primary(single site)
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_acls on on primary(single site)
+      polarion-id: CEPH-9190
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_acls.yaml
+            timeout: 300
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rgw1:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 10ms
+        ceph-rgw2:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 10ms
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+
+  - test:
+      name: ceph ansible
+      module: test_ansible.py
+      clusters:
+        ceph-rgw2:
+          config:
+            ansi_config:
+              ceph_test: True
+              ceph_origin: distro
+              ceph_repository: rhcs
+              osd_scenario: lvm
+              osd_auto_discovery: False
+              journal_size: 1024
+              ceph_stable: True
+              ceph_stable_rh_storage: True
+              fetch_directory: ~/fetch
+              copy_admin_key: true
+              dashboard_enabled: False
+              rgw_multisite: true
+              rgw_zone: US_WEST
+              rgw_zonegroup: US
+              rgw_realm: USA
+              rgw_zonemaster: false
+              rgw_zonesecondary: true
+              rgw_zonegroupmaster: false
+              rgw_zone_user: synchronization-user
+              rgw_zone_user_display_name: "Synchronization User"
+              system_access_key: 86nBoQOGpQgKxh4BLMyq
+              system_secret_key: NTnkbmkMuzPjgwsBpJ6o
+              rgw_multisite_proto: "http"
+              rgw_pull_proto: http
+              rgw_pull_port: 8080
+      desc: Single site to multisite
+      abort-on-fail: true
+
+  - test:
+      name: create user
+      desc: create tenanted user
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-rgw2
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_modify.yaml on secondary
+      polarion-id: CEPH-11214
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_modify.yaml
+            verify-io-on-site: ["ceph-rgw2"]
+            timeout: 300
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_delete.yaml on secondary
+      polarion-id: CEPH-11213
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_delete.yaml
+            verify-io-on-site: ["ceph-rgw2"]
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_replace on secondary
+      polarion-id: CEPH-11215
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_replace.yaml
+            verify-io-on-site: ["ceph-rgw2"]
+            timeout: 300
+
+


### PR DESCRIPTION
Test single site conversion to multi-site.
The test will create a primary site 'ceph-rgw1', write IOs on the first site and then convert it to a multisite and test sync.
Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N1YLLP
Signed-off-by: viduship <vimishra@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
