### PR TITLE
Added fix for socket timeout issue in NFS move test

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_ganesha.yaml
@@ -80,6 +80,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_move.yaml
         nfs-version: 4  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 8
           subdir_count: 3
@@ -139,6 +140,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_move.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 8
           subdir_count: 3

--- a/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
@@ -80,6 +80,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_move.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 8
           subdir_count: 3


### PR DESCRIPTION
# Problem Statement

NFS move test failed in the pipeline with socket Timeout Exception. Basically, the test is taking more time to execute. The time taken for test execution is higher than the default timeout.

# Solution
Added timeout according to the time taken for execution

Commit which caused timeout Exception in recent runs: https://github.com/red-hat-storage/cephci/commit/6f566b2877c8853583263bfd7000828b42da44ce

# Passed run log

http://magna002.ceph.redhat.com/cephci-jenkins/vivekanandan_logs/cephci-run-3IVP8V/