### PR TITLE
Fix 'ceph.open_firewall_port' library

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -739,17 +739,6 @@ def search_ethernet_interface(ceph_node, ceph_node_list):
     return ceph_node.search_ethernet_interface(ceph_node_list)
 
 
-def open_firewall_port(ceph_node, port, protocol):
-    """
-    Opens firewall ports for given node
-    Args:
-        ceph_node (ceph.ceph.CephNode): ceph node
-        port (str): port
-        protocol (str): protocol
-    """
-    ceph_node.open_firewall_port(port, protocol)
-
-
 def config_ntp(ceph_node, cloud_type="openstack"):
     """
     Configure NTP/Chronyc service based on the OS platform

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -35,7 +35,6 @@ from typing import Dict, Optional, Tuple
 from jinja2 import Template
 
 from ceph.ceph import Ceph, CephNode, CommandFailed
-from ceph.utils import open_firewall_port
 from utility.log import Log
 
 log = Log(__name__)
@@ -143,7 +142,7 @@ def execute_setup(cluster: Ceph, config: dict) -> None:
     create_s3_conf(cluster, build, host, port, secure, kms_keyid)
 
     if not build.startswith("5"):
-        open_firewall_port(rgw_node, port=port, protocol="tcp")
+        rgw_node.open_firewall_port(port=port, protocol="tcp")
 
     add_lc_debug(cluster, build)
 


### PR DESCRIPTION
Fix `ceph.open_firewall_port` library. Changes consists of 

- Separate function to check `firewalld` package
- `int|str|list` type support for `open_firewall_port` function
- Update logic to call `open_firewall_port` in library
- Update `test_s3.py` TC to call `ceph.open_firewall_port`
- Remove `utils.open_firewall_port` library