### PR TITLE
[rbd] [tier-1] [downstream nautilus] Aligning module to all downstream versions

### DIFF
--- a/suites/quincy/cephadm/tier-0.yaml
+++ b/suites/quincy/cephadm/tier-0.yaml
@@ -104,7 +104,6 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: v17.2.3
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -620,7 +620,7 @@ class RbdMirror:
         """
         service_name, rc = self.ceph_rbdmirror.exec_command(
             sudo=True,
-            cmd=f"systemctl list-units --all | grep {service_name} | awk {{'print $1'}}",
+            cmd=f"systemctl list-units --all | grep {service_name} | grep -Ev \\.target | awk {{'print $1'}}",
         )
         log.info(f"Service name : {service_name} ")
         return service_name


### PR DESCRIPTION
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZF1ULE

Small change to suites/quincy/cephadm/tier-0.yaml
- decoupling with cephversion

Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
