### PR TITLE
Uploading results to Report portal with Log attachments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
 cos-aspera; python_version == '3.6'
 python-openstackclient
+xmltodict

--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -1,0 +1,205 @@
+"""
+This Utility will push the results to Report Portal.
+It accepts config file location and payload_directory
+In config file:
+    We will have the details of report portal and launch details
+In Payload_directory:
+    We will have the zipped logs of the suites and error files if there is an error while executing the test case
+
+Payload Directory Structure
+payload
+  |- results
+      - test1.xml
+      - test2.xml
+  |- attachments
+      - test1
+         - test1.zip
+         - failed_test.err
+
+config.json:
+{
+
+    "reportportal": {
+        "api_token": "8ca12f8b-8a3c-4d22-9f04-1e81692b7230",
+        "auto_dashboard": false,
+        "host_url": "https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/",
+        "merge_launches": true,
+        "project": "cephci",
+        "property_filter": [".*"],
+        "simple_xml": false,
+        "launch": {
+            "name": "RHCEPH-4.3 - tier-0-amk",
+            "description": "Test executed on Thu Mar 17 06:16:24 UTC 2022\n",
+            "attributes": {
+                "ceph_version": "14.2.22-86",
+                "rhcs": "4.3",
+                "tier": "tier-0"
+            }
+        }
+    }
+}
+
+We are going to parse the xunit files and get the details of the results and upload them.
+if there are any attachments present for the xunit file in the attachments folder with xunit folder name
+those files will get attached to the suite and if there are any .err files we are going to attach them to the respective
+test cases based on the name of the test case.
+If the .zip file not present in the attachments. for those we are just updating the results and skipping the attachments
+"""
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+
+import xmltodict
+from docopt import docopt
+from rp_utils.preproc import PreProcClient
+from rp_utils.reportportalV1 import Launch, ReportPortalV1, RpLog
+from rp_utils.xunit_xml import TestCase, TestSuite, XunitXML
+
+log = logging.getLogger(__name__)
+doc = """
+Standard script to push all the logs from Xunit files to Report Portal
+
+    Usage:
+        rp_client.py --config_file <str> --payload_dir <str>
+        rp_client.py (-h | --help)
+
+    Options:
+        -h --help          Shows the command usage
+        -c --config_file <str>         Config file with report portal details.
+        -d --payload_dir <str>   Paylod directory where we have results and attachments
+"""
+
+
+def upload_logs(args):
+    """
+    Uploads the logs to Reportportal launch
+    """
+    preproc = PreProcClient((args))
+    rportal = ReportPortalV1(preproc.configs.rp_config)
+    results_file_dir = os.path.join(preproc.configs.payload_dir, "results")
+    payload_subdir = os.listdir(preproc.configs.payload_dir)
+    log.info(f"The payload dir file list is: {payload_subdir}")
+    if preproc.config_file_path:
+        log.info(f"Config file path is {preproc.config_file_path}")
+        filename = os.path.basename(preproc.config_file_path)
+        log.info(f"Remove config file path {filename} from {payload_subdir}")
+        payload_subdir.remove(filename)
+    result_file_list = XunitXML.get_file_list(results_file_dir)
+    if not isinstance(result_file_list, list):
+        log.info("The value of result_file_list is %s" % result_file_list)
+        log.info(
+            "ERROR: The payload directory path %s does not exist" % results_file_dir
+        )
+        return 1
+    return_obj = {}
+    with ThreadPoolExecutor() as executor:
+        log.info("Processing xunit files concurrently")
+        log.info(dir(rportal.service))
+        launch = Launch(rportal)
+        log.info(dir(preproc))
+        launch.start()
+        log.info(result_file_list)
+        list(
+            executor.map(partial(process_xml_file, preproc, rportal), result_file_list)
+        )
+        launch.finish()
+    return_obj["launches"] = rportal.launches.list
+    log.info("RETURN OBJECT: %s", return_obj)
+    return return_obj
+
+
+def process_xml_file(preproc, rportal, fqpath):
+    with open(fqpath) as xmlfd:
+        log.info("Processing fqpath %s", fqpath)
+        filename = os.path.basename(fqpath)
+        filename_base, _ = os.path.splitext(filename)
+        log.info("%s %s", filename, filename_base)
+
+        log.info("Parsing XML...")
+        xml_data = xmltodict.parse(xmlfd.read())
+        xunit_xml = XunitXML(
+            rportal, name=filename_base, configs=preproc._configs, xml_data=xml_data
+        )
+        process(xunit_xml, rportal)
+
+
+def process(xmlObj, rportal):
+    """Process xUnit XML data"""
+    # override env var with config provided vars
+    rp_host_url = os.environ.get("RP_HOST_URL", None)
+    log.info("rp_host_url: %s", rp_host_url)
+
+    # check for multiple testsuites in xUnit
+    if xmlObj.xml_data.get("testsuites"):
+        # get test suites list
+        testsuites_object = xmlObj.xml_data.get("testsuites")
+        testsuites = (
+            testsuites_object.get("testsuite")
+            if isinstance(testsuites_object.get("testsuite"), list)
+            else [testsuites_object.get("testsuite")]
+        )
+    else:
+        testsuites = [xmlObj.xml_data.get("testsuite")]
+    rplog = RpLog(rportal)
+    # create testsuite(s)
+    log.info("Processing %s testsuite(s)", len(testsuites))
+    for testsuite in testsuites:
+        testcases = testsuite.get("testcase")
+        if not testcases:
+            log.info(
+                "Found empty test suite Name: %s. Skipping this test suite"
+                % testsuite.get("@name")
+            )
+            continue
+        elif not isinstance(testcases, list):
+            testcases = [testcases]
+
+        tsuite = TestSuite(xmlObj.rportal, xmlObj.name, testsuite)
+        tsuite.start()
+
+        # create all testcases
+        log.info("Starting testcases")
+        for testcase in testcases:
+            process_testcase(xmlObj, testcase, tsuite)
+        log.info("\nFinished testcases")
+        fqpath = os.path.join(xmlObj._configs.payload_dir, "attachments")
+        if os.path.exists(f"{fqpath}/{tsuite.xml_name}/{tsuite.xml_name}.zip"):
+            rplog.add_attachment(
+                tsuite.item_id, f"{fqpath}/{tsuite.xml_name}/{tsuite.xml_name}.zip"
+            )
+        tsuite.finish()
+
+
+def process_testcase(xunit_xml, testcase, tsuite):
+    # Skip testcases which has empty name
+    if testcase.get("@name") == "" or not testcase.get("@name"):
+        log.info("Skipping testcase because name is empty: %s", testcase)
+        return
+    tcase = TestCase(
+        xunit_xml.rportal,
+        xunit_xml.name,
+        testcase,
+        configs=xunit_xml._configs,
+        parent_id=tsuite.item_id,
+    )
+    tcase.start()
+    fqpath = os.path.join(tcase._configs.payload_dir, "attachments")
+    log.info(f"{fqpath}/{tcase.tc_name}.err")
+    if os.path.exists(f"{fqpath}/{tsuite.xml_name}/{tcase.tc_name}.err"):
+        with open(f"{fqpath}/{tsuite.xml_name}/{tcase.tc_name}.err", "r") as file:
+            error = file.read()
+        tcase.rplog.add_message(
+            message=error, level="ERROR", test_item_id=tcase.test_item_id
+        )
+    tcase.finish()
+
+
+if __name__ == "__main__":
+    args = docopt(doc)
+    log.info(args)
+    arguments = {
+        "config_file": args.get("--config_file"),
+        "payload_dir": args.get("--payload_dir"),
+    }
+    upload_logs(arguments)

