### PR TITLE
[Lib] Add baremetal support

### DIFF
--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -1,16 +1,22 @@
 """Collects the Baremetal information and creates the cephNode object."""
 from copy import deepcopy
+from datetime import datetime, timedelta
 from os.path import expanduser
+from re import search
+from sys import argv
+from time import sleep
 from typing import List, Optional
 
 from ceph.ceph import SSHConnectionManager
 from utility.log import Log
+from utility.utils import get_cephci_config
 
 LOG = Log(__name__)
 
 
 class CephBaremetalNode:
     """Represent the Baremetal Node."""
+    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, **params) -> None:
         """
@@ -35,6 +41,43 @@ class CephBaremetalNode:
         self.keypair: Optional[str] = None
 
         self.params = params
+        self.teuthology_creds = get_cephci_config()["teuthology"]
+        self.conn = None
+
+        # Re-image the node to desired os version
+        self.node = params.get('hostname')
+
+        # Parse the args to get the os details
+        self.os_details = argv[argv.index('--rhel-version') + 1]
+
+        # Parse the teuthology framework related data from config
+        teuthology_infra_node = self.teuthology_creds.get('infra_node')
+        username = self.teuthology_creds.get('username')
+        password = self.teuthology_creds.get('password')
+
+        # Create ssh conn obj
+        r_conn = SSHConnectionManager(teuthology_infra_node,
+                                      username,
+                                      password)
+        try:
+            self.conn = r_conn.get_client()
+        except Exception as conn_excep:
+            print("Failed to establish ssh connection to {node} "
+                  "machine with {error}Aborting!".format(node=self.node, error=str(conn_excep)))
+            exit(1)
+
+        # Re-image the node
+        self._re_image_node()
+
+        # Create root password and enable remote ssh login via magna006
+        self._create_root_credentials_and_remote_login()
+
+        # Perform wipefs (for disk in lsblk, do wipefs)
+        self._perform_wipefs()
+
+        # Close connection
+        self.conn.close()
+
         self.location = params.get("location")
         self.private_key = params.get("root_private_key")
         if self.private_key:
@@ -58,7 +101,7 @@ class CephBaremetalNode:
 
         # Check if user exists
         try:
-            _, out, err = self.rssh().exec_command(
+            _, _, err = self.rssh().exec_command(
                 command="id -u cephuser",
             )
 
@@ -73,6 +116,316 @@ class CephBaremetalNode:
             'echo "cephuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/cephuser'
         )
         self.rssh().exec_command(command="touch /ceph-qa-ready")
+
+    def _re_image_node(self):
+        """
+        Re-images a node to the specified rhel version.
+        The method uses the 'teuthology' framework to handle re-imaging of nodes
+        :return:NIL
+        """
+
+        # Identify the linux flavour and version to which the node has to be re-imaged
+        os_type = 'rhel'
+        os_version = self.os_details
+
+        # Check if the node is locked/unlocked. Lock it under teuthology_infra_node user
+        self._unlock_and_lock_node()
+
+        re_image_cmd = "teuthology-reimage --os-type {os_type} " \
+                       "--os-version {os_version} {node}".format(os_type=os_type,
+                                                                 os_version=os_version,
+                                                                 node=self.node)
+        _, out, err = self._execute_command_in_venv(re_image_cmd)
+        LOG.info(out.read().decode(encoding='UTF-8'))
+        LOG.info(err.read())
+
+        """
+        TODO: The error check is now disabled as teuthology at times returns
+              'teuthology.exceptions.MaxWhileTries:'
+              even after successful reimage. Once the issue is fixed, the below
+              check can be included
+        if err:
+            LOG.error(err.read().decode(encoding='UTF-8'))
+            print("Failure happened while re-imaging {node}. Exiting!".format(node=node))
+            LOG.debug(out.read().decode(encoding='UTF-8'))
+            exit(1)
+        """
+
+        # Validate the os_version is updated
+        if self._get_os_version() != os_version:
+            LOG.error("{} not re-imaged to desired os version.".format(self.node))
+            exit(1)
+
+        # Re-lock the node back to user
+        self._relock_node()
+        LOG.info("Re-image successfull. The cuurent os-version of {node} "
+                 "is {os}".format(node=self.node, os=os_version))
+
+    def _unlock_and_lock_node(self):
+        """
+        Fetch the current lock status of the nodes. Unlock if from the
+        previous user, lock it under the teuthology creds.
+        :return: True/False
+        """
+        t_user = "{}@{}".format(self.teuthology_creds.get('username'),
+                                self.teuthology_creds.get('hostname'))
+
+        # Get the lock status of the node
+        lock_status = self._get_node_lock_status()
+
+        # Check 1: Verify the node is already locked, if yes, proceed to unlock, and finally lock
+        if lock_status['is_locked']:
+            locked_user = lock_status['locked_user']
+            self.node_owner = locked_user
+            # Now that the machine is locked, check if its already locked by the teuthology user
+            if locked_user != t_user:
+                # If not, then perform unlock
+                LOG.debug("{} is currently locked by {}".format(self.node, locked_user))
+
+                # Unlock the node using the current locked user data
+                cmd = "teuthology-lock --unlock --owner {} {}".format(locked_user, self.node)
+                _, out, _ = self._execute_command_in_venv(cmd)
+                print(out.read().decode(encoding='UTF-8'))
+            else:
+                LOG.debug("The node is already locked by teuthology user {}."
+                          "Skipping the locking steps".format(t_user))
+                return
+
+        # Now that the machine is unlocked, perform lock using t_user
+        cmd = "teuthology-lock --lock --owner {} {}".format(t_user, self.node)
+        _, out, _ = self._execute_command_in_venv(cmd)
+        print(out.read().decode(encoding='UTF-8'))
+
+        # Verify the lock command has been successful
+        lock_status = self._get_node_lock_status()
+        if not (lock_status['is_locked'] and lock_status['locked_user'] == t_user):
+            LOG.error("Lock failed. {} still under {}".format(self.node,
+                                                              lock_status['locked_user']))
+            exit(1)
+
+        # The lock command executed successful
+        LOG.debug("{} successfully locked by {}".format(self.node, t_user))
+
+    def _relock_node(self):
+        """
+        Relock the node to the actual owner. This step is done to ensure that the
+        node is assigned back to user and not reserved under the teuthology master node.
+        :return: (bool) based on lock status
+        """
+        # Unlock the node from teuthology master node
+        # Unlock the node using the current locked user data
+        locked_user = "{}@{}".format(self.teuthology_creds.get('username'),
+                                     self.teuthology_creds.get('hostname'))
+        cmd = "teuthology-lock --unlock --owner {} {}".format(locked_user, self.node)
+        _, out, _ = self._execute_command_in_venv(cmd)
+        print(out.read().decode(encoding='UTF-8'))
+        print("Node Unlocked\n")
+
+        # Lock it back to the user
+        cmd = "teuthology-lock --lock --owner {} {}".format(self.node_owner, self.node)
+        _, out, _ = self._execute_command_in_venv(cmd)
+        print(out.read().decode(encoding='UTF-8'))
+
+        # Verify the lock command has been successful
+        lock_status = self._get_node_lock_status()
+        if not (lock_status['is_locked'] and lock_status['locked_user'] == self.node_owner):
+            LOG.error("Lock failed. {} still under {}".format(self.node,
+                                                              lock_status['locked_user']))
+            exit(1)
+
+        LOG.debug("{} successfully locked back to {}".format(self.node, self.node_owner))
+
+    def _execute_command_in_venv(self, command):
+        """
+        Executes the command inside venv, deactivate the venv after execution, returns the result
+        :param command: command to execute
+        :return: res,out,err
+        """
+        v_env_path = self.teuthology_creds.get('v_env_path')
+        v_env_cmd = "source {venv}/bin/activate;{command};deactivate".format(venv=v_env_path,
+                                                                             command=command)
+        res, out, err = self.conn.exec_command(
+            command=v_env_cmd,
+        )
+        print("Executed ", v_env_cmd)
+        return res, out, err
+
+    def _get_node_summary(self):
+        """
+        Returns teuthology-lock --list {node} output
+        :param conn:
+        :return:
+        """
+        lock_list_cmd = "teuthology-lock --list {node}".format(node=self.node)
+        _, out, _ = self._execute_command_in_venv(lock_list_cmd)
+        lock_summary = out.readlines()
+        if not lock_summary:
+            LOG.error("Failed to fetch lock status of {node}. Exiting".format(node=self.node))
+            exit(1)
+        return lock_summary
+
+    def _get_node_lock_status(self):
+        """
+        Checks if the node is locked or not
+        :return: (dict) lock_status
+        """
+
+        lock_status = {}
+        lock_summary = self._get_node_summary()
+
+        is_locked = [True for entry in lock_summary if '"locked": true' in entry]
+        if is_locked:
+            lock_status['is_locked'] = True
+            lock_status['locked_user'] = [search('"(.*)"', entry.split(":")[-1]).group(1)
+                                          for entry in lock_summary if "locked_by" in entry][0]
+        else:
+            lock_status['is_locked'] = False
+
+        return lock_status
+
+    def _get_os_version(self):
+        """
+        Parses /etc/os-release and returns the os version
+        :return: (str) OS Version (e.g: 8.5, 7.9 etc)
+        """
+        cmd = "cat /etc/os-release"
+        _, out, err = self.conn.exec_command(
+            command=cmd,
+        )
+        if err:
+            LOG.error(err.read().decode(encoding='UTF-8'))
+
+        # If the os_version is not same as the one specified, raise error and exit
+        os_version = search('"(.*)"', out.readlines()[4]).group(1)
+        LOG.info("OS details of {} : {}".format(self.node, os_version))
+        return os_version
+
+    def _create_root_credentials_and_remote_login(self):
+        """
+        Creates a root login in the node and enable root login via ssh
+        Steps:
+        1. ssh to the machine using the predefined oub key
+        2. Set root passwd (default to "passswd")
+        3. Update /etc/ssh/sshd_config with "PermitRootLogin Yes"
+        4. Restart sshd service
+        :return: NIL
+        """
+
+        cmd = "ssh -i ~/.ssh/magna_002_rsa ubuntu@{node} 'echo \"passwd\" | " \
+              "sudo passwd --stdin root;grep -qxF \"PermitRootLogin yes\" " \
+              "/etc/ssh/sshd_config || echo \"PermitRootLogin yes\" | " \
+              "sudo tee -a /etc/ssh/sshd_config;" \
+              "sudo service sshd restart' ".format(node=self.node)
+        _, _, err = self.conn.exec_command(
+            command=cmd,
+        )
+        if err:
+            LOG.error(err.read().decode(encoding='UTF-8'))
+
+        # Verify ssh over root is successful
+        test_root_conn = SSHConnectionManager(self.node, "root", "passwd")
+        conn = None
+        try:
+            conn = test_root_conn.get_client()
+        except Exception as conn_excep:
+            print("Failed to establish ssh connection over root user to {node} "
+                  "machine with {error}Aborting!".format(node=self.node, error=str(conn_excep)))
+            conn.close()
+            exit(1)
+        conn.close()
+        LOG.info("Creation of root user and ssh remote login successful for {}".format(self.node))
+
+    def _perform_wipefs(self):
+        """
+        Perform wipefs on nodes where cephfs entries are found
+        root@argo026 ~]# lsblk
+        NAME                             MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
+        sda                              8:0    0 447.1G  0 disk
+        └─sda1                           8:1    0 447.1G  0 part /
+        sdb                              8:16   0   1.8T  0 disk
+        └─ceph--41d33927--a3ff...        253:1    0   1.8T  0 lvm
+        nvme0n1                          259:0    0 931.5G  0 disk
+        └─ceph--7050dc1e--428d-...       253:0    0 931.5G  0 lvm
+        :return:
+        """
+
+        get_all_disks = "lsblk -o NAME -d"
+        get_root_disk = r"lsblk -oMOUNTPOINT,PKNAME -rn | awk '$1 ~ /^\/$/ { print $2 }'"
+        root_conn = SSHConnectionManager(self.node, "root", "passwd")
+        conn = None
+        try:
+            conn = root_conn.get_client()
+        except Exception as conn_excep:
+            print("Failed to establish ssh connection over root user to {node} "
+                  "machine with {error}Aborting!".format(node=self.node, error=str(conn_excep)))
+            conn.close()
+            exit(1)
+
+        # Get all disks
+        _, out, _ = conn.exec_command(command=get_all_disks,)
+        all_disks = out.readlines()[1:]
+
+        # Get root disk
+        _, out, _ = conn.exec_command(command=get_root_disk,)
+        root_disk = out.readlines()
+
+        # For all the non root disk, perform wipefs
+        for non_root_disk in set(all_disks) - set(root_disk):
+            disk = (non_root_disk.strip())
+            cmd = "wipefs -a --force /dev/{}".format(disk)
+            _, out, _ = conn.exec_command(command=cmd, )
+            LOG.info(out.readlines())
+
+        LOG.info("wipefs completed on all disks")
+
+        # Perform a reboot - keep 600 secs
+        conn = self._reboot_node(conn)
+
+        # Verify the wipefs is successful by grepping for cephs in lsblk
+        cmd = "lsblk | grep ceph"
+        _, out, _ = conn.exec_command(
+            command=cmd,
+        )
+
+        res = out.readlines()
+        if res:
+            LOG.error("Ceph entry found in disk even after wipefs on {}."
+                      "Aborting!!".format(self.node))
+            exit(1)
+        conn.close()
+        LOG.info("Wipefs successful. No cephfs entry found on disks")
+
+    def _reboot_node(self, conn):
+        """
+        Reboots the node and waits till reboot is complete
+        :return: NIL
+        """
+        timeout = 600
+        start_time = datetime.now()
+        end_time = start_time + timedelta(seconds=timeout)
+
+        conn.exec_command("/sbin/reboot -f > /dev/null 2>&1 &")
+        LOG.info("Rebooted {}. Waiting for 60 secs".format(self.node))
+        sleep(60)
+        is_connected = False
+        while datetime.now() < end_time:
+            try:
+                root_conn = SSHConnectionManager(self.node, "root", "passwd")
+                conn = root_conn.get_client()
+                _, out, _ = conn.exec_command("hostname")
+                LOG.info("Connected back to {}".format(out.readlines()))
+                is_connected = True
+                break
+            except Exception:
+                LOG.info("Reboot on {} not complete. Waiting...".format(self.node))
+                sleep(20)
+        if not is_connected:
+            LOG.error("Timeout of 600 seconds reached. Reboot failed on {}."
+                      "Exiting!!".format(self.node))
+            exit(1)
+        else:
+            LOG.info("Reboot complete on {}".format(self.node))
+        return conn
 
     def _create_user(self, name: str = "cephuser") -> None:
         """

