### PR TITLE
Fix Multisite testcase failure due to module used is of single site

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
@@ -324,11 +324,13 @@ tests:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
       polarion-id: CEPH-83573545
-      module: sanity_rgw.py
-      config:
-        script-name: test_bucket_listing.py
-        config-file-name: test_bucket_listing_pseudo_ordered.yaml
-        timeout: 300
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered.yaml
+            timeout: 300
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on primary
       desc: test_versioning_copy_objects on secondary

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
@@ -285,11 +285,13 @@ tests:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
       polarion-id: CEPH-83573545
-      module: sanity_rgw.py
-      config:
-        script-name: test_bucket_listing.py
-        config-file-name: test_bucket_listing_pseudo_ordered.yaml
-        timeout: 300
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered.yaml
+            timeout: 300
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on secondary
       desc: test_versioning_copy_objects on secondary

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
@@ -309,11 +309,13 @@ tests:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
       polarion-id: CEPH-83573545
-      module: sanity_rgw.py
-      config:
-        script-name: test_bucket_listing.py
-        config-file-name: test_bucket_listing_pseudo_ordered.yaml
-        timeout: 300
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered.yaml
+            timeout: 300
 
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on secondary


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Test case failed due to usage of single site module(sanity_rgw.py) in multisite setup
LOG: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JJ0433/ordered_listing_of_bucket_with_pseudo_directories_and_objects_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
