### PR TITLE
bootstrap.py: adding "--yes-i-know" flag for all builds greater than 5.0

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -275,7 +275,7 @@ class BootstrapMixin:
 
         # Todo: This patch is specific to 5.1 release,
         #   should be removed for next 5.x development builds or release.
-        if rhbuild.startswith("5.1"):
+        if float(rhbuild) > 5.0:
             cmd += " --yes-i-know"
 
         out, err = self.installer.exec_command(


### PR DESCRIPTION
Adding the fix as without this, deployment with 5.2 build fails

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>
