### PR TITLE
Added fix for NFS Tests failing with SocketTimeout

### DIFF
--- a/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
@@ -119,6 +119,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_delete.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 2
           objects_count: 50
@@ -138,6 +139,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_move.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 4
           objects_count: 100


### PR DESCRIPTION
# Description

Added fix for NFS Tests failing with SocketTimeout 

# Test run after fix

http://magna002.ceph.redhat.com/cephci-jenkins/vivekanandan_logs/cephci-run-W4BEWG/

# Failed run in cephci before fix

https://159.23.92.24/blue/organizations/jenkins/tier-x/detail/tier-x/148/pipeline/76/

# JIRA

https://issues.redhat.com/browse/RHCEPHQE-3045