### PR TITLE
Force shortname for PSI test environment.

### DIFF
--- a/conf/inventory/rhel-7.8-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.8-server-x86_64.yaml
@@ -33,10 +33,10 @@ instance:
 
       runcmd:
         - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
-        - yum --setopt=skip_missing_names_on_install=False install -y wget git
-        - systemctl stop firewalld
-        - sudo yum clean metadata
-        - sudo yum clean all
+        - subscription-manager clean
+        - hostnamectl set-hostname $(hostname -s)
+        - yum clean metadata
+        - yum clean all
         - touch /ceph-qa-ready
 
       final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rhel-7.9-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.9-server-x86_64.yaml
@@ -33,8 +33,10 @@ instance:
 
       runcmd:
         - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
-        - sudo yum clean metadata
-        - sudo yum clean all
+        - subscription-manager clean
+        - hostnamectl set-hostname $(hostname -s)
+        - yum clean metadata
+        - yum clean all
         - touch /ceph-qa-ready
 
       final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rhel-8.4-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.4-server-x86_64.yaml
@@ -33,11 +33,10 @@ instance:
 
     runcmd:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
-      - subscription-manager release --set=8.4
-      - yum --setopt=skip_missing_names_on_install=False install -y wget git
-      - systemctl stop firewalld
-      - sudo yum clean metadata
-      - sudo yum clean all
+      - subscription-manager clean
+      - hostnamectl set-hostname $(hostname -s)
+      - yum clean metadata
+      - yum clean all
       - touch /ceph-qa-ready
 
 

--- a/conf/inventory/rhel-8.5-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.5-server-x86_64.yaml
@@ -32,10 +32,11 @@ instance:
 
     runcmd:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
-      - subscription-manager release --set=8.5
+      - subscription-manager clean
+      - hostnamectl set-hostname $(hostname -s)
       - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
-      - sudo yum clean metadata
-      - sudo yum clean all
+      - yum clean metadata
+      - yum clean all
       - touch /ceph-qa-ready
 
     final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rhel-8.6-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.6-server-x86_64.yaml
@@ -32,12 +32,13 @@ instance:
 
     runcmd:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
-      - subscription-manager release --set=8.6
+      - subscription-manager clean
+      - hostnamectl set-hostname $(hostname -s)
       - curl -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
       - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
       - update-ca-trust
-      - sudo yum clean metadata
-      - sudo yum clean all
+      - yum clean metadata
+      - yum clean all
       - touch /ceph-qa-ready
 
     final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rhel-9.0-server-x86_64.yaml
+++ b/conf/inventory/rhel-9.0-server-x86_64.yaml
@@ -33,11 +33,12 @@ instance:
 
     runcmd:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
-      - subscription-manager release --set=9.0
+      - subscription-manager clean
+      - hostnamectl set-hostname $(hostname -s)
       - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
-      - sudo systemctl restart sshd
-      - sudo yum clean metadata
-      - sudo yum clean all
+      - systemctl restart sshd
+      - yum clean metadata
+      - yum clean all
       - touch /ceph-qa-ready
 
     final_message: "Ready for ceph qa testing"


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
This PR forces us to use host shortnames for those systems created using PSI OSP environment.

```
__main__.Error: hostname is a fully qualified domain name (ceph-ci-uwje5-v594h0-node1-installer.novalocal); either fix (e.g., "sudo hostname ceph-ci-uwje5-v594h0-node1-installer" or similar) or pass --allow-fqdn-hostname
```