### PR TITLE
Fix ignore-latest-container flag

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -728,7 +728,7 @@ def update_ca_cert(node, cert_url, out_file, timeout=120, check_ec=True):
         output_dir = "/usr/local/share/ca-certificates/"
         update_cmd = "update-ca-certificates"
 
-    download_cmd = f"curl --fail {cert_url} -o {output_dir}{out_file}"
+    download_cmd = f"curl -m 120 --fail {cert_url} -o {output_dir}{out_file}"
     for cmd in [download_cmd, update_cmd]:
         node.exec_command(
             sudo=True,

--- a/conf/inventory/rhel-7.9-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.9-server-x86_64.yaml
@@ -35,6 +35,9 @@ instance:
         - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
         - subscription-manager clean
         - hostnamectl set-hostname $(hostname -s)
+        - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+        - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
+        - update-ca-trust
         - yum clean metadata
         - yum clean all
         - touch /ceph-qa-ready

--- a/conf/inventory/rhel-8.5-server-x86_64-large.yaml
+++ b/conf/inventory/rhel-8.5-server-x86_64-large.yaml
@@ -34,6 +34,9 @@ instance:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
       - hostnamectl set-hostname $(hostname -s)
+      - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
+      - update-ca-trust
       - sudo yum clean metadata
       - sudo yum clean all
       - touch /ceph-qa-ready

--- a/conf/inventory/rhel-8.6-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.6-server-x86_64.yaml
@@ -34,8 +34,8 @@ instance:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - subscription-manager clean
       - hostnamectl set-hostname $(hostname -s)
-      - curl -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
-      - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
+      - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
       - update-ca-trust
       - yum clean metadata
       - yum clean all

--- a/conf/inventory/rhel-9.0-server-x86_64.yaml
+++ b/conf/inventory/rhel-9.0-server-x86_64.yaml
@@ -37,6 +37,9 @@ instance:
       - hostnamectl set-hostname $(hostname -s)
       - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
       - systemctl restart sshd
+      - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
+      - update-ca-trust
       - yum clean metadata
       - yum clean all
       - touch /ceph-qa-ready

--- a/osp/osp-cred-ci-2.yaml
+++ b/osp/osp-cred-ci-2.yaml
@@ -4,7 +4,7 @@ globals:
         password: '<user_password>'
         auth-url: 'https://rhos-d.infra.prod.upshift.rdu2.redhat.com:13000'
         auth-version: '3.x_password'
-        tenant-name: 'ceph-jenkins'
+        tenant-name: 'ceph-ci'
         service-region: 'regionOne'
         domain: 'redhat.com'
         tenant-domain-id: '62cf1b5ec006489db99e2b0ebfb55f57'

--- a/run.py
+++ b/run.py
@@ -397,6 +397,7 @@ def run(args):
     rp_logger = None
     if post_to_report_portal:
         rp_logger = ReportPortal()
+
     TestMetaData(run_id=run_id, rhbuild=rhbuild, rhcs="rhcs", rp_logger=rp_logger)
     run_dir = create_run_dir(run_id, log_directory)
     startup_log = os.path.join(run_dir, "startup.log")
@@ -446,18 +447,18 @@ def run(args):
     platform = args["--platform"]
     build = args.get("--build", None)
 
-    if build and build not in ["released"]:
+    if build and build not in ["released"] and not ignore_latest_nightly_container:
         base_url, docker_registry, docker_image, docker_tag = fetch_build_artifacts(
             build, rhbuild, platform, args.get("--upstream-build", None)
         )
 
     store = args.get("--store", False)
 
-    base_url = args.get("--rhs-ceph-repo") or base_url
-    ubuntu_repo = args.get("--ubuntu-repo") or ubuntu_repo
-    docker_registry = args.get("--docker-registry") or docker_registry
-    docker_image = args.get("--docker-image") or docker_image
-    docker_tag = args.get("--docker-tag") or docker_tag
+    base_url = args.get("--rhs-ceph-repo", base_url)
+    ubuntu_repo = args.get("--ubuntu-repo", ubuntu_repo)
+    docker_registry = args.get("--docker-registry", docker_registry)
+    docker_image = args.get("--docker-image", docker_image)
+    docker_tag = args.get("--docker-tag", docker_tag)
     kernel_repo = args.get("--kernel-repo", None)
 
     docker_insecure_registry = args.get("--insecure-registry", False)

--- a/utility/psi_volume_cleanup.py
+++ b/utility/psi_volume_cleanup.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 
 import yaml
 from docopt import docopt
-from libcloud.common.exceptions import BaseHTTPError
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 
@@ -59,7 +58,7 @@ def volume_cleanup(volume, driver):
     try:
         driver.detach_volume(volume)
         driver.destroy_volume(volume)
-    except BaseHTTPError as e:
+    except BaseException as e:
         print(e)
 
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

The execution run fails or is stuck when the file server is inaccessible. Also, `ignore-latest-container` option is broken. In this PR, we attempt to fix the above mentioned issues by introducing timeouts and fixing the flag.

__Logs__
```
All test logs located here: /tmp/cephci-run-U8KHYA

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
test suite setup                 Install prerequisites for RHCeph cluster deployment.           0:14:15.052093                   Pass                             
Test cluster deployment using    Bootstrap the cluster with minimal configuration.              0:08:30.811623                   Pass                             
Test host add with labels and    Adding hosts to the cluster using labels and IP information.   0:04:45.235282                   Pass                             
Test apply osd with all-availa   Deploying OSD daemons using all-available-devices option.      0:04:35.869012                   Pass                             
Test apply rgw with label        Deploying RGW daemon using label placement.                    0:02:55.639048                   Pass                             
Create volume with               Create and configure a volume with 2 MDS limit                 0:00:14.045563                   Pass                             
Test OSD daemon deployment wit   Test deploying MDS daemons on hosts with label mds.            0:02:52.540520                   Pass                             
configure client                 Configure the ceph client                                      0:00:48.374209                   Pass                             
Get ceph cluster details.        Retrieve the deployed cluster information.                     0:00:29.020150                   Pass      
```


__Command__
```
python run.py \
  --osp-cred ~/.osp-jenkins.yaml \
  --log-level debug \
  --global-conf conf/pacific/integrations/7_node_ceph.yaml \
  --inventory conf/inventory/rhel-8-latest.yaml \
  --suite suites/pacific/integrations/ocs.yaml \
  --store \
  --docker-registry registry-proxy.engineering.redhat.com \
  --insecure-registry \
  --docker-image rh-osbs/rhceph \
  --docker-tag ceph-5.2-rhel-8-containers-candidate-80266-20220720015823 \
  --rhs-ceph-repo http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.2-rhel-8/RHCEPH-5.2-RHEL-8-20220719.ci.0 \
  --ignore-latest-container \
  --rhbuild 5.2 \
  --platform rhel-8
```