### PR TITLE
Include rgw upgrade test suites in scheduler pipeline

### DIFF
--- a/pipeline/metadata/4.3.yaml
+++ b/pipeline/metadata/4.3.yaml
@@ -541,3 +541,35 @@
     - ibmc
     - rgw
     - stage-1
+
+- name: "test rgw ssl upgrade 4 to latest"
+  suite: "suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
+  global-conf: "conf/nautilus/rgw/5-node-cluster.yaml"
+  platform: "rhel-7"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-7-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-7-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-1
+
+- name: "test rgw 4x ganesha upgrade to latest"
+  suite: "suites/nautilus/rgw/tier-2_rgw_test-4x-ganesha-upgrade-to-latest.yaml"
+  global-conf: "conf/nautilus/rgw/tier-2_rgw_ganesha.yaml"
+  platform: "rhel-7"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-7-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-7-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -645,3 +645,67 @@
     - ibmc
     - rgw
     - stage-4
+
+- name: "test-rgw-ssl-upgrade-4-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "test-rgw-upgrade-4-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/5-node-with-iscsi-role.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "test-rgw-upgrade-5-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "Tier-2 RGW single site upgrade from 5.x GA to latest developmet build"
+  suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -907,3 +907,83 @@
     - ibmc
     - rgw
     - stage-6
+
+- name: "test-rgw-ms-upgrade-4-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-1
+
+- name: "test-rgw-ms-upgrade-5-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-1
+
+- name: "test-rgw-ssl-upgrade-4-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "test-rgw-upgrade-4-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/5-node-with-iscsi-role.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "test-rgw-upgrade-5-to-latest"
+  suite: "suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml"
+  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
Include rgw upgrade test suites in scheduler pipeline

Pacific:
tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
tier-1_rgw_multisite_upgrade-5-to-latest.yaml
tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
tier-1_rgw_test-upgrade-4-to-latest.yaml
tier-1_rgw_test_upgrade-5-to-latest.yaml

Nautilus:
tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
tier-2_rgw_test-4x-ganesha-upgrade-to-latest.yaml


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
