### PR TITLE
Automation - Add tc to validate deletion of the cluster logs after ce…

### DIFF
--- a/suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml
@@ -226,3 +226,12 @@ tests:
           ceph_origin: rhcs
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
           ireallymeanit: 'yes'
+  - test:
+      name: test deletion of the cluster logs in the cephadm rm-cluster
+      module: exec.py
+      polarion-id: CEPH-83575104
+      config:
+        commands:
+          - '[ ! -d "/var/log/ceph" ]'
+        sudo: true
+      desc: Verifies Log files from previous installations are cleared after executing purge-cluster playbook.


### PR DESCRIPTION
Add tc to validate deletion of the cluster logs after cephadm purge

This test validates whether the Log files from previous installations
are cleared after executing Cephadm-ansible purge playbook

Signed-off-by: Pranav <prprakas@redhat.com>

Polarion TC : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575104
Test Execution result : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-S217J2/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
