### PR TITLE
add a check to verify radoslist and bucket stats before and after upgrade

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -77,16 +77,16 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_manual_resharding.yaml
+        config-file-name: test_manual_resharding_without_bucket_delete.yaml
         timeout: 500
   - test:
-      name: Dynamic Resharding tests pre upgrade
+      name: Dynamic Resharding tests with version pre upgrade
       desc: Resharding test - dynamic
       polarion-id: CEPH-83571740
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding.yaml
+        config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
         timeout: 500
 
   # lifecycle tests
@@ -109,6 +109,16 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration.py
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
         timeout: 300
+
+  - test:
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+      desc: Test bucket stats and radoslist on all buckets
+      module: sanity_rgw.py
+      name: test bucket stats and radoslist
+      polarion-id: CEPH-83574480
 
   # switch from rpm to container
   - test:
@@ -194,7 +204,7 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_manual_resharding.yaml
+        config-file-name: test_manual_resharding_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -204,7 +214,7 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding.yaml
+        config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
         timeout: 500
 
   # lifecycle tests
@@ -238,3 +248,13 @@ tests:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
         timeout: 300
+
+  - test:
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+      desc: Test bucket stats and radoslist on all buckets
+      module: sanity_rgw.py
+      name: test bucket stats and radoslist
+      polarion-id: CEPH-83574480

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
@@ -107,7 +107,7 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding.yaml
+        config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -160,6 +160,15 @@ tests:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_version_copy_op.yaml
         timeout: 500
+  - test:
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+      desc: Test bucket stats and radoslist on all buckets
+      module: sanity_rgw.py
+      name: test bucket stats and radoslist
+      polarion-id: CEPH-83574480
 
 # Perform upgrade and some parallel IOs
   - test:
@@ -233,13 +242,13 @@ tests:
 
 # Dynamic resharding test
   - test:
-      name: Dynamic Resharding tests post upgrade
+      name: Dynamic Resharding tests with version post upgrade
       desc: Resharding test - dynamic
       polarion-id: CEPH-83571740
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding.yaml
+        config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -293,3 +302,13 @@ tests:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_version_copy_op.yaml
         timeout: 500
+
+  - test:
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+      desc: Test bucket stats and radoslist on all buckets
+      module: sanity_rgw.py
+      name: test bucket stats and radoslist
+      polarion-id: CEPH-83574480

--- a/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
@@ -216,7 +216,7 @@ tests:
     module: sanity_rgw.py
     config:
       script-name: test_dynamic_bucket_resharding.py
-      config-file-name: test_manual_resharding.yaml
+      config-file-name: test_manual_resharding_without_bucket_delete.yaml
       timeout: 500
 - test:
     name: dynamic resharding tests pre upgrade
@@ -225,7 +225,7 @@ tests:
     module: sanity_rgw.py
     config:
       script-name: test_dynamic_bucket_resharding.py
-      config-file-name: test_dynamic_resharding.yaml
+      config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
       timeout: 500
 
 - test:
@@ -247,6 +247,15 @@ tests:
       script-name: test_dynamic_bucket_resharding.py
       config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
       timeout: 500
+- test:
+    name: test bucket stats and radoslist
+    desc: Test bucket stats and radoslist on all buckets
+    polarion-id: CEPH-83574480
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_radoslist.yaml
+      timeout: 300
 
 # switch from rpm to container
 - test:
@@ -437,7 +446,7 @@ tests:
     module: sanity_rgw.py
     config:
       script-name: test_dynamic_bucket_resharding.py
-      config-file-name: test_manual_resharding.yaml
+      config-file-name: test_manual_resharding_without_bucket_delete.yaml
       timeout: 500
 - test:
     name: dynamic resharding tests post upgrade
@@ -446,7 +455,7 @@ tests:
     module: sanity_rgw.py
     config:
       script-name: test_dynamic_bucket_resharding.py
-      config-file-name: test_dynamic_resharding.yaml
+      config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
       timeout: 500
 
 - test:
@@ -468,3 +477,13 @@ tests:
       script-name: test_dynamic_bucket_resharding.py
       config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
       timeout: 500
+
+- test:
+    name: test bucket stats and radoslist
+    desc: Test bucket stats and radoslist on all buckets
+    polarion-id: CEPH-83574480
+    module: sanity_rgw.py
+    config:
+      script-name: test_bucket_listing.py
+      config-file-name: test_bucket_radoslist.yaml
+      timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
@@ -108,7 +108,7 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding.yaml
+        config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -118,7 +118,17 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_manual_resharding.yaml
+        config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        timeout: 500
+
+  - test:
+      name: Dynamic Resharding tests with version pre upgrade
+      desc: Resharding test - dynamic
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -150,6 +160,16 @@ tests:
       module: sanity_rgw.py
       name: swift basic operations pre upgrade
       polarion-id: CEPH-11019
+
+  - test:
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+      desc: Test bucket stats and radoslist on all buckets
+      module: sanity_rgw.py
+      name: test bucket stats and radoslist
+      polarion-id: CEPH-83574480
 
 # Perform upgrade
   - test:
@@ -203,7 +223,7 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_dynamic_resharding.yaml
+        config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -213,7 +233,17 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
-        config-file-name: test_manual_resharding.yaml
+        config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        timeout: 500
+
+  - test:
+      name: Dynamic Resharding tests with version post upgrade
+      desc: Resharding test - dynamic
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
         timeout: 500
 
   - test:
@@ -245,3 +275,13 @@ tests:
       module: sanity_rgw.py
       name: swift basic operations post upgrade
       polarion-id: CEPH-11019
+
+  - test:
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_radoslist.yaml
+        timeout: 300
+      desc: Test bucket stats and radoslist on all buckets
+      module: sanity_rgw.py
+      name: test bucket stats and radoslist
+      polarion-id: CEPH-83574480


### PR DESCRIPTION

Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Add verify of radoslist and bucket stats in the upgrade path

Pass logs:
suite: tier-1_rgw_test_upgrade-5-to-latest.yaml 
log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IHPMHH/
suite: tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4A2GGU/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