--- a/utility/rp_utils/configs.py
+++ b/utility/rp_utils/configs.py
@@ -1,0 +1,167 @@
+import json
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+# Define sentinel object NULL constant
+NULL = object()
+
+
+# pylint: disable=too-many-instance-attributes
+#         reviewed and disabled (jdh)
+class Configs:
+    """Configuration class to handle config file, args, env tasks.
+    Order of precedence (ordoprec) cli > envvars > config > defaults
+    """
+
+    def __init__(self, args, fqpath=None, config=None):
+        self._args = args
+        log.debug(self._args)
+        self._fqpath = fqpath
+
+        # define args using sentinel (not None)
+        self._service_url = NULL
+        self._payload_dir = NULL
+        self._merge_launches = NULL
+        self._simple_xml = NULL
+        self._debug = NULL
+        self._config = {}
+        log.debug("Configs.init(): reading %s", self._fqpath)
+
+        if config is not None:
+            self._config = config
+        else:
+            self._config = self._read_fqpath(self.fqpath)
+        log.info("Configs.init(): CONFIG: %s", self._config)
+        log.debug("Configs.init(): CONFIG: %s", self._config)
+
+    # PROPERTIES
+    # using these to handle order of presidence of config, args, etc.
+    @property
+    def args(self):
+        """args - the args object from CLI or REST API"""
+        return self._args
+
+    @property
+    def fqpath(self):
+        """fqpath - config file fully qualified path"""
+        if self._fqpath is None:
+            self._fqpath = self.args.get("config_file", None)
+
+        return self._fqpath
+
+    @property
+    def config(self):
+        """Return the config object"""
+        return self._config
+
+    @config.setter
+    def config(self, config):
+        self._config = config
+
+    @property
+    def service_config(self):
+        """The RP PreProc section of the config file"""
+        return self._config.get("rp_preproc", None)
+
+    @property
+    def rp_config(self):
+        """The RP PreProc section of the config file"""
+        if self._config is not None:
+            return self._config.get("reportportal", None)
+
+        return None
+
+    @property
+    def payload_dir(self):
+        """Directory containing the payload files"""
+        if self._payload_dir is NULL:
+            self._payload_dir = self.get_config_item(
+                "payload_dir", config=self.service_config
+            )
+
+        return self._payload_dir
+
+    @payload_dir.setter
+    def payload_dir(self, payload_dir):
+        self._payload_dir = payload_dir
+
+    @property
+    def service_url(self):
+        """use_service - send to service or use local client"""
+        if self._service_url is NULL:
+            self._service_url = self.get_config_item(
+                "service_url", config=self.service_config
+            )
+
+        return self._service_url
+
+    @property
+    def simple_xml(self):
+        """Use simple xml import into ReportPortal instead of processing"""
+        if self._simple_xml is NULL:
+            self._simple_xml = self.get_config_item("simple_xml", config=self.rp_config)
+
+        return self._simple_xml
+
+    @property
+    def merge_launches(self):
+        """Config merge launches after import"""
+        if self._merge_launches is NULL:
+            self._merge_launches = self.get_config_item(
+                "merge_launches", config=self.rp_config
+            )
+
+        return self._merge_launches
+
+    # PRIVATE METHODS
+    def _read_fqpath(self, fqpath=None):
+        """Read a json formatted file into a dictionary"""
+        log.debug("Configs._read_fqpath(): CONFIG FQPATH: %s", fqpath)
+        if fqpath is not None:
+            self._fqpath = fqpath
+
+        configfd = open(self._fqpath, "r")
+        if configfd:
+            self._config = json.load(configfd)
+
+            return self._config
+
+        return None
+
+    def get_config_item(self, config_item, config=None, ordoprec=None, default=None):
+        """Order of precedence helper for configs"""
+        # cli > envvars > config > defaults
+        if config is None:
+            config = self.config
+        if ordoprec is None:
+            ordoprec = ["config", "env", "cli"]
+        ordoprec_dict = dict()
+
+        # cli
+        ordoprec_dict["cli"] = self.args.get(config_item, None)
+        # config
+        log.debug("Configs.get_config_item()...from config: %s", config)
+        ordoprec_dict["config"] = config.get(config_item, None)
+        # env
+        if config_item == "auto-dashboard":
+            env_name = "RP_AUTO_DASHBOARD"
+        else:
+            env_name = "RP_{}".format(config_item.upper())
+        ordoprec_dict["env"] = os.getenv(env_name, None)
+
+        config_value = default
+        for source in ordoprec:
+            log.debug(
+                "Configs.get_config_item()... " "Config item (%s): %s = %s",
+                config_item,
+                source,
+                ordoprec_dict[source],
+            )
+
+            if ordoprec_dict[source] is not None:
+                config_value = ordoprec_dict[source]
+
+        log.debug("Configs.get_config_item()... config_value: %s", config_value)
+        return config_value

