### PR TITLE
Fix openstack command not found issue

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -48,7 +48,7 @@ node("rhel-8-medium || ceph-qe-ci") {
             msgMap = sharedLib.getCIMessageMap()
             println("msgMap : ${msgMap}")
             println("sharedLib: ${sharedLib}")
-            sharedLib.prepareNode()
+            sharedLib.prepareNode(3)
         }
 
         stage('configureReportPortalWorkDir') {

--- a/pipeline/rhos_scripts/Jenkinsfile-cleanup-env.groovy
+++ b/pipeline/rhos_scripts/Jenkinsfile-cleanup-env.groovy
@@ -32,7 +32,7 @@ node("rhel-8-medium || ceph-qe-ci") {
                 poll: false
             )
             sharedLib = load("${env.WORKSPACE}/pipeline/vars/v3.groovy")
-            sharedLib.prepareNode()
+            sharedLib.prepareNode(2)
         }
         stage('cleanup') {
             println("Cleanup environment and Send Email to respective user")

--- a/pipeline/rhos_scripts/Jenkinsfile-quota.groovy
+++ b/pipeline/rhos_scripts/Jenkinsfile-quota.groovy
@@ -32,7 +32,7 @@ node("rhel-8-medium || ceph-qe-ci") {
                 poll: false
             )
             sharedLib = load("${env.WORKSPACE}/pipeline/vars/v3.groovy")
-            sharedLib.prepareNode()
+            sharedLib.prepareNode(2)
         }
         stage('retrieveQuota') {
             println("Fetch quota and Send Email")

--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -4,6 +4,12 @@
 # we require additional configurations to enable us to use the system for
 # executing the cephci test suites. This script performs the required changes.
 
+# Options
+#   0 -> Installs python along with cephci required packages
+#   1 -> Configures the agent with necessary CI packages
+#   2 -> 0 + 1 along with deploying postfix package
+#   3 -> 0 + 1 along with rclone package
+
 echo "Initialize Node"
 # Workaround: Disable IPv6 to have quicker downloads
 sudo sysctl -w net.ipv6.conf.eth0.disable_ipv6=1
@@ -19,25 +25,33 @@ if [ ! -d "/ceph" ]; then
     sudo mount -t nfs -o sec=sys,nfsvers=4.1 reesi004.ceph.redhat.com:/ /ceph
 fi
 
-if [ ${1:-0} -ne 0 ]; then
-  exit 0
+if [ ${1:-0} -ne 1 ]; then
+    sudo yum install -y wget python3
+    # Copy the config from internal file server to the Jenkins user home directory
+    wget http://magna002.ceph.redhat.com/cephci-jenkins/.cephci.yaml -O ${HOME}/.cephci.yaml
+
+    # Install cephci prerequisites
+    rm -rf .venv
+    python3 -m venv .venv
+    .venv/bin/python -m pip install --upgrade pip
+    .venv/bin/python -m pip install -r requirements.txt
 fi
 
-sudo yum install -y wget python3
-# Copy the config from internal file server to the Jenkins user home directory
-wget http://magna002.ceph.redhat.com/cephci-jenkins/.cephci.yaml -O ${HOME}/.cephci.yaml
+# Monitoring jobs have a need to send email using smtplib that requires postfix
+if [ ${1:-0} -eq 2 ]; then
+    postfix_rpm=$(rpm -qa | grep postfix | wc -l)
+    if [ ${postfix_rpm} -eq 0 ]; then
+        sudo yum install -y postfix
+    fi
+    systemctl is-active --quiet postfix || sudo systemctl restart postfix
+fi
 
-# Install cephci pre-requisistes
-rm -rf .venv
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-deactivate
-
-# Install rclone
-curl https://rclone.org/install.sh | sudo bash || echo 0
-mkdir -p ${HOME}/.config/rclone
-wget http://magna002.ceph.redhat.com/cephci-jenkins/.ibm-cos.conf -O ${HOME}/.config/rclone/rclone.conf
+# Post results workflow requires to sync from COS
+if [ ${1:-0} -eq 3 ]; then
+    # Install rclone
+    curl https://rclone.org/install.sh | sudo bash || echo 0
+    mkdir -p ${HOME}/.config/rclone
+    wget http://magna002.ceph.redhat.com/cephci-jenkins/.ibm-cos.conf -O ${HOME}/.config/rclone/rclone.conf
+fi
 
 echo "Done bootstrapping the Jenkins node."

--- a/utility/psi_quota.py
+++ b/utility/psi_quota.py
@@ -35,18 +35,23 @@ def execute(cmd, fail_ok=False, merge_stderr=False):
     proc = subprocess.Popen(cmdlist, stdout=stdout, stderr=stderr)
     result, result_err = proc.communicate()
     result = result.decode("utf-8")
+
     if not fail_ok and proc.returncode != 0:
         raise CommandFailed(proc.returncode, cmd, result, result_err)
+
     return json.loads(result)
 
 
-def openstack_basecmd(*args, **kwargs):
+def openstack_basecmd(*args, **kwargs) -> str:
     """Generates the openstack base command"""
-    return (
-        f'openstack --os-auth-url {kwargs.get("auth-url",None)} --os-project-domain-name  {kwargs.get("domain",None)} '
-        f'--os-user-domain-name {kwargs.get("domain",None)} --os-project-name {kwargs.get("project",None)} '
-        f'--os-username {kwargs.get("username")} --os-password {kwargs.get("password")}'
-    )
+    cmd = ".venv/bin/openstack"
+    cmd += f" --os-auth-url {kwargs['auth-url']}"
+    cmd += f" --os-project-domain-name {kwargs['domain']}"
+    cmd += f" --os-user-domain-name {kwargs['domain']}"
+    cmd += f" --os-project-name {kwargs['project']}"
+    cmd += f" --os-username {kwargs['username']}"
+    cmd += f" --os-password {kwargs['password']}"
+    return cmd
 
 
 def map_userto_instances(os_nodes, os_cred):
@@ -244,7 +249,8 @@ def run(args: Dict) -> None:
                 f"Openstack Command failed to retrieve the server details {cf.args[-1]}"
             )
 
