### PR TITLE
Adding change to handle apply labels when client node is present

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -174,8 +174,8 @@ class GenerateServiceSpec:
         template = self._get_template("host")
         hosts = []
         address = spec.get("address")
-        labels = spec.get("labels")
         for node_name in spec["nodes"]:
+            labels = spec.get("labels")
             host = dict()
             node = get_node_by_id(self.cluster, node_name)
             host["hostname"] = self.get_hostname(node)
@@ -185,7 +185,7 @@ class GenerateServiceSpec:
             if labels:
                 # Skipping client node, if only client label is attached
                 if len(node.role.role_list) == 1 and ["client"] == node.role.role_list:
-                    return
+                    continue
 
                 if isinstance(labels, str) and labels == "apply-all-labels":
                     labels = self.get_labels(node)

--- a/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
+++ b/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
@@ -40,4 +40,7 @@ globals:
         disk-size: 15
       node4:
         role:
+          - rgw
+      node5:
+        role:
           - client

--- a/pipeline/metadata/5.0.yaml
+++ b/pipeline/metadata/5.0.yaml
@@ -68,7 +68,7 @@
     - stage-1
 - name: "test-bootstrap-custom-ssl-dashboard-port-and-apply-spec"
   suite: "suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.0"
   inventory:
@@ -83,7 +83,7 @@
     - stage-1
 - name: "test-bootstrap-skip-dashboard-and-custom-ceph-directory-organisation"
   suite: "suites/pacific/cephadm/tier-1_skip_dashboard.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.0"
   inventory:
@@ -114,7 +114,7 @@
     - stage-1
 - name: "test-cephadm-apply-service-spec"
   suite: "suites/pacific/cephadm/tier-1_service_apply_spec.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.0"
   inventory:

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -68,7 +68,7 @@
     - stage-1
 - name: "test-bootstrap-custom-ssl-dashboard-port-and-apply-spec"
   suite: "suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
   inventory:
@@ -83,7 +83,7 @@
     - stage-1
 - name: "test-bootstrap-skip-dashboard-and-custom-ceph-directory-organisation"
   suite: "suites/pacific/cephadm/tier-1_skip_dashboard.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
   inventory:
@@ -98,7 +98,7 @@
     - stage-1
 - name: "test-cephadm-apply-service-spec"
   suite: "suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
   inventory:

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -41,7 +41,7 @@
 
 - name: "Deploy all services at 5x using a spec file"
   suite: "suites/pacific/cephadm/test-container-cli-args.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"
   inventory:
@@ -91,7 +91,7 @@
 
 - name: "Bootstrap cluster with skip dashboard and custom ceph directory testing"
   suite: "suites/pacific/cephadm/tier-1_skip_dashboard.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"
   inventory:
@@ -107,7 +107,7 @@
 
 - name: "Bootstrap cluster with custom ssl dashboard port and apply-spec"
   suite: "suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml"
-  global-conf: "conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml"
+  global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"
   inventory:

--- a/suites/pacific/cephadm/test-container-cli-args.yaml
+++ b/suites/pacific/cephadm/test-container-cli-args.yaml
@@ -79,6 +79,7 @@ tests:
                 - node2
                 - node3
                 - node4
+                - node5
       destroy-cluster: false
       abort-on-fail: true
   - test:

--- a/suites/pacific/cephadm/test-haproxy-deployment.yaml
+++ b/suites/pacific/cephadm/test-haproxy-deployment.yaml
@@ -6,14 +6,15 @@
 #      Deploy HA proxy service and verify service disable, enable, restart options.
 #
 # Cluster Configuration:
-#   cephci/conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml
+#   cephci/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
 #
 #    4-Node cluster(RHEL-8.3 and above)
 #    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
 #     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
 #     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter, haproxy
 #     Node3 - Mon, OSD, MDS, RGW, node-exporter, haproxy
-#     Node4 - Client
+#     Node4 - RGW
+#     Node5 - Client
 #
 # Test steps:
 #   (1) Bootstrap cluster with options,

--- a/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
+++ b/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
@@ -12,14 +12,15 @@
 #               eg., ceph orch apply -i <spec_file.yaml>
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml
+#    cephci/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
 #
 #    4-Node cluster(RHEL-8.3 and above)
 #    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
 #     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
 #     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
 #     Node3 - Mon, OSD, MDS, RGW, node-exporter
-#     Node4 - Client
+#     Node4 - RGW
+#     Node5 - Client
 #
 # Test Steps :
 #   (1) Bootstrap cluster with options,
@@ -112,6 +113,11 @@ tests:
                   labels: apply-all-labels
                   nodes:
                     - node4
+                - service_type: host
+                  address: true
+                  labels: apply-all-labels
+                  nodes:
+                    - node5
       abort-on-fail: true
   - test:
       name: Service deployment with spec
@@ -303,13 +309,13 @@ tests:
                     rgw_zone: india
   - test:
       name: Configure client
-      desc: Configure client on node4
+      desc: Configure client on node5
       module: test_client.py
       polarion-id:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node4                       # client node
+        node: node5                       # client node
         install_packages:
           - ceph-common                   # install ceph common packages
         copy_admin_keyring: true          # Copy admin keyring to node
@@ -333,7 +339,7 @@ tests:
           client_group: clients
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
   - test:
-      name: check-ceph-health on client node4
+      name: check-ceph-health on client node5
       desc: Check for ceph health debug info
       module: exec.py
       config:

--- a/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
@@ -6,14 +6,15 @@
 #               eg., ceph orch apply -i <spec_file.yaml>
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml
+#    cephci/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
 #
 #    4-Node cluster(RHEL-8.3 and above)
 #    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
 #     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
 #     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
 #     Node3 - Mon, OSD, MDS, RGW, node-exporter
-#     Node4 - Client
+#     Node4 - RGW
+#     Node5 - Client
 #
 # Test Steps :
 #   (1) Bootstrap cluster with options,

--- a/suites/pacific/cephadm/tier-1_skip_dashboard.yaml
+++ b/suites/pacific/cephadm/tier-1_skip_dashboard.yaml
@@ -6,14 +6,15 @@
 #      then enabling the dashboard with provided credentials and validate login
 #
 #  Cluster Configuration:
-#    cephci/conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml
+#    cephci/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
 #
 #    4-Node cluster(RHEL-8.3 and above)
 #    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
 #     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
 #     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
 #     Node3 - Mon, OSD, MDS, RGW, node-exporter
-#     Node4 - Client
+#     Node4 - RGW
+#     Node5 - Client
 #
 # Test Steps:
 #   (1) Bootstrap cluster with options,

--- a/suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml
+++ b/suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml
@@ -6,14 +6,15 @@
 #       and apply-spec options.
 #
 # Cluster Configuration:
-#   cephci/conf/pacific/cephadm/tier-1_3node_cephadm_bootstrap.yaml
+#   cephci/conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
 #
 #    4-Node cluster(RHEL-8.3 and above)
 #    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
 #     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
 #     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
 #     Node3 - Mon, OSD, MDS, RGW, node-exporter
-#     Node4 - Client
+#     Node4 - RGW
+#     Node5 - Client
 #
 # Test steps:
 #   (1) Bootstrap cluster with options,


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description
When client was the only role present in the conf file, the host spec creation was getting abruptly returned with None as the output. Instead I have added a change to continue execution for other nodes if present.

Success Log - https://159.23.92.24/job/rhceph-test-execution-manual/8/console (The RGW IO errors might have been because my branch was a little behind the master while I triggered this job)
Failure Log - without the code update given in this PR - https://159.23.92.24/job/rhceph-test-execution-manual/9/console

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
