### PR TITLE
Fix post results failure due to comma in description

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -296,7 +296,7 @@
     - cephfs
     - stage-1
 
-- name: "FS Scenario based coversion subvolume,snapshot,quota features"
+- name: "FS Scenario based coversion subvolume-snapshot-quota features"
   suite: "suites/pacific/cephfs/tier-1_fs.yaml"
   global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
   platform: "rhel-9"


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes the below error observed when posting the results to Polarion

```
Warning: A secret was passed to "sh" using Groovy String interpolation, which is insecure.
		 Affected argument(s) used the following variable(s): [OSPUSER, OSPCRED]
		 See https://jenkins.io/redirect/groovy-string-interpolation for details.
+ curl -k -u '****:****' -X POST -F file=@/home/jenkins-build/workspace/rhceph-post-results/rp_preproc-7gbjm/payload/results/FS-Scenario-based-coversion-subvolume,snapshot,quota-features.xml https://polarion.engineering.redhat.com/polarion/import/xunit
Warning: setting file 
Warning: /home/jenkins-build/workspace/rhceph-post-results/rp_preproc-7gbjm/pay
Warning: load/results/FS-Scenario-based-coversion-subvolume  failed!
Warning: setting file snapshot  failed!
Warning: setting file quota-features.xml  failed!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   349    0     0    0   349      0    484 --:--:-- --:--:-- --:--:--   484
curl: (26) read function returned funny value
```
Though `,` is acceptable as a file name ... curl throws an error.
