### PR TITLE
Adding support for different extentsions for logs.zip

### DIFF
--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -13,7 +13,7 @@ payload
       - test2.xml
   |- attachments
       - test1
-         - test1.zip
+         - test1.tar.gz
          - failed_test.err
 
 config.json:
@@ -164,9 +164,9 @@ def process(xmlObj, rportal):
             process_testcase(xmlObj, testcase, tsuite)
         log.info("\nFinished testcases")
         fqpath = os.path.join(xmlObj._configs.payload_dir, "attachments")
-        if os.path.exists(f"{fqpath}/{tsuite.xml_name}/{tsuite.xml_name}.zip"):
+        if os.path.exists(f"{fqpath}/{tsuite.xml_name}/{tsuite.xml_name}.tar.gz"):
             rplog.add_attachment(
-                tsuite.item_id, f"{fqpath}/{tsuite.xml_name}/{tsuite.xml_name}.zip"
+                tsuite.item_id, f"{fqpath}/{tsuite.xml_name}/{tsuite.xml_name}.tar.gz"
             )
         tsuite.finish()
 


### PR DESCRIPTION
Adding support for different extentsions for logs.zip

Problem Statment:
IBM Logs not getting attached to the Launches in Report portal.

Root Cause:
There was an extension change in archiving the log files in IBM-COS.
Previous Extention : zip
Current Extension : tar.gz

Solution:
Added code to handle any kind of extension present.
We are just matching the XML names leaving behind the extensions


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
