### PR TITLE
Fix xunit.py as per junitparser==2.6.0

### DIFF
--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -28,7 +28,7 @@ def generate_test_case(name, duration, status, polarion_id=None):
         test_case.time = 0.0
 
     if status != "Pass":
-        test_case.result = Failure("test failed")
+        test_case.result = [Failure("test failed")]
 
     if polarion_id:
         props = Properties()


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

When test-suite failed:
Test <module 'sanity_rgw' from '/home/ckulal/commit/fix_fsconf/cephci/tests/rgw/sanity_rgw.py'> failed
2022-06-01 15:52:33,509 - INFO - cephci.sanity_rgw:110 - 
All test logs located here: /tmp/cephci-run-KXORMY
2022-06-01 15:52:33,510 - INFO - cephci.sanity_rgw:110 - Creating xUnit tier-2_rgw_bucket_lc_multipart_object_expired for test run-id RHCS-5-2-tier-2_rgw_bucket_lc_multipart_object_expired-KXORMY
2022-06-01 15:52:33,515 - INFO - cephci.sanity_rgw:110 - xUnit result file created: /tmp/cephci-run-KXORMY/xunit.xml

All test logs located here: /tmp/cephci-run-KXORMY

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
RHCS deploy cluster using ceph bootstrap with registry-url option and deployment services.    0:11:14.744776       Pass                             
configure client                 Configure the RGW client system                                     0:00:48.856055                         Pass                             
Object Expiration                RGW multipart object expiration through lc                     0:00:23.936756                         Failed    

When test-suite passed:


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
