### PR TITLE
[Automation] Add tc to validate Ceph cluster goes to error state afte…

### DIFF
--- a/cli/ceph/ceph.py
+++ b/cli/ceph/ceph.py
@@ -1,6 +1,7 @@
 from cli import Cli
 
 from .mgr import Mgr
+from .orch.orch import Orch
 
 
 class Ceph(Cli):
@@ -11,6 +12,7 @@ class Ceph(Cli):
 
         self.base_cmd = f"{base_cmd} ceph" if base_cmd else "ceph"
         self.mgr = Mgr(nodes, self.base_cmd)
+        self.orch = Orch(nodes, self.base_cmd)
 
     def version(self):
         """Get ceph version."""

--- a/cli/ceph/orch/orch.py
+++ b/cli/ceph/orch/orch.py
@@ -1,0 +1,70 @@
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class OrchApplyCommandError(Exception):
+    pass
+
+
+class Orch(Cli):
+    def __init__(self, nodes, base_cmd):
+        super(Orch, self).__init__(nodes)
+        self.base_cmd = f"{base_cmd} orch"
+
+    def ls(self, **kw):
+        """
+        Lists the status of the given services running in the Ceph cluster.
+
+        Args:
+            kw (dict): Key/value pairs that needs to be provided to the installer.
+
+            Supported keys:
+                service_type (str): type of service (mon, osd, mgr, mds, rgw).
+                service_name (str): name of host.
+                export (bool): whether to export the service specifications knows to
+                              the orchestrator.
+                format (str): the type to be formatted(yaml).
+                refresh (bool): whether to refresh or not.
+        """
+        cmd = f"{self.base_cmd} ls {build_cmd_from_args(**kw)}"
+        out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out
+
+    def apply(self, service_name, **kw):
+        """
+        Applies the configuration to hosts.
+
+        Args:
+            service_name : name of the service
+            kw (dict): key/value pairs that needs to be provided to the installer.
+
+            Supported keys:
+              hosts (list): name of host.
+              placement (dict): placement on hosts.
+              count (int): number of hosts to be applied
+        """
+        cmd = f"{self.base_cmd} apply {service_name}"
+        for arg in kw.pop("pos_args"):
+            cmd += f" {arg}"
+        cmd += build_cmd_from_args(**kw)
+        out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out
+
+    def rm(self, service_name):
+        """
+        Removes a service.
+        Args:
+          service_name (str): name of the service to be removed
+        """
+        cmd = f"{self.base_cmd} rm {service_name}"
+        out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out

--- a/suites/pacific/iscsi/tier-1_cephadm_test-iscsi_multiple_deployment.yaml
+++ b/suites/pacific/iscsi/tier-1_cephadm_test-iscsi_multiple_deployment.yaml
@@ -1,0 +1,121 @@
+#===============================================================================================
+#--------------------------------------
+# Conf: conf/pacific/cephadm/sanity-cephadm.yaml
+# Verifies : https://bugzilla.redhat.com/show_bug.cgi?id=2007516
+#
+# 1. Deploy 5.x cluster with mgr,mon, osd services
+# 2. Deploy ISCSI service
+# 3. Check "Ceph orch ls" for service status
+# 4. Perform Removal of service and deploy ISCSI for 2-3 times
+# 5. Check the cluster health and Ceph orch ls
+#===============================================================================================
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+
+      desc: bootstrap and deploy services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: Deploy cluster using cephadm
+
+  - test:
+      name: Create replicated pool
+      desc: Add pool for ISCSI service
+      module: test_bootstrap.py
+      polarion-id:
+      config:
+        command: shell
+        args: # command arguments
+          - ceph
+          - osd
+          - pool
+          - create
+          - iscsi
+          - "3"
+          - "3"
+          - replicated
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Enable rbd application on pool
+      desc: enable rbd on iscsi pool
+      module: test_bootstrap.py
+      polarion-id:
+      config:
+        command: shell
+        args: # command arguments
+          - ceph
+          - osd
+          - pool
+          - application
+          - enable
+          - iscsi
+          - rbd
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Deploy and Remove ISCSI Service multiple times
+      desc: Deploys and remove ISCSI multiple times to verify no crash
+      module: test_iscsi_multiple_removal_deployment.py
+      polarion-id: CEPH-83575352
+      config:
+        command: apply
+        service: iscsi
+        base_cmd_args: # arguments to ceph orch
+          verbose: true
+        pos_args:
+          - iscsi                 # name of the pool
+          - api_user              # name of the API user
+          - api_pass              # password of the api_user.
+        args:
+          trusted_ip_list: #it can be used both as keyword/positional arg in 5.x
+            - node1
+            - node6
+          placement:
+            nodes:
+              - node1
+              - node6                   # either label or node.
+      destroy-cluster: false
+      abort-on-fail: true

