### PR TITLE
Adding support for python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - 3.6
-        - 3.7
+        - '3.6'
+        - '3.8'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -1,7 +1,10 @@
 """Custom typing objects to avoid circular imports."""
 from typing import Dict, List
 
-from typing_extensions import Protocol
+try:
+    from typing_extensions import Protocol
+except ImportError:
+    from typing import Protocol
 
 from ceph.ceph import Ceph, CephInstaller
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Ensuring the module is compatible with Python 3.8. The below failure is observed when the interop team executes our test suites
```
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]       File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]       File "/home/fedora/cephci/tests/ceph_installer/test_cephadm.py", line 8, in <module>
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]         from ceph.ceph_admin import CephAdmin
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]       File "/home/fedora/cephci/ceph/ceph_admin/__init__.py", line 14, in <module>
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]         from .bootstrap import BootstrapMixin
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]       File "/home/fedora/cephci/ceph/ceph_admin/bootstrap.py", line 13, in <module>
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]         from .typing_ import CephAdmProtocol
2022-05-02 08:42:51,348 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]       File "/home/fedora/cephci/ceph/ceph_admin/typing_.py", line 4, in <module>
2022-05-02 08:42:51,349 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]         from typing_extensions import Protocol
2022-05-02 08:42:51,349 INFO [teflo.ansible_helpers.exec_local_cmd_pipe:566]     ModuleNotFoundError: No module named 'typing_extensions'
2022-05-02 08:42:51
```

This PR resolves the issue observed with python 3.8

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/indexless/returnCode/