### PR TITLE
Verify ceph-ansible log file is created and contains the logs of a pa…

### DIFF
--- a/suites/nautilus/ansible/tier-2_deploy_test-ceph-rpms.yaml
+++ b/suites/nautilus/ansible/tier-2_deploy_test-ceph-rpms.yaml
@@ -26,6 +26,7 @@ tests:
       module: test_ansible.py
       config:
         is_mixed_lvm_configs: True
+        custom_log: True
         ansi_config:
           ceph_test: True
           ceph_origin: distro


### PR DESCRIPTION
This PR is to verify the ceph-ansible log file is created and contains the logs of a particular playbook!

The following steps are needed to perform the test for CEPH-83571467:

- Set the desired value to the log_path at /usr/share/ceph-ansible/ansible.cfg
- Run the deployment playbooks (example - site.yml, purge-cluster.yml, rolling-update.yml)
- Log file should have been created/appended with the respective playbooks initiated and has the appropriate contents.

Run result: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-443W6Z/ceph_ansible_0.log

Signed-off-by: Aditya Ramteke <aramteke@redhat.com>