### PR TITLE
Fixing conf file name for volume management

### DIFF
--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -477,7 +477,7 @@
     - stage-2
 - name: "test-cephfs-volume-mgmt"
   suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
-  global-conf: "conf/pacific/cephfs/tier_2_cephfs_9-node-cluster.yaml"
+  global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
   inventory:

--- a/pipeline/scripts/cron/5/1/stage-1/test-cephfs-volume-mgmt.sh
+++ b/pipeline/scripts/cron/5/1/stage-1/test-cephfs-volume-mgmt.sh
@@ -6,7 +6,7 @@ instance_name="ci-${random_string}"
 platform="rhel-8"
 rhbuild="5.1"
 test_suite="suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
-test_conf="conf/pacific/cephfs/tier_2_cephfs_9-node-cluster.yaml"
+test_conf="conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
 test_inventory="conf/inventory/rhel-8-latest.yaml"
 return_code=0
 

--- a/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml
@@ -2,7 +2,7 @@
 #===============================================================================================
 # Tier-level: 2
 # Test-Suite: tier-2_cephfs_test-volume-management.yaml
-# Conf file : conf/pacific/cephfs/tier_2_cephfs_9-node-cluster.yaml
+# Conf file : conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
 # Test-Case Covered:
 # CEPH-83574164 : Create cephfs subvolumegroup with desired data pool_layout
 # CEPH-83574193 - cephfs subvolume size expansion test


### PR DESCRIPTION
Fixing conf file name for volume management
Replaced below filename in all the occurances
tier_2_cephfs_test-volume-management.yaml --> tier-2_cephfs_test-volume-management.yaml

Failed log: 
https://ceph-downstream-jenkins-csb-storage.apps.ocp4.prod.psi.redhat.com/blue/organizations/jenkins/rhceph-cron-pipeline-test-executor/detail/rhceph-cron-pipeline-test-executor/104/pipeline/39/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
