### PR TITLE
Fix scheduled pipeline `buildArtifacts` params type

### DIFF
--- a/pipeline/ibm-scheduled-pipeline-executor.groovy
+++ b/pipeline/ibm-scheduled-pipeline-executor.groovy
@@ -34,6 +34,8 @@ node(nodeName) {
             def rhcephVersion = validRecipeFile.split("/").last().replace(".yaml", "")
             def recipeContent = sh(
                     returnStdout: true, script: "${SSHServer} \"yq e '.tier-0' ${validRecipeFile}\"").trim()
+            recipeContent = readYaml text: recipeContent
+            recipeContent = writeJSON returnText: true, json:  recipeContent
 
             println "Starting test execution with parameters:"
             println "\trhcephVersion: ${rhcephVersion}\n\tbuildType: ${buildType}\n\tbuildArtifacts: ${recipeContent}\n\toverrides: ${overrides}\n\ttags: ${tags}"

--- a/pipeline/psi-scheduled-pipeline-executor.groovy
+++ b/pipeline/psi-scheduled-pipeline-executor.groovy
@@ -64,6 +64,7 @@ node(nodeName) {
         for (validRecipeFile in validRecipeFiles) {
             def rhcephVersion = validRecipeFile.split("/").last().replace(".yaml", "")
             def recipeContent = readYaml file: "${validRecipeFile}"
+            recipeContent = writeJSON returnText: true, json:  recipeContent
 
             println "Starting test execution with parameters:"
             println "\trhcephVersion: ${rhcephVersion}\n\tbuildType: ${buildType}\n\tbuildArtifacts: ${recipeContent}\n\toverrides: ${overrides}\n\ttags: ${tags}"


### PR DESCRIPTION
# Description
Currently `(ibm|psi)-scheduled-pipeline-executor` script passing `buildArtifacts` parameter as raw string instead of dict. Added steps to convert raw string to JSON/Dict.