### PR TITLE
Adding results in ceph version file and update confluence page with results of execution

### DIFF
--- a/pipeline/scripts/ci/confluence/base.py
+++ b/pipeline/scripts/ci/confluence/base.py
@@ -1,0 +1,219 @@
+import requests
+from uplink import Consumer, delete, get, json, post, put
+from uplink.arguments import Body, Query
+from uplink.auth import BearerToken
+
+from .constants import API_ENDPOINT, BASE_URL, DELETE_PAGE_ENDOINT, UPDATE_PAGE_ENDPOINT
+
+
+class Confluence(Consumer):
+    def __init__(self, token, **kwargs):
+        auth = BearerToken(token)
+        session = requests.Session()
+        session.verify = False
+        super().__init__(base_url=BASE_URL, auth=auth, client=session, **kwargs)
+
+    @get(API_ENDPOINT)
+    def _get_page(self, title: Query, spaceKey: Query, expand: Query):
+        """
+        Gets the confluence page for given title and spaceKey
+        Args:
+            title: title of the page to be fetched
+            spaceKey: spaceKey to the space to which the page belongs
+            expand: any details to be expanded. For ex: body.storage, history, version
+
+        Returns:
+            The page info based on the details specified
+        """
+
+    @json
+    @post(API_ENDPOINT)
+    def _create_page(self, body: Body):
+        """
+        Creates the page for the details specified in body parameter
+        Args:
+            body: body of the page to be created
+
+        Examples::
+            {
+                'type': 'page',
+                'title': 'new child page in jenkins v3',
+                'ancestors': [
+                    {
+                        'id': 276649316,
+                    },
+                ],
+                'space': {
+                    'key': 'rhcsqe',
+                },
+                'body': {
+                    'storage': {
+                        'value': '<p>This is <br/> a new child page</p>',
+                        'representation': 'storage',
+                    },
+                },
+            }
+
+        Returns:
+            The page info for the page created
+        """
+
+    @json
+    @put(UPDATE_PAGE_ENDPOINT)
+    def _update_page(self, pageId, body: Body):
+        """
+        Updates the page for the given pageId with the given body
+        Args:
+            pageId: pageId for the page to be updated
+            body: body for the page to be updated
+
+        Examples::
+            {
+                'type': 'page',
+                'title': 'new child page in jenkins v3',
+                'ancestors': [
+                    {
+                        'id': 276649316,
+                    },
+                ],
+                'space': {
+                    'key': 'rhcsqe',
+                },
+                'body': {
+                    'storage': {
+                        'value': '<p>This is <br/> a new child page</p>',
+                        'representation': 'storage',
+                    },
+                },
+                'version': {
+                    'number': 2
+                }
+            }
+
+        Returns:
+            Info on the updated page
+        """
+
+    @delete(DELETE_PAGE_ENDOINT)
+    def _delete_page(self, pageId):
+        """
+        Deletes the page with give pageId
+        Args:
+            pageId: pageId of the page to be deleted
+
+        Returns:
+            Info on the deleted page
+        """
+
+    def get_page(self, title, spaceKey, expand):
+        """
+        Gets the confluence page for given title and spaceKey
+        Args:
+            title: title of the page to be fetched
+            spaceKey: spaceKey to the space to which the page belongs
+            expand: any details to be expanded. For ex: body.storage, history, version
+
+        Returns:
+            The page info based on the details specified
+        """
+        resp = self._get_page(title, spaceKey, expand)
+        return resp
+
+    def create_page(
+        self,
+        title,
+        spaceKey,
+        parentId,
+        data,
+        page_type="page",
+        representation="storage",
+    ):
+        """
+        Creates the page for the details specified.
+        Args:
+            title: title of the page to be created
+            spaceKey: spaceKey for the space under which the page to be created
+            parentId: parentId for the page which should be the parent of the page being created
+            data: data to be added into the page in plaintext or html format
+            page_type: type of the page. Default: "page"
+            representation: type of representation. Default: "storage"
+
+        Returns:
+            The info on the page created
+        """
+        body = {
+            "type": page_type,
+            "title": title,
+            "ancestors": [
+                {
+                    "id": parentId,
+                },
+            ],
+            "space": {
+                "key": spaceKey,
+            },
+            "body": {
+                "storage": {
+                    "value": data,
+                    "representation": representation,
+                },
+            },
+        }
+        resp = self._create_page(body)
+        return resp
+
+    def update_page(
+        self,
+        pageId,
+        title,
+        spaceKey,
+        data,
+        version,
+        page_type="page",
+        representation="storage",
+    ):
+        """
+        Updates the page for the given parameters
+        Args:
+            pageId: id of the page to be updated
+            title: title of the page to be updated
+            spaceKey: spaceKey for the given page
+            data: data to be updated
+            version: update version for the page
+            page_type: type of page. Default: "page"
+            representation: type of representation. Default: "storage"
+
+        Returns:
+            Info on updated page
+        """
+        body = {
+            "id": str(pageId),
+            "type": page_type,
+            "title": title,
+            "space": {
+                "key": spaceKey,
+            },
+            "body": {
+                "storage": {
+                    "value": data,
+                    "representation": representation,
+                },
+            },
+            "version": {
+                "number": version,
+            },
+        }
+        resp = self._update_page(pageId, body)
+        return resp
+
+    def delete_page(self, pageId):
+        """
+        Deletes the page with given pageId
+        Args:
+            pageId: id of the page to be deleted
+
+        Returns:
+            Info on deleted page
+        """
+        resp = self._delete_page(pageId)
+        return resp

