### PR TITLE
fix tox issue

### DIFF
--- a/tests/ceph_ansible/shrink_osd.py
+++ b/tests/ceph_ansible/shrink_osd.py
@@ -38,45 +38,30 @@ def run(ceph_cluster, **kw):
     ceph_installer = ceph_cluster.get_ceph_object("installer")
     ceph_installer.node.obtain_root_permissions("/var/log")
     ansible_dir = ceph_installer.ansible_dir
+
+    cmd = f"export ANSIBLE_DEPRECATION_WARNINGS=False; cd {ansible_dir}; ansible-playbook -e ireallymeanit=yes "
     if build.startswith("2"):
         ceph_installer.exec_command(
             sudo=True,
-            cmd="cp -R {ansible_dir}/infrastructure-playbooks/shrink-osd.yml "
-            "{ansible_dir}/shrink-osd.yml".format(ansible_dir=ansible_dir),
+            cmd=f"cp -R {ansible_dir}/infrastructure-playbooks/shrink-osd.yml {ansible_dir}/shrink-osd.yml",
         )
-        cmd = "export ANSIBLE_DEPRECATION_WARNINGS=False ; cd {ansible_dir} ; ansible-playbook -e ireallymeanit=yes \
-                shrink-osd.yml -e osd_to_kill={osd_to_kill} -i hosts".format(
-            ansible_dir=ansible_dir, osd_to_kill=osd_to_kill
-        )
-
-    if build.startswith("3"):
+        cmd += f"shrink-osd.yml -e osd_to_kill={osd_to_kill} -i hosts"
+    elif build.startswith("3"):
         if osd_scenario == "lvm":
             ceph_installer.exec_command(
                 sudo=True,
-                cmd="cp -R {ansible_dir}/infrastructure-playbooks/shrink-osd.yml "
-                "{ansible_dir}/shrink-osd.yml".format(ansible_dir=ansible_dir),
+                cmd=f"cp -R {ansible_dir}/infrastructure-playbooks/shrink-osd.yml {ansible_dir}/shrink-osd.yml",
             )
-            cmd = "export ANSIBLE_DEPRECATION_WARNINGS=False ; cd {ansible_dir} ; ansible-playbook -e ireallymeanit=yes \
-                    shrink-osd.yml -e osd_to_kill={osd_to_kill} -i hosts".format(
-                ansible_dir=ansible_dir, osd_to_kill=osd_to_kill
-            )
+            cmd += f"shrink-osd.yml -e osd_to_kill={osd_to_kill} -i hosts"
         else:
             ceph_installer.exec_command(
                 sudo=True,
-                cmd="cp -R {ansible_dir}/infrastructure-playbooks/shrink-osd-ceph-disk.yml "
-                "{ansible_dir}/shrink-osd-ceph-disk.yml".format(
-                    ansible_dir=ansible_dir
-                ),
+                cmd=f"cp -R {ansible_dir}/infrastructure-playbooks/shrink-osd-ceph-disk.yml "
+                f"{ansible_dir}/shrink-osd-ceph-disk.yml",
             )
-            cmd = "export ANSIBLE_DEPRECATION_WARNINGS=False ; cd {ansible_dir} ; ansible-playbook -e ireallymeanit=yes\
-                    shrink-osd-ceph-disk.yml -e osd_to_kill={osd_to_kill} -i hosts".format(
-                ansible_dir=ansible_dir, osd_to_kill=osd_to_kill
-            )
+            cmd += f"shrink-osd-ceph-disk.yml -e osd_to_kill={osd_to_kill} -i hosts"
     else:
-        cmd = "export ANSIBLE_DEPRECATION_WARNINGS=False ; cd {ansible_dir} ; ansible-playbook -e ireallymeanit=yes \
-                infrastructure-playbooks/shrink-osd.yml -e osd_to_kill={osd_to_kill} -i hosts".format(
-            ansible_dir=ansible_dir, osd_to_kill=osd_to_kill
-        )
+        cmd += f"infrastructure-playbooks/shrink-osd.yml -e osd_to_kill={osd_to_kill} -i hosts"
 
     rc = ceph_installer.exec_command(cmd=cmd, long_running=True)
 


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- fix tox issue.

