### PR TITLE
enable rbd mirror configuration for RDR

### DIFF
--- a/suites/pacific/rbd/test_rbd_mirror_baremetal.yaml
+++ b/suites/pacific/rbd/test_rbd_mirror_baremetal.yaml
@@ -1,0 +1,143 @@
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd-1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    allow-fqdn-hostname: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd-2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    allow-fqdn-hostname: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd-1:
+            config:
+              command: add
+              id: client.1
+              node: magna095.ceph.redhat.com
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd-2:
+            config:
+                command: add
+                id: client.1
+                node: pluto005.ceph.redhat.com
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd-1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd-2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Configure RBD mirror
+      module: test_configure_rbd_mirror.py
+      clusters:
+        ceph-rbd-1:
+          config:
+             primary: ceph-rbd-1
+             secondary: ceph-rbd-2
+             pool-name: rbd
+      desc: RBD mirror configuration over provided pool

--- a/tests/rbd_mirror/test_configure_rbd_mirror.py
+++ b/tests/rbd_mirror/test_configure_rbd_mirror.py
@@ -1,0 +1,32 @@
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """Configure RBD mirroring over pool.
+
+    This module enable RBD mirroring over provided pool,
+    which could be used for Regional DR scenario.
+
+    Args:
+        **kw:
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+    """
+    try:
+        config = kw.get("config")
+        clusters = kw.get("ceph_cluster_dict")
+        primary = rbdmirror.RbdMirror(clusters[config.get("primary")], config)
+        secondary = rbdmirror.RbdMirror(clusters[config.get("secondary")], config)
+        pool_name = config["pool-name"]
+        log.info(f"Configure RBD mirroring over {pool_name} pool")
+        primary.create_pool(poolname=pool_name)
+        secondary.create_pool(poolname=pool_name)
+        primary.config_mirror(secondary, poolname=pool_name, mode="image")
+        return 0
+    except Exception as e:  # noqa
+        log.exception(e)
+        return 1


### PR DESCRIPTION
Signed-off-by: sunilkumarn417 <sunnagar@redhat.com>

- Configure RBD mirror for RDR scenario.
- Added bare metal RBD mirror test suite and cluster configuration.

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D5R8DE  - cluster deployment with rbd-mirror daemon
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CTIXCD  - test case for Enabling rbd mirror 

