### PR TITLE
Decoupling rbd test with ceph version,trimming t0 suite

### DIFF
--- a/suites/pacific/cephadm/tier-0.yaml
+++ b/suites/pacific/cephadm/tier-0.yaml
@@ -104,7 +104,6 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: v16.2.8
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/suites/pacific/rbd/tier-0_rbd.yaml
+++ b/suites/pacific/rbd/tier-0_rbd.yaml
@@ -98,16 +98,7 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: "configure client"
-  -
-    test:
-      config:
-        branch: v16.2.8
-        script: cli_generic.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD CLI Generic scenarios"
-      module: test_rbd.py
-      name: 1_rbd_cli_generic
-      polarion-id: CEPH-83574241
+
   -
     test:
       config:


### PR DESCRIPTION
Refer second test results in - cephci-run-VIG3ZI
Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
