### PR TITLE
use hostname for ceph operations

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -94,7 +94,7 @@ class GenerateServiceSpec:
         Returns:
             hostname (Str)
         """
-        return node.shortname
+        return node.hostname
 
     @staticmethod
     def get_addr(node):
@@ -133,7 +133,7 @@ class GenerateServiceSpec:
             list of hostanmes (List)
         """
         nodes = get_nodes_by_ids(self.cluster, node_names)
-        return [node.shortname for node in nodes]
+        return [node.hostname for node in nodes]
 
     def _get_template(self, service_type):
         """

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -101,7 +101,7 @@ def create_baremetal_ceph_nodes(cluster_conf):
                     "role": RolesContainer(node.get("role")),
                     "no-of-volumes": len(node.get("volumes", [])),
                     "volumes": node.get("volumes"),
-                    "subnet": cluster_conf["ceph-cluster"]["public-network-cidr"],
+                    "subnet": cluster_conf["ceph-cluster"]["networks"]["public"][0],
                 }
             )
 
@@ -1013,7 +1013,7 @@ def get_node_by_id(cluster, node_name):
         node instance (CephVMNode)
     """
     for node in cluster.get_nodes():
-        searches = re.findall(rf"{node_name}?\d*", node.shortname)
+        searches = re.findall(rf"{node_name}?\d*", node.hostname)
         for ele in searches:
             if ele == node_name:
                 return node

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -211,7 +211,7 @@ Examples
       -                                    # List of clusters part of the test env.
         ceph-cluster:                      # Ceph storage cluster deployment
           name: "ceph"                     # String: The name of the cluster
-          networks:                        # Optional: network information
+          networks:                        # network information
             public:                        # Ceph public network
               - "16.128.103.0/24"          # CIDR notation is only supported
               - "16.128.104.0/24"          # Required when deploying in stretched mode.


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- use hostname for all ceph orch operations



