### PR TITLE
avoid service validation check if running/size is 0/0.

### DIFF
--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -102,7 +102,7 @@ class Orch(
                 f"{running}/{count} {service_name if service_name else service_type} up... retrying"
             )
 
-            if count == running:
+            if not (count + running) == 0 and count == running:
                 return True
 
         # Identify the failure


### PR DESCRIPTION
- Avoid service validation check if running/size is 0/0.
```
2022-05-11 10:02:27,017 - ceph.ceph - INFO - Running command cephadm -v shell -- ceph orch  --format json ls  --refresh --service_name osd.stretch_osds on 10.1.45.219 timeout 600
2022-05-11 10:02:29,655 - ceph.ceph - INFO - Command completed successfully
2022-05-11 10:02:29,656 - ceph.ceph_admin.orch - INFO - 0/0 osd.stretch_osds up... retrying
2022-05-11 10:02:29,656 - ceph.ceph_admin.orch - INFO - Validation of service created using a spec file is completed
2022-05-11 10:02:29,656 - ceph.ceph - INFO - Running command cephadm -v shell -- ceph status on 10.1.45.219 timeout 600
```
- Added FQDN check to allow-fqdn-hostname.
