### PR TITLE
Enhance Enhance sanity_rgw_multisite test module

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -188,16 +188,19 @@ def set_test_env(config, rgw_node):
 
     log.info("flushing iptables")
     rgw_node.exec_command(cmd="sudo iptables -F", check_ec=False)
-    rgw_node.exec_command(cmd="sudo yum install python3 -y", check_ec=False)
-    rgw_node.exec_command(cmd="yum install -y ceph-common", check_ec=False, sudo=True)
-    rgw_node.exec_command(cmd="sudo rm -rf " + test_folder)
-    rgw_node.exec_command(cmd="sudo mkdir " + test_folder)
-    utils.clone_the_repo(config, rgw_node, test_folder_path)
+    out, err = rgw_node.exec_command(cmd=f"ls -l {test_folder}", check_ec=False)
+    if not out:
+        rgw_node.exec_command(cmd="sudo mkdir " + test_folder)
+        utils.clone_the_repo(config, rgw_node, test_folder_path)
+        rgw_node.exec_command(cmd="sudo yum install python3 -y", check_ec=False)
+        rgw_node.exec_command(
+            cmd="yum install -y ceph-common", check_ec=False, sudo=True
+        )
 
-    rgw_node.exec_command(cmd="sudo pip3 install --upgrade pip")
-    rgw_node.exec_command(
-        cmd=f"sudo pip3 install -r {test_folder}/ceph-qe-scripts/rgw/requirements.txt"
-    )
+        rgw_node.exec_command(cmd="sudo pip3 install --upgrade pip")
+        rgw_node.exec_command(
+            cmd=f"sudo pip3 install -r {test_folder}/ceph-qe-scripts/rgw/requirements.txt"
+        )
 
 
 def copy_file_from_node_to_node(src_file, src_node, dest_node, dest_file):


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Enhancing git clone logic in sanity_rgw_multisite in such a way that cloning will takes place only once in a cluster,
if clone is already present exclude cloning operation for remaining test-case to reduce time for repeated clone operation.

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GWRWWR/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
