### PR TITLE
Minor modifications: rm inactive TC, rm dup method

### DIFF
--- a/suites/pacific/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/pacific/rbd/tier-1_rbd_mirror.yaml
@@ -177,7 +177,7 @@ tests:
           config:
             imagesize: 2G
             io-total: 200M
-      polarion-id: CEPH-83573618,CEPH-83573619,CEPH-83573620
+      polarion-id: CEPH-83573619,CEPH-83573620
       desc: Create RBD mirrored images and run IOs
   - test:
       name: test_rbd_mirror_rename_image

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1422,16 +1422,6 @@ def clone_the_repo(config, node, path_to_clone):
     node.exec_command(cmd=f"cd {path_to_clone} ; {git_clone_cmd}")
 
 
-def install_fio(client_node):
-    """Install fio package on client node.
-
-    Args:
-        client_node: ceph node
-    """
-    log.info("Installing fio on client node")
-    client_node.exec_command(cmd="yum install fio -y", sudo=True)
-
-
 def run_fio(**kw):
     """Run IO using fio tool on given target.
 
@@ -1441,6 +1431,8 @@ def run_fio(**kw):
         pool: name of rbd image pool
         runtime: fio runtime
         long_running(bool): True for long running required
+
+    Prerequisite: fio package must have been installed on the client node.
     """
     sudo = False
     if kw.get("filename"):


### PR DESCRIPTION
1. TC CEPH-83573618 was marked as inactive, removed it from the suite.
2. There was a method added to install fio package, as existing module test_client.py handles package installation, removing this method which is kind of duplicate.

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
