### PR TITLE
fs_util.get_stat() fix for general file stats

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1480,6 +1480,8 @@ class FsUtils(object):
                 --printf : option to print a particular value
         Return:
             returns stat of a path(file or directory)
+            If no option added to the cmd, it will return a dictionary consisted of
+            "File", "Access", "Blocks", "Birth", "Access", "Uid", "Gid", "Size".
             Sample output :
 
             [root@ceph-hyelloji-9etpcf-node8 ~]# stat /mnt/cephfs_kernelqcnquvmv84_1/volumes/subvolgroup_1/
@@ -1494,13 +1496,28 @@ class FsUtils(object):
              Birth: -
 
         """
-
+        standard_format = " --printf='%n,%A,%b,%w,%x,%u,%g,%s'"
         stat_cmd = f"stat {file_path} "
         if kwargs.get("format"):
             stat_cmd += f" --printf {kwargs.get('format')}"
+        else:
+            stat_cmd += standard_format
+            out, rc = client.exec_command(sudo=True, cmd=stat_cmd)
+            key_list = [
+                "File",
+                "Permission",
+                "Blocks",
+                "Birth",
+                "Access",
+                "Uid",
+                "Gid",
+                "Size",
+            ]
+            output_dic = dict(zip(key_list, out.split(",")))
+            print(log.info(output_dic))
+            return output_dic
         out, rc = client.exec_command(sudo=True, cmd=stat_cmd)
-        stat_output = json.loads(out)
-        return stat_output
+        return out
 
     def wait_for_cmd_to_succeed(self, client, cmd, timeout=180, interval=5):
         """


### PR DESCRIPTION
Since fs_util.get_stat() was not able to return its value in json format, I made it is able to return in dictionary format so that it can converted to json or other format in the future. I also left it the options to add so that "format" could be changed as needed.

get_stat() output without options(For example):

{'File': '/mnt/cephfs_kernelhd1t0dr51d_1/volumes/subvolgroup_1', 'Access': '2022-07-05 15:04:16.372978328 -0400', 'Blocks': '0', 'Birth': '2022-07-05 15:04:16.372978328 -0400', 'Uid': '0', 'Gid': '0', 'Size': '0'}


http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UHHNJI

Signed-off-by: julpark-rh <yonhyun@gmail.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
