### PR TITLE
[PACIFIC]Split RGW testsuite to reduce execution time

### DIFF
--- a/pipeline/metadata/5.0.yaml
+++ b/pipeline/metadata/5.0.yaml
@@ -219,8 +219,23 @@
     - ibmc
     - cephfs
     - stage-3
-- name: "test-rgw-multi-site-secondary-to-primary"
-  suite: "suites/pacific/rgw/tier-1_rgw_multisite-secondary-to-primary.yaml"
+- name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
+  global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.0"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3
+- name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
   global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
   platform: "rhel-8"
   rhbuild: "5.0"

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -204,8 +204,8 @@
     - upgrades
     - dmfg
     - stage-3
-- name: "test-rgw-multi-site-secondary-to-primary"
-  suite: "suites/pacific/rgw/tier-1_rgw_multisite-secondary-to-primary.yaml"
+- name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
   global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
@@ -219,8 +219,38 @@
     - ibmc
     - rgw
     - stage-3
-- name: "test-rgw-ecpool-multiisite-verifying-data-from-primary"
-  suite: "suites/pacific/rgw/tier-1_rgw_ecpool_test-ms-verify-io-from-primary.yaml"
+- name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
+  global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3
+- name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
+  global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3
+- name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
   global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -444,8 +444,8 @@
     - rgw
     - stage-1
 
-- name: "Testing RGW ecpool Multisite Verifying Data from Primary"
-  suite: "suites/pacific/rgw/tier-1_rgw_ecpool_test-ms-verify-io-from-primary.yaml"
+- name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
   global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"
@@ -460,8 +460,40 @@
     - rgw
     - stage-3
 
-- name: "Testing Rgw Multisite Secondary to Primary"
-  suite: "suites/pacific/rgw/tier-1_rgw_multisite-secondary-to-primary.yaml"
+- name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
+  global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3
+
+- name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
+  global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3
+
+- name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
+  suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
   global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
@@ -1,0 +1,409 @@
+# Test suite for evaluating RGW multi-site deployment scenario.
+#
+# This suite deploys a single realm (India) spanning across two RHCS clusters.
+# It has a zonegroup (shared) which also spans across the clusters. There
+# exists a master (pri) and secondary (sec) zones within this group. The master
+# zone is part of the pri cluster whereas the sec zone is part of the sec
+# datacenter (cluster).
+
+# The deployment is evaluated by running IOs across the environments.
+# This particular yaml runs the tests on the primary and verifies IOs on the
+# secondary site.
+
+# In addition to the above, the data bucket is configured to use EC along with
+# network delays between the two clusters.
+---
+
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 30ms 6ms distribution normal
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 20ms 5ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create primary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "primary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node7
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "secondary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node7
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node8
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node8
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node7}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node7}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+              - "ceph osd dump"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+              - "ceph osd dump"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create user
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_unordered.yaml on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
+      polarion-id: CEPH-83573651
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_copy_objects on secondary
+      polarion-id: CEPH-9221
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_copy_objects.py
+            config-file-name: test_versioning_copy_objects.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-sec"]
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_enable on secondary
+      polarion-id: CEPH-9178
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_enable.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_acls on secondary
+      polarion-id: CEPH-9190
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_acls.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_copy on secondary
+      polarion-id: CEPH-14264, CEPH-10646
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_copy.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-sec"]
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_delete on secondary
+      polarion-id: CEPH-14262
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_delete.yaml
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_enable on secondary
+      polarion-id: CEPH-14261, CEPH-9222, CEPH-10652
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_enable.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_suspend on secondary
+      polarion-id: CEPH-14263
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_suspend.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -1,11 +1,19 @@
 # Test suite for evaluating RGW multi-site deployment scenario.
 #
-# This suite deploys a single realm (India) spanning across two RHCS clusters. It has a
-# zonegroup (shared) which also spans across the clusters. There exists a master (pri)
-# and secondary (sec) zones within this group. The master zone is part of the pri
-# cluster whereas the sec zone is part of the sec datacenter (cluster).
+# This suite deploys a single realm (India) spanning across two RHCS clusters.
+# It has a zonegroup (shared) which also spans across the clusters. There
+# exists a master (pri) and secondary (sec) zones within this group. The master
+# zone is part of the pri cluster whereas the sec zone is part of the sec
+# datacenter (cluster).
 
 # The deployment is evaluated by running IOs across the environments.
