### PR TITLE
Adding TFACon for PSI Runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 cos-aspera; python_version == '3.6'
 python-openstackclient
 xmltodict
+tfacon

--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -57,6 +57,7 @@ from docopt import docopt
 from rp_utils.preproc import PreProcClient
 from rp_utils.reportportalV1 import Launch, ReportPortalV1, RpLog
 from rp_utils.xunit_xml import TestCase, TestSuite, XunitXML
+from utils import tfacon
 
 log = logging.getLogger(__name__)
 doc = """
@@ -108,6 +109,7 @@ def upload_logs(args):
         launch.finish()
     return_obj["launches"] = rportal.launches.list
     log.info("RETURN OBJECT: %s", return_obj)
+    tfacon(launch.launch_id)
     return return_obj
 
 


### PR DESCRIPTION
In this PR we are adding tfacon to all the PSI runs with **--report-portal** option

we need to add below details to **.cephci.yaml** in order to connect to tfacon

report-portal:
   endpoint: https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/
   project: cephci
   token: XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 tfacon:
  project_name: cephci
  auth_token: XXXXXXXXXXXXXXXXXXXXXXXXXXXX
  platform_url: https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com
  connector_type: RPCon
  tfa_url: https://dave.corp.redhat.com:443/models/5f248eb11e43c7000602300b/latest/model

Launch with TFA Analysis : https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/3492
Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