--- a/conf/pacific/cephfs/tier-0_fs_baremetal.yaml
+++ b/conf/pacific/cephfs/tier-0_fs_baremetal.yaml
@@ -1,0 +1,65 @@
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.8.128.0/21']
+      nodes:
+        -
+          hostname: magna076.ceph.redhat.com
+          ip: 10.8.128.76
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+        -
+          hostname: magna071.ceph.redhat.com
+          ip: 10.8.128.71
+          root_password: passwd
+          role:
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna074.ceph.redhat.com
+          ip: 10.8.128.74
+          root_password: passwd
+          role:
+            - mon
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna069.ceph.redhat.com
+          ip: 10.8.128.69
+          root_password: passwd
+          role:
+            - mds
+            - nfs
+        -
+          hostname: magna091.ceph.redhat.com
+          ip: 10.8.128.91
+          root_password: passwd
+          role:
+            - osd
+            - mds
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: magna095.ceph.redhat.com
+          ip: 10.8.128.95
+          root_password: passwd
+          role:
+            - nfs
+            - mds
+            - client

--- a/run.py
+++ b/run.py
@@ -64,6 +64,7 @@ A simple test suite wrapper that executes tests based on yaml test configuration
         [--cloud <openstack> | <ibmc> | <baremetal>]
         [--build <name>]
         [--inventory FILE]
