### PR TITLE
CEPH-83575046 - Control functionality for RGW lifecycle

### DIFF
--- a/suites/nautilus/rgw/tier-1-extn_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw.yaml
@@ -143,3 +143,13 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration.py
         config-file-name: test_lc_invalid_date.yaml
         timeout: 300
+
+  - test:
+      name: Control functionality for RGW lifecycle
+      desc: Control functionality for RGW lifecycle with rgw_enable_lc_threads
+      polarion-id: CEPH-83575046
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_rgw_enable_lc_threads.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -171,3 +171,13 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration.py
         config-file-name: test_lc_invalid_date.yaml
         timeout: 300
+
+  - test:
+      name: Control functionality for RGW lifecycle
+      desc: Control functionality for RGW lifecycle with rgw_enable_lc_threads
+      polarion-id: CEPH-83575046
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_rgw_enable_lc_threads.yaml
+        timeout: 300


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Set rgw_enable_lc_threads set to false and lc status in lc list for that bucket should change its state from unintial
but manual lc process for bucke should work

Logs: 
      4.3 log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5KPGO1/
      5.2 log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LNK8DD/


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
