### PR TITLE
adding singlesite to multisite migration suite in rgw pacific

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -1043,3 +1043,19 @@
     - ibmc
     - rgw
     - stage-6
+
+- name: "test-rgw-singlesite-to-multisite-tier-2"
+  suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
+  global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2

--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -1,0 +1,402 @@
+# Below are the multi-site test scenarios run on the master and verified the sync/io on the slave
+# The test  will create a primary site 'ceph-pri', write IOs on the first site, indeuce delay of 10ms on first site and second site, and then convert it to a multisite and test sync.
+# ceph-pri is master/primary site
+# ceph-sec is slave/secondary site
+
+tests:
+  - test:
+      name: pre-req
+      module: install_prereq.py
+      abort-on-fail: true
+      desc: install ceph pre requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+      polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  # Test work flow before migration
+
+  - test:
+      name: create user
+      desc: create non-tenanted user
+      polarion-id: CEPH-83575199
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects on primary(single site)
+      polarion-id: CEPH-9789
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_compression on primary(single site)
+      polarion-id: CEPH-11350
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_aws4 on primary(single site)
+      polarion-id: CEPH-9637
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_delete on primary(single site)
+      polarion-id: CEPH-14237
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_download on primary(single site)
+      polarion-id: CEPH-14237
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_enc on primary(single site)
+      polarion-id: CEPH-11358 # also applies to CEPH-11361
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
+            timeout: 300
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_multipart on primary(single site)
+      polarion-id: CEPH-9801
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_ordered_versionsing on primary(single site)
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            timeout: 300
+
+  - test:
+      name: Bucket listing test
+      desc: test_bucket_listing_flat_unordered.yaml on primary(single site)
+      polarion-id: CEPH-83573545
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_unordered.yaml
+            timeout: 300
+
+  - test:
+      name: Buckets Versioning test
+      desc: test_versioning_objects_acls on on primary(single site)
+      polarion-id: CEPH-9190
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_acls.yaml
+            timeout: 300
+
+  # migrating from singlesite to multisite
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on primary
+      polarion-id: CEPH-83575227
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on secondary
+      polarion-id: CEPH-83575227
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 30ms 6ms distribution normal
+        ceph-sec:
+          config:
+            roles:
+              - rgw
+            rule: root netem delay 20ms 5ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+      polarion-id: CEPH-83575222
+
+  # Test work flow after migration
+
+  - test:
+      name: create user
+      desc: create tenanted user
+      polarion-id: CEPH-83575199
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_modify.yaml on secondary
+      polarion-id: CEPH-11214
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_modify.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_delete.yaml on secondary
+      polarion-id: CEPH-11213
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_delete.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+
+  - test:
+      name: Bucket policy tests
+      desc: test_bucket_policy_replace on secondary
+      polarion-id: CEPH-11215
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_replace.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300


### PR DESCRIPTION
# Description
Singlesite to multisite migration suite exists in nautilus suites. This PR adds same kind of test suite in pacific.
logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-77HGVW/
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
