### PR TITLE
Added suites and conf files for scalelab deployment

### DIFF
--- a/conf/pacific/rgw/scalelab_conf.yaml
+++ b/conf/pacific/rgw/scalelab_conf.yaml
@@ -1,0 +1,459 @@
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['172.16.0.0/16']
+      nodes:
+        -
+          hostname: f10-h29-b02-5039ms.rdu2.scalelab.redhat.com
+          ip: 172.16.37.201
+          root_password: 100yard-
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+        -
+          hostname: f10-h29-b03-5039ms.rdu2.scalelab.redhat.com
+          ip: 172.16.38.30
+          root_password: 100yard-
+          role:
+            - mon
+            - mgr
+        -
+          hostname: f10-h29-b04-5039ms.rdu2.scalelab.redhat.com
+          ip: 172.16.37.250
+          root_password: 100yard-
+          role:
+            - mon
+            - mgr
+        -
+          hostname: f23-h21-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.43.74
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f23-h25-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.43.193
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f23-h29-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.43.39
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h01-000-6048r.rdu2.scalelab.redhat.com 
+          ip: 172.16.44.201
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h05-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.45.64
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h09-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.44.189
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h13-000-6048r.rdu2.scalelab.redhat.com 
+          ip: 172.16.44.134
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h17-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.44.202
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h21-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.45.164
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f26-h25-000-6048r.rdu2.scalelab.redhat.com 
+          ip: 172.16.44.192
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f27-h09-000-6048r.rdu2.scalelab.redhat.com
+          ip: 172.16.45.52
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f11-h21-000-6049p.rdu2.scalelab.redhat.com
+          ip: 172.16.39.76
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz
+        -
+          hostname: f11-h21-000-6049p.rdu2.scalelab.redhat.com
+          ip: 172.16.37.156
+          root_password: 100yard-
+          role:
+            - osd
+            - rgw
+
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+            - /dev/sdm
+            - /dev/sdn
+            - /dev/sdo
+            - /dev/sdp
+            - /dev/sdq
+            - /dev/sdr
+            - /dev/sds
+            - /dev/sdt
+            - /dev/sdu
+            - /dev/sdv
+            - /dev/sdw
+            - /dev/sdx
+            - /dev/sdy
+            - /dev/sdz

--- a/suites/pacific/rgw/scalelab_suite.yaml
+++ b/suites/pacific/rgw/scalelab_suite.yaml
@@ -1,0 +1,127 @@
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: f10-h29-b02-5039ms
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+                skip-dashboard: true               
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              timeout: 900
+              specs:
+                - service_type: osd
+                  service_id: defaultDG
+                  placement:
+                    hosts:
+                    - f23-h21-000-6048r.rdu2.scalelab.redhat.com
+                    - f23-h25-000-6048r.rdu2.scalelab.redhat.com
+                    - f23-h29-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h01-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h05-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h09-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h13-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h17-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h21-000-6048r.rdu2.scalelab.redhat.com
+                    - f26-h25-000-6048r.rdu2.scalelab.redhat.com
+                    - f27-h09-000-6048r.rdu2.scalelab.redhat.com
+                    - f11-h25-000-6049p.rdu2.scalelab.redhat.com
+                    - f11-h21-000-6049p.rdu2.scalelab.redhat.com
+                  data_devices:
+                    paths:
+                    - /dev/sdc
+                    - /dev/sdd
+                    - /dev/sde
+                    - /dev/sdf
+                    - /dev/sdg
+                    - /dev/sdh
+                    - /dev/sdi
+                    - /dev/sdj
+                    - /dev/sdk
+                    - /dev/sdl
+                    - /dev/sdm
+                    - /dev/sdn
+                    - /dev/sdo
+                    - /dev/sdp
+                    - /dev/sdq
+                    - /dev/sdr
+                    - /dev/sds
+                    - /dev/sdt
+                    - /dev/sdu        
+                    - /dev/sdv
+                    - /dev/sdw
+                    - /dev/sdx
+                    - /dev/sdy
+                    - /dev/sdz
+                  db_devices:
+                    rotational: false
+                  filter_logic: AND
+                  objectstore: bluestore
+
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgws
+                  placement:
+                    nodes: 
+                      - f23-h21-000-6048r.rdu2.scalelab.redhat.com
+                      - f23-h25-000-6048r.rdu2.scalelab.redhat.com
+                      - f23-h29-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h01-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h05-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h09-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h13-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h17-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h21-000-6048r.rdu2.scalelab.redhat.com
+                      - f26-h25-000-6048r.rdu2.scalelab.redhat.com
+                      - f27-h09-000-6048r.rdu2.scalelab.redhat.com
+                      - f11-h21-000-6049p.rdu2.scalelab.redhat.com
+                      - f11-h25-000-6049p.rdu2.scalelab.redhat.com
+                  spec:
+                    rgw_zone: default
+                    rgw_realm: default
+                    rgw_frontend_port: 8080
+                    networks: [172.16.0.0/16]
+                    unmanaged: false
+
+      desc: bootstrap with registry-url option and deployment services.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: RHCS deploy cluster using cephadm
+


### PR DESCRIPTION
# Description

Automation of bare-metal deployment of RHCS deployment on scale lab cluster

# Passed log

http://f12-h32-b02-5039ms.rdu2.scalelab.redhat.com:8000/cephci-run-X154J5/

# Cluster health after deployment
[ceph: root@f10-h29-b02-5039ms /]# ceph -s
  cluster:
    id:     71e19310-e67a-11ec-9a05-ac1f6ba409aa
    health: HEALTH_WARN
            clock skew detected on mon.f10-h29-b03-5039ms, mon.f10-h29-b04-5039ms
 
  services:
    mon: 3 daemons, quorum f10-h29-b02-5039ms.rdu2.scalelab.redhat.com,f10-h29-b03-5039ms,f10-h29-b04-5039ms (age 15h)
    mgr: f10-h29-b03-5039ms.rntvvz(active, since 56s), standbys: f10-h29-b04-5039ms.replcf, f10-h29-b02-5039ms.rdu2.scalelab.redhat.com.omlesj
    osd: 312 osds: 312 up (since 15h), 312 in (since 15h)
    rgw: 13 daemons active (13 hosts, 1 zones)
 
  data:
    pools:   5 pools, 105 pgs
    objects: 562 objects, 4.9 KiB
    usage:   12 TiB used, 567 TiB / 579 TiB avail
    pgs:     105 active+clean

