### PR TITLE
Get rhbuild from cephadm config

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -181,7 +181,7 @@ class BootstrapMixin:
         custom_repo = args.pop("custom_repo", "")
         custom_image = args.pop("custom_image", True)
         build_type = self.config.get("build_type")
-        rhbuild = config.get("rhbuild")
+        rhbuild = self.config.get("rhbuild")
 
         if build_type == "upstream":
             self.setup_upstream_repository()


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Fix issue: get rhbuild value from cephadm config.

```

> 2022-04-01 07:34:31,947 - ceph.ceph - INFO - 
> 2022-04-01 07:34:31,947 - ceph.ceph - INFO - Running command rpm -qa | grep cephadm on 10.245.5.96
> 2022-04-01 07:34:32,686 - ceph.ceph - INFO - Command completed successfully
> 2022-04-01 07:34:32,689 - test_cephadm - ERROR - 'NoneType' object has no attribute 'startswith'
> Traceback (most recent call last):
>   File "/data/jenkins/workspace/tier-0/tests/ceph_installer/test_cephadm.py", line 130, in run
>     func(cfg)
>   File "/data/jenkins/workspace/tier-0/ceph/ceph_admin/bootstrap.py", line 278, in bootstrap
>     if rhbuild.startswith("5.1"):

```