### PR TITLE
Use node's hostname instead of shortname for cephadm deployment.

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -93,7 +93,7 @@ class ApplyMixin:
                     verify_service = False
                 else:
                     nodes_ = get_nodes_by_ids(self.cluster, nodes)
-                    node_names = [node.shortname for node in nodes_]
+                    node_names = [node.hostname for node in nodes_]
 
             # Support RGW count-per-host placement option
             if "count-per-host" in placement and self.SERVICE_NAME == "rgw":


### PR DESCRIPTION
Use node's hostname instead of a short name for cephadm deployment.

logs :
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XDBN18/

Signed-off-by: viduship <vimishra@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
