### PR TITLE
Scheduled runs will not update recipe file

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -370,7 +370,11 @@ node(nodeName) {
                                 string(name: 'buildArtifacts', value: buildArtifacts.toString())]
                 ])
             }
-            sharedLib.writeToRecipeFile(buildType, rhcephVersion, tierLevel, currentStageLevel, buildStatus)
+
+            if(tierLevel == "tier-0" && final_stage && buildStatus == "pass"){
+                sharedLib.writeToRecipeFile(rhcephVersion, tierLevel)
+            }
+
             latestContent = sharedLib.readFromRecipeFile(rhcephVersion)
             println "latest content is: ${latestContent}"
         }

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -357,7 +357,7 @@ def uploadResults(def objKey, def dirName, def bucketName="qe-ci-reports") {
 }
 
 def writeToRecipeFile(
-    def buildType, def rhcephVersion, def dataPhase, def currentStage, def status, def infra="10.245.4.89"
+    def rhcephVersion, def dataPhase, def infra="10.245.4.89"
     ) {
     /*
         Method to update content to the recipe file
@@ -365,13 +365,7 @@ def writeToRecipeFile(
     def result = "results"
     def recipeFile = "/data/site/recipe/${rhcephVersion}.yaml"
     recipeFileExist(rhcephVersion, recipeFile, infra)
-    if("${buildType}" == "latest" || "${currentStage}" == "stage-1"){
-        sh "ssh $infra \"yq eval -i '.$dataPhase = .latest' $recipeFile\""
-        sh "ssh $infra \"yq e -i '.$dataPhase.$result.$currentStage = \\\"$status\\\"' $recipeFile\""
-    }
-    else{
-        sh "ssh $infra \"yq e -i '.$dataPhase.$result.$currentStage = \\\"$status\\\"' $recipeFile\""
-    }
+    sh "ssh $infra \"yq eval -i '.$dataPhase = .latest' $recipeFile\""
 }
 
 def executeTestSuite(


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

In IBM environment, recipe file is updated only for sanity runs when tier-0 has passed.


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
