### PR TITLE
Reshuffling fs tier-0 and tier-1 tests

### DIFF
--- a/suites/pacific/cephfs/tier-0_fs.yaml
+++ b/suites/pacific/cephfs/tier-0_fs.yaml
@@ -118,13 +118,7 @@ tests:
       name: nfs-ganesha_with_cephfs
       module: nfs-ganesha_basics.py
       desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
-      polarion-id: CEPH-11308
-      abort-on-fail: false
-  - test:
-      name: Clone Operations
-      module: bug-1980920.py
-      desc: Cancel the clone operation and validate error message
-      polarion-id: CEPH-83574681
+      polarion-id: CEPH-83574439
       abort-on-fail: false
   -
     test:

--- a/suites/pacific/cephfs/tier-1_fs.yaml
+++ b/suites/pacific/cephfs/tier-1_fs.yaml
@@ -209,10 +209,16 @@ tests:
       desc: Test cephfs subvolume client authorize
       module: subvolume_authorize.py
       polarion-id: CEPH-83574596
-      abort-on-fail: true
+      abort-on-fail: false
   - test:
       name: no recover session mount
       module: no_recover_session_mount.py
       polarion-id: CEPH-11260
       desc: test no recover session mount by blocking the client node
+      abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
       abort-on-fail: false

--- a/tests/cephfs/bug-1980920.py
+++ b/tests/cephfs/bug-1980920.py
@@ -29,9 +29,13 @@ def run(ceph_cluster, **kw):
         bz = "1980920"
         tc = "CEPH-83574681"
         fs_util = FsUtils(ceph_cluster)
+
         log.info(f"Running CephFS tests for BZ-{bz}")
         log.info(f"Running CephFS tests for BZ-{tc}")
+        config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
         client1 = clients[0]
         create_cephfs = "ceph fs volume create cephfs"
         client1.exec_command(sudo=True, cmd=create_cephfs)
@@ -42,7 +46,6 @@ def run(ceph_cluster, **kw):
         subvolume = {
             "vol_name": "cephfs",
             "subvol_name": f"subvol_{subvolume_name_generate}",
-            "size": "5368706371",
         }
         subvolume_name = subvolume["subvol_name"]
         fs_util.create_subvolume(client1, **subvolume)
@@ -65,8 +68,8 @@ def run(ceph_cluster, **kw):
         )
         client1.exec_command(
             sudo=True,
-            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 "
-            f"--files 100 --files-per-dir 10 --dirs-per-dir 2 --top "
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 4000 "
+            f"--files 100 --files-per-dir 100 --dirs-per-dir 5 --top "
             f"{kernel_mounting_dir_1}",
             long_running=True,
         )
@@ -74,43 +77,34 @@ def run(ceph_cluster, **kw):
         fs_util.create_snapshot(
             client1, "cephfs", subvolume_name, f"subvol_1_snap{subvolume_name}"
         )
-        for i in range(1, 4):
-            new_subvolume_name = f"subvol_1_snap_clone{subvolume_name}{str(i)}"
-            fs_util.create_clone(
-                client1,
-                "cephfs",
-                subvolume_name,
-                f"subvol_1_snap{subvolume_name}",
-                new_subvolume_name,
-            )
-            out1, err1 = client1.exec_command(
-                sudo=True, cmd=f"ceph fs clone status cephfs {new_subvolume_name}"
-            )
-            output1 = json.loads(out1)
-            output2 = output1["status"]["state"]
-            log.info(new_subvolume_name + " status: " + str(output2))
-            if output2 == "in-progress":
-                result, error = client1.exec_command(
-                    sudo=True,
-                    cmd=f"ceph fs subvolume rm cephfs {new_subvolume_name} --force",
-                    check_ec=False,
-                )
-                log.info("Subvolume Remove Executed")
-                error_result = error
-                if "clone in-progress" in error_result:
-                    log.info("Clone is in-progress as expected")
-                client1.exec_command(
-                    sudo=True, cmd=f"ceph fs clone cancel cephfs {new_subvolume_name}"
-                )
-            result2, error2 = client1.exec_command(
-                sudo=True, cmd=f"ceph fs clone status cephfs {new_subvolume_name}"
-            )
-            out1 = json.loads(result2)
-            out2 = out1["status"]["state"]
-            if out2 == "canceled":
-                fs_util.remove_subvolume(
-                    client1, "cephfs", new_subvolume_name, force=True
-                )
+        new_subvolume_name = f"subvol_1_snap_clone{subvolume_name}_1"
+        fs_util.create_clone(
+            client1,
+            "cephfs",
+            subvolume_name,
+            f"subvol_1_snap{subvolume_name}",
+            new_subvolume_name,
+        )
+        stdout, stderr = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume rm cephfs {new_subvolume_name}",
+            check_ec=False,
+        )
+        log.info(stdout, stderr)
+        error_result = stderr
+        log.info(error_result)
+        if "is not ready for operation rm" in error_result:
+            log.info("Clone is in-progress as expected")
+        client1.exec_command(
+            sudo=True, cmd=f"ceph fs clone cancel cephfs {new_subvolume_name}"
+        )
+        result2, error2 = client1.exec_command(
+            sudo=True, cmd=f"ceph fs clone status cephfs {new_subvolume_name}"
+        )
+        out1 = json.loads(result2)
+        out2 = out1["status"]["state"]
+        if out2 == "canceled":
+            fs_util.remove_subvolume(client1, "cephfs", new_subvolume_name, force=True)
         fs_util.remove_snapshot(
             client1, "cephfs", subvolume_name, f"subvol_1_snap{subvolume_name}"
         )


### PR DESCRIPTION
Reshuffling fs tier-0 and tier-1 tests
As part of revisiting polarion test cases we have reshuffled test cases as per the priority

Tier-0 : https://159.23.92.24/job/custom_run_amk/65/console
Tier-1 : https://159.23.92.24/job/custom_run_amk/89/

I have executed tier-1 almost 4 times and it is passing.
Time takes for tier-1 : 2 hrs 9 min

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
