### PR TITLE
[RHCEPHQE-4994] Adding RHCS 6.0 deployment by layered products

### DIFF
--- a/conf/inventory/rhel-9.0-server-x86_64-large.yaml
+++ b/conf/inventory/rhel-9.0-server-x86_64-large.yaml
@@ -1,0 +1,47 @@
+---
+version_id: 9.0
+id: rhel
+instance:
+  create:
+    image-name: RHEL-9.0.0-x86_64-ga-latest
+    vm-size: ci.m1.large
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: True
+    disable_root: false
+
+    groups:
+        - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4eHmz10szeHNS3dNejKokW85ksB+iR4HGOFsmQM11Ni68Nm5aqEKvkOZU8TpY92vpCQL0A68GlrXB845cACdyk6HUJYyNNNMC43l1FYWOwjMqQBSdj8W3VQDTA6eiG60mt5fgI8fyR38rKzIA1MnTBkSSjuh5kQVJ9bdEp3GuY5oc8vxDNBlGJ6LYnyEWt/pqL2J+mpjqnOjsC+EbE2exhP9O+mvzpQiyo/+dEN1COwX3//pNRXGfOSeOczHNsJE8Eu+j/n/BlW57++sJyFMkzS7bUxMSGM6quvjQZ7RT1c5JM6vLEiQyzQxoRgzY93h1yKlOstBi0NamtpqHQZGP kdreyer@redhat.com
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser:pass123
+      expire: False
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - subscription-manager clean
+      - hostnamectl set-hostname $(hostname -s)
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+      - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
+      - update-ca-trust
+      - yum clean metadata
+      - yum clean all
+      - touch /ceph-qa-ready
+
+    final_message: "Ready for ceph qa testing"

--- a/conf/quincy/integrations/6node-all-roles.yaml
+++ b/conf/quincy/integrations/6node-all-roles.yaml
@@ -1,0 +1,35 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - mds
+          - osd
+          - rgw
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - client

--- a/conf/quincy/integrations/7_node_ceph.yaml
+++ b/conf/quincy/integrations/7_node_ceph.yaml
@@ -1,0 +1,57 @@
+# System Under Test environment configuration for OCS-RHCeph integration.
+---
+globals:
+  - ceph-cluster:
+      name: ceph
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+          - client
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mgr
+          - mon
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node6:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - mds
+          - osd
+
+      node7:
+        disk-size: 20
+        no-of-volumes: 6
+        role:
+          - osd
+          - rgw

--- a/suites/pacific/integrations/ocs_rgw_ssl.yaml
+++ b/suites/pacific/integrations/ocs_rgw_ssl.yaml
@@ -1,0 +1,113 @@
+# This test suite deploys the required environment for OCS CI to validate with external
+# Ceph cluster. Only cluster deployment is validated and the rest of validation occurs
+# in OCS / ODF CI.
+---
+tests:
+
+  - test:
+      abort-on-fail: true
+      desc: "Install prerequisites for RHCeph cluster deployment."
+      module: install_prereq.py
+      name: "test suite setup"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          mon-ip: node1
+        command: bootstrap
+        service: cephadm
+      desc: "Bootstrap the cluster with minimal configuration."
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Test cluster deployment using cephadm"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          attach_ip_address: true
+          labels: apply-all-labels
+        command: add_hosts
+        service: host
+      desc: "Adding hosts to the cluster using labels and IP information."
+      destroy-cluster: false
+      module: test_host.py
+      name: "Test host add with labels and IP"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          all-available-devices: true
+        command: apply
+        service: osd
+      desc: "Deploying OSD daemons using all-available-devices option."
+      destroy-cluster: false
+      module: test_osd.py
+      name: "Test apply osd with all-available-devices option"
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: apply_spec
+        specs:
+          - service_type: rgw
+            service_id: rgw.ssl
+            placement:
+              nodes:
+                - node7
+            spec:
+              ssl: true
+              rgw_frontend_ssl_certificate: create-cert
+      desc: "Deploying RGW endpoint which is SSL terminated."
+      destroy-cluster: false
+      module: test_rgw.py
+      name: "Test rgw ssl endpoint using spec"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - ceph fs volume create fsvol001 --placement='4 label:mds'
+          - ceph fs set fsvol001 max_mds 2
+      desc: "Create and configure a volume with 2 MDS limit"
+      destroy-cluster: false
+      module: exec.py
+      name: "Create volume with"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          placement:
+            label: mds
+        command: apply
+        pos_args:
+          - fsvol001
+        service: mds
+      desc: Test deploying MDS daemons on hosts with label mds.
+      destroy-cluster: false
+      module: test_mds.py
+      name: Test OSD daemon deployment with all-available-devices enabled.
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node1
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the ceph client
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      desc: "Retrieve the deployed cluster information."
+      module: gather_cluster_info.py
+      name: "Get ceph cluster details."

--- a/suites/quincy/integrations/cvp.yaml
+++ b/suites/quincy/integrations/cvp.yaml
@@ -102,7 +102,7 @@ tests:
         - test:
             desc: "Testing rbd CLI Generic scenarios using unit-tests."
             config:
