### PR TITLE
Fix upstream executor pipeline.

### DIFF
--- a/pipeline/upstream_test_executor.groovy
+++ b/pipeline/upstream_test_executor.groovy
@@ -76,8 +76,7 @@ node('ceph-qe-ci || rhel-8-medium') {
                 status = "UNSTABLE"
             }
             sharedLib.sendEmail(buildType, testResults, upstreamArtifact)
-            def msg = "Ceph Version:${upstreamArtifact.ceph_version} Automated test execution summary"
-            def msg = "Upstream test report status of ceph version:${upstreamArtifact.ceph_version} is ${status} .Log:${env.BUILD_URL}"
+            def msg = "Upstream test report status of ceph version:${cephVersion}-${upstreamVersion} is ${status} .Log:${env.BUILD_URL}"
             googlechatnotification(url: "id:rhcephCIGChatRoom", message: msg)
         }
     } catch(Exception err) {


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Fix upstream executor pipeline issue.

```
Commit message: "Merge pull request #1607 from red-hat-storage/fix_4xupdate"
 > git rev-list --no-walk 3782ad2a9fb09119d83554ec9562dfbef20057c0 # timeout=10
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 80: The current scope already contains a variable of the name msg
 @ line 80, column 17.
               def msg = "Upstream test report status of ceph version:${upstreamArtifact.ceph_version} is ${status} .Log:${env.BUILD_URL}"
                   ^

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:958)
	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:605)
	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:554)
	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:142)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:127)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:571)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:523)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:334)
	at hudson.model.ResourceController.execute(ResourceController.java:99)
	at hudson.model.Executor.run(Executor.java:431)
Finished: FAILURE
```

https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/job/cephci-upstream-test-executor/26/console
