### PR TITLE
In upgrade suite abort on fail handled properly 

### DIFF
--- a/suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml
@@ -178,7 +178,7 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
   - test:
-      name: Parallel run
+      name: Upgrade along with I/O's
       module: test_parallel.py
       parallel:
         - test:
@@ -213,8 +213,8 @@ tests:
                 duration: 10
               verify_cluster_health: true
             destroy-cluster: false
-            abort-on-fail: true
       desc: Running upgrade and i/o's parallelly
+      abort-on-fail: true
   - test:
       name: Cephadm-ansible purge playbook
       desc: purge cephadm cluster using cephadm-purge-cluster.yml playbook

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
@@ -77,7 +77,7 @@ tests:
     desc: Check for ceph health debug info
 
 - test:
-     name: Parallel run
+     name: Upgrade along with I/O's
      module: test_parallel.py
      parallel:
        - test:
@@ -123,8 +123,8 @@ tests:
                prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
                alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
            desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest -> cephadm adopt
-           abort-on-fail: True
-     desc: Running upgrade and i/o's parallelly
+     desc: Running upgrade 4.x cdn -> 5.x latest -> cephadm adopt and i/o's parallelly
+     abort-on-fail: True
 
 - test:
     name: check-ceph-health

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
@@ -99,7 +99,7 @@ tests:
     desc: run rados bench for 360 - normal profile
 
 - test:
-    name: Parallel run
+    name: Upgrade along with I/O's
     module: test_parallel.py
     parallel:
       - test:
@@ -145,8 +145,8 @@ tests:
               prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
               alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest -> cephadm adopt
-          abort-on-fail: True
-    desc: Running upgrade and i/o's parallelly
+    desc: Running upgrade 4.x cdn to 5.x latest then cephadm adopt playbook and i/o's parallelly
+    abort-on-fail: True
 
 - test:
     name: check-ceph-health

--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
@@ -88,7 +88,7 @@ tests:
     desc: Check for ceph health debug info
 
 - test:
-    name: Parallel run
+    name: Upgrade along with I/O's
     module: test_parallel.py
     parallel:
      - test:
@@ -130,8 +130,8 @@ tests:
              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
          desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest -> cephadm adopt
-         abort-on-fail: True
-    desc: Running upgrade and i/o's parallelly
+    desc: Test Ceph-Ansible rolling update 4.x cdn -> 5.x latest -> cephadm adopt
+    abort-on-fail: True
 
 - test:
     name: check-ceph-health

--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
@@ -193,7 +193,7 @@ tests:
       destroy-cluster: False
       abort-on-fail: True
   - test:
-      name: Parallel run
+      name: Upgrade along with I/O's
       module: test_parallel.py
       parallel:
         - test:
@@ -226,8 +226,8 @@ tests:
                 duration: 10
               verify_cluster_health: True
             destroy-cluster: False
-            abort-on-fail: True
       desc: Running upgrade and i/o's parallelly
+      abort-on-fail: True
   - test:
       name: Add hosts to ceph cluster
       desc: Add host node(s) with IP address and labels


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
In this PR if the upgrade fails then it aborts,
Handled **abort on fail** for the whole test not only at individual sub-tests in the parallel run.
initially it was handled in sub tests hence even upgrade fails it goes with other tests eventually those tests doesn't make any sense to run
from the issue: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BW3XBH/ 

