### PR TITLE
support long_running command option from cephadm.ShellMixin

### DIFF
--- a/ceph/ceph_admin/shell.py
+++ b/ceph/ceph_admin/shell.py
@@ -20,6 +20,7 @@ class ShellMixin:
         base_cmd_args: Dict = None,
         check_status: bool = True,
         timeout: int = 600,
+        long_running: bool = False,
     ):
         """
         Ceph orchestrator shell interface to run ceph commands.
@@ -29,9 +30,11 @@ class ShellMixin:
             base_cmd_args (Dict)): cephadm base command options
             check_status (Bool): check command status
             timeout (Int): Maximum time allowed for execution.
+            long_running (Bool): Long running command (default: False)
 
         Returns:
             out (Str), err (Str) stdout and stderr response
+            rc (Int) exit status code if long_running command
 
         """
         cmd = deepcopy(BASE_CMD)
@@ -42,12 +45,14 @@ class ShellMixin:
         cmd.append("--")
         cmd.extend(args)
 
-        out, err = self.installer.exec_command(
+        out = self.installer.exec_command(
             sudo=True,
             cmd=" ".join(cmd),
             timeout=timeout,
             check_ec=check_status,
+            long_running=long_running,
         )
 
-        LOG.debug(out)
-        return out, err
+        if isinstance(out, tuple):
+            LOG.debug(out[0])
+        return out

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -30,7 +30,8 @@ class CephAdmProtocol(Protocol):
         args: List[str],
         base_cmd_args: Dict = None,
         check_status: bool = True,
-        timeout: int = 300,
+        timeout: int = 600,
+        long_running: bool = False,
     ):
         ...
 
@@ -45,7 +46,8 @@ class OrchProtocol(CephAdmProtocol, Protocol):
         args: List[str],
         base_cmd_args: Dict = None,
         check_status: bool = True,
-        timeout: int = 300,
+        timeout: int = 600,
+        long_running: bool = False,
     ):
         ...
 

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -120,13 +120,13 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         steps = config.get("steps", [])
         for step in steps:
             cfg = step["config"]
-
-            if cfg["command"] == "shell":
-                cephadm.shell(base_cmd_args=cfg.get("base_cmd_args"), args=cfg["args"])
+            command = cfg.pop("command")
+            if command == "shell":
+                cephadm.shell(**cfg)
                 continue
 
             obj = SERVICE_MAP[cfg["service"]](cluster=ceph_cluster, **config)
-            func = fetch_method(obj, cfg["command"])
+            func = fetch_method(obj, command)
             func(cfg)
 
         if config.get("verify_cluster_health"):


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Support long_running command option from cephadm.shell.
`SSL dashboard test suite`: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-61LKPM/


`long running shel command`: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9WA95U

 ```
 - test:
      name: Test long running command
      desc: .
      module: test_cephadm.py
      polarion-id: 
      config:
        steps:
          - config:
              command: shell      
              long_running: True
              args:               
                - sleep
                - "10"
          - config:
              command: shell      
              args:               
                - sleep
                - "10"
```

> 2022-04-25 18:47:11,130 - ceph.ceph - INFO - long running command -- cephadm -v shell -- sleep 10
> 2022-04-25 18:47:23,646 - ceph.ceph - INFO - 
> 2022-04-25 18:47:24,241 - ceph.ceph - INFO - end-time: 2022-04-25 18:47:24.241516
> 2022-04-25 18:47:24,242 - ceph.ceph - INFO - Running command cephadm -v shell -- sleep 10 on 10.0.210.244 timeout 600
> 2022-04-25 18:47:37,471 - ceph.ceph - INFO - Command completed successfully
> 