### PR TITLE
Automation - Add tc to validate host can be safely stopped without re…

### DIFF
--- a/suites/pacific/cephadm/tier-0_cephadm.yaml
+++ b/suites/pacific/cephadm/tier-0_cephadm.yaml
@@ -86,6 +86,11 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
   - test:
+      name: test_validate_safe_stop_hosts
+      desc: Verify if a host be safely stopped without reducing the availability using ceph orch ok-to-stop command
+      polarion-id: CEPH-83573767
+      module: test_node_safe_stop.py
+  - test:
       name: Remove Host label
       desc: Remove host label osd from node3
       module: test_host.py

--- a/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
@@ -272,4 +272,3 @@ tests:
       desc: Adding admin node again with different labels  does not remove ceph.client.admin.keyring  and ceph.conf file
       polarion-id: CEPH-83574671
       module: test_admin_add_labels.py
-

--- a/tests/cephadm/test_node_safe_stop.py
+++ b/tests/cephadm/test_node_safe_stop.py
@@ -1,0 +1,60 @@
+from ceph.ceph import CommandFailed
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class IncorrectAlertWarningError(Exception):
+    pass
+
+
+def run(ceph_cluster, **kw):
+    """
+    Verify if a host be safely stopped without reducing the availability
+     using ceph orch ok-to-stop command
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        **kw :     Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+    """
+
+    config = kw.get("config")
+
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+
+    ok_to_stop_cmd = "cephadm shell ceph orch host ok-to-stop"
+
+    roles = ["installer", "rgw", "osd", "mgr"]
+    # - When trying to stop the installer_node, it should raise an Alert as
+    #   there is an active mgr running
+    # - Validate no ALERT/WARNING messages are shown when trying to remove a safe node
+    # - When trying to stop RGW node, it should raise a WARNING saying removing
+    #    RGW daemon cause clients to lose connectivity (based on the conf, else no warnings)
+    # -. Validate no ALERT/WARNING messages are shown when trying to remove a safe node
+
+    for role in roles:
+        node = ceph_cluster.get_nodes(role=role)[0]
+        _shortname = node.shortname
+        try:
+            _, err = cephadm.installer.exec_command(
+                cmd=f"{ok_to_stop_cmd} {_shortname}", sudo=True
+            )
+            if "WARNING" in err or "ALERT" in err:
+                if role == "rgw":
+                    raise IncorrectAlertWarningError(
+                        f"Unexpected WARNING/ALERT message shown for {role} : {_shortname}"
+                    )
+            else:
+                if role != "rgw":
+                    raise IncorrectAlertWarningError(
+                        f"No expected ALERT/WARNING message shown for {role} : {_shortname}"
+                    )
+        except CommandFailed:
+            log.error(f"Failed to execute ok-to-stop cmd on {role} node : {_shortname}")
+            return 1
+
+    return 0


### PR DESCRIPTION
Add tc to validate host can be safely stopped without reducing the availability

This test validates the host ok-to-stop command and the Warnings/Alerts returned

Test result : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-81ZA5Z
Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573767

Updated Test result : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YIPSXY/

Signed-off-by: Pranav <prprakas@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
