### PR TITLE
Automation - CEPH-83574670 and CEPH-83574671

### DIFF
--- a/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
@@ -262,3 +262,14 @@ tests:
               args:              # sleep to get all services deployed
                 - sleep
                 - "120"
+  - test:
+      name: test_admin_node_removal
+      desc: Verify removal of _admin node acting as a bootstrap node.
+      polarion-id: CEPH-83574670
+      module: test_admin_node_removal.py
+  - test:
+      name: test_admin_add_labels
+      desc: Adding admin node again with different labels  does not remove ceph.client.admin.keyring  and ceph.conf file
+      polarion-id: CEPH-83574671
+      module: test_admin_add_labels.py
+

--- a/tests/cephadm/test_admin_add_labels.py
+++ b/tests/cephadm/test_admin_add_labels.py
@@ -1,0 +1,74 @@
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class AdminLableValidationError(Exception):
+    pass
+
+
+def _add_host_label(instance):
+    """
+    Method add multiple labels to cephadmin node
+    Args:
+        instance: cluster instance
+    Returns:
+        True|False
+    """
+
+    node = instance.cluster.get_nodes()[0].hostname
+    node_ip = instance.cluster.get_nodes()[0].ip_address
+    cmd = (
+        f"cephadm shell ceph orch host add {node} {node_ip} node-exporter "
+        "crash osd installer grafana prometheus alertmanager"
+    )
+    result = instance.installer.exec_command(cmd, sudo=True)
+    if result:
+        log.info("Multiple labels added to node")
+        return 0
+    raise AdminLableValidationError("Failed to add multiple label to node")
+
+
+def run(ceph_cluster, **kw):
+    """
+    Verify adding admin node again with different labels.
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        **kw :     Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+    """
+
+    config = kw.get("config")
+
+    # Checking files in path /etc/ceph before adding multiple lable
+    instance = CephAdmin(cluster=ceph_cluster, **config)
+    cmd = "ls /etc/ceph"
+    out, _ = instance.installer.exec_command(cmd, sudo=True)
+    files_before = out.split("\n")
+    log.info(
+        f"File exist in path /etc/ceph/ before adding multiple lables '{files_before}'"
+    )
+
+    # Adding multiple roles in same admin node
+    _add_host_label(instance)
+
+    # Checking cluster health and files in path /etc/ceph after multiple lable
+    health, _ = instance.installer.exec_command(
+        cmd="cephadm shell ceph -s | grep health:", sudo=True
+    )
+    log.info("Cluster health {}".format(health))
+    ceph_dir = "/etc/ceph"
+    out, _ = instance.installer.exec_command(cmd="ls {ceph_dir}", sudo=True)
+    files_after = out.split("\n")
+    log.info(
+        f"File exist in path '{ceph_dir}' after adding multiple lables '{files_after}'"
+    )
+
+    if "HEALTH_OK" not in health and files_before != files_after:
+        raise AdminLableValidationError("Test case failed, Admin node removed")
+    log.info("Cluster health is OK and files are same")
+    return 0

--- a/tests/cephadm/test_admin_node_removal.py
+++ b/tests/cephadm/test_admin_node_removal.py
@@ -1,0 +1,34 @@
+from ceph.ceph import CommandFailed
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class AdminNodeRemovalError(Exception):
+    pass
+
+
+def run(ceph_cluster, **kw):
+    """
+    Verify removal of _admin node acting as a bootstrap node.
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        **kw :     Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+    """
+
+    config = kw.get("config")
+    # Removing _admin node from bootstrp node
+    instance = CephAdmin(cluster=ceph_cluster, **config)
+    admin_node = instance.cluster.get_nodes()[0].hostname
+    cmd = f"cephadm shell ceph orch host rm {admin_node}"
+    try:
+        instance.installer.exec_command(cmd, sudo=True)
+        raise AdminNodeRemovalError("Test case failed, Admin node removed")
+    except CommandFailed:
+        log.info("As expected unable to remove _admin node from bootstrap node")
+        return 0


### PR DESCRIPTION
Signed-off-by: Mohit <mobisht@redhat.com>
Automated :
1. CEPH-83574670 - Verify removal of _admin node acting as a bootstrap node
2. CEPH-83574671 - Adding admin node again with different labels  does not remove ceph.client.admin.keyring  and ceph.conf file

Test Case Covered : CEPH-83574670 and CEPH-83574671

Polarion Link  :
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574670
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574671

Test Result:
CEPH-83574670  - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TPDSAK/
CEPH-83574671  - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4SQE6M/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [✓] Create a test case in Polarion reviewed and approved.
- [✓] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [✓] Review the automation design
- [✓] Implement the test script and perform test runs
- [✓] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
