### PR TITLE
Modify upgrades suites to refer to a single testcase

### DIFF
--- a/suites/nautilus/rgw/tier-1_rgw_multisite_test-upgrade-4.x-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_multisite_test-upgrade-4.x-to-latest.yaml
@@ -1,4 +1,4 @@
-# Polarion ID: CEPH-83574658
+# Polarion ID: CEPH-83574647
 # Objective: Testing Multisite upgrade from RHCS 4 GA to latest development build.
 # conf: tier-1_rgw_multisite.yaml
 # platform: rhel-7
@@ -230,7 +230,7 @@ tests:
               upgrade_ceph_packages: true
       desc: Upgrading the clusters to the specified build.
       abort-on-fail: true
-      polarion-id: CEPH-83574658
+      polarion-id: CEPH-83574647
 
   # Test cluster post upgrade
 

--- a/suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -144,7 +144,7 @@ tests:
   # upgrade ceph cluster
   - test:
       name: Upgrade ceph cluster to 4.x latest
-      polarion-id: CEPH-83574675
+      polarion-id: CEPH-83574647
       module: test_ansible_upgrade.py
       config:
         ansi_config:

--- a/suites/nautilus/rgw/tier-1_rgw_test-4x-upgrade-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_test-4x-upgrade-to-latest.yaml
@@ -232,7 +232,7 @@ tests:
 
   - test:
       name: Upgrade ceph ansible to 4.x latest
-      polarion-id: CEPH-83573508
+      polarion-id: CEPH-83574647
       module: test_ansible_upgrade.py
       config:
         ansi_config:

--- a/suites/nautilus/rgw/tier-2_rgw_test-4x-ganesha-upgrade-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-4x-ganesha-upgrade-to-latest.yaml
@@ -129,7 +129,7 @@ tests:
 
   - test:
       name: Upgrade ceph ansible to 4.x latest
-      polarion-id: CEPH-83573508
+      polarion-id: CEPH-83574647
       module: test_ansible_upgrade.py
       config:
         ansi_config:

--- a/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
@@ -1,4 +1,4 @@
-# Polarion ID: CEPH-83574664
+# Polarion ID: CEPH-83574647
 # Objective: Testing Multisite upgrade from RHCS 4 GA to RHCS 5 latest development build.
 # conf: rgw_multisite.yaml
 # platform: rhel-8
@@ -251,7 +251,7 @@ tests:
               upgrade_ceph_packages: true
       desc: Upgrading the clusters to the specified build.
       abort-on-fail: true
-      polarion-id: CEPH-83574664
+      polarion-id: CEPH-83574647
 
   # Test cluster post upgrade
 

--- a/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
@@ -1,4 +1,4 @@
-# Polarion ID: CEPH-83574765
+# Polarion ID: CEPH-83574647
 # Objective: Testing Multisite upgrade from RHCS 5 GA to RHCS 5 latest development build.
 # conf: rgw_multisite.yaml
 # platform: rhel-8
@@ -315,7 +315,7 @@ tests:
       desc: Multisite upgrade
       module: test_cephadm_upgrade.py
       name: multisite ceph upgrade
-      polarion-id: CEPH-83574765
+      polarion-id: CEPH-83574647
 
   - test:
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
@@ -1,4 +1,4 @@
-# Polarion ID: CEPH-83574666
+# Polarion ID: CEPH-83574647
 # Objective: Testing Multisite upgrade from RHCS 5 GA to RHCS 5 latest development build.
 # conf: rgw_multisite.yaml
 # platform: rhel-8
@@ -343,7 +343,7 @@ tests:
       desc: Multisite upgrade
       module: test_cephadm_upgrade.py
       name: multisite ceph upgrade
-      polarion-id: CEPH-83574666
+      polarion-id: CEPH-83574647
 
   - test:
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -1,7 +1,7 @@
 #
 # Objective: Test rgw with ssl configured using ceph-ansible and upgrade
 # with dashboard disabled
-# Polarion ID: CEPH-83574678
+# Polarion ID: CEPH-83574647
 #
 ---
 tests:
@@ -130,7 +130,7 @@ tests:
   # upgrade ceph cluster
   - test:
       name: Upgrade ceph cluster to 5.x latest
-      polarion-id: CEPH-83574678
+      polarion-id: CEPH-83574647
       module: test_ansible_upgrade.py
       config:
         build: '5.x'

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
@@ -1,4 +1,4 @@
-#Polarian ID - CEPH-83574764
+#Polarian ID - CEPH-83574647
 #Objective: Testing single site upgrade from RHCS 5 GA to latest build
 #platform : RHEL-8
 #conf: tier-0_rgw.yaml
@@ -188,7 +188,7 @@ tests:
             name: Upgrade ceph
             desc: Upgrade cluster to latest version
             module: test_cephadm_upgrade.py
-            polarion-id: CEPH-83573791 # also applies to CEPH-83573790
+            polarion-id: CEPH-83574647
             config:
               command: start
               service: upgrade

--- a/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml
@@ -266,7 +266,7 @@ tests:
 
 - test:
     name: Upgrade containerized ceph to 5.x latest
-    polarion-id: CEPH-83573679
+    polarion-id: CEPH-83574647
     module: test_ansible_upgrade.py
     config:
       ansi_config:

--- a/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
@@ -1,4 +1,4 @@
-#Polarian ID -CEPH-83574650
+#Polarian ID -CEPH-83574647
 #Objective: Testing single site upgrade from RHCS 5 GA to latest build
 #platform : RHEL-8
 #conf: tier-0_rgw.yaml
@@ -176,7 +176,7 @@ tests:
       name: Upgrade ceph
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83574650
+      polarion-id: CEPH-83574647
       config:
         command: start
         service: upgrade


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Modify the upgrade suites to refer to a single upgrade testcase  [CEPH-83574647](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574647)

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