--- a/tests/cephadm/test_iscsi_multiple_removal_deployment.py
+++ b/tests/cephadm/test_iscsi_multiple_removal_deployment.py
@@ -1,0 +1,120 @@
+import json
+
+from ceph.utils import get_nodes_by_ids
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class IncorrectIscsiServiceStatus(Exception):
+    pass
+
+
+def _verify_service(node, present=True):
+    """
+    Verifies iscsi service is deployed or removed
+    Args:
+        node (str): monitor node object
+        should_be_present (bool): validation option for iscsi
+    return: (bool)
+    """
+    # Get iscsi service status
+    out = CephAdm(node).ceph.orch.ls(service_type="iscsi", format="json-pretty")
+
+    # If ISCSI was deployed
+    if present:
+        service_details = json.loads(out)[0]
+        return (
+            False
+            if "service was created" not in (service_details["events"][0])
+            else True
+        )
+    else:
+        # If ISCSI was removed, wait for a timeout to check whether its removed
+        timeout, interval = 20, 2
+        for w in WaitUntil(timeout=timeout, interval=interval):
+            out = CephAdm(node).ceph.orch.ls(service_type="iscsi", format="json-pretty")
+            if "No services reported" in out:
+                return True
+        if w.expired:
+            log.info("Service iscsi is not removed after rm operation.")
+    return False
+
+
+def run(ceph_cluster, **kw):
+    """
+    Verifies multiple deployment and removal of ISCSI services
+
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): Ceph cluster object
+        kw: test data
+            e.g:
+            test:
+              name: Deploy and Remove ISCSI Service multiple times
+              desc: Deploys and remove ISCSI multiple times to verify no crash
+              module: test_iscsi_multiple_removal_deployment.py
+              polarion-id: CEPH-83575352
+              config:
+                command: apply
+                service: iscsi
+                base_cmd_args: # arguments to ceph orch
+                  verbose: true
+                pos_args:
+                  - iscsi                 # name of the pool
+                  - api_user              # name of the API user
+                  - api_pass              # password of the api_user.
+                args:
+                  trusted_ip_list: #it can be used both as keyword/positional arg in 5.x
+                    - node1
+                    - node6
+                  placement:
+                    nodes:
+                      - node1
+                      - node6                   # either label or node.
+              destroy-cluster: false
+              abort-on-fail: true
+    """
+    config = kw.get("config")
+
+    node = ceph_cluster.get_nodes(role="mon")[0]
+    conf = {}  # Fetching required data from the test config
+
+    # Get trusted-ip details
+    args = config.get("args")
+    trusted_ip_list = args.get("trusted_ip_list")
+    if trusted_ip_list:
+        node_ips = get_nodes_by_ids(ceph_cluster, trusted_ip_list)
+        conf["trusted_ip_list"] = repr(" ".join([node.ip_address for node in node_ips]))
+
+    # Get placement details
+    conf["pos_args"] = config.get("pos_args")
+    placement = args.get("placement")
+    if placement:
+        nodes = placement.get("nodes")
+        node_ips = get_nodes_by_ids(ceph_cluster, nodes)
+        conf["placement="] = repr(" ".join([node.hostname for node in node_ips]))
+
+    # Deploy and Remove ISCSI 3 times
+    for _ in range(3):
+        log.info("Deploying ISCSI service")
+        CephAdm(node).ceph.orch.apply(service_name="iscsi", **conf)
+
+        # Verify if the service is deployed successfully
+        if not _verify_service(node):
+            raise IncorrectIscsiServiceStatus(
+                "Error - ISCSI service is not running after being deployed"
+            )
+        log.info("ISCSI service is deployed successfully")
+
+        # Remove ISCSI service
+        log.info("Removing ISCSI service")
+        CephAdm(node).ceph.orch.rm(service_name="iscsi.iscsi")
+
+        # Verify if iscsi is removed
+        if not _verify_service(node, False):
+            raise IncorrectIscsiServiceStatus("Error - ISCSI service is not removed.")
+        log.info("ISCSI service is removed successfully")
+
+    return 0


### PR DESCRIPTION
…r performing multiple removal and deployment of ISCSI

Test steps:
1. Deploy 5.x cluster with mgr,mon, osd services
2. Deploy ISCSI service
3. Check "Ceph orch ls" for service status
4. Perform Removal of service and deploy ISCSI for 2-3 times
5. Check the cluster health and Ceph orch ls

Signed-off-by: Pranav <prprakas@redhat.com>

Test run result : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RB47GG/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
