### PR TITLE
Fix rgw 4x to 5x latest upgrade

### DIFF
--- a/conf/pacific/rgw/upgrades.yaml
+++ b/conf/pacific/rgw/upgrades.yaml
@@ -1,0 +1,37 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+      node2:
+        role:
+          - mgr
+          - mon
+      node3:
+        role:
+          - mon
+          - mgr
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+      node5:
+        role:
+          - rgw
+          - osd
+        disk-size: 20
+        no-of-volumes: 4
+      node6:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - osd
+          - grafana
+      node7:
+        role:
+          - client

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -661,7 +661,7 @@
 
 - name: "test-rgw-ssl-upgrade-4-to-latest"
   suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
-  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  global-conf: "conf/pacific/rgw/upgrades.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
   inventory:
@@ -677,7 +677,7 @@
 
 - name: "test-rgw-upgrade-4-to-latest"
   suite: "suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml"
-  global-conf: "conf/pacific/rgw/5-node-with-iscsi-role.yaml"
+  global-conf: "conf/pacific/rgw/upgrades.yaml"
   platform: "rhel-8"
   rhbuild: "5.1"
   inventory:

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -952,7 +952,7 @@
 
 - name: "test-rgw-ssl-upgrade-4-to-latest"
   suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
-  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  global-conf: "conf/pacific/rgw/upgrades.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"
   inventory:
@@ -968,7 +968,7 @@
 
 - name: "test-rgw-upgrade-4-to-latest"
   suite: "suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml"
-  global-conf: "conf/pacific/rgw/5-node-with-iscsi-role.yaml"
+  global-conf: "conf/pacific/rgw/upgrades.yaml"
   platform: "rhel-8"
   rhbuild: "5.2"
   inventory:

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -1,5 +1,6 @@
 #
 # Objective: Test rgw with ssl configured using ceph-ansible and upgrade
+# with dashboard disabled
 # Polarion ID: CEPH-83574678
 #
 ---
@@ -14,7 +15,7 @@ tests:
       module: test_ansible.py
       config:
         use_cdn: true
-        build: "4.x"
+        build: '4.x'
         ansi_config:
           ceph_origin: repository
           ceph_repository_type: cdn

--- a/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
@@ -1,5 +1,6 @@
 #############################################################################
 # - Automation support for upgrade from RHCS4 to RHCS5 cluster with RGW tests
+# with dashboard enabled
 #
 # Test steps:
 # ---------------------------------------------------------------------
@@ -26,6 +27,9 @@ tests:
       ansi_config:
         ceph_origin: repository
         ceph_repository: rhcs
+        ceph_repository_type: cdn
+        ceph_rhcs_version: 4
+        ceph_stable_release: nautilus
         osd_scenario: lvm
         osd_auto_discovery: false
         ceph_stable_rh_storage: true
@@ -233,8 +237,8 @@ tests:
         ceph_rhcs_version: 5
         osd_scenario: lvm
         osd_auto_discovery: false
-        fetch_directory: ~/fetch
         radosgw_num_instances: 2
+        fetch_directory: ~/fetch
         copy_admin_key: true
         containerized_deployment: true
         upgrade_ceph_packages: true


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

# Description

Upgrade from 4x to 5x latest was failing with error: mon is not added to quorum
because of collocated osd and mon

created new conf file to be used for upgrade testing.

Logs:
ssl: http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-28D414/
non-ssl: http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-NETY9V/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
