### PR TITLE
tests/cephadm/test_client.py: Corrected the node/nodes var mismatch

### DIFF
--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -45,10 +45,10 @@ def add(cls, config: Dict) -> None:
         file_.write(content)
         file_.flush()
 
-    if config.get("nodes"):
-        nodes = config["nodes"]
-        if not isinstance(nodes, list):
-            nodes = [nodes]
+    nodes_ = config.get("nodes", config.get("node"))
+    if nodes_:
+        if not isinstance(nodes_, list):
+            nodes = [nodes_]
 
         def setup(host):
             node = get_node_by_id(cls.cluster, host)


### PR DESCRIPTION
Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

With this PR : https://github.com/red-hat-storage/cephci/pull/1666, added support to deploy multiple clients, changing the variable node -> nodes in the process. 

Correcting the Variable name to support suites with single  client node to be deployed.

Fixes #1702 