### PR TITLE
Tuning quincy rbd suite and adding stderr to log error

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1544,6 +1544,7 @@ class CephNode(object):
                 logger.info("Command completed successfully")
             else:
                 logger.error(f"Error {exit_status} during cmd, timeout {timeout}")
+                logger.error(stderr)
                 raise CommandFailed(
                     f"{kw['cmd']} Error:  {str(stderr)} {str(self.ip_address)}"
                 )

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -212,8 +212,10 @@ class BootstrapMixin:
 
         if build_type == "upstream":
             self.setup_upstream_repository()
-            # work-around to enable ceph x86_64 RPM pkgs.
-            # which is currently unavailable in upstream builds.
+            logger.info(
+                "Enabling cdn tool repo to workaround ",
+                "unavailability of ceph x86_64 RPM pkgs in upstream builds",
+            )
             self.set_cdn_tool_repo()
         elif build_type == "released" or custom_repo.lower() == "cdn":
             custom_image = False

--- a/suites/quincy/rbd/basic-operations-unit-testing.yaml
+++ b/suites/quincy/rbd/basic-operations-unit-testing.yaml
@@ -101,7 +101,6 @@ tests:
   -
     test:
       config:
-        branch: master
         script: cli_generic.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Generic scenarios"
@@ -111,7 +110,6 @@ tests:
   -
     test:
       config:
-        branch: master
         script: rbd_groups.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Groups scenarios"
@@ -121,7 +119,6 @@ tests:
   -
     test:
       config:
-        branch: master
         script: import_export.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Import Export scenarios"
@@ -131,7 +128,6 @@ tests:
   -
     test:
       config:
-        branch: master
         script: luks-encryption.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD LUKS Encryption scenarios"
@@ -141,7 +137,6 @@ tests:
   -
     test:
       config:
-        branch: master
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"


### PR DESCRIPTION
1) Tuning Quincy suite to branch name changes in upstream.
2) Adding stderr to log.error to help users to identify issue in reportportal itself.
3) Adding workaround info to logs to avoid users looking at the logs getting confused

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