```
❯ tox -e py
GLOB sdist-make: /home/sunil/pycharm/cephci/setup.py
py inst-nodeps: /home/sunil/pycharm/cephci/.tox/.tmp/package/1/cephci-0.1.zip
py installed: aenum==3.1.11,apache-libcloud==3.6.0,attrs==22.1.0,bcrypt==3.2.2,beautifulsoup4==4.11.1,black==22.6.0,cephci @ file:///home/sunil/pycharm/cephci/.tox/.tmp/package/1/cephci-0.1.zip,certifi==2022.6.15,cffi==1.15.1,charset-normalizer==2.1.0,click==8.1.3,commonmark==0.9.1,cryptography==37.0.4,delayed-assert==0.3.6,distlib==0.3.5,docopt==0.6.2,filelock==3.7.1,flake8==5.0.2,fusepy==3.0.1,future==0.18.2,gevent==21.12.0,greenlet==1.1.2,html5lib==1.1,htmllistparse==0.6.0,ibm-cloud-networking-services==0.18.0,ibm-cloud-sdk-core==3.15.3,ibm-cos-sdk==2.12.0,ibm-cos-sdk-core==2.12.0,ibm-cos-sdk-s3transfer==2.12.0,ibm-vpc==0.12.0,idna==3.3,importlib-metadata==4.2.0,iniconfig==1.1.1,isort==5.10.1,jinja-markdown==1.210911,Jinja2==3.1.2,jmespath==0.10.0,junitparser==2.7.0,Markdown==3.3.4,MarkupSafe==2.1.1,mccabe==0.7.0,mock==4.0.3,mypy-extensions==0.4.3,packaging==21.3,paramiko==2.11.0,pathspec==0.9.0,platformdirs==2.5.2,pluggy==1.0.0,prettytable==3.3.0,prompt-toolkit==3.0.30,py==1.11.0,pycodestyle==2.9.0,pycparser==2.21,pyflakes==2.5.0,Pygments==2.12.0,PyJWT==2.4.0,pymdown-extensions==9.5,PyNaCl==1.5.0,pyparsing==3.0.9,pytest==7.1.2,python-dateutil==2.8.2,PyYAML==6.0,reportportal-client==5.2.3,requests==2.28.1,rich==12.3.0,six==1.16.0,SoftLayer==6.1.0,soupsieve==2.3.2.post1,toml==0.10.2,tomli==2.0.1,tox==3.25.1,typed-ast==1.5.4,typing_extensions==4.3.0,urllib3==1.26.11,virtualenv==20.16.2,wcwidth==0.2.5,webencodings==0.5.1,yamllint==1.27.1,zipp==3.8.1,zope.event==4.5.0,zope.interface==5.4.0
py run-test-pre: PYTHONHASHSEED='4259950793'
py run-test: commands[0] | pytest
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.7.13, pytest-7.1.2, pluggy-1.0.0
cachedir: .tox/py/.pytest_cache
rootdir: /home/sunil/pycharm/cephci
collected 17 items                                                                                                                                                                            

unittests/ceph/ceph_admin/test_add.py ..                                                                                                                                                [ 11%]
unittests/ceph/ceph_admin/test_alert_manager.py .                                                                                                                                       [ 17%]
unittests/ceph/ceph_admin/test_apply.py ....                                                                                                                                            [ 41%]
unittests/utility/test_utils.py ..........                                                                                                                                              [100%]

====================================================================================== warnings summary =======================================================================================
.tox/py/lib/python3.7/site-packages/markdown/util.py:87
  /home/sunil/pycharm/cephci/.tox/py/lib/python3.7/site-packages/markdown/util.py:87: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    INSTALLED_EXTENSIONS = metadata.entry_points().get('markdown.extensions', ())

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ 17 passed, 1 warning in 1.30s ================================================================================
py run-test: commands[1] | flake8
py run-test: commands[2] | isort -c .
Skipped 4 files
py run-test: commands[3] | black --check --diff .
All done! ✨ 🍰 ✨
368 files would be left unchanged.
py run-test: commands[4] | yamllint -d relaxed --no-warnings .
___________________________________________________________________________________________ summary ___________________________________________________________________________________________
  py: commands succeeded
  congratulations :)

```