+# This particular yaml runs the tests on the primary and verifies IOs on the
+# secondary site.
+
+# In addition to the above, the data bucket is configured to use EC along with
+# network delays between the two clusters.
+---
+
 tests:
 
   # Cluster deployment stage
@@ -21,6 +29,23 @@ tests:
       clusters:
         ceph-pri:
           config:
+            roles:
+              - rgw
+            rule: root netem delay 30ms 6ms distribution normal
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 20ms 5ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
             verify_cluster_health: true
             steps:
               - config:
@@ -53,6 +78,21 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create primary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "primary.rgw.buckets.data rgw"
+                  command: shell
               - config:
                   command: apply
                   service: rgw
@@ -61,7 +101,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node5
+                        - node7
         ceph-sec:
           config:
             verify_cluster_health: true
@@ -70,7 +110,6 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-dashboard: true
@@ -98,6 +137,21 @@ tests:
                   args:
                     all-available-devices: true
               - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "secondary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
                   command: apply
                   service: rgw
                   pos_args:
@@ -105,7 +159,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node5
+                        - node7
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py
@@ -117,7 +171,7 @@ tests:
           config:
             command: add
             id: client.1
-            node: node6
+            node: node8
             install_packages:
               - ceph-common
             copy_admin_keyring: true
@@ -125,7 +179,7 @@ tests:
           config:
             command: add
             id: client.1
-            node: node6
+            node: node8
             install_packages:
               - ceph-common
             copy_admin_keyring: true
@@ -141,8 +195,8 @@ tests:
             cephadm: true
             commands:
               - "radosgw-admin realm create --rgw-realm india --default"
-              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node7}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node7}:80 --master --default"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -156,9 +210,9 @@ tests:
             cephadm: true
             commands:
               - "sleep 120"
-              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
@@ -179,6 +233,7 @@ tests:
               - "radosgw-admin realm list"
               - "radosgw-admin zonegroup list"
               - "radosgw-admin zone list"
+              - "ceph osd dump"
       desc: Retrieve the configured environment details
       module: exec.py
       name: get shared realm info
@@ -194,26 +249,10 @@ tests:
               - "radosgw-admin realm list"
               - "radosgw-admin zonegroup list"
               - "radosgw-admin zone list"
+              - "ceph osd dump"
       desc: Retrieve the configured environment details
       module: exec.py
       name: get shared realm info
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 30ms 6ms distribution normal
-        ceph-sec:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 20ms 5ms distribution normal
-      desc: Configuring network traffic delay
-      module: configure-tc.py
-      name: apply-net-qos
 
   # Test work flow
 
@@ -232,12 +271,12 @@ tests:
 
   - test:
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             timeout: 300
-            verify-io-on-site: [ "ceph-pri" ]
+            verify-io-on-site: [ "ceph-sec" ]
       desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py
@@ -248,10 +287,10 @@ tests:
       polarion-id: CEPH-11350
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
             timeout: 300
   - test:
@@ -260,7 +299,7 @@ tests:
       polarion-id: CEPH-9637
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
@@ -271,7 +310,7 @@ tests:
       polarion-id: CEPH-14237
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
@@ -282,10 +321,10 @@ tests:
       polarion-id: CEPH-14237
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
             timeout: 300
   - test:
@@ -294,10 +333,10 @@ tests:
       polarion-id: CEPH-11358,CEPH-11361
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
             timeout: 300
   - test:
@@ -306,10 +345,10 @@ tests:
       polarion-id: CEPH-9801
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             timeout: 300
   - test:
@@ -318,7 +357,7 @@ tests:
       polarion-id: CEPH-9245
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
@@ -329,149 +368,11 @@ tests:
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_ordered_versionsing on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_ordered on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_unordered.yaml on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
-      polarion-id: CEPH-83573651
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_ordered_versionsing on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_copy_objects on secondary
-      polarion-id: CEPH-9221
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_copy_objects.py
-            config-file-name: test_versioning_copy_objects.yaml
-            timeout: 300
-            verify-io-on-site: ["ceph-pri"]
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_enable on secondary
-      polarion-id: CEPH-9178
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_enable.yaml
-            verify-io-on-site: ["ceph-pri"]
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_acls on secondary
-      polarion-id: CEPH-9190
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_acls.yaml
-            verify-io-on-site: ["ceph-pri"]
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_copy on secondary
-      polarion-id: CEPH-14264, CEPH-10646
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
-            verify-io-on-site: ["ceph-pri"]
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_delete on secondary
-      polarion-id: CEPH-14262
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_enable on secondary
-      polarion-id: CEPH-14261, CEPH-9222, CEPH-10652
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_enable.yaml
-            verify-io-on-site: ["ceph-pri"]
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_suspend on secondary
-      polarion-id: CEPH-14263
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_suspend.yaml
-            verify-io-on-site: ["ceph-pri"]
             timeout: 300
   - test:
       name: LargeObjGet_GC test
