### PR TITLE
Updated metadata for suite executed only in PSI env

### DIFF
--- a/pipeline/metadata/4.3.yaml
+++ b/pipeline/metadata/4.3.yaml
@@ -503,12 +503,10 @@
   rhbuild: "4.3"
   inventory:
     openstack: "conf/inventory/rhel-7-latest.yaml"
-    ibmc: "conf/inventory/ibm-vpc-rhel-7-latest.yaml"
   metadata:
     - schedule
     - tier-2
-    - openstack
-    - ibmc
+    - openstack-only
     - upgrades
     - dmfg
     - stage-1

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -602,12 +602,10 @@
   rhbuild: "5.1"
   inventory:
     openstack: "conf/inventory/rhel-8-latest.yaml"
-    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
   metadata:
     - schedule
     - tier-2
-    - openstack
-    - ibmc
+    - openstack-only
     - upgrades
     - dmfg
     - stage-2

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -135,12 +135,10 @@
   rhbuild: "5.2"
   inventory:
     openstack: "conf/inventory/rhel-8-latest.yaml"
-    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
   metadata:
     - schedule
     - tier-2
-    - openstack
-    - ibmc
+    - openstack-only
     - upgrades
     - dmfg
     - stage-1


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Fixes: RHCEPHQE-4473
To fix the issue https://github.com/red-hat-storage/cephci/issues/1592
In IBM environment, we don't have release.yaml file access hence this cron pipeline job suite is failing 
these suites can only be executed in psi-only environments
Hence updated metadata related to that suite.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
