### PR TITLE
RBD FG suites for quincy

### DIFF
--- a/conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+++ b/conf/quincy/rbd/4-node-cluster-with-1-client.yaml
@@ -1,0 +1,40 @@
+# Configuration file for rbd tier-1 and tier-2 testcases
+# Total 4 nodes with 3 - mons, 2 Mgrs, 3 OSDs, 1-Client
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+          - osd
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node2:
+        role:
+          - osd
+          - mon
+          - mgr
+          - node-exporter
+          - alertmanager
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node3:
+        role:
+          - mon
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 3
+        disk-size: 15
+      node4:
+        role:
+          - client

--- a/conf/quincy/rbd/5-node-2-clusters.yaml
+++ b/conf/quincy/rbd/5-node-2-clusters.yaml
@@ -1,0 +1,64 @@
+# Configuration file for testcases with rbd-mirror scenarios
+# Contains two clusters each with -
+# 3 Mon, 2 Mgrs, 3 OSD nodes with 4 disks each, 1 rbd-mirror, 1 client
+# Each cluster to have 5 nodes
+globals:
+  - ceph-cluster:
+     name: ceph-rbd1
+     node1:
+       role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+     node2:
+       role: client
+     node3:
+       role:
+         - osd
+         - mon
+         - mgr
+       no-of-volumes: 4
+       disk-size: 15
+     node4:
+       role:
+          - osd
+          - mon
+       no-of-volumes: 4
+       disk-size: 15
+     node5:
+       role:
+          - osd
+          - rbd-mirror
+       no-of-volumes: 4
+       disk-size: 15
+
+  - ceph-cluster:
+      name: ceph-rbd2
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role: client
+      node3:
+        role:
+          - osd
+          - mon
+          - mgr
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - osd
+          - mon
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role:
+          - osd
+          - rbd-mirror
+        no-of-volumes: 4
+        disk-size: 15

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -214,3 +214,35 @@
     - ibmc
     - rgw
     - stage-1
+
+- name: "Testing RBD basic regression scenarios"
+  suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+  global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rbd
+    - stage-1
+
+- name: "Testing RBD tier-2 regression scenarios"
+  suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
+  global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rbd
+    - stage-1

--- a/suites/quincy/rbd/tier-1_rbd.yaml
+++ b/suites/quincy/rbd/tier-1_rbd.yaml
@@ -1,0 +1,180 @@
+# Tier1: RBD build evaluation
+#
+# This test suite evaluates the build to determine the execution of identified
+# regression test suites.
+# This suite requires node2 to be a client node with mons, mgrs and osds
+# Example config - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: "install ceph pre-requisites"
+  -
+    test:
+      name: Cephadm Bootstrap with custom user option
+      desc: cephadm cluster bootstrap with ssh-user(cephuser) option
+      module: test_bootstrap.py
+      polarion-id: CEPH-83573724
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          ssh-user: cephuser
+          ssh-public-key: /home/cephuser/.ssh/id_rsa.pub # if ssh-public-key is provided then provide with ssh-user
+          ssh-private-key: /home/cephuser/.ssh/id_rsa # ssh-private-key also else validation fails
+          registry-json: registry.redhat.io
+          custom_image: true
+          mon-ip: node1
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          -
+            config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+        verify_cluster_health: true
+      desc: "RHCS cluster deployment using cephadm"
+      destroy-clster: false
+      module: test_cephadm.py
+      name: "deploy cluster"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - rbd-nbd
+          - jq
+        node: node4
+      desc: "Configure the client system"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+      polarion-id: CEPH-83573758
+  -
+    test:
+      config:
+        script: rbd_groups.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD CLI Groups scenarios"
+      module: test_rbd.py
+      name: 1_rbd_cli_groups
+      polarion-id: CEPH-83574239
+  -
+    test:
+      config:
+        script: import_export.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD CLI Import Export scenarios"
+      module: test_rbd.py
+      name: 2_rbd_cli_import_export
+      polarion-id: CEPH-83574240
+  -
+    test:
+      config:
+        script: luks-encryption.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD LUKS Encryption scenarios"
+      module: test_rbd.py
+      name: 3_rbd_luks_encryption
+      polarion-id: CEPH-83574242
+  -
+    test:
+      config:
+        script: cli_migration.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD CLI Migration scenarios"
+      module: test_rbd.py
+      name: 4_rbd_cli_migration
+      polarion-id: CEPH-83574243
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: test_librbd_python.sh
+      desc: Executig upstream LibRBD scenarios
+      module: test_rbd.py
+      name: 5_librbd_python
+      polarion-id: CEPH-83574524
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: permissions.sh
+      desc: Executig upstream RBD permissions scenarios
+      module: test_rbd.py
+      name: 6_rbd_permissions
+      polarion-id: CEPH-83574525
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: read-flags.sh
+      desc: Executig upstream RBD Read Flag scenarios
+      module: test_rbd.py
+      name: 7_rbd_read_flags
+      polarion-id: CEPH-83574526
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: journal.sh
+      desc: Executig upstream RBD Journal scenarios
+      module: test_rbd.py
+      name: 9_journal
+      polarion-id: CEPH-83574527
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: kernel.sh
+      desc: Executig upstream RBD Kernal scenarios
+      module: test_rbd.py
+      name: 10_rbd_kernel
+      polarion-id: CEPH-83574528
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: krbd_exclusive_option.sh
+      desc: Executig upstream RBD kernel exclusive scenarios
+      module: test_rbd.py
+      name: 11_rbd_krbd_exclusive
+      polarion-id: CEPH-83574531

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -1,0 +1,97 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-9230 - verification snap and clone on an imported image
+#   - CEPH-83573308, CEPH-83573307 - clones creation with v2clone format and deletion
+#   - CEPH-83573297 - Check trash if the deleted images are moved to trash automatically
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+ # Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: snap and clone operations on imported image
+      destroy-cluster: false
+      module: rbd_snap_clone_imported_image.py
+      name: snap and clone on imported image
+      polarion-id: CEPH-9230
+
+  - test:
+      desc: Verify that clones creation and deletion of parent image with V2 enabled
+      destroy-cluster: false
+      module: rbd_clonev2.py
+      name: clones creation with v2clone format
+      polarion-id: CEPH-83573309
+
+  - test:
+      desc: Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
+      destroy-cluster: false
+      module: rbd_trash.py
+      name: Check trash if the deleted images are moved to trash automatically
+      polarion-id: CEPH-83573297


### PR DESCRIPTION
RBD suites for quincy downstream runs

- modified:   suites/quincy/rbd/tier-1_rbd.yaml
magna002/cephci-jenkins/cephci-run-0S44EO

- new file:   suites/quincy/rbd/tier-2_rbd_regression.yaml
(without cluster configuration) - magna002/cephci-jenkins/cephci-run-OIFP1O

- new file:   conf/quincy/rbd/4-node-cluster-with-1-client.yaml
conf file to be used with suites/quincy/rbd/tier-2_rbd_regression.yaml and suites/quincy/rbd/tier-1_rbd.yaml

- new file:   conf/quincy/rbd/5-node-2-clusters.yaml
conf file for rbd-mirror test suites

- modified:   pipeline/metadata/6.0.yaml
Adding new suites to pipeline metadata file

Signed-off-by: Vasishta <vashastr@redhat.com>
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
