### PR TITLE
Added OSD down alert test 

### DIFF
--- a/suites/pacific/dashboard/tier-1_dashboard_alerts.yaml
+++ b/suites/pacific/dashboard/tier-1_dashboard_alerts.yaml
@@ -171,3 +171,10 @@ tests:
       config:
         alert: HEALTH_WARN
       desc: verify ceph health warn alert
+  - test:
+      name: ceph osd down alert test
+      polarion-id: CEPH-83575270
+      module: alerts.py
+      config:
+        alert: OSD_DOWN
+      desc: verify ceph osd down alert


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Fixes RHCEPHQE-4324
Added osd down alert test

Test run results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QZVCNK

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
