### PR TITLE
Enabling dashboard for OCS requested deployments

### DIFF
--- a/conf/nautilus/integrations/7_node_ceph.yaml
+++ b/conf/nautilus/integrations/7_node_ceph.yaml
@@ -32,6 +32,7 @@ globals:
         role:
           - mds
           - osd
+          - grafana
 
       node5:
         disk-size: 20

--- a/suites/nautilus/integrations/ocs.yaml
+++ b/suites/nautilus/integrations/ocs.yaml
@@ -15,11 +15,20 @@ tests:
           ceph_test: true
           ceph_origin: distro
           ceph_repository: rhcs
+          ceph_rhcs_version: 4
           osd_scenario: lvm
           osd_auto_discovery: false
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               mon_warn_on_insecure_global_id_reclaim_allowed: false


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

Addresses the issue described in RHCEPHQE-5016, wherein there is a need to have dashboard and monitoring stack enabled.

__Logs__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/5016/