```
Skip dashboard (PSI)
================

All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EEQFCG

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Install ceph pre-requisites      installation of ceph pre-requisites                            0:15:55.026038                   Pass                             
Cephadm Bootstrap with skip-da   cephadm bootstrap with skip dashboard, output configuration    0:04:34.467140                   Pass                             
Add all hosts to ceph cluster    Add all host node with IP address and labels                   0:01:10.404359                   Pass                             
Apply Monitor with limit         Apply monitor service with limit count                         0:01:33.343539                   Pass                             
Apply Manager with limit         Apply Manager service with limit count                         0:00:47.337709                   Pass                             
Discover devices and Apply OSD   Discover devices using orch device ls and deploy OSD service   0:03:56.467061                   Pass                             
Deploy Service(s) deployment a   Validate service(s) deployment using ceph orch ls.             0:02:11.317357                   Pass                             
Configure client                 Configure client on node4                                      0:00:42.530225                   Pass                             
Enable the dashboard             After skip-dashboard enable the dashboard and validate login   0:02:26.454177                   Pass                             
Enable the alertmanager          Enables alertmanager monitoring stack                          0:00:37.060919                   Pass                             
Enable the prometheus            Enables prometheus monitoring stack                            0:00:44.564959                   Pass                             
Enable the grafana               Enables grafana monitoring stack                               0:00:39.353824                   Pass  



Sanity tier-0 suite (IBM)
=====================

All test logs located here: /tmp/cephci-run-8A6OEG

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Install ceph pre-requisites      installation of ceph pre-requisites                            0:11:23.800880                   Pass                             
Cephadm Bootstrap with custom    Bootstrap with initial-dashboard user and password option      0:04:34.755051                   Pass                             
Add Host                         Add host to Bootstrapped Cluster                               0:00:19.168148                   Pass                             
Add new host node with IP addr   Add new host and validate using ceph orch host list            0:00:19.415827                   Pass                             
Add host                         Add new host node with IP address and labels                   0:00:21.046019                   Pass                             
Remove Host label                Remove host label osd from node3                               0:00:20.555936                   Pass                             
Remove Host label                Remove host label node-exporter from node4                     0:00:17.058341                   Pass                             
Add Host label                   Add host label mon,osd to existing node                        0:00:20.213394                   Pass                             
Attach Host label to installer   Add host label(s) to existing installer node                   0:00:47.553377                   Pass                             
Add admin label and validate k   Add admin label existing node4 and validate keyring file exi   0:00:16.945561                   Pass                             
Remove admin label and validat   Remove admin label existing node4 and validate keyring file    0:00:16.778246                   Pass                             
Set Host address                 Set IP address to a existing node                              0:00:17.102453                   Pass                             
Remove host                      Remove node from cluster                                       0:00:18.495067                   Pass                             
Remove host                      Remove node from cluster                                       0:00:18.872570                   Pass                             
Add host with admin label and    Add new host node5 with admin label and validate keyring fil   0:02:20.610948                   Pass                             
Add hosts to ceph cluster        Add host node(s) with IP address and labels                    0:00:35.781979                   Pass                             
Remove all Hosts                 Remove all nodes from cluster execpt installer                 0:00:43.546081                   Pass                             
Add all hosts to ceph cluster    Add all host node with IP address and labels                   0:01:09.488641                   Pass                             
Apply Monitor with placement a   Apply monitor service with placement and limit                 0:02:13.293607                   Pass                             
Apply Monitor with host placem   Apply monitor with placement option on specified hosts         0:00:27.218665                   Pass                             
Apply Monitor using label        Apply monitor using label mon                                  0:00:27.662255                   Pass                             
Apply Manager service            Apply manager service with placement option                    0:00:20.629451                   Pass                             
Apply Manager service            Apply manager service with label option                        0:00:20.570393                   Pass                             
Apply OSD Service                Apply OSD service with all available devices                   0:03:05.897404                   Pass                             
Configure client                 Configure client on node9                                      0:00:30.349352                   Pass                             
Remove client                    remove client on node9                                         0:00:13.339355                   Pass                             
Add cephfs file system volume    Add file system for MDS service                                0:00:03.933961                   Pass                             2022-05-16 15:13:54,948 - INFO - cephci.test_crash:110 - final rc of test run 0

Apply MDS Service                Apply MDS service on all mds nodes                             0:00:29.824176                   Pass                             
Create replicated pool           Add pool for ISCSI service                                     0:00:02.668437                   Pass                             
Enable rbd application on pool   enable rbd on iscsi pool                                       0:00:01.971393                   Pass                             
Apply ISCSI Service              Apply ISCSI target service on iscsi role nodes                 0:00:31.100040                   Pass                             
Apply ISCSI Service              Apply ISCSI target service on iscsi role nodes                 0:00:31.792101                   Pass                             
Apply Prometheus Service         Apply Prometheus service on role nodes                         0:01:08.824956                   Pass                             
Apply Node-exporter Service      Apply Node-exporter service on role nodes                      0:01:45.739834                   Pass                             
Apply Alert-manager Service      Apply Alert-manager service on role nodes                      0:00:46.257786                   Pass                             
Apply Grafana Service            Apply Grafana service on role nodes                            0:00:52.565245                   Pass                             
Apply collocated RGW Service     Apply collocated RGW service using node placements             0:00:33.949935                   Pass                             
Apply collocated RGW Service     Apply collocated RGW service using label placement             0:00:24.109033                   Pass                             
Apply NFS Service                Apply NFS-Ganesha service on role nodes                        0:00:38.141992                   Pass                             
Apply Crash Service              Apply Crash service on all nodes                               0:00:43.484876                   Pass                             
Remove NFS-Ganesha Service       Remove NFS-Ganesha service using orch remove option            0:00:23.581946                   Pass                             
Remove RGW Service               Remove RGW service using orch remove option                    0:00:23.299113                   Pass                             
Remove ISCSI Service             Remove ISCSI service using orch remove option                  0:00:23.942164                   Pass                             
Remove Prometheus Service        Remove Prometheus service using orch remove option             0:00:24.231801                   Pass                             
Remove Node-exporter Service     Remove Node-exporter service using orch remove option          0:00:22.690041                   Pass                             
Remove Alert-manager Service     Remove Alert-manager service using orch remove option          0:00:22.642760                   Pass                             
Remove Grafana Service           Remove Grafana service using orch remove option                0:00:22.675994                   Pass                             
Remove MDS Service               Remove MDS service using orch remove option                    0:00:20.925605                   Pass                             
set mon_allow_pool_delete        set mon_allow_pool_delete to true                              0:00:02.266673                   Pass                             
remove cephfs file system volu   remove file system                                             0:00:06.610388                   Pass                             
Remove Crash Service             Remove Crash service using orch remove option                  0:00:22.677276                   Pass      
```