### PR TITLE
Fix rbd resize test failure

### DIFF
--- a/suites/nautilus/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/nautilus/rbd/tier-1_rbd_mirror.yaml
@@ -111,6 +111,7 @@ tests:
           config:
             imagesize: 2G
             io-total: 200M
+            resize_to: 5G
       polarion-id: CEPH-83573329
       desc: Create RBD mirrored image and run IOs
 

--- a/suites/pacific/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/pacific/rbd/tier-1_rbd_mirror.yaml
@@ -183,6 +183,7 @@ tests:
           config:
             imagesize: 2G
             io-total: 200M
+            resize_to: 5G
       polarion-id: CEPH-83573332
       desc: Create RBD mirrored image in pools  and run IOs
   - test:

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -665,7 +665,7 @@ class RbdMirror:
 
     def resize_image(self, imagespec, size):
         """
-        Resize given provided image
+        Resize provided image
         Args:
             imagespec: image-spec of the image to be resized
             size: size of the image to be updated to

--- a/tests/rbd_mirror/test_rbd_mirror.py
+++ b/tests/rbd_mirror/test_rbd_mirror.py
@@ -32,7 +32,7 @@ def run(**kw):
         mirror1.config_mirror(mirror2, poolname=poolname, mode="pool")
         mirror2.wait_for_status(poolname=poolname, images_pattern=1)
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
-        mirror1.resize_image(imagespec=imagespec, size=config.get("imagesize"))
+        mirror1.resize_image(imagespec=imagespec, size=config.get("resize_to"))
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)


### PR DESCRIPTION
previously rbd resize size test with mirroring was hard coded
After the resize func was generalised, runs are failing as resize being attempted to same size as original
Fixes : https://github.com/red-hat-storage/cephci/issues/1366

Log - https://15x.xx.xx.xx/job/Custom%20Test%20Run/61/console
Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
