### PR TITLE
Fix applying service in suite :test-container-cli-args.yaml

### DIFF
--- a/suites/pacific/cephadm/test-container-cli-args.yaml
+++ b/suites/pacific/cephadm/test-container-cli-args.yaml
@@ -210,6 +210,7 @@ tests:
                     nodes:
                       - node4
                       - node3
+                      - node2
                   spec:
                     rgw_frontend_port: 8080
                     rgw_realm: east


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/4366/103608
RGW service was not applyed in node2, but in conf we have node2 labeled for rgw. IO operation was tring to execute from node2
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3J1PUN/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
