### PR TITLE
Fix issues seen with docopt

### DIFF
--- a/run.py
+++ b/run.py
@@ -111,7 +111,9 @@ Options:
   --osp-cred <file>                 openstack credentials as separate file
   --rhbuild <1.3.0>                 ceph downstream version
                                     eg: 1.3.0, 2.0, 2.1 etc
-  --build <latest>                  eg: latest|tier-0|tier-1|tier-2|cvp|released|upstream
+  --build <latest>                  Type of build to be use for testing
+                                    eg: latest|tier-0|tier-1|tier-2|released|upstream
+                                    [default: released]
   --upstream-build <upstream-build> eg: quincy|pacific
   --platform <rhel-8>               select platform version eg., rhel-8, rhel-7
   --rhs-ceph-repo <repo>            location of rhs-ceph repo
@@ -376,22 +378,22 @@ def run(args):
         glb_file = args["--cluster-conf"]
 
     # Deciders
-    reuse = args.get("--reuse", None)
-    cloud_type = args.get("--cloud", "openstack")
+    reuse = args.get("--reuse")
+    cloud_type = args.get("--cloud")
 
     # These are not mandatory options
     inventory_file = args.get("--inventory")
     osp_cred_file = args.get("--osp-cred")
 
     osp_cred = load_file(osp_cred_file) if osp_cred_file else dict()
-    cleanup_name = args.get("--cleanup", None)
+    cleanup_name = args.get("--cleanup")
 
-    ignore_latest_nightly_container = args.get("--ignore-latest-container", False)
+    ignore_latest_nightly_container = args.get("--ignore-latest-container")
 
     # Set log directory and get absolute path
     console_log_level = args.get("--log-level")
     log_directory = args.get("--log-dir")
-    post_to_report_portal = args.get("--report-portal", False)
+    post_to_report_portal = args.get("--report-portal")
 
     run_id = generate_unique_id(length=6)
     rp_logger = None
@@ -445,43 +447,43 @@ def run(args):
         raise Exception("Require system configuration information to provision.")
 
     platform = args["--platform"]
-    build = args.get("--build", None)
+    build = args.get("--build")
 
     if build and build not in ["released"] and not ignore_latest_nightly_container:
         base_url, docker_registry, docker_image, docker_tag = fetch_build_artifacts(
             build, rhbuild, platform, args.get("--upstream-build", None)
         )
 
-    store = args.get("--store", False)
+    store = args.get("--store") or False
 
-    base_url = args.get("--rhs-ceph-repo", base_url)
-    ubuntu_repo = args.get("--ubuntu-repo", ubuntu_repo)
-    docker_registry = args.get("--docker-registry", docker_registry)
-    docker_image = args.get("--docker-image", docker_image)
-    docker_tag = args.get("--docker-tag", docker_tag)
-    kernel_repo = args.get("--kernel-repo", None)
+    base_url = args.get("--rhs-ceph-repo") or base_url
+    ubuntu_repo = args.get("--ubuntu-repo") or ubuntu_repo
+    docker_registry = args.get("--docker-registry") or docker_registry
+    docker_image = args.get("--docker-image") or docker_image
+    docker_tag = args.get("--docker-tag") or docker_tag
+    kernel_repo = args.get("--kernel-repo")
 
-    docker_insecure_registry = args.get("--insecure-registry", False)
+    docker_insecure_registry = args.get("--insecure-registry")
 
     post_results = args.get("--post-results")
-    skip_setup = args.get("--skip-cluster", False)
-    skip_subscription = args.get("--skip-subscription", False)
+    skip_setup = args.get("--skip-cluster")
+    skip_subscription = args.get("--skip-subscription")
 
     instances_name = args.get("--instances-name")
     if instances_name:
         instances_name = instances_name.replace(".", "-")
 
     osp_image = args.get("--osp-image")
-    filestore = args.get("--filestore", False)
-    ec_pool_vals = args.get("--use-ec-pool", None)
-    skip_version_compare = args.get("--skip-version-compare", False)
+    filestore = args.get("--filestore")
+    ec_pool_vals = args.get("--use-ec-pool")
+    skip_version_compare = args.get("--skip-version-compare")
     custom_config = args.get("--custom-config")
     custom_config_file = args.get("--custom-config-file")
-    xunit_results = args.get("--xunit-results", False)
+    xunit_results = args.get("--xunit-results")
 
-    enable_eus = args.get("--enable-eus", False)
-    skip_enabling_rhel_rpms = args.get("--skip-enabling-rhel-rpms", False)
-    skip_sos_report = args.get("--skip-sos-report", False)
+    enable_eus = args.get("--enable-eus")
+    skip_enabling_rhel_rpms = args.get("--skip-enabling-rhel-rpms")
+    skip_sos_report = args.get("--skip-sos-report")
 
     # load config, suite and inventory yaml files
     conf = load_file(glb_file)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

