### PR TITLE
support multiple network interface(s) for a  node.

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -332,6 +332,7 @@ def create_ceph_nodes(
                     node_params["role"],
                 )
 
+                node_params["networks"] = node_dict.get("networks", [])
                 if node_dict.get("no-of-volumes"):
                     node_params["no-of-volumes"] = node_dict.get("no-of-volumes")
                     node_params["size-of-disks"] = node_dict.get("disk-size")
@@ -384,7 +385,7 @@ def setup_vm_node(node, ceph_nodes, **params):
             image_name=params["image-name"],
             vm_size=params["vm-size"],
             cloud_data=params["cloud-data"],
-            vm_network=params.get("network", None),
+            vm_network=params.get("networks", []),
             size_of_disks=params.get("size-of-disks", 0),
             no_of_volumes=params.get("no-of-volumes", 0),
         )

--- a/compute/openstack.py
+++ b/compute/openstack.py
@@ -78,6 +78,17 @@ def get_openstack_driver(
 class CephVMNodeV2:
     """Represent the VMNode required for cephci."""
 
+    default_network_names = [
+        "provider_net_cci_12",
+        "provider_net_cci_11",
+        "provider_net_cci_9",
+        "provider_net_cci_8",
+        "provider_net_cci_7",
+        "provider_net_cci_6",
+        "provider_net_cci_5",
+        "provider_net_cci_4",
+    ]
+
     def __init__(
         self,
         username: str,
@@ -156,7 +167,9 @@ class CephVMNodeV2:
         try:
             image = self._get_image(name=image_name)
             vm_size = self._get_vm_size(name=vm_size)
-            vm_network = self._get_network(vm_network)
+            vm_network = self.get_network(vm_network)
+
+            LOG.info(f"{node_name} networks: {[i.name for i in vm_network]}")
 
             self.node = self.driver.create_node(
                 name=node_name,
@@ -352,8 +365,9 @@ class CephVMNodeV2:
 
         return False
 
-    def _get_network(
-        self, name: Optional[Union[List, str]] = None
+    def get_network(
+        self,
+        name: Optional[Union[List, str]] = None,
     ) -> List[OpenStackNetwork]:
         """
         Return the first available OpenStackNetwork with a free IP address to lease.
@@ -372,23 +386,12 @@ class CephVMNodeV2:
         Raises:
             ResourceNotFound when there no suitable networks in the environment.
         """
-        default_network_names = [
-            "provider_net_cci_12",
-            "provider_net_cci_11",
-            "provider_net_cci_9",
-            "provider_net_cci_8",
-            "provider_net_cci_7",
-            "provider_net_cci_6",
-            "provider_net_cci_5",
-            "provider_net_cci_4",
-        ]
         default_network_count = 1
-
         if name:
             network_names = name if isinstance(name, list) else [name]
             default_network_count = len(network_names)
         else:
-            network_names = default_network_names
+            network_names = self.default_network_names
 
         rtn_nets = list()
         for net in network_names:

--- a/conf/pacific/cephadm/3-node-cluster-multiple-subnets.yaml
+++ b/conf/pacific/cephadm/3-node-cluster-multiple-subnets.yaml
@@ -1,0 +1,27 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_12
+          - provider_net_cci_11
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 1
+        disk-size: 15
+      node2:
+        networks:
+          - provider_net_cci_8
+          - provider_net_cci_7
+        role:
+          - osd
+          - mon
+          - mgr
+          - mds
+          - rgw
+        no-of-volumes: 1
+        disk-size: 15


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- support multiple interface using global configuration file using logical names.
- Same subnet definition would be used to spin instances with more NIC(s).
- This enables support for strech mode cluster.
 
![image](https://user-images.githubusercontent.com/31158377/165944379-471566c9-779c-4432-9166-7cace743561f.png)

```
globals:
  - ceph-cluster:
      name: ceph
      node1:
        networks:
          - subnet1
          - subnet3
        role:
          - _admin
          - installer
          - mon
          - mgr
          - osd
        no-of-volumes: 1
        disk-size: 15
      node2:
        networks:
          - subnet2
          - subnet4
        role:
          - osd
          - mon
          - mgr
          - mds
          - rgw
        no-of-volumes: 1
        disk-size: 15
```

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F94E7C/



