### PR TITLE
Upgrades ceph-common package on upgraded cluster

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -117,6 +117,18 @@ def run(ceph_cluster, **kw):
     # Clone the repository once for the entire test suite
     pip_cmd = "venv/bin/pip"
     python_cmd = "venv/bin/python"
+    if ceph_cluster.rhcs_version.version[0] > 4:
+        setup_cluster_access(ceph_cluster, rgw_node)
+        rgw_node.exec_command(
+            sudo=True, cmd="yum install -y ceph-common --nogpgcheck"
+        )
+
+    if ceph_cluster.rhcs_version.version[0] in [3, 4]:
+        if ceph_cluster.containerized:
+            # install ceph-common on the host hosting the container
+            rgw_node.exec_command(
+                sudo=True, cmd="yum install -y ceph-common --nogpgcheck"
+            )
     out, err = rgw_node.exec_command(cmd="ls -l venv", check_ec=False)
 
     if not out:
@@ -130,19 +142,6 @@ def run(ceph_cluster, **kw):
             cmd=f"{pip_cmd} install "
             + f"-r {test_folder}/ceph-qe-scripts/rgw/requirements.txt"
         )
-
-        if ceph_cluster.rhcs_version.version[0] > 4:
-            setup_cluster_access(ceph_cluster, rgw_node)
-            rgw_node.exec_command(
-                sudo=True, cmd="yum install -y ceph-common --nogpgcheck"
-            )
-
-        if ceph_cluster.rhcs_version.version[0] in [3, 4]:
-            if ceph_cluster.containerized:
-                # install ceph-common on the host hosting the container
-                rgw_node.exec_command(
-                    sudo=True, cmd="yum install -y ceph-common --nogpgcheck"
-                )
 
     script_name = config.get("script-name")
     config_file_name = config.get("config-file-name")


### PR DESCRIPTION
Upgrades ceph-common package on upgraded cluster for avoiding version mismatch inside and outside container

Log link of run:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LWII2E/ (Ignore failures occured in ceph-qe-script)

Issue:
https://issues.redhat.com/browse/RHCEPHQE-4556


Signed-off-by: uday kurundwade <ukurundw@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