+        [--rhel-version FLAVOUR-VERSION]
         [--osp-cred <file>]
         [--rhs-ceph-repo <repo>]
         [--ubuntu-repo <repo>]
@@ -107,6 +108,8 @@ Options:
   --global-conf <file>              global cloud configuration file
   --cluster-conf <file>             cluster configuration file
   --inventory <file>                hosts inventory file
+  --rhel-version <version>          version of the os to be installed
+                                    eg: 8.5, 7.9. Mandatory for baremetal
   --cloud <cloud_type>              cloud type [default: openstack]
   --osp-cred <file>                 openstack credentials as separate file
   --rhbuild <1.3.0>                 ceph downstream version
@@ -380,6 +383,11 @@ def run(args):
     # Deciders
     reuse = args.get("--reuse")
     cloud_type = args.get("--cloud")
+
+    # if cloud_type is baremetal, the rhel-version arg is mandatory
+    if "baremetal" in cloud_type and not args.get("--rhel-version"):
+        log.error("ERROR! --rhel-version is a mandatory argument for cloud type baremetal.")
+        exit(1)
 
     # These are not mandatory options
     inventory_file = args.get("--inventory")

--- a/suites/pacific/cephfs/tier-0_fs_baremetal.yaml
+++ b/suites/pacific/cephfs/tier-0_fs_baremetal.yaml
@@ -1,0 +1,140 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: magna076
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        args:
+          - ceph
+          - fs
+          - set
+          - cephfs
+          - max_mds
+          - "2"
+        command: shell
+      desc: "Add Active Active configuration of MDS for cephfs"
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Add Active Active configuration of MDS"
+      polarion-id: CEPH-11344
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: magna095
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Deploy MDS with default values using cephadm"
+      module: mds_default_values.py
+      name: cephfs default values for mds
+      polarion-id: "CEPH-83574284"
+  -
+    test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295"
+  -
+    test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+  - test:
+      name: Increase and Decrease of MDS
+      module: mds_Inc_dec.py
+      desc: Deploy mds using cephadm and increase & decrease number of mds.
+      polarion-id: CEPH-83574286
+      abort-on-fail: false
+  -
+    test:
+      desc: "generate sosreport"
+      module: sosreport.py
+      name: "generate sosreport"


