### PR TITLE
Fix ceph-common pkg install logic

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -118,20 +118,20 @@ def run(ceph_cluster, **kw):
         rgw_node.exec_command(cmd=f"sudo mkdir {test_folder}")
         utils.clone_the_repo(config, rgw_node, test_folder_path)
 
-        if ceph_cluster.rhcs_version.version[0] > 4:
-            setup_cluster_access(ceph_cluster, rgw_node)
-            rgw_node.exec_command(
-                sudo=True, cmd="yum install -y ceph-common --nogpgcheck", check_ec=False
-            )
+    if ceph_cluster.rhcs_version.version[0] > 4:
+        setup_cluster_access(ceph_cluster, rgw_node)
+        rgw_node.exec_command(
+            sudo=True, cmd="yum install -y ceph-common --nogpgcheck", check_ec=False
+        )
 
-        if ceph_cluster.rhcs_version.version[0] in [3, 4]:
-            if ceph_cluster.containerized:
-                # install ceph-common on the host hosting the container
-                rgw_node.exec_command(
-                    sudo=True,
-                    cmd="yum install -y ceph-common --nogpgcheck",
-                    check_ec=False,
-                )
+    if ceph_cluster.rhcs_version.version[0] in [3, 4]:
+        if ceph_cluster.containerized:
+            # install ceph-common on the host hosting the container
+            rgw_node.exec_command(
+                sudo=True,
+                cmd="yum install -y ceph-common --nogpgcheck",
+                check_ec=False,
+            )
     out, err = rgw_node.exec_command(cmd="ls -l venv", check_ec=False)
 
     if not out:


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

moving ceph-common package installation out of the if condition of clone_exist check.
In case of upgrade suites it is required to upgrade/reinstall ceph-common post upgrade due to dbr feature,
if not we will get an error for radosgw-admin bucket stats command.

Failed log: https://159.23.92.24/blue/rest/organizations/jenkins/pipelines/rhceph-test-execution-pipeline/runs/227/nodes/61/steps/86/log/?start=0
Pass log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JJ9CGQ/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