-    project_dir = os.path.dirname(os.path.abspath(__file__))
+    # This path we are looking for is <repo-dir>/templates
+    project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     template_dir = os.path.join(project_dir, "templates")
     jinja_env = Environment(
         extensions=[MarkdownExtension],


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes the below error observed

```
+ .venv/bin/python /home/jenkins-build/workspace/rhos_quota/utility/psi_quota.py --osp-cred /home/jenkins-build/osp-cred-ci-2.yaml
/home/jenkins-build/workspace/rhos_quota/.venv/lib64/python3.6/site-packages/paramiko/transport.py:33: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography and will be removed in a future release.
  from cryptography.hazmat.backends import default_backend
/home/jenkins-build/workspace/rhos_quota/run.py:6: MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported may lead to errors, including RecursionError on Python 3.6. It may also silently lead to incorrect behaviour on Python 3.7. Please monkey-patch earlier. See https://github.com/gevent/gevent/issues/1016. Modules that had direct imports (NOT patched): ['urllib3.util.ssl_ (/home/jenkins-build/workspace/rhos_quota/.venv/lib64/python3.6/site-packages/urllib3/util/ssl_.py)', 'urllib3.util (/home/jenkins-build/workspace/rhos_quota/.venv/lib64/python3.6/site-packages/urllib3/util/__init__.py)']. 
  monkey.patch_all()
Traceback (most recent call last):
  File "/home/jenkins-build/workspace/rhos_quota/utility/psi_quota.py", line 277, in <module>
    run(arguments)
  File "/home/jenkins-build/workspace/rhos_quota/utility/psi_quota.py", line 235, in run
    cmd=openstack_basecmd(**os_cred) + " server list -f json"
  File "/home/jenkins-build/workspace/rhos_quota/utility/psi_quota.py", line 35, in execute
    proc = subprocess.Popen(cmdlist, stdout=stdout, stderr=stderr)
  File "/home/jenkins-build/workspace/rhos_quota/.venv/lib64/python3.6/site-packages/gevent/subprocess.py", line 822, in __init__
    start_new_session)
  File "/home/jenkins-build/workspace/rhos_quota/.venv/lib64/python3.6/site-packages/gevent/subprocess.py", line 1837, in _execute_child
    raise child_exception
FileNotFoundError: [Errno 2] No such file or directory: 'openstack'
```

There was another issue observed during the fix
```
Error 111: Connection refused
```
this occurred due to missing `postfix` that was required by `smtplib` to send e-mails in the python scripts.

__Log__
https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/view/RHCS%20QE/job/rhos_quota/276/console