### PR TITLE
Abort the test suite when client is not properly configured

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
@@ -1,5 +1,5 @@
 # Suite contains tests related to election strategy and Stretched mode
-
+---
 tests:
   - test:
       name: setup install pre-requisistes
@@ -64,34 +64,35 @@ tests:
           - config:
               command: apply
               service: mds
-              base_cmd_args:          # arguments to ceph orch
+              base_cmd_args:
                 verbose: true
               pos_args:
-                - cephfs              # name of the filesystem
+                - cephfs
               args:
                 placement:
                   nodes:
                     - node2
                     - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
+                  limit: 2
+                  sep: " "
       destroy-cluster: false
       abort-on-fail: true
 
   - test:
+      abort-on-fail: true
       name: Configure client admin
       desc: Configures client admin node on cluster
       module: test_client.py
-      polarion-id:
+      polarion-id: CEPH-83573758
       config:
         command: add
-        id: client.1                      # client Id (<type>.<Id>)
-        node: node8                       # client node
+        id: client.1
+        node: node8
         install_packages:
           - ceph-common
           - ceph-base
-        copy_admin_keyring: true          # Copy admin keyring to node
-        caps:                             # authorize client capabilities
+        copy_admin_keyring: true
+        caps:
           mon: "allow *"
           osd: "allow *"
           mds: "allow *"
@@ -157,18 +158,21 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   # Running basic rbd and rgw tests after deployment of stretch cluster
+
   - test:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
-          io-total: 100M
+        io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
+      polarion-id: CEPH-9876
 
   - test:
       name: rgw sanity tests
       module: sanity_rgw.py
       config:
-          script-name: test_multitenant_user_access.py
-          config-file-name: test_multitenant_access.yaml
-          timeout: 300
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
       desc: Perform rgw tests
+      polarion-id: CEPH-9740

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
@@ -1,5 +1,5 @@
 # Suite contains tests related to election strategy and Stretched mode
-
+---
 tests:
   - test:
       name: setup install pre-requisistes
@@ -47,7 +47,7 @@ tests:
                 all-available-devices: true
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:
                 - ceph
                 - fs
                 - volume
@@ -64,17 +64,17 @@ tests:
           - config:
               command: apply
               service: mds
-              base_cmd_args:          # arguments to ceph orch
+              base_cmd_args:
                 verbose: true
               pos_args:
-                - cephfs              # name of the filesystem
+                - cephfs
               args:
                 placement:
                   nodes:
                     - node2
                     - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
+                  limit: 2
+                  sep: " "
       destroy-cluster: false
       abort-on-fail: true
 
@@ -82,16 +82,16 @@ tests:
       name: Configure client admin
       desc: Configures client admin node on cluster
       module: test_client.py
-      polarion-id:
+      polarion-id: CEPH-83573758
       config:
         command: add
-        id: client.1                      # client Id (<type>.<Id>)
-        node: node8                       # client node
+        id: client.1
+        node: node8
         install_packages:
           - ceph-common
           - ceph-base
-        copy_admin_keyring: true          # Copy admin keyring to node
-        caps:                             # authorize client capabilities
+        copy_admin_keyring: true
+        caps:
           mon: "allow *"
           osd: "allow *"
           mds: "allow *"
@@ -157,18 +157,21 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   # Running basic rbd and rgw tests after deployment of stretch cluster
+
   - test:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
-          io-total: 100M
+        io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
+      polarion-id: CEPH-9876
 
   - test:
       name: rgw sanity tests
       module: sanity_rgw.py
       config:
-          script-name: test_multitenant_user_access.py
-          config-file-name: test_multitenant_access.yaml
-          timeout: 300
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
       desc: Perform rgw tests
+      polarion-id: CEPH-9740


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

`Deploy stretch cluster` test suite has a dependency on `configure client` suite hence aborting the run when it fails.

__Logs__
https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/1232/console