--- a/utility/rp_utils/preproc.py
+++ b/utility/rp_utils/preproc.py
@@ -1,0 +1,88 @@
+import json
+import logging
+import os
+import uuid
+
+import xmltodict
+
+from utility.rp_utils.configs import Configs
+from utility.rp_utils.xunit_xml import XunitXML
+
+log = logging.getLogger(__name__)
+
+
+class PreProcClient:
+    """PreProc client class for preprocessing test results for ReportPortal"""
+
+    @property
+    def args(self):
+        """Args from cli or service"""
+        return self._args
+
+    @property
+    def configs(self):
+        """Configs arg"""
+        return self._configs
+
+    def __init__(self, args):
+        # read config files and update g.config attributes
+        self._args = args
+        self._config_file = self.args.get("config_file", None)
+        log.debug("ARGS: %s", self._args)
+        self._configs = None
+        self.config_file_path = None
+        self._configs = Configs(args)
+
+    @staticmethod
+    def get_uuid():
+        """Unique ID helper"""
+        return uuid.uuid1()
+
+    @staticmethod
+    def read_config_file(fqpath):
+        """Read a json formatted file into a dictionary"""
+        configfd = open(fqpath, "r")
+        if configfd:
+            config = json.load(configfd)
+
+            return config
+
+        return None
+
+    @staticmethod
+    def process_response(response):
+        """Process an HTTP response into something usable"""
+        # TODO: process status code and set return
+        log.debug("RESPONSE...")
+        log.debug(response)
+        log.debug("status_code: %s", response.status_code)
+        log.debug("text: %s", response.text)
+        return_code = response.status_code
+        if response.status_code == 200:
+            return_code = 0
+
+        return return_code
+
+    @staticmethod
+    def get_results_dir(args, config):
+        """Get the directoy containing results from config, args, etc."""
+        if args.results_dir is not None:
+            results_dir = args.results_dir
+        else:
+            results_dir = config.get("results_dir", None)
+
+        return results_dir
+
+    def __process_file(self, rportal, fqpath):
+        with open(fqpath) as xmlfd:
+            log.debug("Processing fqpath %s", fqpath)
+            filename = os.path.basename(fqpath)
+            filename_base, _ = os.path.splitext(filename)
+            log.debug("%s %s", filename, filename_base)
+
+            log.debug("Parsing XML...")
+            xml_data = xmltodict.parse(xmlfd.read())
+            xunit_xml = XunitXML(
+                rportal, name=filename_base, configs=self._configs, xml_data=xml_data
+            )
+            xunit_xml.process()

