### PR TITLE
Logic to abort ibm-sanity job when new builds are available

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -110,6 +110,18 @@ node(nodeName) {
         }
         print(overrides)
         // Till the pipeline matures, using the build that has passed tier-0 suite.
+
+        if (tags_list.containsAll(["ibmc","sanity"])){
+            def recipeFileContent = sharedLib.readFromRecipeFile(rhcephVersion)
+            def content = recipeFileContent['latest']
+            println "recipeFile ceph-version : ${content['ceph-version']}"
+            println "buildArtifacts ceph-version : ${buildArtifacts['ceph-version']}"
+            if ( buildArtifacts['ceph-version'] != content['ceph-version']) {
+                currentBuild.result = "ABORTED"
+                error "Aborting the execution as new builds are available.."
+            }
+        }
+
         print("Fetching stages")
         fetchStages = sharedLib.fetchStages(tags, overrides, testResults, rhcephVersion)
         print("Stages fetched")


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
Logic to abort ibm-sanity job when new builds are available
https://159.23.92.24/job/ckulal-test-execution/5/console



# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
