### PR TITLE
Fix smoke test failures

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -934,18 +934,19 @@ class Ceph(object):
     @staticmethod
     def generate_repository_file(base_url, repos, cloud_type="openstack"):
         """
-        Generate rhel repository file for given repos
+        Generate rhel repository file for given repos.
+
         Args:
             base_url(str): rhel compose url
             repos(list): repos behind compose/ to process
-
+            cloud_type (str): The environment used for testing
         Returns:
             str: repository file content
         """
         repo_file = ""
         for repo in repos:
             base_url = base_url.rstrip("/")
-            if cloud_type == "ibmc":
+            if "ibmc" in cloud_type:
                 repo_to_use = f"{base_url}/{repo}/"
             else:
                 repo_to_use = f"{base_url}/compose/{repo}/x86_64/os/"
@@ -961,6 +962,7 @@ class Ceph(object):
                 gpgcheck = "gpgcheck=0\n"
                 enabled = "enabled=1\n\n"
                 repo_file = repo_file + header + name + baseurl + gpgcheck + enabled
+
         return repo_file
 
     def get_osd_container_name_by_id(self, osd_id, client=None):

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -192,6 +192,7 @@ class BootstrapMixin:
         build_type = self.config.get("build_type")
         rhbuild = self.config.get("rhbuild")
         base_url = self.config.get("base_url")
+        cloud_type = self.config.get("cloud-type", "openstack")
 
         # Support installation of the baseline cluster whose version is not available in
         # CDN. This is primarily used for an upgrade scenario. This support is currently
@@ -227,7 +228,7 @@ class BootstrapMixin:
         else:
             repos = ["Tools"]
             for node in self.cluster.get_nodes():
-                setup_repos(node, base_url=base_url, repos=repos)
+                setup_repos(node, base_url=base_url, repos=repos, cloud_type=cloud_type)
 
         ansible_run = config.get("cephadm-ansible", None)
         if ansible_run:

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -515,10 +515,16 @@ def keep_alive(ceph_nodes):
         node.exec_command(cmd="uptime", check_ec=False)
 
 
-def setup_repos(ceph, base_url, installer_url=None, repos: List[str] = None):
+def setup_repos(
+    ceph,
+    base_url,
+    installer_url=None,
+    repos: List[str] = None,
+    cloud_type: str = "openstack",
+):
     if not repos:
         repos = ["MON", "OSD", "Tools"]
-    base_repo = generate_repo_file(base_url, repos)
+    base_repo = generate_repo_file(base_url, repos, cloud_type)
     base_file = ceph.remote_file(
         sudo=True, file_name="/etc/yum.repos.d/rh_ceph.repo", file_mode="w"
     )
@@ -616,8 +622,8 @@ def check_ceph_healthly(
     return 0
 
 
-def generate_repo_file(base_url, repos):
-    return Ceph.generate_repository_file(base_url, repos)
+def generate_repo_file(base_url, repos, cloud_type="openstack"):
+    return Ceph.generate_repository_file(base_url, repos, cloud_type)
 
 
 def get_iso_file_url(base_url):


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR provides the cloud-type information to construct the correct `baseurl` in the repo file based on the test environment.

__Error__
```
Traceback (most recent call last):
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/tests/ceph_installer/test_cephadm.py", line 136, in run
    func(cfg)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/ceph_admin/bootstrap.py", line 241, in bootstrap
    self.install()
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/ceph_admin/init.py", line 202, in install
    node.exec_command(cmd="rpm -qa | grep cephadm")
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline@2/ceph/ceph.py", line 1549, in exec_command
    f"{kw['cmd']} Error:  {str(stderr)} {str(self.ip_address)}"
ceph.ceph.CommandFailed: rpm -qa | grep cephadm Error:   10.245.5.245
```