### PR TITLE
Correcting the Values for K , M for the EC pool tests in RADOS

### DIFF
--- a/conf/pacific/rados/test-confs/pool-configurations.yaml
+++ b/conf/pacific/rados/test-confs/pool-configurations.yaml
@@ -29,7 +29,7 @@ erasure:
     pool_type: erasure
     pg_num: 32
     k: 4
-    m: 2
+    m: 3
     plugin: jerasure
     crush-failure-domain: osd
   sample-pool-3:

--- a/suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -113,8 +113,8 @@ tests:
         ec_pool_recovery_improvement:
           create: true
           pool_name: ec_pool_recovery
-          k: 3
-          m: 2
+          k: 8
+          m: 4
           pg_num: 32
           plugin: jerasure
           rados_write_duration: 100
@@ -134,8 +134,8 @@ tests:
           create: true
           pool_name: test_ec_pool
           pg_num: 64
-          k: 4
-          m: 2
+          k: 8
+          m: 4
           plugin: jerasure
           disable_pg_autoscale: true
           rados_write_duration: 50

--- a/suites/pacific/rados/tier-3_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-ecpool-osd-rebalance.yaml
@@ -104,8 +104,8 @@ tests:
               rados_put: true
               pg_num: 32
               pgp_num: 32
-              k: 3
-              m: 2
+              k: 8
+              m: 3
               plugin: jerasure
               crush-failure-domain: host
         delete_pools:


### PR DESCRIPTION
Coreected the values in the suites to configure EC pools with one of the 3 supported configurations
Supported :
k=8 m=3
k=8 m=4
k=4 m=2
Doc : https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/5/html/storage_strategies_guide/erasure_code_pools#erasure_code_profiles

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

