### PR TITLE
Waiting for the MDS deamons after FS creation

### DIFF
--- a/tests/cephfs/multifs/multifs_kernelmounts.py
+++ b/tests/cephfs/multifs/multifs_kernelmounts.py
@@ -2,6 +2,7 @@ import random
 import string
 import traceback
 
+from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
 
@@ -36,9 +37,23 @@ def run(ceph_cluster, **kw):
             )
             return 1
         client1 = clients[0]
+        host_list = [
+            client1.node.hostname.replace("node7", "node2"),
+            client1.node.hostname.replace("node7", "node3"),
+        ]
+        hosts = " ".join(host_list)
+        fs_name = "cephfs_new"
         client1.exec_command(
-            sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
+            sudo=True,
+            cmd=f"ceph fs volume create {fs_name} --placement='2 {hosts}'",
+            check_ec=False,
         )
+
+        for host in host_list:
+            if not fs_util.wait_for_mds_deamon(
+                client=client1, process_name=fs_name, host=host
+            ):
+                raise CommandFailed(f"Failed to start MDS on particular nodes {host}")
         total_fs = fs_util.get_fs_details(client1)
         if len(total_fs) < 2:
             log.error(


### PR DESCRIPTION
Fix for multifs Failure

Failure :
 https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/4154/95138?item1Params=filter.eq.hasStats%3Dtrue%26filter.eq.hasChildren%3Dfalse%26filter.in.issueType%3Dti_r1iw9nemxb1w

Multifs Failure :
1. We are creating new volume cephfs_new
2. Before we mount the mds for the new volume were not up and running state
failure : b'mount error: no mds server is up or the cluster is laggy'
3. I will add wait_for_mds_deamons method after volume create.
https://github.com/red-hat-storage/cephci/blob/baf636938c9b14b38c557b7ccdb4bac509ece0e4/tests/cephfs/cephfs_utilsV1.py#L255
Signed-off-by: Amarnath K <amk@amk.remote.csb>

PSI Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XKFTFL/
IBM-C : https://159.23.92.24/job/rhceph-test-execution-manual/23/console 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
