### PR TITLE
Add data omap offload with fifo log type on upgrade

### DIFF
--- a/suites/nautilus/rgw/tier-1_rgw_multisite_test-upgrade-4.x-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_multisite_test-upgrade-4.x-to-latest.yaml
@@ -157,6 +157,18 @@ tests:
       name: test unordered listing of buckets
       polarion-id: CEPH-83573545
 
+  - test:
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_data_omap_offload.py
+            config-file-name: test_data_omap_offload_change_datatype_fifo.yaml
+            timeout: 300
+      desc: change datalog type to fifo before upgrade
+      module: sanity_rgw_multisite.py
+      name: change datalog type to fifo before upgrade
+      polarion-id: CEPH-83573697
+
   # Performing cluster upgrade
 
   - test:
@@ -297,3 +309,16 @@ tests:
       module: sanity_rgw_multisite.py
       name: test unordered listing of buckets
       polarion-id: CEPH-83573545
+
+  #  datalog offload tests
+  - test:
+      clusters:
+        ceph-rgw1:
+          config:
+            script-name: test_data_omap_offload.py
+            config-file-name: test_data_omap_offload.yaml
+            timeout: 300
+      desc: verify datalog type is fifo after upgrade
+      module: sanity_rgw_multisite.py
+      name: verify datalog type is fifo after upgrade
+      polarion-id: CEPH-83573697


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
add upgrade with fifio omap offload 
logs:  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-131WPA/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
