### PR TITLE
Tuning pacific/rbd suites - branch name

### DIFF
--- a/suites/pacific/cephadm/tier-0.yaml
+++ b/suites/pacific/cephadm/tier-0.yaml
@@ -104,7 +104,7 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: master
+              branch: v16.2.8
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/suites/pacific/rbd/tier-0_rbd.yaml
+++ b/suites/pacific/rbd/tier-0_rbd.yaml
@@ -101,7 +101,7 @@ tests:
   -
     test:
       config:
-        branch: master
+        branch: v16.2.8
         script: cli_generic.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Generic scenarios"
@@ -111,7 +111,7 @@ tests:
   -
     test:
       config:
-        branch: master
+        branch: pacific
         script: rbd_groups.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Groups scenarios"
@@ -121,7 +121,7 @@ tests:
   -
     test:
       config:
-        branch: master
+        branch: pacific
         script: import_export.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Import Export scenarios"
@@ -131,7 +131,7 @@ tests:
   -
     test:
       config:
-        branch: master
+        branch: pacific
         script: luks-encryption.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD LUKS Encryption scenarios"
@@ -140,7 +140,7 @@ tests:
   -
     test:
       config:
-        branch: master
+        branch: pacific
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"

--- a/suites/pacific/rbd/tier-1_rbd.yaml
+++ b/suites/pacific/rbd/tier-1_rbd.yaml
@@ -101,7 +101,7 @@ tests:
 
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: test_librbd_python.sh
       desc: Executig upstream LibRBD scenarios
@@ -110,7 +110,7 @@ tests:
       polarion-id: CEPH-83574524
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: permissions.sh
       desc: Executig upstream RBD permissions scenarios
@@ -119,7 +119,7 @@ tests:
       polarion-id: CEPH-83574525
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: read-flags.sh
       desc: Executig upstream RBD Read Flag scenarios
@@ -128,7 +128,7 @@ tests:
       polarion-id: CEPH-83574526
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: qos.sh
       desc: Executig upstream RBD QOS scenarios
@@ -136,7 +136,7 @@ tests:
       name: 4_rbd_qos
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: journal.sh
       desc: Executig upstream RBD Journal scenarios
@@ -145,7 +145,7 @@ tests:
       polarion-id: CEPH-83574527
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: kernel.sh
       desc: Executig upstream RBD Kernal scenarios
@@ -154,7 +154,7 @@ tests:
       polarion-id: CEPH-83574528
   - test:
       config:
-        branch: master
+        branch: pacific
         script_path: qa/workunits/rbd
         script: krbd_exclusive_option.sh
       desc: Executig upstream RBD kernel exclusive scenarios

--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -95,11 +95,3 @@ tests:
       name: Check trash if the deleted images are moved to trash automatically
       polarion-id: CEPH-83573297
 
-  - test:
-      config:
-        branch: master
-        script_path: qa/workunits/rbd
-        script: krbd_rxbounce.sh
-      desc: Executig upstream RBD kernel exclusive scenarios
-      module: test_rbd.py
-      name: 8_rbd_krbd_rxbounce


### PR DESCRIPTION
rbd tests which consume upstream scripts are failing as branch name of upstream master branch was renamed.
This PR is to change branch name in respective suites.

Apart from this -
- suites/pacific/rbd/tier-2_rbd_regression.yaml - Removed a duplicate test

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
