### PR TITLE
Volume mgmt fix 83574163 and 83573428

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -444,16 +444,30 @@ class FsUtils(object):
         Returns:
 
         """
-        fs_cmd = f"ceph fs create {vol_name}"
-        cmd_out, cmd_rc = client.exec_command(
-            sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
-        )
-        if validate:
-            out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
-            volname_ls = json.loads(out)
-            if vol_name not in [i["name"] for i in volname_ls]:
-                raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
-        return cmd_out, cmd_rc
+        output, err = client.exec_command(sudo=True, cmd="ceph version")
+        output_split = output.split()
+        if "nautilus" in output_split:
+            fs_cmd = f"ceph fs volume create {vol_name}"
+            cmd_out, cmd_rc = client.exec_command(
+                sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
+            )
+            if validate:
+                out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
+                volname_ls = json.loads(out)
+                if vol_name not in [i["name"] for i in volname_ls]:
+                    raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
+            return cmd_out, cmd_rc
+        if "pacific" in output_split:
+            fs_cmd = f"ceph fs volume create {vol_name}"
+            cmd_out, cmd_rc = client.exec_command(
+                sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
+            )
+            if validate:
+                out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
+                volname_ls = json.loads(out)
+                if vol_name not in [i["name"] for i in volname_ls]:
+                    raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
+            return cmd_out, cmd_rc
 
     def create_subvolumegroup(
         self, client, vol_name, group_name, validate=True, **kwargs

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_create_vol_component_exist_name.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_create_vol_component_exist_name.py
@@ -1,3 +1,5 @@
+import random
+import string
 import traceback
 
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -31,10 +33,16 @@ def run(ceph_cluster, **kw):
             fs_util.create_fs(client1, "cephfs")
         fs_util.auth_list([client1])
         fs_util.prepare_clients(clients, build)
-        volume_name = "vol_01"
-        subvolume_name = "subvol_01"
-        subvolume_group_name = "subvol_group_name_01"
-        fs_util.create_fs(client1, vol_name=volume_name)
+
+        random_name = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(5))
+        )
+        volume_name = "vol_01" + random_name
+        subvolume_name = "subvol_01" + random_name
+        subvolume_group_name = "subvol_group_name_01" + random_name
+        log.info("Ceph Build number is " + build[0])
+        fs_util.create_fs(client1, volume_name)
         fs_util.create_subvolume(client1, volume_name, subvolume_name)
         fs_util.create_subvolumegroup(client1, "cephfs", subvolume_group_name)
         output1, err1 = fs_util.create_fs(client1, volume_name, check_ec=False)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_invalid_pool_layout.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_invalid_pool_layout.py
@@ -28,7 +28,12 @@ def run(ceph_cluster, **kw):
         subvol_group_name = "subvol_group"
         invalid_pool_name = "non_exist_pool"
         out1, err1 = fs_util.create_subvolumegroup(
-            client1, "cephfs", subvol_group_name, pool_layout=invalid_pool_name
+            client1,
+            "cephfs",
+            subvol_group_name,
+            validate=False,
+            pool_layout=invalid_pool_name,
+            check_ec=False,
         )
         out2, err2 = client1.exec_command(
             sudo=True,


### PR DESCRIPTION
Fix for 83574163 and 83573428
83574163: Added `validate=False` option for pool layout
83573428: Added the `ceph fs create` for both 4 and 5
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VPNQST/

Signed-off-by: julpark-rh <yonhyun@gmail.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
