### PR TITLE
Add etag testcase to cephci

### DIFF
--- a/suites/nautilus/rgw/tier-1_rgw_test-4x-upgrade-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_test-4x-upgrade-to-latest.yaml
@@ -99,6 +99,15 @@ tests:
         config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
         timeout: 300
 
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        timeout: 300
 
   # Bucket Listing Tests
   - test:
@@ -285,6 +294,16 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
+        timeout: 300
+
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
         timeout: 300
 
   # Bucket Listing Tests

--- a/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
@@ -119,6 +119,15 @@ tests:
       config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
       timeout: 300
 
+- test:
+      name: Mbuckets_with_Nobjects with etag verification
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        timeout: 300
 
 # Bucket Listing Tests
 - test:
@@ -310,6 +319,16 @@ tests:
       script-name: test_Mbuckets_with_Nobjects.py
       config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
       timeout: 300
+
+- test:
+      name: Mbuckets_with_Nobjects with etag verification
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        timeout: 300
 
 # Bucket Listing Tests
 

--- a/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
@@ -92,6 +92,16 @@ tests:
       polarion-id: CEPH-14237
 
   - test:
+      name: Mbuckets_with_Nobjects with etag verification
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        timeout: 300
+
+  - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
       polarion-id: CEPH-83571740
@@ -175,6 +185,16 @@ tests:
       module: sanity_rgw.py
       name: download with M buckets with N objects
       polarion-id: CEPH-14237
+
+  - test:
+      name: Mbuckets_with_Nobjects with etag verification
+      desc: test etag verification
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574871
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        timeout: 300
 
   - test:
       name: Dynamic Resharding tests


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>


Adding etag verification testcase to cephci
Nautilus: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-Z7SM7K/
Pacific:
4.x to 5.2: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-P1RJ32/ (upgrade failed due to https://github.com/red-hat-storage/cephci/issues/1662)
5.1 to 5.2 latest: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-5FX4M0/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