The recent changes have broken the execution due to the below error

__Error__
```
2022-07-22 18:38:13,957 - INFO - cephci.utility.xunit:110 - Startup log location: /tmp/cephci-run-U6C7E6/startup.log
The base url is None
2022-07-22 18:38:14,617 - INFO - cephci.utility.xunit:110 - final rc of test run 1
```

__Default values__
```
[('--rhbuild', '5.2'), ('--platform', 'rhel-8'), ('--suite', ['suites/pacific/integrations/ocs.yaml']), ('--global-conf', 'conf/pacific/integrations/7_node_ceph.yaml'), ('--cluster-conf', None), ('--cloud', 'openstack'), ('<ibmc>', None), ('<baremetal>', None), ('--build', 'latest'), ('--inventory', 'conf/inventory/rhel-8.5-server-x86_64-large.yaml'), ('--osp-cred', '/home/psathyan/.osp-jenkins.yaml'), ('--rhs-ceph-repo', None), ('--ubuntu-repo', None), ('--add-repo', None), ('--kernel-repo', None), ('--store', False), ('--reuse', None), ('--skip-cluster', False), ('--skip-subscription', False), ('--docker-registry', None), ('--docker-image', None), ('--docker-tag', None), ('--insecure-registry', False), ('--post-results', False), ('--report-portal', False), ('--upstream-build', None), ('--log-level', 'debug'), ('--log-dir', None), ('--instances-name', None), ('--osp-image', None), ('--filestore', False), ('--use-ec-pool', None), ('--hotfix-repo', None), ('--ignore-latest-container', False), ('--skip-version-compare', False), ('--custom-config', []), ('--custom-config-file', None), ('--xunit-results', False), ('--enable-eus', False), ('--skip-enabling-rhel-rpms', False), ('--skip-sos-report', False), ('--cleanup', None)]
```
Notice the default values assigned in `args` dict. This prevents us from using `args.get('rhs-add-repo', 'http://default/link')`. We would need to do `args.get('rhs-add-repo') or default_value)`

__Log__
```
(cephci) [psathyan@psathyan cephci]$ python run.py --osp-cred ~/.osp.yaml --instances-name prag00 --rhbuild 5.2 --build latest --platform rhel-8 --global-conf conf/pacific/rgw/tier-0_rgw.yaml --inventory conf/inventory/rhel-8-latest.yaml --suite suites/pacific/rgw/tier-0_rgw.yaml
/home/psathyan/venv/cephci/lib64/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography and will be removed in a future release.
  from cryptography.hazmat.backends import default_backend

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /tmp/cephci-run-PWPQOV
2022-07-22 19:09:09,721 - INFO - cephci.utility.xunit:110 - Startup log location: /tmp/cephci-run-PWPQOV/startup.log
2022-07-22 19:09:10,834 - INFO - cephci.utility.xunit:110 - List of test suites provided: 
['suites/pacific/rgw/tier-0_rgw.yaml']
2022-07-22 19:09:10,834 - INFO - cephci.utility.xunit:110 - Provided suite is a file
2022-07-22 19:09:10,846 - INFO - cephci.utility.xunit:110 - The CLI for the current run :
/home/psathyan/venv/cephci/bin/python run.py --osp-cred /home/psathyan/.osp.yaml --instances-name prag00 --rhbuild 5.2 --build latest --platform rhel-8 --global-conf conf/pacific/rgw/tier-0_rgw.yaml --inventory conf/inventory/rhel-8-latest.yaml --suite suites/pacific/rgw/tier-0_rgw.yaml

2022-07-22 19:09:10,847 - INFO - cephci.utility.xunit:110 - RPM Compose source - http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.2-rhel-8/RHCEPH-5.2-RHEL-8-20220722.ci.0
2022-07-22 19:09:10,847 - INFO - cephci.utility.xunit:110 - Red Hat Ceph Image used - registry-proxy.engineering.redhat.com/rh-osbs/rhceph:ceph-5.2-rhel-8-containers-candidate-27592-20220722022332
2022-07-22 19:09:12,435 - INFO - cephci.utility.xunit:110 - Compose id is: RHCEPH-5.2-RHEL-8-20220722.ci.0
2022-07-22 19:09:12,435 - INFO - cephci.utility.xunit:110 - Testing Ceph Version: 16.2.8-79.el8cp
2022-07-22 19:09:12,435 - INFO - cephci.utility.xunit:110 - Testing Ceph Ansible Version: 6.0.27.7-1.el8cp.noarch
```
