### PR TITLE
Added fio method in utils for i/os

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -228,6 +228,10 @@ class Rbd:
         image_info = json.loads(out)
         return any(image["name"] == image_name for image in image_info)
 
+    def image_map(self, pool_name, image_name):
+        """Map provided rbd image."""
+        return self.exec_cmd(cmd=f"rbd map {pool_name}/{image_name}", output=True)
+
     def clean_up(self, **kw):
         if kw.get("dir_name"):
             self.exec_cmd(cmd="rm -rf {}".format(kw.get("dir_name")))


### PR DESCRIPTION
new method can be used in two different ways
1) Pass Rbd image with pool name.
2) Provide device (rbd mapped device as in below examples).

 install_fio(client_node)
 o,err = run_fio(client_node = client_node, pool_name=pool, image_name=image, runtime=30)

 device_name = rbd.image_map(pool_name=pool, image_name=image)[:-1]
 o, err = run_fio(client_node = client_node, filename=device_name, runtime=30)

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
