### PR TITLE
This fix will add support of updating pip package required for paramiko package

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -194,6 +194,7 @@ def set_test_env(config, rgw_node):
     rgw_node.exec_command(cmd="sudo mkdir " + test_folder)
     utils.clone_the_repo(config, rgw_node, test_folder_path)
 
+    rgw_node.exec_command(cmd="sudo pip3 install --upgrade pip")
     rgw_node.exec_command(
         cmd=f"sudo pip3 install -r {test_folder}/ceph-qe-scripts/rgw/requirements.txt"
     )


### PR DESCRIPTION
We have added paramiko package in ceph-qe-script and it needs updated pip version
This fix will add support of updating pip package

Following is the log of successful run
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RSZ65T/ (Please avoid known failures)
Signed-off-by: uday kurundwade <ukurundw@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
