### PR TITLE
Removing dependency on branch config

### DIFF
--- a/suites/pacific/integrations/cvp.yaml
+++ b/suites/pacific/integrations/cvp.yaml
@@ -102,7 +102,6 @@ tests:
         - test:
             desc: "Testing rbd CLI Generic scenarios using unit-tests."
             config:
-              branch: master
               script_path: qa/workunits/rbd
               script: cli_generic.sh
             module: test_rbd.py

--- a/suites/pacific/interop/test-ceph-sanity.yaml
+++ b/suites/pacific/interop/test-ceph-sanity.yaml
@@ -106,7 +106,6 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: master
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/suites/quincy/cephadm/sanity-test.yaml
+++ b/suites/quincy/cephadm/sanity-test.yaml
@@ -98,7 +98,6 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: master
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"


### PR DESCRIPTION
Now each test in suite name need not to have branch
Handling branch name decider would help individuals to avoid branch name in each test and also make changes accordingly each time.

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
