### PR TITLE
Set mon_allow_pool_delete for ceph version >5

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -229,11 +229,8 @@ class Rbd:
                 pool_list.append(self.datapool)
 
             # mon_allow_pool_delete must be True for removing pool
-            if self.ceph_version == 5:
+            if self.ceph_version >= 5:
                 self.exec_cmd(cmd="ceph config set mon mon_allow_pool_delete true")
-                self.exec_cmd(cmd="ceph orch restart mon")
-
-                # ToDo: Unable to confirm service restart
                 sleep(60)
 
             for pool in pool_list:


### PR DESCRIPTION
Along with mon_allow_pool_delete, removed ceph mon restart
as it should not be required.

Fixes: #1293

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
