### PR TITLE
Multipart object expiration with lc debug interval 600

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
@@ -70,3 +70,13 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration.py
         config-file-name: test_lc_current_version_object_expiration.yaml
         timeout: 300
+
+  - test:
+      name: Multipart object expiration through lc
+      desc: Multipart object expiration with lc debug interval 600
+      polarion-id: CEPH-83574803
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lc_object_exp_multipart.py
+        config-file-name: test_bucket_lc_multipart_object_expiration.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
@@ -95,3 +95,12 @@ tests:
         config-file-name: test_lc_current_version_object_expiration.yaml
         timeout: 300
 
+  - test:
+      name: Multipart object expiration through lc
+      desc: Multipart object expiration with lc debug interval 600
+      polarion-id: CEPH-83574803
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lc_object_exp_multipart.py
+        config-file-name: test_bucket_lc_multipart_object_expiration.yaml
+        timeout: 300


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Multipart object expiration with lc debug interval 600
4.3 log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3QI9IM/Multipart_object_expiration_through_lc_0.log
5.3 log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HEQ5JV/Multipart_object_expiration_through_lc_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
