### PR TITLE
Initial fix for resolving missing xmlstarlet package

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -136,8 +136,13 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         """
         Enable the cdn Tools repo on all ceph node.
         """
-        cdn_repo = "rhceph-5-tools-for-rhel-8-x86_64-rpms"
-        cmd = f"subscription-manager repos --enable={cdn_repo}"
+        os_major_version = self.config.get("rhbuild", "6.0-rhel-9").split("-")[-1]
+        cdn_repo = {
+            "8": "rhceph-5-tools-for-rhel-8-x86_64-rpms",
+            "9": "rhceph-5-tools-for-rhel-9-x86_64-rpms",
+        }
+
+        cmd = f"subscription-manager repos --enable={cdn_repo[os_major_version]}"
         for node in self.cluster.get_nodes():
             node.exec_command(sudo=True, cmd=cmd)
 

--- a/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
+++ b/conf/inventory/ibm-vpc-rhel-7.9-minimal-amd64-3.yaml
@@ -36,4 +36,5 @@ instance:
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.89/.ceph-qe-ca.pem
       - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.89/.RH-IT-Root-CA.crt
       - update-ca-trust
+      - yum-config-manager --add-repo https://10.245.4.89/repos/7/lab-extras.repo
       - touch /ceph-qa-ready

--- a/conf/inventory/ibm-vpc-rhel-8.6-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-8.6-minimal-amd64-1.yaml
@@ -36,5 +36,6 @@ instance:
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.89/.ceph-qe-ca.pem
       - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.89/.RH-IT-Root-CA.crt
       - update-ca-trust
+      - yum-config-manager --add-repo https://10.245.4.89/repos/8/lab-extras.repo
       - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
       - touch /ceph-qa-ready

--- a/conf/inventory/ibm-vpc-rhel-9.0-minimal-amd64-1.yaml
+++ b/conf/inventory/ibm-vpc-rhel-9.0-minimal-amd64-1.yaml
@@ -36,5 +36,6 @@ instance:
       - curl -k -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem https://10.245.4.89/.ceph-qe-ca.pem
       - curl -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://10.245.4.89/.RH-IT-Root-CA.crt
       - update-ca-trust
+      - yum-config-manager --add-repo https://10.245.4.89/repos/9/lab-extras.repo
       - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
       - touch /ceph-qa-ready

--- a/conf/inventory/rhel-7.9-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.9-server-x86_64.yaml
@@ -38,6 +38,7 @@ instance:
         - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
         - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
         - update-ca-trust
+        - yum-config-manager --add-repo http://magna002.ceph.redhat.com/cephci-jenkins/repos/7/lab-extras.repo
         - yum clean metadata
         - yum clean all
         - touch /ceph-qa-ready

--- a/conf/inventory/rhel-8.6-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.6-server-x86_64.yaml
@@ -37,6 +37,7 @@ instance:
       - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
       - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
       - update-ca-trust
+      - yum-config-manager --add-repo http://magna002.ceph.redhat.com/cephci-jenkins/repos/8/lab-extras.repo
       - yum clean metadata
       - yum clean all
       - touch /ceph-qa-ready

--- a/conf/inventory/rhel-9.0-server-x86_64-large.yaml
+++ b/conf/inventory/rhel-9.0-server-x86_64-large.yaml
@@ -40,6 +40,7 @@ instance:
       - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
       - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
       - update-ca-trust
+      - yum-config-manager --add-repo http://magna002.ceph.redhat.com/cephci-jenkins/repos/9/lab-extras.repo
       - yum clean metadata
       - yum clean all
       - touch /ceph-qa-ready

--- a/conf/inventory/rhel-9.0-server-x86_64.yaml
+++ b/conf/inventory/rhel-9.0-server-x86_64.yaml
@@ -40,6 +40,7 @@ instance:
       - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
       - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
       - update-ca-trust
+      - yum-config-manager --add-repo http://magna002.ceph.redhat.com/cephci-jenkins/repos/9/lab-extras.repo
       - yum clean metadata
       - yum clean all
       - touch /ceph-qa-ready


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes the below error message that is being observed in the build smoke test

```
Exception in parallel execution
Traceback (most recent call last):
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/parallel.py", line 88, in exit
    for result in self:
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/parallel.py", line 106, in next
    resurrect_traceback(result)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/parallel.py", line 35, in resurrect_traceback
    raise exc_info[0](https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/exc_info%5B1%5D).with_traceback(exc_info[2])
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/parallel.py", line 22, in capture_traceback
    return func(args, *kwargs)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/tests/parallel/test_parallel.py", line 83, in execute
    clients=args["clients"],
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/tests/rbd/test_rbd.py", line 136, in run
    one_time_setup(node, rhbuild, branch=branch)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/tests/rbd/test_rbd.py", line 83, in one_time_setup
    node.exec_command(**command)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/ceph.py", line 1549, in exec_command
    f"{kw['cmd']} Error:  {str(stderr)} {str(self.ip_address)}"
ceph.ceph.CommandFailed: yum install -y xmlstarlet rbd-nbd qemu-img cryptsetup --nogpgcheck Error:  Error: Unable to find a match: xmlstarlet
```

__Logs__