--- a/pipeline/scripts/ci/confluence/constants.py
+++ b/pipeline/scripts/ci/confluence/constants.py
@@ -1,0 +1,3 @@
+BASE_URL = "https://docs.engineering.redhat.com/"
+API_ENDPOINT = "rest/api/content/"
+UPDATE_PAGE_ENDPOINT = DELETE_PAGE_ENDOINT = API_ENDPOINT + "{pageId}"

--- a/pipeline/scripts/ci/update_confluence.py
+++ b/pipeline/scripts/ci/update_confluence.py
@@ -1,0 +1,155 @@
+import copy
+import json
+import pdb
+
+import xmltodict
+from confluence.base import Confluence
+from docopt import docopt
+
+doc = """
+    This script updates the confluence page titled "RHCS Test Execution Summary"
+    with the results of execution given as input.
+
+    Usage:
+        update_confluence.py --content <resultJson> --token <token> --title <pageTitle> --space <confSpace>
+
+        update_confluence.py (-h | --help)
+
+    Options:
+        -h --help          Shows the command usage
+        -c --content resultJson     The results to be appended to the confluence page's table in json format.
+                                            Ex: '{"RHCS Version": "RHCS 5.2", "Ceph Version": "16.2.8-79",
+                                                "tier-0-sanity_run": "PASS", "tier-1-sanity_run": "FAIL",
+                                                "tier-2-sanity_run": "SKIP", "tier-1-scheduled_run": "SKIP"} '
+        --token token          The auth token to be used to connect to confluence
+        --title pageTitle      The title of the page to be updated
+        --space confSpace      The space in confluence under which the page is present.
+"""
+
+
+def get_updated_page_body(pageBody, content):
+    """
+    This method fetches the updated content after updating the existing content of the page
+    "RHCS Test Execution Summary" with results of new version's execution passed in content parameter
+    Args:
+        pageBody: existing content of the page
+        content: new content to be appended to the existing
+
+    Returns:
+        None
+    """
+    pdb.set_trace()
+    if not pageBody:
+        # If page is empty append add a help text
+        data = (
+            "<p><strong>NOTE: </strong><strong>DO NOT edit this Page from UI. Results are updated automatically "
+            "after each Jenkins CI run.</strong></p><p><br /></p> "
+        )
+    elif "<table" not in pageBody:
+        # If page does not contain a table, create one and fill it with the contents passed
+        tableHeader = {"th": []}
+        tableRow = {"td": []}
+        for key, value in content.items():
+            tableHeader["th"].append(key)
+            tableRow["td"].append(value)
+        rowList = [tableHeader, tableRow]
+        tableDict = {"table": {"tbody": {"tr": rowList}}}
+        newTable = xmltodict.unparse(tableDict).split("\n")[1]
+        data = pageBody + newTable
+    else:
+        # If page and table exist, then append new content to the table on top.
+        existingContent = pageBody.split("<table")[0]
+        existingTable = (
+            "<table" + pageBody.split("<table")[1].split("</table>")[0] + "</table>"
+        )
+        tableDict = xmltodict.parse(existingTable)
+        tableHeaders = tableDict["table"]["tbody"]["tr"][0]
+        tableRows = tableDict["table"]["tbody"]["tr"][1:]
+        tableRow = copy.deepcopy(tableRows)[0]
+        new_ceph_version = content["Ceph Version"]
+        ceph_version_exists = [
+            [rIdx, rVal]
+            for rIdx, rVal in enumerate(tableRows)
+            if new_ceph_version in rVal["td"]
+        ]
+        for key, value in content.items():
+            if key not in tableHeaders["th"]:
+                tableHeaders["th"].append(key)
+                for rowIdx, rowVal in enumerate(tableRows):
+                    if ceph_version_exists and rowIdx == ceph_version_exists[0][0]:
+                        tableRows[rowIdx]["td"].append(value)
+                    else:
+                        tableRows[rowIdx]["td"].append("")
+                tableRow["td"].append(value)
+            else:
+                index = tableHeaders["th"].index(key)
+                if ceph_version_exists:
+                    rIdx = ceph_version_exists[0][0]
+                    tableRows[rIdx]["td"][index] = value
+                tableRow["td"][index] = value
+        newTableRows = (
+            [tableHeaders] + tableRows
+            if ceph_version_exists
+            else [tableHeaders] + [tableRow] + tableRows
+        )
+        newTableDict = {"table": {"tbody": {"tr": newTableRows}}}
+        newTable = xmltodict.unparse(newTableDict).split("\n")[1]
+        data = existingContent + newTable
+    return data
+
+
+def update_confluence_page(content, auth_token, page_title, conf_space):
+    """
+    This method updates the page "RHCS Test Execution Summary" with the given content
+    Args:
+        conf_space: The confluence space under which the page is present
+        page_title: The title of the page to be updated
+        auth_token: The token used to connect to confluence
+        content: The results to be appended in the form of json
+    Examples::
+        content = '{"RHCS Version": "RHCS 5.2", "Ceph Version": "16.2.8-79", "tier-0-sanity_run": "PASS", ' \
+               '"tier-1-sanity_run": "FAIL", "tier-2-sanity_run": "SKIP", "tier-3-sanity_run": "SKIP"} '
+
+    Returns:
+        None
+    """
+    client = Confluence(token=auth_token)
+    expand = "body.storage,version"
+    contentDict = json.loads(content)
+
+    page = client.get_page(page_title, conf_space, expand)
+    if page.json() and page.json()["results"]:
+        pageContent = page.json()["results"][0]
+        pageId = pageContent["id"]
+        pageType = pageContent["type"]
+        pageVersion = pageContent["version"]["number"] + 1
+        pageBody = pageContent["body"]["storage"]["value"]
+        pageRepresentation = pageContent["body"]["storage"]["representation"]
+        pageBody = get_updated_page_body(pageBody, contentDict)
+        updatePageResp = client.update_page(
+            title=page_title,
+            pageId=pageId,
+            spaceKey=conf_space,
+            data=pageBody,
+            version=pageVersion,
+            page_type=pageType,
+            representation=pageRepresentation,
+        )
+        if updatePageResp.status_code != 200:
+            print("Error occurred while updating page")
+    else:
+        print("Error occurred while fetching parent page")
+
+
+if __name__ == "__main__":
+    cli_args = docopt(doc)
+    pageContents = cli_args.get("--content")
+    title = cli_args.get("--title")
+    space = cli_args.get("--space")
+    token = cli_args.get("--token")
+    try:
+        update_confluence_page(
+            content=pageContents, auth_token=token, page_title=title, conf_space=space
+        )
+    except Exception as e:
+        raise e

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cos-aspera; python_version == '3.6'
 python-openstackclient
 xmltodict
 tfacon
+uplink


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

# Description
This PR is to create ceph version based pages in the http://magna002.ceph.redhat.com/cephci-jenkins/results folder to update the test results for each ceph version. The PR also updates confluence page titled "RHCS Test Execution Summary" with the results of execution.

Confluence page sample
![confluence](https://user-images.githubusercontent.com/67956438/180746896-7e7a04b0-b057-46b9-bdef-8b20e32aeeff.png)


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
