### PR TITLE
Fix cdn repos to els at 3x

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1708,9 +1708,9 @@ class CephNode(object):
         ]
 
         repos_3x = [
-            "rhel-7-server-rhceph-3-tools-rpms",
-            "rhel-7-server-rhceph-3-osd-rpms",
-            "rhel-7-server-rhceph-3-mon-rpms",
+            "rhel-7-server-rhceph-3-tools-els-rpms",
+            "rhel-7-server-rhceph-3-osd-els-rpms",
+            "rhel-7-server-rhceph-3-mon-els-rpms",
         ]
 
         repos_4x_rhel7 = [


### PR DESCRIPTION
Fixed 3x tools repository 
test failure logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GDN323/
suite suites/nautilus/upgrades/tier-2_upgrade_test-multi-path-upgrade-to-4-latest.yaml

Reference - https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html-single/installation_guide_for_red_hat_enterprise_linux/index#enabling-the-red-hat-ceph-storage-repositories

Signed-off-by: rlepaksh <rlepaksh@redhat.com>

