### PR TITLE
ceph/cephadm/apply.py: fix issue with validate spec services

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -12,6 +12,7 @@ from typing import Dict
 from ceph.utils import get_nodes_by_ids
 
 from .common import config_dict_to_string
+from .helper import check_service_exists
 from .typing_ import ServiceProtocol
 
 
@@ -124,5 +125,7 @@ class ApplyMixin:
         if not verify_service:
             return
 
-        if not self.check_service_exists(service_name=service_name):
+        if not check_service_exists(
+            self.installer, service_name=service_name, service_type=self.SERVICE_NAME
+        ):
             raise OrchApplyServiceFailure(self.SERVICE_NAME)

--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -882,7 +882,7 @@ def check_service_exists(
             _retries = 3
 
     # Identify the failure
-    out, err = installer.shell(args=cmd_args)
+    out, err = installer.exec_command(sudo=True, cmd=" ".join(cmd_args))
     out = json.loads(out)
     LOG.error(f"{service_name or service_type} failed with \n{out[0].get('events')}")
     return False

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -60,15 +60,6 @@ class OrchProtocol(CephAdmProtocol, Protocol):
     def get_hosts_by_label(self, label: str) -> List:
         ...
 
-    def check_service_exists(
-        self,
-        service_name: str = None,
-        service_type: str = None,
-        timeout: int = 300,
-        interval: int = 5,
-    ) -> bool:
-        ...
-
     def check_service(
         self,
         service_name: str,
@@ -82,9 +73,6 @@ class OrchProtocol(CephAdmProtocol, Protocol):
         ...
 
     def verify_status(self, op: str) -> None:
-        ...
-
-    def validate_spec_services(self, steps):
         ...
 
 

--- a/unittests/ceph/ceph_admin/test_apply.py
+++ b/unittests/ceph/ceph_admin/test_apply.py
@@ -8,41 +8,36 @@ class MockApplyMixinTestWithShellOutput(ApplyMixin):
     def __init__(self):
         self.cluster = None
         self.service_name = "rgw"
+        self.installer = None
 
     def shell(self, args):
         return "Scheduled rgw update", 0
-
-    def check_service_exists(self, service_name="rgw"):
-        return True
 
 
 class MockApplyMixinTestWithOutShellOutput(ApplyMixin):
     def __init__(self):
         self.cluster = None
         self.service_name = "rgw"
+        self.installer = None
 
     def shell(self, args):
         return 0, 0
-
-    def check_service_exists(self, service_name="rgw"):
-        return True
 
 
 class MockApplyMixinTestWithOutServiceOutput(ApplyMixin):
     def __init__(self):
         self.cluster = None
         self.service_name = "rgw"
+        self.installer = None
 
     def shell(self, args):
         return 0, 0
 
-    def check_service_exists(self, service_name="rgw"):
-        return False
-
 
 class TestApply:
+    @mock.patch("ceph.ceph_admin.apply.check_service_exists")
     @mock.patch("ceph.ceph_admin.apply.config_dict_to_string")
-    def test_apply_with_shell_output(self, mock_config):
+    def test_apply_with_shell_output(self, mock_config, mock_check_service):
         config = {
             "command": "apply",
             "service": "rgw",
@@ -62,13 +57,15 @@ class TestApply:
             "pos_args": ["node1", "dev/vdb", "dev"],
         }
         mock_config.return_value = ["ceph", "orch", " --verbose"]
+        mock_check_service.return_value = True
         self._apply = MockApplyMixinTestWithShellOutput()
         self._apply.SERVICE_NAME = "rgw"
         self._apply.apply(config)
         assert mock_config.call_count == 2
 
+    @mock.patch("ceph.ceph_admin.apply.check_service_exists")
     @mock.patch("ceph.ceph_admin.apply.config_dict_to_string")
-    def test_apply_without_shell_output(self, mock_config):
+    def test_apply_without_shell_output(self, mock_config, mock_check_service):
         try:
             config = {
                 "command": "apply",
@@ -89,6 +86,7 @@ class TestApply:
                 "pos_args": ["node1", "dev/vdb", "dev"],
             }
             mock_config.return_value = ["ceph", "orch", " --verbose"]
+            mock_check_service.return_value = True
             self._apply = MockApplyMixinTestWithOutShellOutput()
             self._apply.SERVICE_NAME = "rgw"
             self._apply.apply(config)
@@ -96,8 +94,9 @@ class TestApply:
             assert self._apply.SERVICE_NAME == "rgw"
         assert mock_config.call_count == 2
 
+    @mock.patch("ceph.ceph_admin.apply.check_service_exists")
     @mock.patch("ceph.ceph_admin.apply.config_dict_to_string")
-    def test_apply_without_service_output(self, mock_config):
+    def test_apply_without_service_output(self, mock_config, mock_check_service):
         try:
             config = {
                 "command": "apply",
@@ -117,6 +116,7 @@ class TestApply:
                 "pos_args": ["node1", "dev/vdb", "dev"],
             }
             mock_config.return_value = ["ceph", "orch", " --verbose"]
+            mock_check_service.return_value = True
             self._apply = MockApplyMixinTestWithOutServiceOutput()
             self._apply.SERVICE_NAME = "rgw"
             self._apply.apply(config)
@@ -124,8 +124,9 @@ class TestApply:
             assert self._apply.SERVICE_NAME == "rgw"
         assert mock_config.call_count == 2
 
+    @mock.patch("ceph.ceph_admin.apply.check_service_exists")
     @mock.patch("ceph.ceph_admin.apply.config_dict_to_string")
-    def test_apply_without_placement(self, mock_config):
+    def test_apply_without_placement(self, mock_config, mock_check_service):
         try:
             config_without_placement = {
                 "command": "apply",
@@ -139,6 +140,7 @@ class TestApply:
                 "pos_args": ["node1", "dev/vdb", "dev"],
             }
             mock_config.return_value = ["ceph", "orch", " --verbose"]
+            mock_check_service.return_value = True
             self._apply = MockApplyMixinTestWithOutServiceOutput()
             self._apply.SERVICE_NAME = "rgw"
             self._apply.apply(config_without_placement)


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

**Issue:**
```
2022-08-17 06:30:16,286 - ERROR - cephci.test_cephadm:110 - 'Mgr' object has no attribute 'check_service_exists'
Traceback (most recent call last):
  File "/home/vasishta/cephci/tests/ceph_installer/test_cephadm.py", line 130, in run
    func(cfg)
  File "/home/vasishta/cephci/ceph/ceph_admin/mgr.py", line 41, in apply
    super().apply(config=config)
  File "/home/vasishta/cephci/ceph/ceph_admin/apply.py", line 127, in apply
    if not self.check_service_exists(service_name=service_name):
AttributeError: 'Mgr' object has no attribute 'check_service_exists'
```

**Fix:**
```
In apply.py
1) Import this line `from .helper import check_service_exists`
2) Replace line:128 with below,
     if not check_service_exists(self.installer, service_name=service_name, service_type=self.SERVICE_NAME):

In helper.py
1) replace line:885 with 
     out, err = installer.exec_command(sudo=True, cmd=" ".join(cmd_args))
```


**Test results:**
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JJ6KJ5/cluster_deployment_0.log  - with apply commands
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9C1EV7/ - apply, apply-spec and bootstrap with apply-spec
