### PR TITLE
Adding Exception to rp_clients log entries

### DIFF
--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -215,17 +215,20 @@ def process_testcase(xunit_xml, testcase, tsuite):
 def generate_log_events(file_handler):
     log_events = {}
     for line in file_handler:
-        if line.startswith(match_start_line(line)):
-            if log_events:
-                yield log_events
-            log_events = {
-                "date": line.split("__")[0][:23],
-                "type": line.split("-", 5)[3],
-                "text": line.split("-", 5)[-1],
-            }
-        else:
-            log_events["text"] += line
-    yield log_events
+        try:
+            if line.startswith(match_start_line(line)):
+                if log_events:
+                    yield log_events
+                log_events = {
+                    "date": line.split("__")[0][:23],
+                    "type": line.split("-", 5)[3],
+                    "text": line.split("-", 5)[-1],
+                }
+            else:
+                log_events["text"] += line
+        except Exception:
+            log.error(f"Unable to parse the below Line : {line}")
+        yield log_events
 
 
 def match_start_line(line):


### PR DESCRIPTION
Adding Exception to rp_clients log entries
**Problem:**
Updating error messages to the Report portal were failing if we have unexpected tokens.
Because of this launches were not ending
**Solution:**
We have added an exception block for those lines which can not be parsed as part of adding logs.

Complete logs can be downloaded if required

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
