### PR TITLE
Fix: With RHEL-9 only Tools repo is being built separately causing an error in the compose listener job

### DIFF
--- a/pipeline/scripts/ci/upload_compose.py
+++ b/pipeline/scripts/ci/upload_compose.py
@@ -1,11 +1,9 @@
 """
 This script executes the development build upload workflow to IBM COS.
-
 The steps followed are
 - Create the necessary repo files
 - Perform a repo sync on all required repositories
 - Upload all the packages to IBM Cloud Object Storage
-
 Note:
     The script is required to be executed with sudo privileges. This is required as
     we would create .repo files in /etc/yum.conf.d/ for sync operations. Also, the
@@ -15,7 +13,9 @@ import logging
 import subprocess
 import sys
 import tempfile
+from typing import List
 
+import requests
 from docopt import docopt
 from jinja2 import Template
 
@@ -23,53 +23,77 @@ from storage.ibm_cos import CloudObjectStorage
 
 LOG = logging.getLogger(__name__)
 REPO_TEMPLATE = """
-{%- for repo in ["OSD", "MON", "Tools"] -%}
+{%- for repo in data.repos -%}
 [{{ repo }}]
 name = {{ repo }}
 baseurl = {{ data.base_url }}/compose/{{ repo }}/$basearch/os
 enabled = 0
 gpgcheck = 0
-
 {% endfor %}
 """
 
 usage = """Upload Compose.
-
 This script pulls the development RPMs available in the given base_url and uploads an
 archive of it using the provided object_name to the mentioned bucket.
-
 In the context of CephCI,
     bucket_name     is the name of the RHCS build
     ceph_version    is the ceph version which is the prefixed to the uploaded items.
     base_url        base uri from which the OSD, MON, Tools repo can be constructed.
-
   Example:
     python upload_compose.py \
            ceph-4.2-rhel-7 \
            14.2.11-196 \
            http://download.eng.bos.redhat.com/rhel-7/composes/auto/ceph-4.2-rhel-7/RHCEPH-4.2-RHEL-7-20210909.ci.0
-
 Usage:
   upload_compose.py <bucket_name> <ceph_version> <base_url>
   upload_compose.py -h | --help
-
 Options:
   -h --help     Show this screen
-
 """
 
 
-def create_repo(url: str) -> None:
+def get_repos(url: str) -> List:
+    """
+    Returns the list of known repositories from the given url.
+    The list of repos are known hence not using any parsers. This allows us not add any
+    additional packages. In the future, we may want to change the approach to include
+    parsers if the requirement changes.
+    Args:
+        url (str):  The link to check for the presence of known repositories.
+    Returns:
+        list - of repos
+    """
+    repos = list()
+
+    try:
+        url.rstrip("/")
+        r = requests.get(f"{url}/compose")
+        if "MON" in r.text:
+            repos.append("MON")
+
+        if "OSD" in r.text:
+            repos.append("OSD")
+
+        if "Tools" in r.text:
+            repos.append("Tools")
+
+    except BaseException as be:  # noqa
+        LOG.error(be)
+
+    return repos
+
+
+def create_repo(url: str, repos: List) -> None:
     """
     Creates all the required repo files based on the given base_url.
-
     Args:
         url: str    URL holding the RPMs to be uploaded
+        repos: List The list of repos to be created.
     Returns:
         None
     """
     _tmpl = Template(REPO_TEMPLATE)
-    data = dict({"base_url": url})
+    data = dict({"base_url": url, "repos": repos})
     repo_file = _tmpl.render(data=data)
     LOG.debug(f"The repo file is \n {repo_file}")
 
@@ -79,16 +103,17 @@ def create_repo(url: str) -> None:
     LOG.info("Successfully created repo file.")
 
 
-def compress_build() -> str:
+def compress_build(repos: List) -> str:
     """
     Returns the compressed file name containing the development RPMs.
-
+    Args:
+        repos (list):   The list of repos to be uploaded.
     Returns:
         str: The complete file path to the archive file created.
     """
-    repos = tempfile.mkdtemp()
+    repo_dir = tempfile.mkdtemp()
 
-    for repo in ["OSD", "MON", "Tools"]:
+    for repo in repos:
         subprocess.run(
             [
                 "reposync",
@@ -100,18 +125,17 @@ def compress_build() -> str:
                 "--repoid",
                 f"{repo}",
                 "--download_path",
-                repos,
+                repo_dir,
             ],
             check=True,
         )
 
-    return repos
+    return repo_dir
 
 
 def upload_directory(local_dir: str, bucket: str, item: str) -> None:
     """
     Uploads the given file to the provided bucket with the mentioned name.
-
     Args:
         local_dir (str):    Complete path to the file that needs to be uploaded
         bucket (str):       The name of container to which file has to be uploaded
@@ -142,6 +166,8 @@ if __name__ == "__main__":
     ceph_version = _args["<ceph_version>"]
     base_url = _args["<base_url>"]
 
-    create_repo(url=base_url)
-    temp_dir = compress_build()
+    repo_list = get_repos(url=base_url)
+    create_repo(url=base_url, repos=repo_list)
+    temp_dir = compress_build(repos=repo_list)
+
     upload_directory(temp_dir, bucket_name, ceph_version)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes an issue seen in `upload_compose` as it assumed that all required repos would be available. Here, we check if the repo is available before processing it.

__Error__
```
Error setting up repositories: failure: repodata/repomd.xml from OSD: [Errno 256] No more mirrors to try.
http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-5.2-rhel-9/RHCEPH-5.2-RHEL-9-20220610.ci.0/compose/OSD/x86_64/os/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found
Traceback (most recent call last):
  File "pipeline/scripts/ci/upload_compose.py", line 146, in <module>
    temp_dir = compress_build()
  File "pipeline/scripts/ci/upload_compose.py", line 105, in compress_build
    check=True,
  File "/usr/lib64/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['reposync', '-l', '-m', '--delete', '--newest-only', '--download-metadata', '--repoid', 'OSD', '--download_path', '/tmp/tmp1wf0fn4u']' returned non-zero exit status 1.
```
__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-unsigned-compose-listener/512/console