### PR TITLE
[Cephci]: Include CEPH-83574806 into suites

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_s3cmd_test-bucket-object-stats.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_s3cmd_test-bucket-object-stats.yaml
@@ -52,3 +52,13 @@ tests:
         script-name: ../s3cmd/test_header_size.py
         config-file-name: ../../s3cmd/configs/test_header_size.yaml
         timeout: 300
+
+  - test:
+      name: Test single delete marker for versioned object using s3cmd
+      desc: Test single delete marker for versioned object using s3cmd
+      polarion-id: CEPH-83574806
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -148,3 +148,12 @@ tests:
         config-file-name: ../../s3cmd/configs/test_rgw_opslog.yaml
         timeout: 300
 
+  - test:
+      name: Test single delete marker for versioned object using s3cmd
+      desc: Test single delete marker for versioned object using s3cmd
+      polarion-id: CEPH-83574806
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
+        timeout: 300


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
Include CEPH-83574806 into suites
Testing single delete marker creation for versioned object.

Logs: [5.3]- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TTLZ8E/
          [4.3]- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K22WCZ/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
