### PR TITLE
Fix cannot stat xunit.xml

### DIFF
--- a/pipeline/ibm-tier-0.groovy
+++ b/pipeline/ibm-tier-0.groovy
@@ -99,7 +99,7 @@ node(nodeName) {
         sh (script: "mkdir -p ${targetDir} ${attachDir}")
         testResults.each { key, value ->
             def logDir = value["log-dir"]
-            sh "cp ${logDir}/xunit.xml ${targetDir}/${key}.xml"
+            sh "find ${logDir} -maxdepth 1 -type f -name xunit.xml -exec cp '{}' ${targetDir}/${key}.xml \\;"
             sh "tar -zcvf ${logDir}/${key}.tar.gz ${logDir}/*.log"
             sh "mkdir -p ${attachDir}/${key}"
             sh "cp ${logDir}/${key}.tar.gz ${attachDir}/${key}/"

--- a/pipeline/ibm-tier-x.groovy
+++ b/pipeline/ibm-tier-x.groovy
@@ -122,7 +122,7 @@ node(nodeName) {
         sh (script: "mkdir -p ${targetDir} ${attachDir}")
         testResults.each { key, value ->
             def logDir = value["log-dir"]
-            sh "cp ${logDir}/xunit.xml ${targetDir}/${key}.xml"
+            sh "find ${logDir} -maxdepth 1 -type f -name xunit.xml -exec cp '{}' ${targetDir}/${key}.xml \\;"
             sh "tar -zcvf ${logDir}/${key}.tar.gz ${logDir}/*.log"
             sh "mkdir -p ${attachDir}/${key}"
             sh "cp ${logDir}/${key}.tar.gz ${attachDir}/${key}/"


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR allows the IBM tier jobs to execute other stages when a test suite was not executed due to infra related issues.

__Error__

```
+ cp /data/jenkins/workspace/tier-x/logs/7ic1h-88/xunit.xml /data/jenkins/workspace/tier-x/ibm_tier-x_88/results/test-cephfs-extended-mat.xml

cp: cannot stat ‘/data/jenkins/workspace/tier-x/logs/7ic1h-88/xunit.xml’: No such file or directory

script returned exit code 1
```

__Fix__
```
[psathyan@psathyan tmp]$ sudo find . -maxdepth 1 -type f -name test22.txt -exec cp '{}' test/ \;
[psathyan@psathyan tmp]$ echo $?
0
[psathyan@psathyan tmp]$ sudo find . -maxdepth 1 -type f -name test22.txt -exec cp '{}' test/new.txt \;
[psathyan@psathyan tmp]$ ls test/
[psathyan@psathyan tmp]$ sudo find . -maxdepth 1 -type f -name test2.txt -exec cp '{}' test/new.txt \;
[psathyan@psathyan tmp]$ ls test
new.txt
```