### PR TITLE
Adding testsuite for testing polarion ID CEPH-11197

### DIFF
--- a/suites/nautilus/rgw/tier-1-extn_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw.yaml
@@ -145,6 +145,16 @@ tests:
         timeout: 300
 
   - test:
+      name: LC enabled on bucket removes pre and post uploaded objects
+      desc: Bucket in which LC is enabled should delete object existed and objects added in future
+      polarion-id: CEPH-11197
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_config_ops.py
+        config-file-name: test_bucket_lc_enable_object_exp.yaml
+        timeout: 300
+
+  - test:
       name: Control functionality for RGW lifecycle
       desc: Control functionality for RGW lifecycle with rgw_enable_lc_threads
       polarion-id: CEPH-83575046

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -173,6 +173,16 @@ tests:
         timeout: 300
 
   - test:
+      name: LC enabled on bucket removes pre and post uploaded objects
+      desc: Bucket in which LC is enabled should delete object existed and objects added in future
+      polarion-id: CEPH-11197
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_config_ops.py
+        config-file-name: test_bucket_lc_enable_object_exp.yaml
+        timeout: 300
+
+  - test:
       name: Control functionality for RGW lifecycle
       desc: Control functionality for RGW lifecycle with rgw_enable_lc_threads
       polarion-id: CEPH-83575046


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Bucket in which LC is enabled should delete object existed and objects added in future
Log:
   5.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8FM9VX/LC_enabled_on_bucket_removes_pre_and_post_uploaded_objects_0.log
   4.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-J0HEPN/LC_enabled_on_bucket_removes_pre_and_post_uploaded_objects_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