@@ -479,7 +380,7 @@ tests:
       polarion-id: CEPH-83574416
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
@@ -504,11 +405,11 @@ tests:
       polarion-id: CEPH-11214
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
   - test:
       name: Bucket policy tests
@@ -516,11 +417,11 @@ tests:
       polarion-id: CEPH-11213
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300
 
   - test:
@@ -529,9 +430,9 @@ tests:
       polarion-id: CEPH-11215
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
             timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
@@ -1,0 +1,370 @@
+# Test suite for evaluating RGW multi-site deployment scenario.
+#
+# This suite deploys a single realm (India) spanning across two RHCS clusters. It has a
+# zonegroup (shared) which also spans across the clusters. There exists a master (pri)
+# and secondary (sec) zones within this group. The master zone is part of the pri
+# cluster whereas the sec zone is part of the sec datacenter (cluster).
+
+# The deployment is evaluated by running IOs across the environments.
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 30ms 6ms distribution normal
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 20ms 5ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create user
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_unordered.yaml on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
+      polarion-id: CEPH-83573651
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            timeout: 300
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on secondary
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_copy_objects on secondary
+      polarion-id: CEPH-9221
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_copy_objects.py
+            config-file-name: test_versioning_copy_objects.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-pri"]
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_enable on secondary
+      polarion-id: CEPH-9178
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_enable.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_acls on secondary
+      polarion-id: CEPH-9190
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_acls.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_copy on secondary
+      polarion-id: CEPH-14264, CEPH-10646
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_copy.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-pri"]
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_delete on secondary
+      polarion-id: CEPH-14262
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_delete.yaml
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_enable on secondary
+      polarion-id: CEPH-14261, CEPH-9222, CEPH-10652
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_enable.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_suspend on secondary
+      polarion-id: CEPH-14263
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_suspend.yaml
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -1,19 +1,11 @@
 # Test suite for evaluating RGW multi-site deployment scenario.
 #
-# This suite deploys a single realm (India) spanning across two RHCS clusters.
-# It has a zonegroup (shared) which also spans across the clusters. There
-# exists a master (pri) and secondary (sec) zones within this group. The master
-# zone is part of the pri cluster whereas the sec zone is part of the sec
-# datacenter (cluster).
+# This suite deploys a single realm (India) spanning across two RHCS clusters. It has a
+# zonegroup (shared) which also spans across the clusters. There exists a master (pri)
+# and secondary (sec) zones within this group. The master zone is part of the pri
+# cluster whereas the sec zone is part of the sec datacenter (cluster).
 
 # The deployment is evaluated by running IOs across the environments.
-# This particular yaml runs the tests on the primary and verifies IOs on the
-# secondary site.
-
-# In addition to the above, the data bucket is configured to use EC along with
-# network delays between the two clusters.
----
-
 tests:
 
   # Cluster deployment stage
@@ -29,23 +21,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            roles:
-              - rgw
-            rule: root netem delay 30ms 6ms distribution normal
-        ceph-sec:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 20ms 5ms distribution normal
-      desc: Configuring network traffic delay
-      module: configure-tc.py
-      name: apply-net-qos
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
             verify_cluster_health: true
             steps:
               - config:
@@ -78,21 +53,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  args:
-                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
-                    - "crush-failure-domain=host crush-device-class=hdd"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool create primary.rgw.buckets.data 32 32"
-                    - "erasure rgwec01"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool application enable"
-                    - "primary.rgw.buckets.data rgw"
-                  command: shell
               - config:
                   command: apply
                   service: rgw
@@ -101,7 +61,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node7
+                        - node5
         ceph-sec:
           config:
             verify_cluster_health: true
@@ -110,6 +70,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
+                    registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-dashboard: true
@@ -137,21 +98,6 @@ tests:
                   args:
                     all-available-devices: true
               - config:
-                  args:
-                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
-                    - "crush-failure-domain=host crush-device-class=hdd"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
-                    - "erasure rgwec01"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool application enable"
-                    - "secondary.rgw.buckets.data rgw"
-                  command: shell
-              - config:
                   command: apply
                   service: rgw
                   pos_args:
