### PR TITLE
Add support for deploying release version binaries unavailable in CDN

### DIFF
--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -126,6 +126,9 @@ class ApplyMixin:
             return
 
         if not check_service_exists(
-            self.installer, service_name=service_name, service_type=self.SERVICE_NAME
+            self.installer,
+            service_name=service_name,
+            service_type=self.SERVICE_NAME,
+            rhcs_version=self.cluster.rhcs_version,
         ):
             raise OrchApplyServiceFailure(self.SERVICE_NAME)

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -6,7 +6,7 @@ from typing import Dict
 from ceph.ceph import ResourceNotFoundError
 from ceph.ceph_admin.cephadm_ansible import CephadmAnsible
 from utility.log import Log
-from utility.utils import get_cephci_config
+from utility.utils import fetch_build_artifacts, get_cephci_config
 
 from .common import config_dict_to_string
 from .helper import GenerateServiceSpec, create_ceph_config_file, validate_spec_services
@@ -171,10 +171,18 @@ class BootstrapMixin:
                 ftp://partners.redhat.com/d960e6f2052ade028fa16dfc24a827f5/rhel-8/Tools/x86_64/os/
 
             boolean:
-                True: use latest image from test config
-                False: do not use latest image from test config,
-                        and also indicates usage of default image from cephadm source-code.
+                True:   use the latest image from test config
+                False:  do not use the latest image from test config,
+                        and also indicates usage of default image from cephadm
+                        source-code.
 
+            # Install a released version unavailable in CDN
+                config:
+                  command: bootstrap
+                  args:
+                    rhcs-version: 5.0
+                    release: <ga | z1 | z1-async1>
+                    mon-ip: <node-name>
         """
         self.cluster.setup_ssh_keys()
         args = config.get("args")
@@ -182,6 +190,25 @@ class BootstrapMixin:
         custom_image = args.pop("custom_image", True)
         build_type = self.config.get("build_type")
         rhbuild = self.config.get("rhbuild")
+
+        # Support installation of the baseline cluster whose version is not available in
+        # CDN. This is primarily used for an upgrade scenario. This support is currently
+        # available only for RH network.
+        _rhcs_version = args.pop("rhcs-version")
+        _rhcs_release = args.pop("release")
+        if _rhcs_release and _rhcs_version:
+            _platform = "-".join(rhbuild.split("-")[1:])
+            _details = fetch_build_artifacts(_rhcs_release, _rhcs_version, _platform)
+
+            # The cluster object is configured so that the values are persistent till
+            # an upgrade occurs. This enables us to execute the test in the right
+            # context.
+            self.config["base_url"] = _details[0]
+            self.config[
+                "container_image"
+            ] = f"{_details[1]}/{_details[2]}:{_details[3]}"
+            self.cluster.rhcs_version = _rhcs_version
+            rhbuild = f"{_rhcs_version}-{_platform}"
 
         if build_type == "upstream":
             self.setup_upstream_repository()
@@ -335,6 +362,8 @@ class BootstrapMixin:
 
         # validate spec file
         if specs:
-            validate_spec_services(self.installer, specs=specs)
+            validate_spec_services(
+                self.installer, specs=specs, rhcs_version=self.cluster.rhcs_version
+            )
 
         return out, err

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -165,7 +165,11 @@ class Orch(
         # validate services
         validate_spec_svcs = config.get("validate-spec-services")
         if validate_spec_svcs:
-            validate_spec_services(installer=self.installer, specs=specs)
+            validate_spec_services(
+                installer=self.installer,
+                specs=specs,
+                rhcs_version=self.cluster.rhcs_version,
+            )
             LOG.info("Validation of service created using a spec file is completed")
 
     def op(self, op, config):

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -4,6 +4,8 @@ Test suite that verifies the deployment of Red Hat Ceph Storage via the cephadm 
 The intent of the suite is to simulate a standard operating procedure expected by a
 customer.
 """
+from copy import deepcopy
+
 from ceph.ceph import Ceph
 from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.alert_manager import AlertManager
@@ -113,8 +115,12 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                             - ceph osd pool create <pool_name> 3 3 replicated
     """
     LOG.info("Starting Ceph cluster deployment.")
-    config = kwargs["config"]
+
+    # Avoid shallow reference conflicts. This is done for supporting installation of
+    # RH Ceph versions unavailable in CDN.
+    config = deepcopy(kwargs["config"])
     config["overrides"] = kwargs.get("test_data", {}).get("custom-config")
+
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     try:
         steps = config.get("steps", [])

--- a/unittests/ceph/ceph_admin/test_apply.py
+++ b/unittests/ceph/ceph_admin/test_apply.py
@@ -4,9 +4,13 @@ import pytest
 from ceph.ceph_admin.apply import ApplyMixin, OrchApplyServiceFailure
 
 
+class MockCephCluster:
+    rhcs_version = ""
+
+
 class MockApplyMixinTestWithShellOutput(ApplyMixin):
     def __init__(self):
-        self.cluster = None
+        self.cluster = MockCephCluster()
         self.service_name = "rgw"
         self.installer = None
 
@@ -16,7 +20,7 @@ class MockApplyMixinTestWithShellOutput(ApplyMixin):
 
 class MockApplyMixinTestWithOutShellOutput(ApplyMixin):
     def __init__(self):
-        self.cluster = None
+        self.cluster = MockCephCluster()
         self.service_name = "rgw"
         self.installer = None
 
@@ -26,7 +30,7 @@ class MockApplyMixinTestWithOutShellOutput(ApplyMixin):
 
 class MockApplyMixinTestWithOutServiceOutput(ApplyMixin):
     def __init__(self):
-        self.cluster = None
+        self.cluster = MockCephCluster()
         self.service_name = "rgw"
         self.installer = None
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description
This PR adds support for deploying a base cluster version that is unavailable in the CDN repository. The reason could be a newer version was released. 

This support addresses the gap wherein a customer skip versions during upgrades.

Scope.
This support is limited to RH environment only.

Example
For 5.x
```
args:
  rhcs-version: 5.1   # RH Ceph Storage version
  release: ga            # Or any of the supported build values - ga, z1, z2, z1-async1, z1-async2
```

For 4.x
```
config:
  use_internal:
    rhcs-version: 4.2
    release: z2
  ansi_config:
    ceph_origin: distro
    ...
```

__Logs__
5: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/internal/5/
4: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/internal/4/