### PR TITLE
To configure multiple public network using ceph config option

### DIFF
--- a/conf/pacific/cephadm/5-node-cluster-multiple-subnet-openstack-only.yaml
+++ b/conf/pacific/cephadm/5-node-cluster-multiple-subnet-openstack-only.yaml
@@ -1,0 +1,50 @@
+# This conf needs to use only for openstack environment as this subnets are from rhos-d infra.
+# node1, node2, node3 are part of subnet provider_net_cci_9 with CIDR(10.0.104.0/22)
+# node4, node5 are part of subnet provider_net_cci_11 with CIDR(10.0.204.0/22)
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_9
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+      node2:
+        networks:
+          - provider_net_cci_9
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
+      node3:
+        networks:
+          - provider_net_cci_9
+        role:
+          - mon
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
+      node4:
+        networks:
+          - provider_net_cci_11
+        role:
+          - mon
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
+      node5:
+        networks:
+          - provider_net_cci_11
+        role:
+          - mon
+          - mgr

--- a/suites/pacific/cephadm/customer_bz/tier-2_multiple_subnet_openstack_only.yaml
+++ b/suites/pacific/cephadm/customer_bz/tier-2_multiple_subnet_openstack_only.yaml
@@ -1,0 +1,117 @@
+---
+# ==================================================================================
+# NOTE: This test suite is for different subnet configured cluster
+# as per it's conf file it needs to be run only openstack env.
+#
+# Tier-level: 2
+# Test-Case:
+#   cephadm cluster bootstrap with mutiple public network
+# Test-Suite:
+#   tier-2_multiple_subnet_openstack_only.yaml
+# Cluster Configuration:
+#   cephci/conf/pacific/cephadm/5-node-cluster-multiple-subnet-openstack-only.yaml
+#
+# Node1 - admin, Mon, Mgr, Installer, alertmanager, grafana,
+#         prometheus, node-exporter , crash
+# Node2 - Mon, Mgr, OSD
+# Node3 - Mon, OSD
+# Node4 - Mon, OSD
+# Node5 - Mon, Mgr
+#
+#
+# Test steps:
+#   (1) Bootstrap cluster with options,
+##       - registry-json: <registry-URL>
+##       - mon-ip: <monitor IP address: Required>
+##       - public-network: <CIDR of provider_net_cci_9 and provider_net_cci_11
+##   (2) Copy SSH keys to nodes.
+##   (3) Add nodes to cluster with address and role labels attached to it using
+#        Host spec yaml file.
+##   (4) Deploy services using apply spec option,
+#        (" ceph orch apply -i <spec_file>)
+##       - 5 Mon on node1, node2, node3, node4 and node5 using host placements.
+##       - MGR using host placement on node1, node2 and node5.
+##       - addition of OSD's using "all-avialable-devices" option.
+##       - crash and node-exporter on all nodes using placement="*".
+##   (5) Test to validate multiple public network
+# ==================================================================================
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: Cluster deployment with multiple subnet
+      desc: Ceph cluster with multiple public network
+      module: test_cephadm.py
+      polarion-id: CEPH-83575132
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                custom_image: true
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                config:
+                  global:
+                    public_network: 10.0.104.0/22,10.0.204.0/22
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                nodes:
+                  - node2
+                  - node3
+                  - node4
+                  - node5
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  nodes:
+                    - node1
+                    - node2
+                    - node3
+                    - node4
+                    - node5
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  nodes:
+                    - node1
+                    - node2
+                    - node5
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: crash
+              base_cmd_args:
+                verbose: true
+              args:
+                placement:
+                  nodes: "*"
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: validate multiple public network
+      desc: Verify multiple public network option
+      module: test_config.py
+      config:
+        public_network: 10.0.104.0/22,10.0.204.0/22
+      polarion-id: CEPH-83575132
+      abort-on-fail: true

--- a/tests/cephadm/test_config.py
+++ b/tests/cephadm/test_config.py
@@ -1,0 +1,42 @@
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def verify_multiple_public_network(cls, configured_network):
+    """
+    To validate multiple public network set from ceph conf.
+    Args:
+        cls: cephadm instance object
+        configured_network: subnet address of config
+
+    Returns:
+        False -> Test Failed to set multiple public network to ceph
+        True -> Test passed to validate multiple public network to ceph
+    """
+    # To validate the set address using get operation
+    public_network, _ = cls.shell(
+        args=["ceph", "config", "get", "mon", "public_network"]
+    )
+    if configured_network == public_network.rstrip():
+        return True
+    return False
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test to validate to configure any specific ceph commands using ceph config option.
+
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): Ceph cluster object
+        kw: test data
+    """
+    config = kw["config"]
+    instance = CephAdmin(cluster=ceph_cluster, **config)
+    configured_network = config["public_network"]
+    if verify_multiple_public_network(instance, configured_network):
+        log.info("Verified multiple public network to ceph")
+        return 0
+    log.error("Test failed to set multiple public network to ceph")
+    return 1


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Test case: CEPH-83575132
Fixes: RHCEPHQE-4071
Added new test suite to deploy ceph cluster with multiple public network using cephadm.
also validated configured public network using `config get` option.
Test result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BH4Q3G/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
