### PR TITLE
Fix: user creation failure while cluster deployed with 4.x ver and rhbuild was 5.x

### DIFF
--- a/run.py
+++ b/run.py
@@ -725,6 +725,7 @@ def run(args):
     tests = suite.get("tests")
     tcs = []
     jenkins_rc = 0
+    _rhcs_version = rhbuild[:3]
     # use ceph_test_data to pass around dynamic data between tests
     ceph_test_data = dict()
     ceph_test_data["custom-config"] = custom_config
@@ -831,10 +832,9 @@ def run(args):
                     rp_logger.log(message=f"Logfile location - {tc['log-link']}")
                     rp_logger.log(message=f"Polarion ID: {tc['polarion-id']}")
 
-                # Initialize the cluster with the expected rhcs_version hence the
-                # precedence would be from test suite.
-                # rhbuild would start with the version for example 5.0 or 4.2-rhel-7
-                _rhcs_version = test.get("ceph_rhcs_version", rhbuild[:3])
+                if "build" in config.keys():
+                    _rhcs_version = config["build"]
+                # Initialize the cluster with the expected rhcs_version
                 ceph_cluster_dict[cluster_name].rhcs_version = _rhcs_version
 
                 rc = test_mod.run(

--- a/suites/nautilus/rgw/tier-2_rgw_test-bucket-acls-and-links.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-bucket-acls-and-links.yaml
@@ -96,6 +96,7 @@ tests:
   - test:
       name: User rename
       desc: RGW User rename script
+      polarion-id: CEPH-83574811
       module: sanity_rgw.py
       config:
         script-name: test_user_bucket_rename.py

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -559,6 +559,7 @@ tests:
 
   - test:
       name: User rename
+      polarion-id: CEPH-83574811
       desc: RGW User rename script
       module: sanity_rgw.py
       config:

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd-5-0-only.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd-5-0-only.yaml
@@ -96,6 +96,7 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+      polarion-id: CEPH-83573713
 
 #   S3CMD tests
   - test:

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -94,6 +94,7 @@ tests:
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py
+      polarion-id: CEPH-83573713
       name: deploy cluster
 
 #   S3CMD tests

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -92,7 +92,7 @@ def run(**kw):
         set_test_env(config, primary_rgw_node)
         set_test_env(config, secondary_rgw_node)
 
-        if primary_cluster.rhcs_version.version[0] == 5:
+        if primary_cluster.rhcs_version.version[0] >= 5:
             setup_cluster_access(primary_cluster, primary_rgw_node)
             setup_cluster_access(secondary_cluster, secondary_rgw_node)
 


### PR DESCRIPTION
…ld was given 5.x

Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Latest LOG: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Z62A93/create_user_0.log


Fix for user creation failure when cluster was deployed with 4.x and rhbuild was 5.x
In user craetion decision was craeted using rhbuild
Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/create_user_0.log

cli: python3 run.py --rhbuild 5.2 --platform rhel-8 --global-conf conf/pacific/rgw/rgw_multisite.yaml --osp-cred <cred>.yaml --inventory conf/inventory/rhel-8-latest.yaml --suite suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml --log-level info --ignore-latest-container --instances-name 43_upgrade_52 --store --skip-sos-report --build tier-0 

And also included some polarion ids

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
