### PR TITLE
fix sphinx doc build failure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|build-status|
+|build-status|  |docbuild-status|
 
 CEPH-CI project documentation
 =============================
@@ -17,3 +17,7 @@ documentation in markdown_ or rst_ formats.
 .. |build-status| image:: https://github.com/red-hat-storage/cephci/workflows/tests/badge.svg
     :alt: build status
     :target: https://github.com/red-hat-storage/cephci/actions
+
+.. |docbuild-status| image:: https://readthedocs.org/projects/cephci/badge/?version=latest
+    :alt: docbuild-status
+    :target: https://readthedocs.org/projects/cephci/builds

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==2.4.4
-sphinx-autopackagesummary==1.3
-sphinx_rtd_theme==0.5.0
-recommonmark==0.6.0
+sphinx
+sphinx-autopackagesummary
+sphinx_rtd_theme
+recommonmark
 -r ../requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "paramiko==2.10.1",
         "pyOpenSSL==20.0.1",
         "pyyaml>=4.2b1",
-        "jinja2",
+        "jinja2<3.1.0",
         "junitparser==1.4.0",
         "jinja_markdown",
         "htmllistparse==0.5.2",


### PR DESCRIPTION
Signed-off-by: Chebrolu Harika <hchebrol@redhat.com>

Fix sphinx docs build failure due to latest release of Jinja2
For reference: https://github.com/readthedocs/readthedocs.org/issues/9037

Passed build from my forked-repo: https://readthedocs.org/projects/cephci-harika/builds/16524410/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
