### PR TITLE
Update ceph packages post-upgrade to avoid failure

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
@@ -259,6 +259,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
             timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
@@ -340,6 +340,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
             verify-io-on-site: ["ceph-sec"]

--- a/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
@@ -368,6 +368,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
             timeout: 300


### PR DESCRIPTION
We are seeing test case failures for MS suites after upgrading cluster.
This is happening due to older version of ceph package installed outside of the container.
Thsi PR will fix this issue by updating ceph packages outside of the container after upgrade.

Following is the log link of successful run:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7IK8M7

Signed-off-by: uday kurundwade <ukurundw@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
