### PR TITLE
Integration of CEPH-11196 into cephci

### DIFF
--- a/suites/nautilus/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
@@ -57,3 +57,13 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
         timeout: 300
+
+  - test:
+      name: Enable lifecycle and disable it on a bucket before objects expires
+      desc: Enable lifecycle and disable it on a bucket before the objects get expired
+      polarion-id: CEPH-11196
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_config_ops.py
+        config-file-name: test_bucket_lc_disable_object_exp.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
@@ -80,3 +80,13 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
         timeout: 300
+
+  - test:
+      name: Enable lifecycle and disable it on a bucket before objects expires
+      desc: Enable lifecycle and disable it on a bucket before the objects get expired
+      polarion-id: CEPH-11196
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_config_ops.py
+        config-file-name: test_bucket_lc_disable_object_exp.yaml
+        timeout: 300


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Integration of CEPH-11196 into cephci
Automate polarion: CEPH-11196 - Enable lifecycle and disable it on a bucket before objects expires
log: 
  4.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Y1MKBD/Enable_lifecycle_and_disable_it_on_a_bucket_before_objects_expires_0.log
  5.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HWC1EK/Enable_lifecycle_and_disable_it_on_a_bucket_before_objects_expires_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
