### PR TITLE
[2] verify_io incorrectly tests object size and stats with rgw-ms versioning tests

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
@@ -322,7 +322,6 @@ tests:
           config:
             script-name: test_versioning_copy_objects.py
             config-file-name: test_versioning_copy_objects.yaml
-            verify-io-on-site: ["ceph-pri"]
             timeout: 300
 
   - test:
@@ -361,7 +360,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_copy.yaml
-            verify-io-on-site: ["ceph-pri"]
             timeout: 300
 
   - test:


### PR DESCRIPTION
verify_io incorrectly tests object size and stats with rgw-ms versioning tests