-              branch: v16.2.8
+              branch: v17.2.3
               script_path: qa/workunits/rbd
               script: cli_generic.sh
             module: test_rbd.py

--- a/suites/quincy/integrations/ocs.yaml
+++ b/suites/quincy/integrations/ocs.yaml
@@ -1,0 +1,110 @@
+# This test suite deploys the required environment for OCS CI to validate with external
+# Ceph cluster. Only cluster deployment is validated and the rest of validation occurs
+# in OCS / ODF CI.
+---
+tests:
+
+  - test:
+      abort-on-fail: true
+      desc: "Install prerequisites for RHCeph cluster deployment."
+      module: install_prereq.py
+      name: "test suite setup"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          mon-ip: node1
+        command: bootstrap
+        service: cephadm
+      desc: "Bootstrap the cluster with minimal configuration."
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Test cluster deployment using cephadm"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          attach_ip_address: true
+          labels: apply-all-labels
+        command: add_hosts
+        service: host
+      desc: "Adding hosts to the cluster using labels and IP information."
+      destroy-cluster: false
+      module: test_host.py
+      name: "Test host add with labels and IP"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          all-available-devices: true
+        command: apply
+        service: osd
+      desc: "Deploying OSD daemons using all-available-devices option."
+      destroy-cluster: false
+      module: test_osd.py
+      name: "Test apply osd with all-available-devices option"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          placement:
+            label: rgw
+        command: apply
+        pos_args:
+          - rgw.1
+        service: rgw
+      desc: "Deploying RGW daemon using label placement."
+      destroy-cluster: false
+      module: test_rgw.py
+      name: "Test apply rgw with label"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - ceph fs volume create fsvol001 --placement='4 label:mds'
+          - ceph fs set fsvol001 max_mds 2
+      desc: "Create and configure a volume with 2 MDS limit"
+      destroy-cluster: false
+      module: exec.py
+      name: "Create volume with"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          placement:
+            label: mds
+        command: apply
+        pos_args:
+          - fsvol001
+        service: mds
+      desc: Test deploying MDS daemons on hosts with label mds.
+      destroy-cluster: false
+      module: test_mds.py
+      name: Test OSD daemon deployment with all-available-devices enabled.
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node1
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the ceph client
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      desc: "Retrieve the deployed cluster information."
+      module: gather_cluster_info.py
+      name: "Get ceph cluster details."

--- a/suites/quincy/integrations/ocs_rgw_ssl.yaml
+++ b/suites/quincy/integrations/ocs_rgw_ssl.yaml
@@ -1,0 +1,113 @@
+# This test suite deploys the required environment for OCS CI to validate with external
+# Ceph cluster. Only cluster deployment is validated and the rest of validation occurs
+# in OCS / ODF CI.
+---
+tests:
+
+  - test:
+      abort-on-fail: true
+      desc: "Install prerequisites for RHCeph cluster deployment."
+      module: install_prereq.py
+      name: "test suite setup"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          mon-ip: node1
+        command: bootstrap
+        service: cephadm
+      desc: "Bootstrap the cluster with minimal configuration."
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Test cluster deployment using cephadm"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          attach_ip_address: true
+          labels: apply-all-labels
+        command: add_hosts
+        service: host
+      desc: "Adding hosts to the cluster using labels and IP information."
+      destroy-cluster: false
+      module: test_host.py
+      name: "Test host add with labels and IP"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          all-available-devices: true
+        command: apply
+        service: osd
+      desc: "Deploying OSD daemons using all-available-devices option."
+      destroy-cluster: false
+      module: test_osd.py
+      name: "Test apply osd with all-available-devices option"
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: apply_spec
+        specs:
+          - service_type: rgw
+            service_id: rgw.ssl
+            placement:
+              nodes:
+                - node7
+            spec:
+              ssl: true
+              rgw_frontend_ssl_certificate: create-cert
+      desc: "Deploying RGW endpoint which is SSL terminated."
+      destroy-cluster: false
+      module: test_rgw.py
+      name: "Test rgw ssl endpoint using spec"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - ceph fs volume create fsvol001 --placement='4 label:mds'
+          - ceph fs set fsvol001 max_mds 2
+      desc: "Create and configure a volume with 2 MDS limit"
+      destroy-cluster: false
+      module: exec.py
+      name: "Create volume with"
+
+  - test:
+      abort-on-fail: true
+      config:
+        args:
+          placement:
+            label: mds
+        command: apply
+        pos_args:
+          - fsvol001
+        service: mds
+      desc: Test deploying MDS daemons on hosts with label mds.
+      destroy-cluster: false
+      module: test_mds.py
+      name: Test OSD daemon deployment with all-available-devices enabled.
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node1
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the ceph client
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      desc: "Retrieve the deployed cluster information."
+      module: gather_cluster_info.py
+      name: "Get ceph cluster details."


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Adding support to deploying a Ceph cluster with RGW SSL daemon. This spec is deployed when `rgw_secure: true` is provided in the UMB message.

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/4994/
https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/job/rhceph-deploy-cluster/41/console
