### PR TITLE
minor improvements on cephadm-ansible and validation of service(s).

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1171,7 +1171,7 @@ class SSHConnectionManager(object):
         password,
         look_for_keys=False,
         private_key_file_path="",
-        outage_timeout=300,
+        outage_timeout=600,
     ):
         self.ip_address = ip_address
         self.username = username

--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -157,8 +157,7 @@ class CephAdmin(BootstrapMixin, ShellMixin):
             node.exec_command(sudo=True, cmd="yum update metadata", check_ec=False)
 
     def install(self, **kwargs: Dict) -> None:
-        """
-        Install the cephadm package in the installer node.
+        """Install the cephadm package in all node(s).
 
         Args:
           kwargs (Dict): Key/value pairs that needs to be provided to the installer
@@ -179,17 +178,18 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         if kwargs.get("nogpgcheck", True):
             cmd += " --nogpghceck"
 
-        self.installer.exec_command(
-            sudo=True,
-            cmd="yum install cephadm -y --nogpgcheck",
-            long_running=True,
-        )
+        for node in self.cluster.get_nodes():
+            node.exec_command(
+                sudo=True,
+                cmd="yum install cephadm -y --nogpgcheck",
+                long_running=True,
+            )
 
-        if kwargs.get("upgrade", False):
-            self.installer.exec_command(sudo=True, cmd="yum update metadata")
-            self.installer.exec_command(sudo=True, cmd="yum update -y cephadm")
+            if kwargs.get("upgrade", False):
+                node.exec_command(sudo=True, cmd="yum update metadata")
+                node.exec_command(sudo=True, cmd="yum update -y cephadm")
 
-        self.installer.exec_command(cmd="rpm -qa | grep cephadm")
+            node.exec_command(cmd="rpm -qa | grep cephadm")
 
     def get_cluster_state(self, commands):
         """

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -204,8 +204,8 @@ class BootstrapMixin:
                 extra_vars=ansible_run.get("extra-vars"),
                 extra_args=ansible_run.get("extra-args"),
             )
-
-        self.install()
+        else:
+            self.install()
 
         cmd = "cephadm"
         if config.get("base_cmd_args"):

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -64,7 +64,7 @@ class Orch(
         service_name: str = None,
         service_type: str = None,
         timeout: int = 1800,
-        interval: int = 30,
+        interval: int = 20,
     ) -> bool:
         """
         Verify the provided service is running for the given list of ids.
@@ -226,9 +226,6 @@ class Orch(
         # validate services
         validate_spec_services = config.get("validate-spec-services")
         if validate_spec_services:
-            # wait 60 seconds for initial start of daemons,
-            # which avoids 0/0 check and 1/1 when expected count is 3.
-            sleep(60)
             self.validate_spec_services(specs=specs)
             LOG.info("Validation of service created using a spec file is completed")
 


### PR DESCRIPTION
- Remove unwanted sleep at validation of service(s), since we have 3 retries solution to get stable results.
- cephadm ansible improvements,
    - install pkg(s) either with cephadm-ansible or regular `yum add-config` way.
    - if non-cephadm-ansible, installing cephadm on all nodes to support at any stages later.
- increase timeout to 600 seconds on node reconnect .

**Test Results**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7OBTFW/