### PR TITLE
subvolumegroup creation with invalid pool

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml
@@ -16,6 +16,7 @@
 # CEPH-83574162 - cephfs_vol_mgmt_non_exist_subvol_group_deletetion
 # CEPH-83573528 - cephfs_vol_mgmt_pool_name_option_test
 # CEPH-83574181 - Checking default subvolume group gid and uid
+# CEPH-83574163 - cephfs_vol_mgmt_invalid_pool_layout
 #===============================================================================================
 tests:
   - test:
@@ -236,4 +237,10 @@ tests:
       module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
       polarion-id: CEPH-83574181
       desc: Checking default subvolume group gid and uid
+      abort-on-fail: true
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
       abort-on-fail: true

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_invalid_pool_layout.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_invalid_pool_layout.py
@@ -1,0 +1,44 @@
+import traceback
+
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    pre-requisites:
+    1. prepare invalid pool_name
+    Test operation:
+    1. Try to create a subvolume group with invalid pool
+    2. Check if the subvolume group is not created beacuse of the invalid pool
+    3. Using get_path, check if subvolumegroup path is cleaned up
+    """
+    try:
+        tc = "CEPH-83574163"
+        log.info(f"Running CephFS tests for BZ-{tc}")
+        fs_util = FsUtils(ceph_cluster)
+        clients = ceph_cluster.get_ceph_objects("client")
+        client1 = clients[0]
+        fs_details = fs_util.get_fs_info(client1)
+        if not fs_details:
+            fs_util.create_fs(client1, "cephfs")
+        fs_util.auth_list([client1])
+        subvol_group_name = "subvol_group"
+        invalid_pool_name = "non_exist_pool"
+        out1, err1 = fs_util.create_subvolumegroup(
+            client1, "cephfs", subvol_group_name, pool_layout=invalid_pool_name
+        )
+        out2, err2 = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume getpath cephfs {subvol_group_name}",
+            check_ec=False,
+        )
+        if out1 == 0 or out2 == 0:
+            return 1
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1


### PR DESCRIPTION
pre-requisites:
1. prepare invalid pool_name

Test operation:
1. Try to create a subvolume group with invalid pool
2. Check if the subvolume group is not created beacuse of the invalid pool
3. Using get_path, check if subvolumegroup path is cleaned up

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574163
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AU0I6O/

Signed-off-by: julpark-rh <yonhyun@gmail.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