### PR DESCRIPTION
This patch enables the cephci to execute tests in baremetal env.
There are three major steps added to handle this integration, as follows:

1. Re-image the baremetal node to the desired OS version
2. Enable remote login and create root credentials
3. Perform wipefs on all disks except the root and reboot

The re-imaging part is now handled via Teuthology framework. For this,
magna006 node has been configured with Teuthology and its dependecies.
All the Teuthology related commands are executed on the baremetal nodes
via Magna006 (Teuthology infra node).
As mentioned, the 'reimage' command is used to reimage the baremetal node
to the desired os and for the same, other Teuthology commands are also used
to identify the current owner, unlock/lock the node, release the node etc.

To enable the remote login, the ssh_config file of the node is searched for the
'PermitRootLogin yes', if not present, the same will be added. Also the root
password is reset to a predefined one for easier root access within the framework.
The first time connection is made possible via the magna002 ssh key which is copied
to the Teuthology infra node. This helps in connecting to the node before remote login
is permitted or root credentials are set

Once the reimage and remote logins setup are complete, the disks has to be cleared for
any previous ceph data (all except the root). Wipefs command is used to handle this.
This step is followed by a reboot command.

A new required argument is also added along with the changes. In run.py, '--rhel-version'
argument is added which helps the user to specify which version of Rhel should be used to
reimage the node. This parameter is mandatory if the cloud type is baremetal, else it can
be ignored

Attaching the complete run result with the changes

Run 1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Baremetal-Integration/
Run 2 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Baremetal-Integration-run2/

Signed-off-by: Pranav <prprakas@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
