### PR TITLE
Adding RBD-mirror suites for downstream quincy 

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -246,3 +246,35 @@
     - ibmc
     - rbd
     - stage-1
+
+- name: "Testing RBD-mirror tier-1 regression scenarios"
+  suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+  global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+  metadata:
+    - sanity
+    - tier-1
+    - openstack
+    - ibmc
+    - rbd
+    - stage-1
+
+- name: "Testing RBD-mirror tier-2 regression scenarios"
+  suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
+  global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+    ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+  metadata:
+    - sanity
+    - tier-2
+    - openstack
+    - ibmc
+    - rbd
+    - stage-1

--- a/suites/quincy/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/quincy/rbd/tier-1_rbd_mirror.yaml
@@ -5,17 +5,9 @@
 # Polarion ID : CEPH-83573329 - RBD HA MirroringDraft
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
+#    Conf file - conf/quincy/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
-#    Each cluster configuration
-#    6-Node cluster(RHEL-8.3 and above)
-#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
-#     Node1 - Mon, Mgr, Installer
-#     Node2 - client
-#     Node3 - OSD
-#     Node4 - OSD
-#     Node5 - OSD
-#     Node6 - RBD Mirror
+#    Node 2 must to be a client node
 #
 # The following evaluations are carried out
 #   (1) Configures RBD Mirroring on cephadm

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -1,26 +1,12 @@
 #===============================================================================================
-# Tier-level: 1
-# Test-Suite: tier-1_rbd_mirror.yaml
-# Test-Case: Configure RBD Mirror setup and run IOs
-# Polarion ID : CEPH-83573329 - RBD HA MirroringDraft
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_regression.yaml
+# Suite contains rbd-mirror tier-2 testcases
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
+#    Conf file - conf/quincy/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
-#    Each cluster configuration
-#    6-Node cluster(RHEL-8.3 and above)
-#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
-#     Node1 - Mon, Mgr, Installer
-#     Node2 - client
-#     Node3 - OSD
-#     Node4 - OSD
-#     Node5 - OSD
-#     Node6 - RBD Mirror
-#
-# The following evaluations are carried out
-#   (1) Configures RBD Mirroring on cephadm
-#   (2) Creates Pool Image and enables Mirroring
-#   (3) Runs IO using rbd bench
+#    Node 2 must to be a client node
 #===============================================================================================
 tests:
   - test:
@@ -71,7 +57,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node6
+                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -80,7 +66,6 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     skip-monitoring-stack: true
@@ -113,7 +98,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node6
+                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -157,44 +142,38 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
+
   - test:
-      name: test_rbd_mirror
-      module: test_rbd_mirror.py
+      name: test-image-delete-from-primary-site
+      module: test-image-delete-primary-site.py
       clusters:
         ceph-rbd1:
           config:
             imagesize: 2G
             io-total: 200M
-            resize_to: 5G
-      polarion-id: CEPH-83573332
-      desc: Create RBD mirrored image in pools  and run IOs
+      polarion-id: CEPH-9501
+      desc: Verify that image deleted at primary site updated at secondary
+
   - test:
-      name: test_rbd_mirror_image
-      module: test_rbd_mirror_image.py
+      name: Attempt shrinking secondary image
+      module: test_9500_shrink_img_at_secondary.py
       clusters:
         ceph-rbd1:
           config:
             imagesize: 2G
             io-total: 200M
-      polarion-id: CEPH-83573619,CEPH-83573620
-      desc: Create RBD mirrored images and run IOs
+      polarion-id: CEPH-9500
+      desc: Verify that deleting secondary image fails
+
   - test:
-      name: test_rbd_mirror_rename_image
-      module: test_rbd_mirror_rename_image.py
+      name: test image meta operations sync to secondary
+      module: test_rbd_image_meta_mirroring.py
       clusters:
         ceph-rbd1:
           config:
             imagesize: 2G
             io-total: 200M
-      polarion-id: CEPH-83573614
-      desc: Rename primary image and check on secondary for this change
-  - test:
-      name: test_rbd_mirror_daemon_status
-      module: test_rbd_mirror_daemon_status.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-83573760
-      desc: Verify rbd mirror and daemon status on cluster
+            key: ping
+            value: pong
+      polarion-id: CEPH-9525
+      desc: Verify removal of image meta gets mirrored

--- a/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
+++ b/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
@@ -60,7 +60,6 @@ def run(**kw):
         mirror1.config_mirror(mirror2, poolname=poolname, mode="image")
         mirror1.enable_mirror_image(poolname, imagename, "journal")
         mirror2.wait_for_status(poolname=poolname, images_pattern=1)
-        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
 
@@ -68,7 +67,6 @@ def run(**kw):
         mirror1.create_image(imagespec=imagespec_1, size=config.get("imagesize"))
         mirror1.enable_mirror_image(poolname, imagename_1, "snapshot")
         mirror2.wait_for_status(poolname=poolname, images_pattern=2)
-        mirror1.benchwrite(imagespec=imagespec_1, io=config.get("io-total"))
         mirror1.wait_for_status(imagespec=imagespec_1, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec_1, state_pattern="up+replaying")
 
@@ -80,7 +78,6 @@ def run(**kw):
             if i == imagespec_1:
                 mirror1.create_mirror_snapshot(i)
             time.sleep(30)
-
             # Verify value at secondary
             if value != rbd2.image_meta(action="get", image_spec=i, key=key)[:-1]:
                 log.error(f"Meta value did not get mirrored on {i}")

--- a/tests/rbd_mirror/test_rbd_mirror_image.py
+++ b/tests/rbd_mirror/test_rbd_mirror_image.py
@@ -27,7 +27,6 @@ def run(**kw):
     try:
         log.info("Starting RBD mirroring test case")
         config = kw.get("config")
-        build = config.get("build", config.get("rhbuild"))
         mirror1, mirror2 = [
             rbdmirror.RbdMirror(cluster, config)
             for cluster in kw.get("ceph_cluster_dict").values()
@@ -48,10 +47,7 @@ def run(**kw):
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
 
         # Stop the rdb-mirror service and cehck the status
-        if build.startswith("5"):
-            service_name = mirror2.get_rbd_service_name("rbd-mirror")
-        if build.startswith("4"):
-            service_name = mirror2.get_rbd_service_name("rbd-mirror@admin.service")
+        service_name = mirror2.get_rbd_service_name("rbd-mirror")
         mirror2.change_service_state(service_name=service_name, operation="stop")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="down+stopped")
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))


### PR DESCRIPTION
# Description
new file:   suites/quincy/rbd/tier-1_rbd_mirror.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZP5LVW

modified:   suites/pacific/rbd/tier-1_rbd_mirror.yaml
Minor trim

modified:   pipeline/metadata/6.0.yaml
Added rbd-mirror suites

modified:   tests/rbd_mirror/test_rbd_mirror_image.py
Tuned to support latest downstream versions

new file:   suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-788AR6/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XKX9MZ

Signed-off-by: Vasishta <vashastr@redhat.com>


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
