### PR TITLE
Stabilize the upstream pipeline script with easy way of file lock

### DIFF
--- a/pipeline/vars/lib.groovy
+++ b/pipeline/vars/lib.groovy
@@ -564,9 +564,9 @@ def updateUpstreamFile(def version) {
         
     */
     try {
-        def cmd = "sudo ${env.WORKSPACE}/.venv/bin/python"
-        sh ".venv/bin/python -m pip install packaging"
-        sh "sudo dnf install podman -y"
+        def cmd = "sudo ${env.WORKSPACE}/.venv/bin/python3"
+        sh ".venv/bin/python3 -m pip install packaging"
+        sh "sudo yum install podman -y"
         def scriptFile = "pipeline/scripts/ci/upstream_cli.py"
         def args = "build ${version}"
         sh script: "${cmd} ${scriptFile} ${args}"


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Stabilize the upstream pipeline script with easy way of file lock.
Test Result:
```
[sangadi@sangadi ci]$ sudo python3 upstream_cli.py build quincy
2022-06-08 12:16:38,823 - INFO - upstream_cli.py:144 - Upstream repo for the given branch is https://3.chacra.ceph.com/repos/ceph/quincy/f6bf9c64044cfcaa1e115e8efe104468843f0069/centos/8/flavors/default/repo
2022-06-08 12:16:38,823 - INFO - upstream_cli.py:149 - Upstream image for the given branch is quay.ceph.io/ceph-ci/ceph:f6bf9c64044cfcaa1e115e8efe104468843f0069
podman version 3.4.2
Trying to pull quay.ceph.io/ceph-ci/ceph:f6bf9c64044cfcaa1e115e8efe104468843f0069...
Getting image source signatures
Copying blob 0a1439ae153b skipped: already exists  
Copying blob c08cdfc8cc65 skipped: already exists  
Copying blob 36183769f78d skipped: already exists  
Copying blob e043f1f2adf0 skipped: already exists  
Copying blob 8c0d5ebd25cf skipped: already exists  
Copying config 103ed06909 done  
Writing manifest to image destination
Storing signatures
103ed06909aa1c05c46c306f1a9c03196a69d03782ffa7d5c2ddfdcebd5bc348
2022-06-08 12:16:47,008 - INFO - upstream_cli.py:173 - Upstream version for the given branch is 17.2.0-423
ls: cannot access '/ceph/cephci-jenkins/latest-rhceph-container-info/upstream.yaml.lock': No such file or directory
File lock does not exist, Creating it
File un-locked successfully
2022-06-08 12:16:52,828 - INFO - upstream_cli.py:71 - Updated build info in /ceph/cephci-jenkins/latest-rhceph-container-info/upstream.yaml for the version 17.2.0-423


```
also Tested using pipeline job script works fine.