--- a/utility/rp_utils/reportportalV1.py
+++ b/utility/rp_utils/reportportalV1.py
@@ -1,0 +1,530 @@
+import json
+import logging
+import os
+import posixpath
+import re
+import time
+import uuid
+from mimetypes import guess_type
+from zipfile import ZipFile
+
+import requests
+import urllib3
+from reportportal_client import ReportPortalService
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+log = logging.getLogger(__name__)
+
+
+class ReportPortalV1:
+    """ReportPortal class to assist with RP API calls"""
+
+    def __init__(
+        self,
+        config,
+        endpoint=None,
+        api_token=None,
+        project=None,
+        merge_launches=None,
+        rpuid=None,
+    ):
+        """Create a ReportPortal client instance
+
+        Args:
+            config (str): the reportportal config section from file
+        """
+        self._rpuid = rpuid
+        self._service = None
+        self._config = config
+        self._endpoint = endpoint
+        self._api_token = api_token
+        self._project = project
+        self._merge_launches = merge_launches
+        self._launches = Launches(self)
+
+    @property
+    def rpuid(self):
+        """get the unique id of this instance"""
+        if self._rpuid is None:
+            self._rpuid = uuid.uuid1().hex
+
+        return self._rpuid
+
+    @property
+    def config(self):
+        """get the rp section json object"""
+        # TODO: add validation for required elements
+
+        return self._config
+
+    @property
+    def endpoint(self):
+        """get endpoint"""
+        if self._endpoint is None:
+            self._endpoint = self.config.get(
+                "host_url", os.environ.get("RP_HOST_URL", None)
+            )
+        # TODO: raise exception on endpoint is still None
+        return self._endpoint
+
+    @property
+    def api_token(self):
+        """Get the user api_token"""
+        if self._api_token is None:
+            self._api_token = self.config.get(
+                "api_token", os.environ.get("RP_API_TOKEN", None)
+            )
+        # TODO: validate api_token is not None
+        # TODO: validate api_token works ???
+        return self._api_token
+
+    @property
+    def project(self):
+        """project attr getter"""
+        if self._project is None:
+            self._project = self.config.get(
+                "project", os.environ.get("RP_PROJECT", None)
+            )
+
+        return self._project
+
+    @property
+    def service(self):
+        """get service"""
+        # creating service on first call to get service
+        if self._service is None:
+            self._service = ReportPortalService(
+                endpoint=self.endpoint,
+                project=self.project,
+                token=self.api_token,
+                log_batch_size=1,
+            )
+            self._service.session.verify = False
+
+            # TODO: validate the service works
+
+        return self._service
+
+    @property
+    def launches(self):
+        """launch list attr getter"""
+        return self._launches
+
+    @property
+    def merge_launches(self):
+        """Should launches be merged?"""
+        if self._merge_launches is None:
+            self._merge_launches = self.config.get("merge_launches", False)
+
+        log.debug("ReportPortal.merge_launches: %s", self._merge_launches)
+        return self._merge_launches
+
+    @merge_launches.setter
+    def merge_launches(self, merge_launches_value):
+        """Override merge_launches setting"""
+        self._merge_launches = merge_launches_value
+
+    @property
+    def launch_config(self):
+        """launch_config attr gettr"""
+        launch_config = Launch.get_config(self.config)
+
+        return launch_config
+
+    def api_put(self, api_path, put_data=None, verify=False):
+        """PUT to the ReportPortal API"""
+        url = posixpath.join(self.endpoint, "api/v1/", self.project, api_path)
+        log.debug("url: %s", url)
+
+        session = requests.Session()
+        session.headers["Authorization"] = "bearer {0}".format(self.api_token)
+        session.headers["Content-type"] = "application/json"
+        session.headers["Accept"] = "application/json"
+        response = session.put(url, data=json.dumps(put_data), verify=verify)
+
+        log.debug("r.status_code: %s", response.status_code)
+        log.debug("r.text: %s", response.text)
+
+        return response
+
+    def api_get(self, api_path, get_data=None, verify=False):
+        """GET from the ReportPortal API
+
+        Args:
+            get_data (list): list of key=value pairs
+
+        Returns:
+            session response object
+        """
+        url = posixpath.join(self.endpoint, "api/v1/", self.project, api_path)
+        if get_data is not None:
+            get_string = "?{}".format("&".join(get_data))
+            url += get_string
+        log.debug("url: %s", url)
+
+        session = requests.Session()
+        session.headers["Authorization"] = "bearer {0}".format(self.api_token)
+        session.headers["Accept"] = "application/json"
+
+        response = session.get(url, verify=verify)
+
+        log.debug("r.status_code: %s", response.status_code)
+        log.debug("r.text: %s", response.text)
+
+        return response
+
+    def api_post(self, api_path, post_data=None, filepath=None, verify=False):
+        """POST to the ReportPortal API"""
+        url = posixpath.join(self.endpoint, "api/v1/", self.project, api_path)
+        log.debug("url: %s", url)
+
+        session = requests.Session()
+        session.headers["Authorization"] = "bearer {0}".format(self.api_token)
+
+        if filepath is None:
+            session.headers["Content-type"] = "application/json"
+            session.headers["Accept"] = "application/json"
+            log.debug("API_POST(): %s" % json.dumps(post_data))
+            response = session.post(url, data=json.dumps(post_data), verify=verify)
+        else:
+            files = {"file": open(filepath, "rb")}
+            response = session.post(url, data={}, files=files, verify=False)
+
+        log.debug("r.status_code: %s", response.status_code)
+        log.debug("r.text: %s", response.text)
+
+        return response
+
+    def api_post_zipfile(self, infile, outfile="/tmp/myresults.zip"):
+        """POST a single zip file to the ReportPortal API"""
+        with ZipFile(outfile, "w") as zipit:
+            zipit.write(infile)
+        api_path = "launch/import"
+
+        response = self.api_post(api_path, filepath=outfile)
+
+        try:
+            response_json = response.json()
+            log.debug("r.json: %s", response_json)
+            idregex = re.match(".*id = (.*) is.*", response_json["message"])
+            # this gives the uuid of the launch
+            launch_uuid = idregex.group(1)
+
+            # to get the launch id
+            api_path = "launch"
+            get_string = "filter.eq.uuid={}".format(launch_uuid)
+            response = self.api_get(api_path, get_data=[get_string])
+            response_json = response.json()
+            log.debug("GET LAUNCH ID BY UUID: %s", response_json)
+            if response_json["content"]:
+                response_filter = response_json["content"][0]
+                launch_id = response_filter["id"]
+                log.debug("Launch id from xml import: %s", launch_id)
+                self.launches.add(launch_id)
+                return response_json
+        except json.JSONDecodeError:
+            return_response = response.text
+            log.debug("r.text: %s", return_response)
+
+        return None
+
+
+class Launches:
+    """Class to handle multiple launches"""
+
+    def __init__(self, rportal):
+        self._rportal = rportal
+        self._list = []
+
+    @property
+    def list(self):
+        """Get the list of launches"""
+        return self._list
+
+    def add(self, launch_id):
+        """Add a launch to the list"""
+        self.list.append(launch_id)
+
+    def merge(
+        self, name="Merged Launch", description="merged launches", merge_type="BASIC"
+    ):
+        """Merge all launches in the list into one launch"""
+        log.debug("merging launches: %s", self.list)
+
+        name = self._rportal.launch_config.get("name", name)
+        description = self._rportal.launch_config.get("description", description)
+        post_merge_json = {
+            "description": description,
+            "extendSuitesDescription": True,
+            "launches": self.list,
+            "mergeType": merge_type,
+            "mode": "DEFAULT",
+            "name": name,
+        }
+        api_path = "launch/merge"
+        response = self._rportal.api_post(api_path, post_data=post_merge_json)
+
+        try:
+            return_response = response.json()
+            log.debug("r.json: %s", return_response)
+            merged_launch = return_response["id"]
+            log.debug("merged launch: %s", merged_launch)
+
+            return merged_launch
+        except json.JSONDecodeError:
+            # TODO: chase down the specific json exception
+            return_response = response.text
+            log.debug("r.text: %s", return_response)
+
+        return None
+
+
+class Launch:
+    """ReportPortal launch class"""
+
+    @staticmethod
+    def get_config(config):
+        """Get the launch config section from a ReportPortal config"""
+        launch_config = config.get("launch", None)
+
+        return launch_config
+
+    def __init__(self, rportal, name=None, description=None, attributes=None):
+        """Create an instance of ReportPortal launch class
+
+        Args:
+            rportal (obj): A ReportPortal class instance
+            name (str): The name of the launch
+            description (str): Information describing the launch
+            attributes (list): A list of attributes to add to the launch
+        """
+        self._rportal = rportal
+        self._service = rportal.service
+        self._config = Launch.get_config(rportal.config)
+        self._name = name
+        self._attributes = attributes
+        self._description = description
+        self._start_time = None
+        self._end_time = None
+        self._launch_uuid = None
+        self._launch_id = None
+
+        log.debug("launch_name: %s", self.name)
+        log.debug("launch_description: %s", self._description)
+        log.debug("launch_attributes: %s", self._attributes)
+
+    @property
+    def name(self):
+        """Get the name of the launch from config, env, etc."""
+        if self._name is None:
+            if self._config.get("merge_launches"):
+                self._name = self._rportal.rpuid
+            else:
+                self._name = self._config.get("name", "RP_PreProc_Example_Launch")
+
+        return self._name
+
+    @property
+    def description(self):
+        """Get the description of the launch from config, env, etc."""
+        default = "Example launch created by RP PreProc"
+        if self._description is None:
+            if self._config.get("merge"):
+                self._description = self._config.get("name")
+            else:
+                self._description = self._config.get("description", default)
+
+        return self._description
+
+    @property
+    def attributes(self):
+        """Get launch attributes from the config"""
+        if self._attributes is None:
+            self._attributes = self._config.get("attributes", None)
+
+        return self._attributes
+
+    @property
+    def start_time(self):
+        """Get the launch start time"""
+        if self._start_time is None:
+            # TODO: get this from the config and default to NOW if None
+            self._start_time = str(int(time.time() * 1000))
+
+        return self._start_time
+
+    @property
+    def end_time(self):
+        """Get the launch end time"""
+        if self._end_time is None:
+            # TODO: get this from the config and default to NOW if None
+            self._end_time = str(int(time.time() * 1000))
+
+        return self._end_time
+
+    @property
+    def launch_id(self):
+        """Return the longint ID number"""
+        if self._launch_id is None:
+            self._launch_id = self._lookup_launch_id()
+
+        return self._launch_id
+
+    def _lookup_launch_id(self):
+        api_path = "launch"
+        get_string = "filter.eq.uuid={}".format(self._launch_uuid)
+        response = self._rportal.api_get(api_path, get_data=[get_string])
+        response_json = response.json()
+        log.debug("GET LAUNCH ID BY UUID: %s", response_json)
+        if response_json["content"]:
+            response_filter = response_json["content"][0]
+            launch_id = response_filter["id"]
+
+            return launch_id
+
+        return None
+
+    def start(self, start_time=None):
+        """Start a launch
+
+        Args:
+            start_time (str): Launch start time (default: None)
+
+        Returns:
+            launch_id (str) on success
+            None on fail
+
+        """
+
+        if start_time is not None:
+            self._start_time = start_time
+
+        log.debug("Starting launch %s @ %s", self.name, self.start_time)
+        self._launch_uuid = self._service.start_launch(
+            name=self.name,
+            start_time=self.start_time,
+            attributes=self.attributes,
+            description=self.description,
+        )
+        log.debug("Started launch with uuid %s ", self._launch_uuid)
+
+        return self._launch_uuid
+
+        # TODO: "requests.exceptions.HTTPError: 401 Client Error: "
+        #       "Unauthorized for url: <https://reportportal.example.com/"
+        #       "api/v1/myproject/launch "
+        # TODO: UMB integration (here @ launch and start finish???)
+        # TODO: set launch id class attr
+
+    def finish(self, end_time=None):
+        """Finish the launch"""
+        if end_time is not None:
+            self._end_time = end_time
+
+        self._service.finish_launch(end_time=self.end_time)
+        log.debug("time elapsed = %s - %s", self.end_time, self.start_time)
+        time_elapsed = int(self.end_time) - int(self.start_time)
+        self._rportal.launches.add(self.launch_id)
+        log.debug("Finished launch")
+        log.debug("Launch import completed in %s seconds", time_elapsed)
+
+        # TODO: ERROR CHECKING and return the result
+        return self.launch_id
+
+
+class RpLog:
+    """Log an event in ReportPortal.
+    ReportPortal works with the concept of "logging" results"""
+
+    def __init__(self, rportal):
+        self.service = rportal.service
+
+    def add_attachment(self, test_item_id, filepath, level="INFO"):
+        """Add an attachment to a testcase in ReportPortal"""
+
+        filename = os.path.basename(filepath)
+        log.debug("Attaching file %s", filepath)
+        with open(filepath, "rb") as file_handle:
+            file_data = file_handle.read()
+        mime_type = guess_type(filepath)[0]
+
+        attachment = {"name": filename, "data": file_data, "mime": mime_type}
+        log_item_id = self.service.log(
+            str(int(time.time() * 1000)),
+            message=filename,
+            level=level,
+            attachment=attachment,
+            item_id=test_item_id,
+        )
+
+        log.debug("Log ID: %s", log_item_id)
+
+        return log_item_id
+
+    def add_attachments(self, fqpath, xml_name, tc_attach_dir, test_item_id):
+        """Add attachments from testcase directory
+
+        Args:
+            fqpath (str): fullpath to attachments base dir
+            xml_name (str): name from the xml file
+            tc_attach_dir (str): testcase attachment subdirectory
+            test_item_id (str): test item ID returned from RP
+        """
+        basepath = os.path.join(fqpath, tc_attach_dir)
+        xml_dirpath = os.path.join(fqpath, xml_name, tc_attach_dir)
+        testitem_path = os.path.join(fqpath, test_item_id)
+
+        attached_files = []
+        for dirpath in [xml_dirpath, basepath, testitem_path]:
+            if os.path.exists(dirpath):
+                # added followlinks=True for allowing symlinks
+                for root, _, files in os.walk(dirpath, followlinks=True):
+                    for file in files:
+                        file_name = os.path.join(root, file)
+                        log.debug(file_name)
+                        self.add_attachment(test_item_id, file_name)
+                        attached_files.append(file_name)
+        return attached_files
+
+    def add_message(
+        self, message="N/A", level="INFO", msg_time=None, test_item_id=None
+    ):
+        """Log a message in ReportPortal"""
+        if msg_time is None:
+            msg_time = str(int(time.time() * 1000))
+        self.service.log(
+            time=msg_time, message=message, level=level, item_id=test_item_id
+        )
+
+    def truncate_message(self, msg_txt, tc_name, test_item_id, itempath, type):
+        """Checks if the message to be logged is of a certain length. If it is greater than that
+        then it truncates the message and logs it and then puts the remaining message as an attachment"
+        """
+        message_length = len(msg_txt)
+        file_name = type + ".txt"
+        if message_length > 500000:
+            log.debug("\tMESSAGE LENGTH: %d", len(msg_txt))
+            log.debug("TEST CASE: %s as %s", tc_name, test_item_id)
+
+            # write out to attachments dir
+            sysout_filepath = os.path.join(itempath, file_name)
+            log.debug("WRITING AS ATTACHMENT: %s", sysout_filepath)
+
+            if not os.path.exists(itempath):
+                log.debug("Creating item dir %s", itempath)
+                os.makedirs(itempath)
+            write_fh = open(sysout_filepath, "wb")
+            # TODO: make this limit configurable
+            write_fh.write(msg_txt[-10000000:].encode("utf8"))
+            write_fh.write(b"\n")
+            write_fh.close()
+
+            # TODO: make these limits configurable
+            # cut message to first 1000 and last 3000 bytes
+            message = msg_txt[:1000]
+            message += (
+                "\n\n...\n\n  TRUNCATED by RP PREPROC " "(see attachments)\n...\n\n"
+            )
+            message += msg_txt[-10000:]
+            return message
+        return msg_txt

