### PR TITLE
Fixing Nonetype object for rp_logger

### DIFF
--- a/run.py
+++ b/run.py
@@ -169,7 +169,7 @@ def create_nodes(
     rp_logger: Optional[ReportPortal] = None,
 ):
     """Creates the system under test environment."""
-    if report_portal_session:
+    if rp_logger:
         name = create_unique_test_name("ceph node creation", test_names)
         test_names.append(name)
         desc = "Ceph cluster preparation"
@@ -268,10 +268,12 @@ def create_nodes(
             try:
                 instance.connect()
             except BaseException:
-                rp_logger.finish_test_item(status="FAILED")
+                if rp_logger:
+                    rp_logger.finish_test_item(status="FAILED")
                 raise
 
-    rp_logger.finish_test_item(status="PASSED")
+    if rp_logger:
+        rp_logger.finish_test_item(status="PASSED")
 
     return ceph_cluster_dict, clients
 


### PR DESCRIPTION
Fixing Nonetype object for rp_logger

Logs with --report-portal : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZMTK7I/
RP launch Details : https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/3721

Logs without --report-portal : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8K503X/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
