### PR TITLE
Fix finding of error logs

### DIFF
--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -126,7 +126,7 @@ node(nodeName) {
             sh "tar -zcvf ${logDir}/${key}.tar.gz ${logDir}/*.log"
             sh "mkdir -p ${attachDir}/${key}"
             sh "cp ${logDir}/${key}.tar.gz ${attachDir}/${key}/"
-            sh "find ${logDir} -maxdepth 1 -type f -not -size 0 -exec cp '{}' ${attachDir}/${key}/"
+            sh "find ${logDir} -maxdepth 1 -type f -not -size 0 -name '*.err' -exec cp '{}' ${attachDir}/${key}/ \\;"
         }
 
         // Adding metadata information


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we address the issue in the way we are finding the `.err` logs.

```
[](https://159.23.92.24/blue/organizations/jenkins/tier-x/detail/tier-x/81/pipeline/259#step-265-log-2)[](https://159.23.92.24/blue/organizations/jenkins/tier-x/detail/tier-x/81/pipeline/259#step-265-log-3)+ find /data/jenkins/workspace/tier-x/logs/273zl-81 -maxdepth 1 -type f -not -size 0 -exec cp '{}' /data/jenkins/workspace/tier-x/ibm_tier-x_81/attachments/test-cephfs-extended-mat/

find: missing argument to `-exec'

script returned exit code 1
```

The logic is the same between ibm-tier-0 and ibm-tier-x