### PR TITLE
Added reshard cancel TC into RGW T1

### DIFF
--- a/suites/nautilus/rgw/tier-1-extn_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw.yaml
@@ -91,6 +91,15 @@ tests:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
         timeout: 500
+  - test:
+      name: reshard cancel command
+      desc: reshard cancel command
+      polarion-id: CEPH-11474
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
+        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -126,6 +126,15 @@ tests:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
         timeout: 500
+  - test:
+      name: reshard cancel command
+      desc: reshard cancel command
+      polarion-id: CEPH-11474
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
+        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled


### PR DESCRIPTION
Added reshard cancel TC into RGW T1
Following is the log link of successful run
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WZX5OQ
Signed-off-by: uday kurundwade <ukurundw@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
