### PR TITLE
Pick quincy scripts for version 6.x

### DIFF
--- a/pipeline/test_executor.groovy
+++ b/pipeline/test_executor.groovy
@@ -11,8 +11,11 @@ def getCLI(){
     /*
         Generates the CLI using the arguments provided and returns it.
     */
-    def cephVersion = 'pacific'
-    if(params.RHCS_Build.contains("3.")){
+    def cephVersion = 'quincy'
+    if(params.RHCS_Build.contains("5.")){
+        cephVersion = 'pacific'
+    }
+    else if(params.RHCS_Build.contains("3.")){
         cephVersion = 'luminous'
     }
     else if(params.RHCS_Build.contains("4.")){


### PR DESCRIPTION
Observed that despite selecting 6.x version pacific suites were selected to generate cli
Ref - https://jenkins.xxxxxxx/view/RHCS%20QE/job/rhceph-test-executor/830/consoleFull

This PR is intended to modify groovy script to generate apt cli

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
