### PR TITLE
Adding prepare node script for Baremetal

### DIFF
--- a/pipeline/rhcs-bm-executor.groovy
+++ b/pipeline/rhcs-bm-executor.groovy
@@ -1,0 +1,40 @@
+/*
+    Script to execute the cephci on baremetals
+*/
+// Global variables section
+def sharedLib
+def versions
+def cephVersion
+def composeUrl
+def platform
+
+// Pipeline script entry point
+node("rhel-8-medium || ceph-qe-ci") {
+        stage('prepareNode') {
+            if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
+            checkout(
+                scm: [
+                    $class: 'GitSCM',
+                    branches: [[name: 'origin/master']],
+                    extensions: [[
+                        $class: 'CleanBeforeCheckout',
+                        deleteUntrackedNestedRepositories: true
+                    ], [
+                        $class: 'WipeWorkspace'
+                    ], [
+                        $class: 'CloneOption',
+                        depth: 1,
+                        noTags: true,
+                        shallow: true,
+                        timeout: 10,
+                        reference: ''
+                    ]],
+                    userRemoteConfigs: [[
+                        url: 'https://github.com/red-hat-storage/cephci.git'
+                    ]]
+                   ],)
+
+            sharedLib = load("${env.WORKSPACE}/pipeline/vars/v3.groovy")
+            sharedLib.prepareNode(4)
+        }
+        }

--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -9,6 +9,7 @@
 #   1 -> Configures the agent with necessary CI packages
 #   2 -> 0 + 1 along with deploying postfix package
 #   3 -> 0 + 1 along with rclone package
+#   4 -> 0 + 1 along with teuthology clone and install
 
 echo "Initialize Node"
 # Workaround: Disable IPv6 to have quicker downloads
@@ -52,6 +53,14 @@ if [ ${1:-0} -eq 3 ]; then
     curl https://rclone.org/install.sh | sudo bash || echo 0
     mkdir -p ${HOME}/.config/rclone
     wget http://magna002.ceph.redhat.com/cephci-jenkins/.ibm-cos.conf -O ${HOME}/.config/rclone/rclone.conf
+fi
+
+# Install teuthology prerequisites
+if [ ${1:-0} -eq 4 ]; then
+    # Install teuthology
+    sudo yum install ipmitool -y
+    wget http://magna002.ceph.redhat.com/cephci-jenkins/.teuthology.yaml -O ${HOME}/.teuthology.yaml
+    .venv/bin/python -m pip install git+https://github.com/ceph/teuthology.git
 fi
 
 echo "Done bootstrapping the Jenkins node."


### PR DESCRIPTION
Adding prepare node script for Baremetal
This will install cephci and teuthology prerequisites
Logs : 
with argument 4 for **prepareNode**: 
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/test_amk/29/console
**will install teuthology prerequisites** 

with no argument : 
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/test_amk/28/console


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
