### PR TITLE
pool_tests.py: Verify bulk flag feature

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -218,9 +218,6 @@ class RadosOrchestrator:
 
         cmd = f"ceph osd pool get {pool} {props} -f json"
         out, err = self.node.shell([cmd])
-        if err:
-            log.info(f"The property : {props} not set on the cluster. Error: {err}")
-            return False
         prop_details = json.loads(out)
         return prop_details
 
@@ -318,11 +315,14 @@ class RadosOrchestrator:
          Returns: True -> pass, False -> fail
         """
 
-        log.info(f"creating pool_name {pool_name}")
-        pg_num = kwargs.get("pg_num", 64)
-        cmd = f"ceph osd pool create {pool_name} {pg_num} {pg_num}"
+        log.debug(f"creating pool_name {pool_name}")
+        cmd = f"ceph osd pool create {pool_name}"
+        if kwargs.get("pg_num"):
+            cmd = f"{cmd} {kwargs['pg_num']} {kwargs['pg_num']}"
         if kwargs.get("ec_profile_name"):
             cmd = f"{cmd} erasure {kwargs['ec_profile_name']}"
+        if kwargs.get("bulk"):
+            cmd = f"{cmd} --bulk"
         try:
             self.node.shell([cmd])
         except Exception as err:

--- a/suites/pacific/rados/tier-3_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-pool-functionalities.yaml
@@ -256,3 +256,13 @@ tests:
         pool-1-conf: sample-pool-2
         pool-2-conf: sample-pool-3
       desc: Migrating data between different pools. Scenario-4. Ec -> EC
+
+  - test:
+      name: Pg autoscaler bulk flag
+      module: pool_tests.py
+      polarion-id: CEPH-83573412
+      desc: Ceph PG autoscaler bulk flag tests
+      config:
+        test_autoscaler_bulk_feature: true
+        pool_name: test_bulk_features
+        delete_pool: true


### PR DESCRIPTION
Tests to verify the autoscaler bulk flag, which allows pools to make use of
scale-down profile, making those pools start with full compliments of PG sets.
        Tests include
        1. creating new pools with bulk,
        2. enabling/disabling bulk flag on existing pools
        3. Verify the PG changes when the flag is set/unset
Verifies bugs : https://bugzilla.redhat.com/show_bug.cgi?id=2049851

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>
