### PR TITLE
[Nautilus]: Add missing tier-2 testsuites to metadata file

### DIFF
--- a/pipeline/metadata/4.3.yaml
+++ b/pipeline/metadata/4.3.yaml
@@ -589,3 +589,147 @@
     - ibmc
     - rgw
     - stage-1
+
+- name: "test-rgw-ms-lc-from-secondary"
+  suite: "suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml"
+  global-conf: "conf/nautilus/rgw/tier-1_rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "test-rgw-ms-lc-from-primary"
+  suite: "suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml"
+  global-conf: "conf/nautilus/rgw/tier-1_rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2
+
+- name: "test-rgw-ms-metadata-sync"
+  suite: "suites/nautilus/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml"
+  global-conf: "conf/nautilus/rgw/tier-1_rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3
+
+- name: "test-rgw-image-bucket-lifecycle-and-listing"
+  suite: "suites/nautilus/rgw/tier-2_rgw_image_test-bucket-lifecycle-and-listing.yaml"
+  global-conf: "conf/nautilus/rgw/5-node-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-4
+
+- name: "test-rgw-bucket-object-stats"
+  suite: "suites/nautilus/rgw/tier-2_rgw_s3cmd_test-bucket-object-stats.yaml"
+  global-conf: "conf/nautilus/rgw/5-node-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-4
+
+- name: "test-rgw-s3tests"
+  suite: "suites/nautilus/rgw/tier-2_rgw_s3tests.yaml"
+  global-conf: "conf/nautilus/rgw/ec-profile-4+2-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-4
+
+- name: "test-rgw-bucket-acls-and-links"
+  suite: "suites/nautilus/rgw/tier-2_rgw_test-bucket-acls-and-links.yaml"
+  global-conf: "conf/nautilus/rgw/5-node-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-4
+
+- name: "test-rgw-bucket-notifications"
+  suite: "suites/nautilus/rgw/tier-2_rgw_test-bucket-notifications.yaml"
+  global-conf: "conf/nautilus/rgw/5-node-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-4
+
+- name: "test-rgw-bucket-bucket-ops-and-versioning"
+  suite: "suites/nautilus/rgw/tier-2_rgw_test-bucket-ops-and-versioning.yaml"
+  global-conf: "conf/nautilus/rgw/5-node-cluster.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-5

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
@@ -93,7 +93,6 @@ tests:
             config-file-name: test_lc_rule_prefix_and_tag.yaml
             script-name: test_bucket_lifecycle_object_expiration.py
             timeout: 300
-            verify-io-on-site: [ "ceph-rgw2" ]
       desc: test_lifecycle  on secondary with AND rule filter
       module: sanity_rgw_multisite.py
       polarion-id: CEPH-11179 # also applies to CEPH-11180
@@ -107,6 +106,5 @@ tests:
         ceph-rgw1:
           config:
             script-name: test_bucket_lifecycle_object_expiration.py
-            verify-io-on-site: ["ceph-rgw2"]
             config-file-name: test_lc_rule_prefix_non_current_days.yaml
             timeout: 300

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
@@ -93,7 +93,6 @@ tests:
             config-file-name: test_lc_rule_prefix_and_tag.yaml
             script-name: test_bucket_lifecycle_object_expiration.py
             timeout: 300
-            verify-io-on-site: [ "ceph-rgw1" ]
       desc: test_lifecycle  on secondary with AND rule filter
       module: sanity_rgw_multisite.py
       polarion-id: CEPH-11179 # also applies to CEPH-11180
@@ -107,6 +106,5 @@ tests:
         ceph-rgw2:
           config:
             script-name: test_bucket_lifecycle_object_expiration.py
-            verify-io-on-site: ["ceph-rgw1"]
             config-file-name: test_lc_rule_prefix_non_current_days.yaml
             timeout: 300


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
[nautilus]: Add missing tier-2 test suites(which was previously part of scripts->tier-3 place holder in pipeline v2)
from RGW FG to 4.3 meta data file.

logs:
tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary(1hr 25min)
https://159.23.92.24/job/rhceph-test-execution-manual/48/console

tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary(95 min)
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-JU3873/

tier-2_rgw_test-multisite-metadata-sync(1hr 12 min)
https://159.23.92.24/job/rhceph-test-execution-manual/40/console

tier-2_rgw_image_test-bucket-lifecycle-and-listing(89 min)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OVQ3LZ/

tier-2_rgw_s3cmd_test-bucket-object-stats(24 min)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-20U4GV/

tier-2_rgw_s3tests(45 min)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-86GIFI/

tier-2_rgw_test-bucket-acls-and-links(26 min)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SVMNB2/

tier-2_rgw_test-bucket-notifications(32 min)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZGBXJP/

tier-2_rgw_test-bucket-ops-and-versioning(29 min)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6HWD0H/

2) removed verify-io from LC Mult-isite test suite. Will be added back once the verify-io is enhanced to support delete operation verification.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
