### PR TITLE
cephfs_upgrade 5x to 5x

### DIFF
--- a/suites/pacific/cephfs/tier-0_cephfs_upgrade_5x_to_5x.yaml
+++ b/suites/pacific/cephfs/tier-0_cephfs_upgrade_5x_to_5x.yaml
@@ -1,0 +1,175 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/pacific/cpehfs/tier-0.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - rhcs-version: 5.1 in this suite, but it can be changed to 5.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                rhcs-version: 5.1
+                release: ga
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        args:
+          - ceph
+          - fs
+          - set
+          - cephfs
+          - max_mds
+          - "2"
+        command: shell
+      desc: "Add Active Active configuration of MDS for cephfs"
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Add Active Active configuration of MDS"
+      polarion-id: CEPH-11344
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Deploy MDS with default values using cephadm"
+      module: mds_default_values.py
+      name: cephfs default values for mds
+      polarion-id: "CEPH-83574284"
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        -
+          test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83573791,CEPH-83573790
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados                      # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+      desc: Running upgrade and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575313


### PR DESCRIPTION
Upgrade scenario for 5.x to 5.x
 
I have re-arranged the suite files for upgrade. Among the upgrade scenario, I have added MDS configuration and cephfs_IOs during upgrade. Upgrade starts from 5.1 and target build can be passed by cmd line arguement. start build can be changed by edit the configuration.

Test Steps:
   (1) Bootstrap cluster using latest released ceph 5.x with below options,
       - **rhcs-version:** 5.1 in this suite, but it can be changed to 5.x for upgrade start version as needed
       - **release**: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
       - registry-url: <registry-URL>
       - mon-ip: <monitor address, Required>
   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
   (3) Upgrade to distro build(N) by provided Ceph image version.


 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6K57M8/

Signed-off-by: julpark <yonhyun@gmail.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
