### PR TITLE
Stabilized NFS tests as different NFS tests are failing with intermit…

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_ganesha.yaml
@@ -41,6 +41,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_create.yaml
         nfs-version: 4  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 4
           subdir_count: 10
@@ -60,6 +61,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_delete.yaml
         nfs-version: 4  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 5
           subdir_count: 10
@@ -101,6 +103,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_create.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 4
           subdir_count: 10
@@ -120,6 +123,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_delete.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 5
           subdir_count: 10
@@ -161,6 +165,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_create.yaml
         nfs-version: 4  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 3
           objects_count: 20
@@ -179,6 +184,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_delete.yaml
         nfs-version: 4  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 2
           objects_count: 20
@@ -198,6 +204,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_move.yaml
         nfs-version: 4  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 4
           objects_count: 20
@@ -217,6 +224,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_create.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 3
           objects_count: 20

--- a/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
@@ -41,6 +41,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_create.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 4
           subdir_count: 10
@@ -60,6 +61,7 @@ tests:
         script-name: test_on_nfs_io.py
         config-file-name: test_on_nfs_io_delete.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           basedir_count: 5
           subdir_count: 10
@@ -101,6 +103,7 @@ tests:
         script-name: test_on_s3_io.py
         config-file-name: test_on_s3_io_create.yaml
         nfs-version: 3  # To be added in rgw_user.yaml
+        timeout: 900
         test-config:
           bucket_count: 3
           objects_count: 20


### PR DESCRIPTION
# Description

Different NFS tests are getting failed in pipeline runs with the Timeout issue. Added Timeout for all NFS tests to make it more stable in pipeline runs

# Recent run log

http://magna002.ceph.redhat.com/cephci-jenkins/vivekanandan_logs/cephci-run-AY2Z92/
