### PR TITLE
script to collect upstream build information

### DIFF
--- a/pipeline/scripts/ci/upstream_cli.py
+++ b/pipeline/scripts/ci/upstream_cli.py
@@ -1,0 +1,179 @@
+"""
+This script provides the upstream latest rpm repo path and container image.
+Please note that this script should be run under root privilages
+inorder to pull the image and podman should be installed on that host.
+"""
+import fcntl
+import logging
+import os
+import re
+import sys
+import time
+
+import requests
+import yaml
+from docopt import docopt
+from packaging import version
+
+LOG = logging.getLogger(__name__)
+
+
+def update_upstream(file_name, content):
+    """Method to update for the provided file
+    along with file set lock to avoid race condition.
+    Args:
+        file_name: Name of the file to update
+        content: things to update in file
+    """
+    # waiting for 10 minutes in case lock is held indefinitely
+    timeout = 600
+    timeout_start = time.time()
+    while time.time() < timeout_start + timeout:
+        try:
+            # try/except in case the file is still locked by another process
+            # open the file for editing
+            with open(file_name, "w") as yaml_file:
+                # To lock the file to avoid race condition
+                fcntl.flock(yaml_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                # update the file with write operation
+                yaml_file.write(yaml.dump(content, default_flow_style=False))
+                # unlock it so other processed can use it
+                fcntl.flock(yaml_file, fcntl.LOCK_UN)
+                LOG.info(f"Updated build info in {file_name}")
+                break
+
+        except IOError:
+            # wait for 2 minutes before retrying
+            time.sleep(120)
+
+
+def store_in_upstream(branch_name, repo, image, upstream_version):
+    """Method to update it in upstream.yaml.
+    Args:
+        branch_name: Name of upstream branch
+        repo: upstream branch compose URL
+        image: upstream branch image
+        version: upstream branch ceph version.
+    """
+    file_name = "/ceph/cephci-jenkins/latest-rhceph-container-info/upstream.yaml"
+    stream = open(file_name, "r")
+    repo_details = yaml.load(stream)
+    # To handle new release which is not updated yet
+    if repo_details.get(branch_name):
+        existing_version = repo_details[branch_name]["ceph-version"]
+    else:
+        # updating new branch details in upstream.yaml
+        repo_details[branch_name] = {
+            "ceph-version": upstream_version,
+            "composes": repo,
+            "image": image,
+        }
+        update_upstream(file_name, repo_details)
+        return
+    # version.parse helps to compare version as easy as integers.
+    old_version = version.parse(existing_version)
+    new_version = version.parse(upstream_version)
+    # update only if current version is greater than existing version.
+    if new_version > old_version:
+        # edit the file
+        stream = open(file_name, "r")
+        data = yaml.load(stream)
+        data[branch_name]["composes"] = repo
+        data[branch_name]["image"] = image
+        data[branch_name]["ceph-version"] = upstream_version
+        update_upstream(file_name, data)
+
+
+usage = """
+This script helps to provide needed info for upstream specific.
+
+Usage:
+  upstream_cli.py build <branch_name>
+
+
+Example:
+    python upstream_cli.py build quincy
+
+Options:
+    -h --help                       Show this screen
+"""
+
+
+def fetch_upstream_build(branch: str):
+    """
+    Method to get rpm repo path,container image and ceph version of given branch.
+
+    Args:
+        branch: str    Upstream branch name
+    """
+    branch = branch.lower()
+    branch_repo = branch + "/latest/centos/8/repo/"
+    url = "https://shaman.ceph.com/api/repos/ceph/" + branch_repo
+
+    # if any connection issue to URL it will wait for 30 seconds to establish connection.
+    response = requests.get(url, timeout=30)
+    if response.status_code != 200:
+        response.raise_for_status()
+    repo = response.url
+    LOG.info(f"Upstream repo for the given branch is {repo}")
+
+    # To get image for that rpm repo
+    id = re.search("[0-9a-f]{5,40}", repo).group()
+    image = "quay.ceph.io/ceph-ci/ceph:" + id
+    LOG.info(f"Upstream image for the given branch is {image}")
+
+    cmd = "podman -v"
+    exit_status = os.system(cmd)
+    if exit_status:
+        raise Exception("Please install podman on host")
+
+    cmd = f"sudo podman pull {image}"
+    exit_status = os.system(cmd)
+    if exit_status:
+        raise Exception(f"{image} is unable to pull")
+
+    # Regex to get sprm url to find ceph version
+    content = response.text
+    regex = "(?i)(https?://|www.|\\w+\\.)[^\\s]+"
+    urls = [match.group() for match in re.finditer(regex, content)]
+    srpm = urls[2]
+
+    response = requests.get(srpm, timeout=30)
+    content = response.text
+
+    # Regex to match ceph version
+    pattern = re.search(r"ceph.*rpm", content).group(0)
+    version = re.search(r"\d(?:.*?(-).[0-9]*){1}", pattern).group(0)
+    LOG.info(f"Upstream version for the given branch is {version}")
+    store_in_upstream(branch_name, repo, image, version)
+
+
+OPS = {
+    "build": fetch_upstream_build,
+}
+
+if __name__ == "__main__":
+
+    _args = docopt(usage, help=True, version=None, options_first=False)
+    logging.basicConfig(
+        handlers=[logging.StreamHandler(sys.stdout)],
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s",
+    )
+
+    try:
+        method = None
+        for key, value in OPS.items():
+            if _args[key]:
+                method = value
+                break
+        else:
+            raise Exception("please provide right action")
+
+        branch_name = _args["<branch_name>"]
+        args = [branch_name]
+
+        method(*args)
+    except BaseException as be:
+        LOG.exception(be)
+        print(usage)


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Python script to collect upstream build information
Solves: https://issues.redhat.com/browse/RHCEPHQE-2668

Test Results:
Script returns upstream repo path and container image.
https://3.chacra.ceph.com/repos/ceph/quincy/43e2e60a7559d3f46c9d53f1ca875fd499a1e35e/centos/8/flavors/default/repo
quay.ceph.io/ceph-ci/ceph:43e2e60a7559d3f46c9d53f1ca875fd499a1e35e
