### PR TITLE
Adding verify-io to rgw upgrade suites

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
@@ -101,6 +101,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects
       module: sanity_rgw_multisite.py
@@ -113,6 +114,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
@@ -125,6 +127,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
@@ -163,6 +166,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
             timeout: 300
       desc: Before upgrade create bucket and add objects for dynamic resharding brownfield scenario
       module: sanity_rgw_multisite.py
@@ -175,6 +179,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
             timeout: 300
       desc: Before upgrade create bucket and add objects for manual resharding brownfield scenario
       module: sanity_rgw_multisite.py
@@ -267,6 +272,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
@@ -281,6 +287,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
@@ -293,6 +300,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
@@ -336,6 +344,7 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
             timeout: 300
 
   - test:
@@ -344,6 +353,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
             timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
@@ -356,6 +366,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
             timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py

--- a/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
@@ -223,6 +223,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
@@ -259,6 +260,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
@@ -309,6 +311,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
@@ -345,6 +348,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py

--- a/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
@@ -236,6 +236,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects
       module: sanity_rgw_multisite.py
@@ -248,6 +249,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
@@ -260,6 +262,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
@@ -348,6 +351,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
@@ -362,6 +366,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
@@ -374,6 +379,7 @@ tests:
           config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
+            verify-io-on-site: ["ceph-sec"]
             timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
Adding verify IO's for rgw multi-site upgrade suites
Log: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-32F5YP
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UG6XM3

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
