### PR TITLE
Verify rbd mirror and daemon status on cluster

### DIFF
--- a/suites/pacific/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/pacific/rbd/tier-1_rbd_mirror.yaml
@@ -189,4 +189,14 @@ tests:
             io-total: 200M
       polarion-id: CEPH-83573614
       desc: Rename primary image and check on secondary for this change
-
+  - test:
+      name: test_rbd_mirror_daemon_status
+      module: test_rbd_mirror_daemon_status.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-83573760
+      desc: Verify rbd mirror and daemon status on cluster
+      

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -712,3 +712,22 @@ class RbdMirror:
                 raise IOonSecondaryError("Detected I/O Operation on secondary")
             else:
                 raise
+
+    def mirror_daemon_status(self, daemon):
+        """
+        Gets the rbd mirror daemon status where the rbd mirror daemon running
+        Args:
+            daemon
+        Returns:
+            0 - if daemon_status is active
+            1 - it daemon_status is not active
+        """
+        daemon_status, rc = self.ceph_rbdmirror.exec_command(
+            sudo=True,
+            cmd=f"systemctl | grep {daemon} | awk {{'print $3'}}",
+        )
+        log.info(f"Daemon Runing Status : {daemon_status}")
+        if daemon_status.strip("\n") != "active":
+            return 1
+        return 0
+        

--- a/tests/rbd_mirror/test_rbd_mirror_daemon_status.py
+++ b/tests/rbd_mirror/test_rbd_mirror_daemon_status.py
@@ -1,0 +1,51 @@
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """
+    --> Deploy two clusters using Cephadm
+    --> Configures RBD Mirroring
+    --> Check the mirror status on primary and secoundary clusters
+    --> Check the rbd-daemons on cluster
+    Args:
+        **kw:
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+    """
+    try:
+        log.info("Starting RBD mirroring test case")
+        config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
+        # Check the mirror status
+        poolname = mirror1.random_string() + "_tier_1_rbd_mirror_pool"
+        imagename = mirror1.random_string() + "_tier_1_rbd_mirror_image"
+        imagespec = poolname + "/" + imagename
+        mirror1.create_pool(poolname=poolname)
+        mirror2.create_pool(poolname=poolname)
+        mirror1.create_image(imagespec=imagespec, size=config.get("imagesize"))
+        mirror1.config_mirror(mirror2, poolname=poolname, mode="pool")
+        mirror2.wait_for_status(poolname=poolname, images_pattern=1)
+        # Check rbd-daemon runing status
+        out1 = mirror1.mirror_daemon_status("rbd-mirror")
+        out2 = mirror1.mirror_daemon_status("rbd-mirror")
+        log.info(f"RBD Daemon Status of cluster rbd1 : {out1}")
+        log.info(f"RBD Daemon Status of cluster rbd2 : {out2}")
+        if out1 == 1 or out2 == 1:
+            return 1
+        return 0
+
+    except ValueError as ve:
+        log.error(
+            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
+        )
+        log.exception(ve)
+    except Exception as e:
+        log.exception(e)
+        return 1


### PR DESCRIPTION
Automated Verify rbd mirror and daemon status on cluster
TC covered: CEPH-83573760

Signed-off-by: Mohit mobisht@redhat.com

# Description
Automated Verify rbd mirror and daemon status on cluster
TC covered: CEPH-83573760
Test Results: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HWXS1E

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [✓] Create a test case in Polarion reviewed and approved.
- [✓] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [✓] Review the automation design
- [✓] Implement the test script and perform test runs
- [✓] Submit PR for code review and approve
- [✓] Update Polarion Test with Automation script details and update automation fields
- [✓] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
