### PR TITLE
RGW s3tests command to be executed with long_running enabled

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -177,15 +177,11 @@ def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> in
             tests = "s3tests_boto3"
 
         cmd = f"{base_cmd} {extra_args} {tests}"
-        out, err = node.exec_command(cmd=cmd, timeout=3600)
-        log.info(out)
-        log.error(err)
+        return node.exec_command(cmd=cmd, long_running=True)
     except CommandFailed as e:
         log.warning("Received CommandFailed")
         log.warning(e)
         return 1
-
-    return 0
 
 
 def execute_teardown(cluster: Ceph, build: str) -> None:


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

In this PR, we move to use `long_running=True` so that we can view the log events immediately. As we are interested only with the exit status of the command... this is an improved addition.

__Logs__
https://159.23.92.24/job/custom_run_amk/54/console