--- a/utility/rp_utils/xunit_xml.py
+++ b/utility/rp_utils/xunit_xml.py
@@ -1,0 +1,267 @@
+import logging
+import os
+import re
+import time
+from functools import partial, reduce
+
+from utility.rp_utils.reportportalV1 import RpLog
+
+log = logging.getLogger(__name__)
+
+
+class XunitXML:
+    """Class for processing the xUnit XML file for ReportPortal"""
+
+    def __init__(self, rportal, name=None, configs=None, xml_data=None):
+        self.rportal = rportal
+        self.name = name
+        self._configs = configs
+        self.xml_data = xml_data
+
+    @staticmethod
+    def get_file_list(results_dir):
+        """Get a list of XML results files from a directory"""
+        # get list of xml result files
+        result_file_list = []
+        if os.path.exists(results_dir):
+            for root, _, files in os.walk(results_dir):
+                log.debug("root dir : %s" % root)
+                for thefile in files:
+                    fqpath = os.path.join(root, thefile)
+                    if os.path.splitext(fqpath)[1] == ".xml":
+                        result_file_list.append(fqpath)
+                        log.debug("fqpath %s", fqpath)
+
+            return result_file_list
+        log.debug("payload directory path %s does not exist" % results_dir)
+        return False
+
+
+class TestSuite:
+    """Class to handle TestSuite xUnit specific items"""
+
+    def __init__(self, rportal, xml_name, testsuite):
+        self.service = rportal.service
+        self.xml_name = xml_name
+        self.testsuite = testsuite
+        self.item_id = None
+        self.name = testsuite.get("@name", testsuite.get("@id", "NULL"))
+        self.item_type = "SUITE"
+        self.num_failures = int(self.testsuite.get("@failures", "0"))
+        self.num_errors = int(self.testsuite.get("@errors", "0"))
+        if self.num_failures > 0 or self.num_errors > 0:
+            self.status = "FAILED"
+        else:
+            self.status = "PASSED"
+        self.ts_properties = None
+
+        if testsuite.get("properties"):
+            properties = testsuite.get("properties").get("property")
+            if not isinstance(properties, list):
+                properties = [properties]
+            self.ts_properties = map_attributes(
+                properties,
+                partial(filter_property, rportal.config.get("property_filter", list())),
+            )
+            # rp client cannot consume empty dict
+            if not self.ts_properties:
+                self.ts_properties = None
+
+    def start(self):
+        """Start a testsuite section in ReportPortal"""
+        log.debug("Starting testsuite %s", self.name)
+        # adding ts_properties as attributes(seen as tags on RP)
+        self.item_id = self.service.start_test_item(
+            name=self.name,
+            start_time=str(int(time.time() * 1000)),
+            item_type=self.item_type,
+            attributes=self.ts_properties,
+        )
+
+    def finish(self):
+        """Finish a testsuite section in ReportPortal"""
+        self.service.finish_test_item(
+            self.item_id, end_time=str(int(time.time() * 1000)), status=self.status
+        )
+        log.debug("Finished testsuite %s", self.name)
+
+
+class TestCase:
+    """Class to handle xUnit TestCase conversion to ReportPortal API calls"""
+
+    def __init__(self, rportal, xml_name, testcase, configs=None, parent_id=None):
+        self.service = rportal.service
+        self.xml_name = xml_name
+        self.testcase = testcase
+        self._configs = configs
+        self.parent_id = parent_id
+        self.tc_classname = testcase.get("@classname", "")
+        self.tc_name = testcase.get("@name", testcase.get("@id", None))
+        self.tc_time = testcase.get("@time")
+        self.description = "{} time: {}".format(self.tc_name, self.tc_time)
+        self.status = "PASSED"
+        self.issue = None
+        self.rplog = RpLog(rportal)
+        self.test_item_id = None
+        self.tc_properties = dict()
+
+        if testcase.get("properties"):
+            properties = testcase.get("properties").get("property")
+            if not isinstance(properties, list):
+                properties = [properties]
+            self.tc_properties = map_attributes(
+                properties,
+                partial(filter_property, rportal.config.get("property_filter", list())),
+            )
+
+    def start(self):
+        """Start a testcase in ReportPortal"""
+
+        # getting test case properties if any to be attached as tags for the test cases
+        attributes = list()
+        if self.tc_properties:
+            for key, val in self.tc_properties.items():
+                # creating the property in format key:val to be used as tag
+                attributes.append(key + ":" + val)
+
+        self.test_item_id = self.service.start_test_item(
+            name=self.tc_name[:255],
+            description=self.description,
+            attributes=attributes,
+            start_time=str(int(time.time() * 1000)),
+            item_type="STEP",
+            parent_item_id=self.parent_id,
+        )
+        # FIXME: start_time line length
+
+        # Add system_out log
+        if self.testcase.get("system-out"):
+            # TODO: resolve get each call vs above for efficiency in python
+
+            sys_out = self.testcase.get("system-out")
+            if not isinstance(sys_out, list):
+                sys_out = [sys_out]
+            msg_txt = ""
+            for msg in sys_out:
+                msg_txt = msg_txt + msg
+
+            itempath = os.path.join(
+                self._configs.payload_dir, "attachments", self.test_item_id
+            )
+            message = self.rplog.truncate_message(
+                msg_txt, self.tc_name, self.test_item_id, itempath, "system-out"
+            )
+
+            # write the message as a log entry
+            self.rplog.add_message(
+                message=message, level="INFO", test_item_id=self.test_item_id
+            )
+
+        # Add system_err log
+        if self.testcase.get("system-err"):
+            # TODO: resolve get each call vs above for efficiency in python
+
+            sys_err = self.testcase.get("system-err")
+            if not isinstance(sys_err, list):
+                sys_out = [sys_err]
+            msg_txt = ""
+            for msg in sys_err:
+                msg_txt = msg_txt + msg
+
+            itempath = os.path.join(
+                self._configs.payload_dir, "attachments", self.test_item_id
+            )
+            message = self.rplog.truncate_message(
+                msg_txt, self.tc_name, self.test_item_id, itempath, "system-err"
+            )
+
+            # write the message as a log entry
+            self.rplog.add_message(
+                message=message, level="INFO", test_item_id=self.test_item_id
+            )
+
+        # Indicate type of test case (skipped, failures, passed)
+        if self.testcase.get("skipped"):
+            self.issue = {"issue_type": "NOT_ISSUE"}
+            self.status = "SKIPPED"
+            skipped_case = self.testcase.get("skipped")
+            msg = (
+                skipped_case.get("@message", "#text")
+                if isinstance(skipped_case, dict)
+                else skipped_case
+            )
+            self.rplog.add_message(
+                message=msg, level="DEBUG", test_item_id=self.test_item_id
+            )
+        elif self.testcase.get("failure") or self.testcase.get("error"):
+            self.status = "FAILED"
+            failures = self.testcase.get("failure", self.testcase.get("error"))
+            failures_txt = ""
+            if not isinstance(failures, list):
+                failures = [failures]
+            for failure in failures:
+                msg = failure.get("@message") if isinstance(failure, dict) else failure
+                failures_txt += "Message: {msg}\n".format(msg=msg)
+                failtype = (
+                    failure.get("@type") if isinstance(failure, dict) else failure
+                )
+                failures_txt += "Type: {failtype}\n".format(failtype=failtype)
+                txt = failure.get("#text") if isinstance(failure, dict) else failure
+                failures_txt += "\nText:\n{txt}\n".format(txt=txt)
+
+            self.rplog.add_message(
+                message=failures_txt, level="ERROR", test_item_id=self.test_item_id
+            )
+
+            # handle attachments
+            tc_attach_dir = "{}.{}".format(self.tc_classname, self.tc_name)
+            fqpath = os.path.join(self._configs.payload_dir, "attachments")
+            attached_files = self.rplog.add_attachments(
+                fqpath, self.xml_name, tc_attach_dir, self.test_item_id
+            )
+            log.debug(
+                "Finished attaching files for failed test cases %s", attached_files
+            )
+
+        else:
+            self.status = "PASSED"
+
+    def finish(self):
+        """Finish a testcase in ReportPortal"""
+        self.service.finish_test_item(
+            self.test_item_id,
+            end_time=str(int(time.time() * 1000)),
+            status=self.status,
+            issue=self.issue,
+        )
+
+
+def valid_attribute(prop):
+    """Check if property can be used as report portal attribute"""
+    return bool(
+        prop.get("@value").strip() and 0 < len(prop.get("@name").strip()) <= 128
+    )
+
+
+def map_attributes(properties, filter_function):
+    """Map properties to attributes"""
+    if not isinstance(properties, list):
+        properties = list(properties)
+
+    return dict(
+        map(
+            lambda x: (x.get("@name"), x.get("@value")),
+            filter(filter_function, properties),
+        )
+    )
+
+
+def filter_property(filters, prop):
+    """Test if testsuite property is allowed"""
+    name = prop.get("@name")
+
+    allowed = reduce(
+        lambda x, y: x or y, map(lambda x: bool(re.match(x, name)), filters), False
+    )
+
+    return allowed and valid_attribute(prop)


