### PR TITLE
Fix for multihop upgrade suite, wrong container image picked during rpm to container conversion

### DIFF
--- a/tests/upgrades/test_upgrade.py
+++ b/tests/upgrades/test_upgrade.py
@@ -191,23 +191,24 @@ def run(ceph_cluster, **kw):
                             is_repo_present = (
                                 True if config.get("container_image") else False
                             )
-                        upgrade_config = get_ansible_conf(
-                            config, version, is_repo_present, False
+                        container_config = get_ansible_conf(
+                            config, prev_version, is_repo_present, False
                         )
                         if not ceph_cluster.containerized:
                             rc = switch_rpm_to_container.run(
                                 ceph_cluster=ceph_cluster_dict[cluster_name],
                                 ceph_nodes=ceph_cluster_dict[cluster_name],
-                                config=upgrade_config,
+                                config=container_config,
                                 test_data=kw.get("test_data"),
                                 ceph_cluster_dict=ceph_cluster_dict,
                                 clients=kw.get("clients"),
                             )
                             if rc != 0:
                                 return rc
-                            upgrade_config["ansi_config"][
-                                "containerized_deployment"
-                            ] = True
+                        upgrade_config = get_ansible_conf(
+                            config, version, is_repo_present, False
+                        )
+                        upgrade_config["ansi_config"]["containerized_deployment"] = True
                         rc = test_ansible_upgrade.run(
                             ceph_cluster=ceph_cluster_dict[cluster_name],
                             ceph_nodes=ceph_cluster_dict[cluster_name],


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Test Results of execution : https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/596/console 

Magna logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M1QUD6

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
