### PR TITLE
fix for rados test suite failure

### DIFF
--- a/suites/pacific/rados/tier-3_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-ecpool-osd-rebalance.yaml
@@ -107,6 +107,6 @@ tests:
               k: 8
               m: 3
               plugin: jerasure
-              crush-failure-domain: host
+              crush-failure-domain: osd
         delete_pools:
           - ec_pool_9212


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for rados 5.3 failure.

logs - 
https://159.23.92.24/blue/organizations/jenkins/rhceph-test-execution-manual/detail/rhceph-test-execution-manual/57/pipeline

https://159.23.92.24/blue/rest/organizations/jenkins/pipelines/rhceph-test-execution-manual/runs/57/log/?start=0