### PR TITLE
[Automation] Add tc to validate legacy services infer cephadm shell

### DIFF
--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
@@ -165,3 +165,9 @@ tests:
     module: test_cephadm_shell_run.py
     desc: Verification cephadm shell when running from a non-monitor node
     polarion-id: CEPH-83575009
+
+- test:
+    name: test_check_non_exisiting_legacy_services
+    module: test_legacy_services.py
+    desc: Verify if the cephadm shell tries to infer config from a dummy mon created
+    polarion-id: CEPH-83575342

--- a/tests/cephadm/test_legacy_services.py
+++ b/tests/cephadm/test_legacy_services.py
@@ -1,0 +1,48 @@
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Verify if the cephadm shell tries to infer config from
+    a dummy mon created.
+    Verifies bz:2080242
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        **kw :     Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+    """
+
+    config = kw.get("config")
+
+    # Creating a dummy mon on a non monitor node
+    for node in ceph_cluster.get_nodes():
+        if node.role not in ["mon", "client"]:
+            # Create a dummy mon
+            hostname = node.hostname
+            dummy_mon = f"sudo touch /var/lib/ceph/mon/ceph-{hostname}"
+            _, err = node.exec_command(cmd=f"{dummy_mon}")
+            if err:
+                log.error("Failed to create dummy mon")
+                return 1
+
+            # Try cephadm shell command to make sure the above dummy mon doesn't interfere
+            # Checking cluster health
+            status = ceph_cluster.check_health(
+                rhbuild=config.get("rhbuild"), client=node
+            )
+            if status:
+                log.error(
+                    "Unexpected!! Cephadm shell is trying to access config from the dummy mon"
+                )
+                return 1
+            log.info(
+                "Expected. Cephadm shell doesn't tries to infer the config from the dummy mon"
+            )
+            break
+
+    return 0


### PR DESCRIPTION
Validates bz: 2080242

Test Steps:

1. Create a 4.x cluster	Cluster creation should be successful
2. Upgrade the cluster to 5.x latest
3. Create a dummy mon on the nodes /var/lib//ceph/mon/ceph-<hostname>
4. Try running the cephadm shell eg. any command, 'ceph -s'

Signed-off-by: Pranav <prprakas@redhat.com>

Test run results: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GNLSUA/
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