@@ -159,7 +105,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node7
+                        - node5
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py
@@ -171,7 +117,7 @@ tests:
           config:
             command: add
             id: client.1
-            node: node8
+            node: node6
             install_packages:
               - ceph-common
             copy_admin_keyring: true
@@ -179,7 +125,7 @@ tests:
           config:
             command: add
             id: client.1
-            node: node8
+            node: node6
             install_packages:
               - ceph-common
             copy_admin_keyring: true
@@ -195,8 +141,8 @@ tests:
             cephadm: true
             commands:
               - "radosgw-admin realm create --rgw-realm india --default"
-              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node7}:80 --master --default"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node7}:80 --master --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -210,9 +156,9 @@ tests:
             cephadm: true
             commands:
               - "sleep 120"
-              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
@@ -233,7 +179,6 @@ tests:
               - "radosgw-admin realm list"
               - "radosgw-admin zonegroup list"
               - "radosgw-admin zone list"
-              - "ceph osd dump"
       desc: Retrieve the configured environment details
       module: exec.py
       name: get shared realm info
@@ -249,10 +194,26 @@ tests:
               - "radosgw-admin realm list"
               - "radosgw-admin zonegroup list"
               - "radosgw-admin zone list"
-              - "ceph osd dump"
       desc: Retrieve the configured environment details
       module: exec.py
       name: get shared realm info
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 30ms 6ms distribution normal
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 20ms 5ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
 
   # Test work flow
 
@@ -271,12 +232,12 @@ tests:
 
   - test:
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             timeout: 300
-            verify-io-on-site: [ "ceph-sec" ]
+            verify-io-on-site: [ "ceph-pri" ]
       desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py
@@ -287,10 +248,10 @@ tests:
       polarion-id: CEPH-11350
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
             timeout: 300
   - test:
@@ -299,7 +260,7 @@ tests:
       polarion-id: CEPH-9637
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
@@ -310,7 +271,7 @@ tests:
       polarion-id: CEPH-14237
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
@@ -321,10 +282,10 @@ tests:
       polarion-id: CEPH-14237
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
             timeout: 300
   - test:
@@ -333,10 +294,10 @@ tests:
       polarion-id: CEPH-11358,CEPH-11361
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
             timeout: 300
   - test:
@@ -345,10 +306,10 @@ tests:
       polarion-id: CEPH-9801
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             timeout: 300
   - test:
@@ -357,7 +318,7 @@ tests:
       polarion-id: CEPH-9245
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
@@ -368,151 +329,11 @@ tests:
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_ordered_versionsing on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
-
-
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_ordered on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_unordered.yaml on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
-      polarion-id: CEPH-83573651
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
-  - test:
-      name: Bucket listing test
-      desc: test_bucket_listing_flat_ordered_versionsing on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_copy_objects on secondary
-      polarion-id: CEPH-9221
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_copy_objects.py
-            config-file-name: test_versioning_copy_objects.yaml
-            timeout: 300
-            verify-io-on-site: ["ceph-sec"]
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_enable on secondary
-      polarion-id: CEPH-9178
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_enable.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_acls on secondary
-      polarion-id: CEPH-9190
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_acls.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_copy on secondary
-      polarion-id: CEPH-14264, CEPH-10646
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
-            verify-io-on-site: ["ceph-sec"]
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_delete on secondary
-      polarion-id: CEPH-14262
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_enable on secondary
-      polarion-id: CEPH-14261, CEPH-9222, CEPH-10652
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_enable.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
-  - test:
-      name: Buckets Versioning test
-      desc: test_versioning_objects_suspend on secondary
-      polarion-id: CEPH-14263
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_suspend.yaml
-            verify-io-on-site: ["ceph-sec"]
             timeout: 300
   - test:
       name: LargeObjGet_GC test
@@ -520,7 +341,7 @@ tests:
       polarion-id: CEPH-83574416
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
@@ -545,11 +366,11 @@ tests:
       polarion-id: CEPH-11214
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             timeout: 300
   - test:
       name: Bucket policy tests
@@ -557,11 +378,11 @@ tests:
       polarion-id: CEPH-11213
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             timeout: 300
 
   - test:
@@ -570,9 +391,9 @@ tests:
       polarion-id: CEPH-11215
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
-            verify-io-on-site: ["ceph-sec"]
+            verify-io-on-site: ["ceph-pri"]
             timeout: 300


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8P4ONL/ 

tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W9TWI1

tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FM76G7

tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-85DOPD

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
