### PR TITLE
Fixing the return code status

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -159,7 +159,7 @@ def run(ceph_cluster, **kw):
         remote_fp.write(yaml.dump(test_config, default_flow_style=False))
 
     cmd_env = " ".join(config.get("env-vars", []))
-    rgw_node.exec_command(
+    test_status = rgw_node.exec_command(
         cmd=cmd_env
         + f"sudo {python_cmd} "
         + test_folder_path
@@ -181,4 +181,4 @@ def run(ceph_cluster, **kw):
         log.info(verify_out)
         log.error(err)
 
-    return 0
+    return test_status


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Returning the exit status of the executed test to avoid false positives. The test failed with the below error message

```
2022-05-03 06:51:39,238 ERROR: error: error, indexless buckets do not maintain stats; bucket=scotti.113-bucky-3476-0
failure: (22) Invalid argument: 
 
returncode: 22
2022-05-03 06:51:39,238 INFO: get ceph version
2022-05-03 06:51:39,239 INFO: executing cmd: sudo ceph version
2022-05-03 06:51:39,712 INFO: cmd excuted
2022-05-03 06:51:39,712 INFO: ceph version 16.2.7-109.el8cp (9f20d0292c5f7b341bc2bc580fb119416323fdc1) pacific (stable)

2022-05-03 06:51:39,712 INFO: executing cmd: sudo ls -t /var/lib/ceph/*/crash/*/log | head -1
2022-05-03 06:51:39,737 INFO: cmd excuted
2022-05-03 06:51:39,738 INFO: 
2022-05-03 06:51:39,738 INFO: the JSON object must be str, bytes or bytearray, not 'bool'
2022-05-03 06:51:39,739 INFO: Traceback (most recent call last):
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_indexless_buckets.py", line 183, in <module>
    test_exec(config)
  File "/home/cephuser/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_indexless_buckets.py", line 107, in test_exec
    bucket_stats_json = json.loads(bucket_stats)
  File "/usr/lib64/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'bool'

2022-05-03 06:51:39,740 INFO: status: test failed
```

__Test Run with false positive__
test-rgw-ssl-image https://159.23.92.24/blue/organizations/jenkins/tier-x/detail/tier-x/146/pipeline/159

__Log__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/indexless/returnCode/