### PR TITLE
Aborting the signed container image listener job, when compose has not been updated yet.

### DIFF
--- a/pipeline/signed-container-image-listener.groovy
+++ b/pipeline/signed-container-image-listener.groovy
@@ -85,6 +85,8 @@ node(nodeName) {
                 sharedLib.unSetLock(majorVersion, minorVersion)
                 println "Current Ceph Version : ${currentCephVersion}"
                 println "New Ceph Version : ${cephVersion}"
+                currentBuild.result = "ABORTED"
+                error "Abort: Compose information is not updated yet for the current ceph version."
             }
 
             releaseMap.rc.repository = containerImage


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
