### PR TITLE
put/Set lifeycle to bucket with invalid date format in Lifecycle configuration

### DIFF
--- a/suites/nautilus/rgw/tier-1-extn_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw.yaml
@@ -133,3 +133,13 @@ tests:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
         timeout: 500
+
+  - test:
+      name: Bucket setlifeycle with invalid date in LC conf
+      desc: Setlifeycle to bucket with invalid date format in Lifecycle configuration
+      polarion-id: CEPH-11186
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_invalid_date.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -161,3 +161,13 @@ tests:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
         timeout: 500
+
+  - test:
+      name: Bucket setlifeycle with invalid date in LC conf
+      desc: Setlifeycle to bucket with invalid date format in Lifecycle configuration
+      polarion-id: CEPH-11186
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_invalid_date.yaml
+        timeout: 300


### PR DESCRIPTION

Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
put/Set lifeycle to bucket with invalid date format in Lifecycle configuration
Openstack has issue with subcription so triggered from IBM

cephci,
5.2 : https://159.23.92.24/job/rhceph-test-execution-manual/33/consoleFull

4.3 : https://159.23.92.24/job/rhceph-test-execution-manual/34/consoleFull

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
