### PR TITLE
Changing retries from 3 to 6 while checking for service existence

### DIFF
--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -91,7 +91,7 @@ class Orch(
         if service_type:
             check_status_dict["args"]["service_type"] = service_type
 
-        _retries = 3  # cross-verification retries
+        _retries = 6  # cross-verification retries
         _count = 0
         while end_time > datetime.now():
             sleep(interval)


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description
Workaround for the issue seen in https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/3937/85701/85746/log 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
