### PR TITLE
Adding close loop of bi_purge test (BZ 1910503) to rhcs-5.3 specific fixes.

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -1028,8 +1028,8 @@
     - rgw
     - stage-1
 
-- name: "test-empty-bucket-notification"
-  suite: "suites/pacific/rgw/tier-2_rgw_test-empty-bucket-notifcations.yaml"
+- name: "test-5.3-specific-fixes"
+  suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
   global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
   platform: "rhel-8"
   rhbuild: "5.3"

--- a/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
@@ -1,8 +1,9 @@
 #
-# Objective: Test empty bucket notifications with kafka endpoint
+# Objective: Test RHCS-5.3 fixes
+# 1.Test empty bucket notifications with kafka endpoint
 #       - with ack_type broker
 #       - w/o persistent flag
-#
+# 2. Test bi purge for a bucket
 tests:
   - test:
       abort-on-fail: true
@@ -62,14 +63,27 @@ tests:
 
       # kafka broker type with empty bucket notifcation
   - test:
-      name: test bucket notifcation with empty configuration
-      desc: verify empty bucket notification deletes the existing configuration
-      module: sanity_rgw.py
-      polarion-id: CEPH-83575035
-      config:
-        extra-pkgs:
-          - wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm
-        install_start_kafka: true
-        script-name: test_bucket_notifications.py
-        config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-        timeout: 300
+      name: Parallel run test for empty bucket notification and bi purge
+      module: test_parallel.py
+      parallel:
+        - test:
+            name: test bucket notifcation with empty configuration
+            desc: verify empty bucket notification deletes the existing configuration
+            module: sanity_rgw.py
+            polarion-id: CEPH-83575035
+            config:
+              extra-pkgs:
+                - wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm
+              install_start_kafka: true
+              script-name: test_bucket_notifications.py
+              config-file-name: test_empty_bucket_notification_kafka_broker.yaml
+              timeout: 300
+        - test:
+            name: test_bi_purge for a bucket
+            desc: test bi_purge should not error
+            module: sanity_rgw.py
+            polarion-id: CEPH-83575234
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_bi_purge.yaml
+              timeout: 300


### PR DESCRIPTION
This PR is for RHCS-5.3 specific fixes and also addresses the tests to be executed in parallel.

Additionally it also addresses a new close-loop: Adding test for bi purge bug-1910503



Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NQ3GVK

Signed-off-by: viduship <vimishra@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
