### PR TITLE
Integrate testcase CEPH-11192 in ceph-ci

### DIFF
--- a/pipeline/metadata/4.3.yaml
+++ b/pipeline/metadata/4.3.yaml
@@ -733,3 +733,19 @@
     - ibmc
     - rgw
     - stage-5
+
+- name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+  suite: "suites/nautilus/rgw/tier-2_rgw_test-lc-prefix.yaml"
+  global-conf: "conf/nautilus/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "4.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-1

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -736,3 +736,19 @@
     - ibmc
     - rgw
     - stage-1
+
+- name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+  suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
+  global-conf: "conf/nautilus/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.1"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-2

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -1043,3 +1043,19 @@
     - ibmc
     - rgw
     - stage-6
+
+- name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+  suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
+  global-conf: "conf/nautilus/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.2"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -1043,3 +1043,19 @@
     - ibmc
     - rgw
     - stage-6
+
+- name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+  suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
+  global-conf: "conf/nautilus/rgw/tier-0_rgw.yaml"
+  platform: "rhel-8"
+  rhbuild: "5.3"
+  inventory:
+    openstack: "conf/inventory/rhel-8-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+  metadata:
+    - schedule
+    - tier-2
+    - openstack
+    - ibmc
+    - rgw
+    - stage-3

--- a/suites/nautilus/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -1,0 +1,83 @@
+tests:
+  - test:
+      name: install ceph pre-requisities
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: ceph ansible
+      module: test_ansible.py
+      config:
+        ansi_config:
+          ceph_test: True
+          ceph_origin: distro
+          ceph_repository: rhcs
+          osd_scenario: lvm
+          osd_auto_discovery: False
+          journal_size: 1024
+          ceph_stable: True
+          ceph_stable_rh_storage: True
+          fetch_directory: ~/fetch
+          copy_admin_key: true
+          dashboard_enabled: False
+          ceph_conf_overrides:
+            global:
+              osd_pool_default_pg_num: 64
+              osd_default_pool_size: 2
+              osd_pool_default_pgp_num: 64
+              mon_max_pg_per_osd: 1024
+      desc: test cluster setup using ceph-ansible
+      polarion-id: CEPH-83571467
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        cmd: ceph -s
+        sudo: True
+      desc: Check for ceph health debug info
+      polarion-id: CEPH-83575200
+
+  # Testing stage
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_dot.yaml
+        timeout: 300
+      desc: test lc with prefix containing dot
+      module: sanity_rgw.py
+      name: test lc with prefix containing dot
+      polarion-id: CEPH-11192
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_hyphen.yaml
+        timeout: 300
+      desc: test lc with prefix containing hyphen
+      module: sanity_rgw.py
+      name: test lc with prefix containing hyphen
+      polarion-id: CEPH-11192
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_slash.yaml
+        timeout: 300
+      desc: test lc with prefix containing slash
+      module: sanity_rgw.py
+      name: test lc with prefix containing slash
+      polarion-id: CEPH-11192
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_underscore.yaml
+        timeout: 300
+      desc: test lc with prefix containing underscore
+      module: sanity_rgw.py
+      name: test lc with prefix containing underscore
+      polarion-id: CEPH-11192

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -1,0 +1,103 @@
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: bootstrap with registry-url option and deployment services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: RHCS deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  # Testing stage
+
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_dot.yaml
+        timeout: 300
+      desc: test lc with prefix containing dot
+      module: sanity_rgw.py
+      name: test lc with prefix containing dot
+      polarion-id: CEPH-11192
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_hyphen.yaml
+        timeout: 300
+      desc: test lc with prefix containing hyphen
+      module: sanity_rgw.py
+      name: test lc with prefix containing hyphen
+      polarion-id: CEPH-11192
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_slash.yaml
+        timeout: 300
+      desc: test lc with prefix containing slash
+      module: sanity_rgw.py
+      name: test lc with prefix containing slash
+      polarion-id: CEPH-11192
+
+  - test:
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_with_prefix_underscore.yaml
+        timeout: 300
+      desc: test lc with prefix containing underscore
+      module: sanity_rgw.py
+      name: test lc with prefix containing underscore
+      polarion-id: CEPH-11192


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Integrating test case: CEPH-11192 - Test object prefixes with delimiter '/', '_', '-', '.' 

1. Created test suite to include  test-cases in Pacific and Nautilus place holder
2. Added test suite to the scheduled pipeline

Logs: 
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QEA3NF/
Nautilus: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EGJ656/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
