### PR TITLE
Integrate testcase single deletemarker for versioned object using LC

### DIFF
--- a/suites/nautilus/rgw/tier-1-extn_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw.yaml
@@ -174,3 +174,13 @@ tests:
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
         timeout: 300
+
+  - test:
+      name: Test single delete marker for versioned object using LC
+      desc: Test single delete marker for versioned object using LC
+      polarion-id: CEPH-83574806
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_multiple_delete_marker.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -202,3 +202,13 @@ tests:
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
         timeout: 300
+
+  - test:
+      name: Test single delete marker for versioned object using LC
+      desc: Test single delete marker for versioned object using LC
+      polarion-id: CEPH-83574806
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_multiple_delete_marker.yaml
+        timeout: 300


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Integrate test case single delete marker for versioned object using LC in cephci
Polarian ID: CEPH-83574806

Logs:
Nautilus: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AFAXIF/
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JAKM6T/

Failure in provided log is handled in the PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/322
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