### PR DESCRIPTION
Uploading results to Report portal with Log attachments

We are uploading the logs and results that are generated from IBM-C execution.

Report portal launch details : https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/3193
### Pre-requsites:
We are expecting the logs and results in following directory structure

|- payload_dir
      - results
               - test_results_xuint_1.xml
               - test_results_xuint_2.xml
               - test_results_xuint_3.xml
       - attachments
             - test_results_xuint_1
                  - test_results_xuint_1.zip
                  - test_case_name.err 
             - test_results_xuint_2
                   - test_results_xuint_2.zip
                  
### Functionality:
It accepts config file location and payload_directory
**In config file:**
We will have the details of report portal and launch details
**In Payload_directory:**
We will have the zipped logs of the suites and error files if there is an error while executing the test case

We are going to parse the xunit files and get the details of the results and upload them.
if there are any attachments present for the xunit file in the attachments folder with xunit folder name those files will get attached to the suite and if there are any .err files we are going to attach them to the respective test cases based on the name of the test case.
If the .zip file not present in the attachments. for those we are just updating the results and skipping the attachments

### Sample Payload directory structure:
[amk@amk payload]$ ls -lart
total 0
drwxrwxr-x. 2 amk amk 257 Mar 17 12:41 results
drwxr-xr-x. 3 amk amk  21 Mar 18 16:50 ..
drwxr-xr-x. 4 amk amk  40 Mar 18 16:50 .
drwxr-xr-x. 6 amk amk 138 Mar 22 19:51 attachments
[amk@amk payload]$ ls -lart results/
total 28
-rw-rw-r--. 1 amk amk 2363 Mar 17 12:41 test-cephfs-core-features.xml
-rw-rw-r--. 1 amk amk 1970 Mar 17 12:41 test-rhceph-rhel-7-rpm.xml
-rw-rw-r--. 1 amk amk 2014 Mar 17 12:41 test-rhceph-image-on-rhel-7.xml
-rw-rw-r--. 1 amk amk 2081 Mar 17 12:41 test-rbd-core-features.xml
-rw-rw-r--. 1 amk amk 2007 Mar 17 12:41 test-rhceph-image-on-rhel-8.xml
-rw-rw-r--. 1 amk amk 1972 Mar 17 12:41 test-rhceph-rhel-8-rpm.xml
drwxrwxr-x. 2 amk amk  257 Mar 17 12:41 .
-rw-rw-r--. 1 amk amk 2538 Mar 17 12:41 test-rgw-core-features.xml
drwxr-xr-x. 4 amk amk   40 Mar 18 16:50 ..
[amk@amk payload]$ ls -lart attachments/
total 0
drwxr-xr-x. 4 amk amk  40 Mar 18 16:50 ..
drwxr-xr-x. 2 amk amk  68 Mar 22 19:50 test-cephfs-core-features
drwxr-xr-x. 2 amk amk  40 Mar 22 19:51 test-rbd-core-features
drwxr-xr-x. 2 amk amk  40 Mar 22 19:51 test-rgw-core-features
drwxr-xr-x. 2 amk amk  49 Mar 22 19:51 test-rhceph-deployment-features
drwxr-xr-x. 6 amk amk 138 Mar 22 19:51 .
[amk@amk payload]$ ls -lart attachments/test-cephfs-core-features
total 8
-rw-r--r--. 1 amk amk 2647 Mar 17 07:14 test-cephfs-core-features.zip
-rw-------. 1 amk amk   32 Mar 18 20:17 cephfs-basics.err
drwxr-xr-x. 2 amk amk   68 Mar 22 19:50 .
drwxr-xr-x. 6 amk amk  138 Mar 22 19:51 ..
[amk@amk payload]$ ls -lart attachments/test-rbd-core-features
total 4
-rw-r--r--. 1 amk amk 2524 Mar 17 07:14 test-rbd-core-features.zip
drwxr-xr-x. 2 amk amk   40 Mar 22 19:51 .
drwxr-xr-x. 6 amk amk  138 Mar 22 19:51 ..
[amk@amk payload]$ 


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
