### PR TITLE
Enhance sanity_rgw test module

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -110,25 +110,28 @@ def run(ceph_cluster, **kw):
 
     test_folder = "rgw-tests"
     test_folder_path = f"~/{test_folder}"
-    rgw_node.exec_command(cmd=f"sudo rm -rf {test_folder}")
-    rgw_node.exec_command(cmd=f"sudo mkdir {test_folder}")
-    utils.clone_the_repo(config, rgw_node, test_folder_path)
-
     # Clone the repository once for the entire test suite
     pip_cmd = "venv/bin/pip"
     python_cmd = "venv/bin/python"
-    if ceph_cluster.rhcs_version.version[0] > 4:
-        setup_cluster_access(ceph_cluster, rgw_node)
-        rgw_node.exec_command(
-            sudo=True, cmd="yum install -y ceph-common --nogpgcheck", check_ec=False
-        )
+    out, err = rgw_node.exec_command(cmd=f"ls -l {test_folder}", check_ec=False)
+    if not out:
+        rgw_node.exec_command(cmd=f"sudo mkdir {test_folder}")
+        utils.clone_the_repo(config, rgw_node, test_folder_path)
 
-    if ceph_cluster.rhcs_version.version[0] in [3, 4]:
-        if ceph_cluster.containerized:
-            # install ceph-common on the host hosting the container
+        if ceph_cluster.rhcs_version.version[0] > 4:
+            setup_cluster_access(ceph_cluster, rgw_node)
             rgw_node.exec_command(
                 sudo=True, cmd="yum install -y ceph-common --nogpgcheck", check_ec=False
             )
+
+        if ceph_cluster.rhcs_version.version[0] in [3, 4]:
+            if ceph_cluster.containerized:
+                # install ceph-common on the host hosting the container
+                rgw_node.exec_command(
+                    sudo=True,
+                    cmd="yum install -y ceph-common --nogpgcheck",
+                    check_ec=False,
+                )
     out, err = rgw_node.exec_command(cmd="ls -l venv", check_ec=False)
 
     if not out:


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Enhancing git clone logic in sanity_rgw in such a way that cloning will takes place only once in a cluster,
if clone is already present exclude cloning operation for remaining test-case to reduce time for repeated clone operation. 

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HTCR8H/

Failures in the log doesn't seem to be due to the changes done in this PR, will be look into the failure
Failure for LC, PR raised: https://github.com/red-hat-storage/ceph-qe-scripts/pull/329

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
