### PR TITLE
Adhering to latest changes of exec_command

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -240,7 +240,7 @@ class FsUtils(object):
                 cmd="ceph orch ps --daemon_type=mds --format json",
                 check_ec=False,
             )
-            mds_hosts = json.loads(out.read().decode())
+            mds_hosts = json.loads(out)
             for mds in mds_hosts:
                 log.info(mds)
                 if process_name in mds["daemon_id"] and ispresent:


### PR DESCRIPTION
Modified function to adhere to latest changes pushed to exec_command

Problem:
Return value for exec_command has been modified which affected one of the function where we used to apply read().decode() to return value

Removed read().decode() and now we are directly loading the string to json object



Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
