### PR TITLE
Adding wait for MDS to move to running state

### DIFF
--- a/tests/cephfs/multifs/multifs_fusemounts.py
+++ b/tests/cephfs/multifs/multifs_fusemounts.py
@@ -2,6 +2,7 @@ import random
 import string
 import traceback
 
+from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
 
@@ -39,7 +40,8 @@ def run(ceph_cluster, **kw):
         client1.exec_command(
             sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
         )
-        fs_util.wait_for_mds_process(client1, "cephfs_new")
+        if not fs_util.wait_for_mds_process(client1, "cephfs_new"):
+            raise CommandFailed("Failed to start MDS deamons")
         total_fs = fs_util.get_fs_details(client1)
         if len(total_fs) < 2:
             log.error(


### PR DESCRIPTION
Adding wait for MDS to move to running state

This will fix intermittent issue https://github.com/red-hat-storage/cephci/issues/1639 

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PO9SU0/
https://159.23.92.24/job/rhceph-test-execution-manual/25


Multifs Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QQJWNV/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
