### PR TITLE
Include rgw tier-0 suites to 6.0 metadata file

### DIFF
--- a/conf/quincy/rgw/tier-0_rgw.yaml
+++ b/conf/quincy/rgw/tier-0_rgw.yaml
@@ -1,0 +1,43 @@
+# System Under Test environment configuration for RGW Tier-0 test suite.
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+          - osd
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - mon
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+
+      node5:
+        role:
+          - rgw
+
+      node6:
+        role:
+          - client

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -198,3 +198,19 @@
     - ibmc
     - rados
     - stage-5
+
+- name: "Basic operation test suite for 6x for RGW sanity"
+  suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+  global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rgw
+    - stage-1

--- a/suites/quincy/rgw/test-basic-object-operations.yaml
+++ b/suites/quincy/rgw/test-basic-object-operations.yaml
@@ -66,6 +66,7 @@ tests:
           - ceph-common
         copy_admin_keyring: true
       desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
       destroy-cluster: false
       module: test_client.py
       name: configure client


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Including rgw basic operation test suite to the 6.0 metadata file for pipeline execution
Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-VVSRVU/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
