### PR TITLE
Fixing MultiFs failures

### DIFF
--- a/tests/cephfs/multifs/multifs_default_values.py
+++ b/tests/cephfs/multifs/multifs_default_values.py
@@ -61,18 +61,20 @@ def run(ceph_cluster, **kw):
         hosts = " ".join(host_list)
         client1.exec_command(
             sudo=True,
-            cmd=f"ceph fs volume create cephfs_new --placement='2 {hosts}'",
+            cmd=f"ceph fs volume create cephfs_df_fs --placement='2 {hosts}'",
             check_ec=False,
         )
-        fs_util.wait_for_mds_process(client1, "cephfs_new")
+        fs_util.wait_for_mds_process(client1, "cephfs_df_fs")
         out, rc = client1.exec_command(
             sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
         )
         daemon_ls_after = json.loads(out.read().decode())
         daemon_count_after = len(daemon_ls_after)
         assert daemon_count_after > daemon_count_before, (
-            "daemon count is reduced after creating FS. "
-            "Expectation is MDS daemons whould be more"
+            f"daemon count is reduced after creating FS. "
+            f"Expectation is MDS daemons whould be more"
+            f"daemon count before: {daemon_count_before}"
+            f"daemon count after: {daemon_count_after}"
         )
 
         total_fs = fs_util.get_fs_details(client1)
@@ -81,7 +83,7 @@ def run(ceph_cluster, **kw):
                 "We can't proceed with the test case as we are not able to create 2 filesystems"
             )
         fs_names = [fs["name"] for fs in total_fs]
-        validate_mds_placements("cephfs_new", daemon_ls_after, hosts, 2)
+        validate_mds_placements("cephfs_df_fs", daemon_ls_after, hosts, 2)
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
@@ -126,4 +128,4 @@ def run(ceph_cluster, **kw):
         ]
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)
-        fs_util.remove_fs(client1, "cephfs_new")
+        fs_util.remove_fs(client1, "cephfs_df_fs")

--- a/tests/cephfs/multifs/multifs_fusemounts.py
+++ b/tests/cephfs/multifs/multifs_fusemounts.py
@@ -39,6 +39,7 @@ def run(ceph_cluster, **kw):
         client1.exec_command(
             sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
         )
+        fs_util.wait_for_mds_process(client1, "cephfs_new")
         total_fs = fs_util.get_fs_details(client1)
         if len(total_fs) < 2:
             log.error(
@@ -125,6 +126,5 @@ def run(ceph_cluster, **kw):
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)
         client1.exec_command(
-            sudo=True, cmd="cp /etc/fstab.backup /etc/fstab", check_ec=False
+            sudo=True, cmd="mv /etc/fstab.backup /etc/fstab", check_ec=False
         )
-        client1.exec_command(sudo=True, cmd="rm -f /etc/fstab.backup", check_ec=False)

--- a/tests/cephfs/multifs/multifs_kernelmounts.py
+++ b/tests/cephfs/multifs/multifs_kernelmounts.py
@@ -98,5 +98,5 @@ def run(ceph_cluster, **kw):
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)
         client1.exec_command(
-            sudo=True, cmd="cp /etc/fstab.backup /etc/fstab", check_ec=False
+            sudo=True, cmd="mv /etc/fstab.backup /etc/fstab", check_ec=False
         )


### PR DESCRIPTION
Fixing MultiFs failures on IBM C environment
Ceph-fuse command was failing as the new file system was taking time to get mounted.
for now we have added delay of 100 sec after the MDS daemons are listed and up in **ceph orch ps**

Log for the IBM-C execution : https://159.23.92.24/job/custom_run_amk/22/console


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
