### PR TITLE
Adding Recommendation for the failures with older runs

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1280,6 +1280,7 @@ def tfacon(launch_id):
     auth_token = tfacon_cfg.get("auth_token")
     platform_url = tfacon_cfg.get("platform_url")
     tfa_url = tfacon_cfg.get("tfa_url")
+    re_url = tfacon_cfg.get("re_url")
     connector_type = tfacon_cfg.get("connector_type")
     cmd = (
         f"~/.local/bin/tfacon run --auth-token {auth_token} "
@@ -1287,6 +1288,7 @@ def tfacon(launch_id):
         f"--platform-url {platform_url} "
         f"--project-name {project_name} "
         f"--tfa-url {tfa_url} "
+        f"--re-url {re_url} -r "
         f"--launch-id {launch_id}"
     )
     log.info(cmd)
@@ -1298,6 +1300,7 @@ def tfacon(launch_id):
         stderr=subprocess.PIPE,
     )
     result, result_err = p1.communicate()
+
     log.info(result.decode("utf-8"))
     if p1.returncode != 0:
         log.warning("Unable to get the TFA anaylsis for the results")


### PR DESCRIPTION
We have added an option to tfacon command to get the recommendations based on the older failures that have occurred.
![image](https://user-images.githubusercontent.com/80021994/186250810-d02193f5-5a19-478c-bcc2-d932bd694bfa.png)


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
