### PR TITLE
logging.basicConfig has no support for encoding in py36

### DIFF
--- a/utility/log.py
+++ b/utility/log.py
@@ -34,7 +34,7 @@ class Log:
     def __init__(self, name=None) -> None:
         """Initializes the logging mechanism based on the inputs provided."""
         self._logger = logging.getLogger("cephci")
-        logging.basicConfig(format=LOG_FORMAT, encoding="utf-8", level=logging.INFO)
+        logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
 
         if name:
             self._logger.name = f"cephci.{name}"


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

```
(cephci.venv) [psathyan@psathyan cephci]$ python run.py --log-level debug --osp-cred ~/.osp.yaml --cleanup WSEIB3
Traceback (most recent call last):
  File "run.py", line 27, in <module>
    import init_suite
  File "/home/psathyan/source/cephci/init_suite.py", line 11, in <module>
    log = Log(__name__)
  File "/home/psathyan/source/cephci/utility/log.py", line 37, in __init__
    logging.basicConfig(format=LOG_FORMAT, encoding="utf-8", level=logging.INFO)
  File "/usr/lib64/python3.6/logging/__init__.py", line 1829, in basicConfig
    raise ValueError('Unrecognised argument(s): %s' % keys)
ValueError: Unrecognised argument(s): encoding

```
The above error is seen with `python 3.6` and `python 3.7` as `encoding` argument is not supported. In this PR, we are removing the argument to keep it consistent.

__Log__
```
...
2022-05-16 15:16:58,073 - INFO - cephci.utility.xunit:110 - Done cleaning up nodes
2022-05-16 15:16:58,074 - INFO - cephci.utility.xunit:110 - final rc of test run 0
(cephci.venv) [psathyan@psathyan cephci]$ 
```