### PR TITLE
Enabling Dashboard in rgw test suites

### DIFF
--- a/conf/quincy/rgw/rgw_multisite.yaml
+++ b/conf/quincy/rgw/rgw_multisite.yaml
@@ -1,0 +1,85 @@
+# System Under Test environment configuration for RGW multi site suites.
+globals:
+  - ceph-cluster:
+      name: ceph-pri
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client
+
+  - ceph-cluster:
+      name: ceph-sec
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -826,7 +826,7 @@
     - stage-4
 
 - name: "S3Tests against Red Hat RGW with SSL"
-  suite: "suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml"
+  suite: "suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml"
   global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
   platform: "rhel-9"
   rhbuild: "6.0"

--- a/suites/nautilus/rgw/tier-0_rgw.yaml
+++ b/suites/nautilus/rgw/tier-0_rgw.yaml
@@ -19,7 +19,15 @@ tests:
           ceph_stable_rh_storage: True
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               osd_pool_default_pg_num: 64

--- a/suites/nautilus/rgw/tier-1-extn_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw.yaml
@@ -18,7 +18,15 @@ tests:
           ceph_stable_rh_storage: True
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               osd_pool_default_pg_num: 64

--- a/suites/nautilus/rgw/tier-1-extn_rgw_multisite-primary-to-secondary.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw_multisite-primary-to-secondary.yaml
@@ -26,7 +26,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -63,7 +71,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/nautilus/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -25,7 +25,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -57,7 +65,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-1_rgw.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw.yaml
@@ -18,7 +18,15 @@ tests:
           ceph_stable_rh_storage: True
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               osd_pool_default_pg_num: 64

--- a/suites/nautilus/rgw/tier-1_rgw_ecpool_verifying-data-from-primary.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_ecpool_verifying-data-from-primary.yaml
@@ -51,7 +51,15 @@ tests:
               osd_auto_discovery: false
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -85,7 +93,15 @@ tests:
               osd_auto_discovery: false
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-1_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_multisite-secondary-to-primary.yaml
@@ -25,7 +25,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -57,7 +65,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-1_rgw_multisite_test-upgrade-4.x-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_multisite_test-upgrade-4.x-to-latest.yaml
@@ -30,7 +30,15 @@ tests:
               ceph_docker_image_tag: latest
               ceph_docker_registry: registry.redhat.io
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -59,7 +67,15 @@ tests:
               ceph_docker_image_tag: latest
               ceph_docker_registry: registry.redhat.io
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US
@@ -186,7 +202,15 @@ tests:
               osd_auto_discovery: false
               containerized_deployment: true
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -211,7 +235,15 @@ tests:
               osd_auto_discovery: false
               containerized_deployment: true
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-1_rgw_ssl_containerized-regression.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_ssl_containerized-regression.yaml
@@ -39,7 +39,15 @@ tests:
           ceph_stable_rh_storage: True
           containerized_deployment: true
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       destroy-cluster: False
       abort-on-fail: true

--- a/suites/nautilus/rgw/tier-1_rgw_ssl_regression.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_ssl_regression.yaml
@@ -36,7 +36,15 @@ tests:
           ceph_stable_rh_storage: true
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83574747
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -26,7 +26,15 @@ tests:
           osd_auto_discovery: false
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           radosgw_frontend_ssl_certificate: "/etc/ceph/server.pem"
           radosgw_frontend_port: 443
           ceph_conf_overrides:
@@ -157,7 +165,15 @@ tests:
           radosgw_frontend_ssl_certificate: "/etc/ceph/server.pem"
           radosgw_frontend_port: 443
           upgrade_ceph_packages: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
               client:
                 rgw_override_bucket_index_max_shards: 17

--- a/suites/nautilus/rgw/tier-1_rgw_test-4x-upgrade-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_test-4x-upgrade-to-latest.yaml
@@ -20,7 +20,15 @@ tests:
           osd_scenario: lvm
           osd_auto_discovery: False
           ceph_docker_registry_auth: false
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           copy_admin_key: True
           configure_firewall: True
           ceph_conf_overrides:
@@ -246,7 +254,15 @@ tests:
           fetch_directory: ~/fetch
           copy_admin_key: true
           configure_firewall: True
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           upgrade_ceph_packages: True
           ceph_rhcs_version: 4
           ceph_iscsi_config_dev: false

--- a/suites/nautilus/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
+++ b/suites/nautilus/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
@@ -33,7 +33,15 @@ tests:
           ceph_stable_rh_storage: true
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83571467
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-2_rgw-single-bucket-process.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw-single-bucket-process.yaml
@@ -19,7 +19,15 @@ tests:
           ceph_stable_rh_storage: True
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               osd_pool_default_pg_num: 64

--- a/suites/nautilus/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
@@ -36,7 +36,15 @@ tests:
           ceph_stable_rh_storage: true
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83574747
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-2_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_ganesha.yaml
@@ -20,7 +20,15 @@ tests:
           ceph_stable_rh_storage: true
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83574747
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-2_rgw_image_test-bucket-lifecycle-and-listing.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_image_test-bucket-lifecycle-and-listing.yaml
@@ -23,7 +23,15 @@ tests:
           ceph_stable_rh_storage: true
           containerized_deployment: true
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             mon:
               mon_allow_pool_delete: true

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-primary-to-secondary.yaml
@@ -25,7 +25,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -51,7 +59,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_multisite_test-bucket-lifecycle-secondary-to-primary.yaml
@@ -25,7 +25,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -51,7 +59,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-2_rgw_s3cmd_test-bucket-object-stats.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_s3cmd_test-bucket-object-stats.yaml
@@ -18,7 +18,15 @@ tests:
           osd_auto_discovery: false
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83571467
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-2_rgw_s3tests.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_s3tests.yaml
@@ -20,7 +20,15 @@ tests:
           ceph_rhcs_version: 4
           osd_scenario: lvm
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           rgw_create_pools:
             "{{ rgw_zone }}.rgw.buckets.data":
               type: ec

--- a/suites/nautilus/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -27,7 +27,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -203,7 +211,15 @@ tests:
               ceph_stable_rh_storage: True
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-2_rgw_test-4x-ganesha-upgrade-to-latest.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-4x-ganesha-upgrade-to-latest.yaml
@@ -20,7 +20,15 @@ tests:
           osd_scenario: lvm
           osd_auto_discovery: False
           ceph_docker_registry_auth: false
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           copy_admin_key: True
           configure_firewall: True
           ceph_conf_overrides:
@@ -143,7 +151,15 @@ tests:
           fetch_directory: ~/fetch
           copy_admin_key: true
           configure_firewall: True
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           upgrade_ceph_packages: True
           ceph_rhcs_version: 4
           ceph_iscsi_config_dev: false

--- a/suites/nautilus/rgw/tier-2_rgw_test-bucket-acls-and-links.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-bucket-acls-and-links.yaml
@@ -24,7 +24,15 @@ tests:
           osd_scenario: lvm
           containerized_deployment: true
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             mon:
               mon_allow_pool_delete: true

--- a/suites/nautilus/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -22,7 +22,15 @@ tests:
           osd_auto_discovery: false
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83571467
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-2_rgw_test-bucket-ops-and-versioning.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-bucket-ops-and-versioning.yaml
@@ -28,7 +28,15 @@ tests:
           ceph_stable_rh_storage: true
           containerized_deployment: true
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           osd_scenario: lvm
       desc: "test cluster setup using ceph-ansible"
       destroy-cluster: false

--- a/suites/nautilus/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -19,7 +19,15 @@ tests:
           ceph_stable_rh_storage: True
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               osd_pool_default_pg_num: 64

--- a/suites/nautilus/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml
@@ -25,7 +25,15 @@ tests:
               osd_auto_discovery: False
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -48,7 +56,15 @@ tests:
               osd_auto_discovery: False
               fetch_directory: ~/fetch
               copy_admin_key: true
-              dashboard_enabled: False
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/nautilus/rgw/tier-2_rgw_test-quota-management.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-quota-management.yaml
@@ -26,7 +26,15 @@ tests:
           ceph_stable_rh_storage: True
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: False
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_conf_overrides:
             global:
               osd_pool_default_pg_num: 64

--- a/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
+++ b/suites/nautilus/rgw/tier-3_rgw_ganesha.yaml
@@ -20,7 +20,15 @@ tests:
           ceph_stable_rh_storage: true
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: true
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: test cluster setup using ceph-ansible
       polarion-id: CEPH-83571467
       destroy-cluster: false

--- a/suites/pacific/rgw/tier-0_rgw.yaml
+++ b/suites/pacific/rgw/tier-0_rgw.yaml
@@ -31,6 +31,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -55,6 +57,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Service(s) deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -24,6 +24,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -64,6 +66,37 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83573777
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   # STS tests
 

--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -30,7 +30,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -74,7 +75,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -112,6 +114,69 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Service deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_longevity.yaml
+++ b/suites/pacific/rgw/tier-1_longevity.yaml
@@ -30,7 +30,8 @@ tests:
                     mon-ip: extensa003
                     allow-fqdn-hostname: true
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -99,7 +100,8 @@ tests:
                     mon-ip: extensa010
                     allow-fqdn-hostname: true
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -162,6 +164,68 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - extensa003
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - extensa003
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - extensa010
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - extensa010
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-1_rgw.yaml
+++ b/suites/pacific/rgw/tier-1_rgw.yaml
@@ -21,6 +21,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -61,6 +63,36 @@ tests:
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       name: Deploy RHCS cluster using cephadm
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
   - test:
       name: enable bucket versioning
       desc: Basic versioning test, also called as test to enable bucket versioning

--- a/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
@@ -25,7 +25,8 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-dashboard: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -92,6 +93,37 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -55,7 +55,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -113,7 +114,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -166,6 +168,67 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml
@@ -32,7 +32,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,7 +77,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -114,6 +116,67 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
@@ -29,7 +29,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -73,7 +74,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -111,6 +113,67 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -29,7 +29,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -73,7 +74,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -111,6 +113,67 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
@@ -32,7 +32,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,7 +77,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -114,6 +116,67 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
@@ -31,7 +31,15 @@ tests:
               ceph_docker_image_tag: latest
               ceph_docker_registry: registry.redhat.io
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -61,7 +69,15 @@ tests:
               ceph_docker_image_tag: latest
               ceph_docker_registry: registry.redhat.io
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: true
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US
@@ -206,7 +222,15 @@ tests:
               osd_auto_discovery: false
               containerized_deployment: true
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_EAST
               rgw_zonegroup: US
@@ -232,7 +256,15 @@ tests:
               osd_auto_discovery: false
               containerized_deployment: true
               copy_admin_key: true
-              dashboard_enabled: false
+              dashboard_enabled: True
+              dashboard_admin_user: admin
+              dashboard_admin_password: p@ssw0rd
+              grafana_admin_user: admin
+              grafana_admin_password: p@ssw0rd
+              node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+              grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
+              prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+              alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
               rgw_multisite: true
               rgw_zone: US_WEST
               rgw_zonegroup: US

--- a/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
@@ -26,7 +26,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
                   cephadm-ansible:
                     playbook: cephadm-preflight.yml
                     extra-vars:
@@ -75,7 +76,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
                   cephadm-ansible:
                     playbook: cephadm-preflight.yml
                     extra-vars:
@@ -117,6 +119,67 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml
@@ -28,7 +28,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
                   cephadm-ansible:
                     playbook: cephadm-preflight.yml
                     extra-vars:
@@ -80,7 +81,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
                   cephadm-ansible:
                     playbook: cephadm-preflight.yml
                     extra-vars:
@@ -125,6 +127,68 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -25,7 +25,15 @@ tests:
           osd_auto_discovery: false
           fetch_directory: ~/fetch
           copy_admin_key: true
-          dashboard_enabled: false
+          dashboard_enabled: True
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
           ceph_docker_image: "rhceph/rhceph-4-rhel8"
           ceph_docker_image_tag: "latest"
           ceph_docker_registry: "registry.redhat.io"
@@ -149,7 +157,15 @@ tests:
           copy_admin_key: true
           containerized_deployment: true
           upgrade_ceph_packages: true
-          dashboard_enabled: false
+          dashboard_enabled: True
+          dashboard_admin_user: admin
+          dashboard_admin_password: p@ssw0rd
+          grafana_admin_user: admin
+          grafana_admin_password: p@ssw0rd
+          node_exporter_container_image: registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.6
+          grafana_container_image: registry.redhat.io/rhceph/rhceph-5-dashboard-rhel8:5
+          prometheus_container_image: registry.redhat.io/openshift4/ose-prometheus:v4.6
+          alertmanager_container_image: registry.redhat.io/openshift4/ose-prometheus-alertmanager:v4.6
       desc: Test Ceph-Ansible rolling update 4.x cdn-> 5.x latest
       abort-on-fail: true
 

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml
@@ -22,7 +22,8 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-dashboard: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
               cephadm-ansible:
                 playbook: cephadm-preflight.yml
                 extra-vars:
@@ -67,6 +68,37 @@ tests:
       polarion-id: CEPH-83573777
       module: test_cephadm.py
       name: Deploy RHCS cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
 # basic versioning tests
   - test:

--- a/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
@@ -32,6 +32,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -56,6 +58,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
@@ -23,7 +23,8 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 orphan-initial-daemons: true
-                skip-dashboard: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
               cephadm-ansible:
                 playbook: cephadm-preflight.yml
                 extra-vars:
@@ -64,6 +65,37 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: Deploy RHCS cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml
+++ b/suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml
@@ -19,6 +19,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -43,6 +45,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
@@ -35,6 +35,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -59,6 +61,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -61,6 +61,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -97,6 +99,37 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83573713
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   # Basic Bucket Operation Tests
 

--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -23,7 +23,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -67,7 +68,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -105,6 +107,68 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
@@ -31,7 +31,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -92,7 +93,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -148,6 +150,67 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
@@ -31,7 +31,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -92,7 +93,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -148,6 +150,67 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml
@@ -31,6 +31,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -95,6 +97,37 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -23,6 +23,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -59,6 +61,37 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   # kafka broker type broker with persistent flag enabled
   - test:

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -19,6 +19,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -43,6 +45,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
@@ -30,7 +30,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -74,7 +75,8 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -111,6 +113,67 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml
@@ -28,7 +28,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -71,7 +72,8 @@ tests:
                   args:
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-dashboard: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
               - config:
                   command: add_hosts
                   service: host
@@ -109,6 +111,67 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml
@@ -23,6 +23,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -47,6 +49,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd-5-0-only.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd-5-0-only.yaml
@@ -61,6 +61,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -97,6 +99,37 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83573713
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
 #   S3CMD tests
   - test:

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -60,6 +60,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -96,6 +98,37 @@ tests:
       module: test_cephadm.py
       polarion-id: CEPH-83573713
       name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
 #   S3CMD tests
   - test:

--- a/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
@@ -24,6 +24,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -60,6 +62,37 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
       # kafka broker type with empty bucket notifcation
   - test:

--- a/suites/quincy/rgw/test-basic-object-operations.yaml
+++ b/suites/quincy/rgw/test-basic-object-operations.yaml
@@ -31,6 +31,8 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -55,6 +57,37 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/quincy/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_multisite.yaml
@@ -1,22 +1,13 @@
 # Test suite for evaluating RGW multi-site deployment scenario.
 #
-# This suite deploys a single realm (India) spanning across two RHCS clusters.
-# It has a zonegroup (shared) which also spans across the clusters. There
-# exists a master (pri) and secondary (sec) zones within this group. The master
-# zone is part of the pri cluster whereas the sec zone is part of the sec
-# datacenter (cluster).
+# This suite deploys a single realm (India) spanning across two RHCS clusters. It has a
+# zonegroup (shared) which also spans across the clusters. There exists a master (pri)
+# and secondary (sec) zones within this group. The master zone is part of the pri
+# cluster whereas the sec zone is part of the sec datacenter (cluster).
 
 # The deployment is evaluated by running IOs across the environments.
-# This particular yaml runs the tests on the primary and verifies IOs on the
-# secondary site.
-
-# In addition to the above, the data bucket is configured to use EC along with
-# network delays between the two clusters.
----
-
+# conf : conf/quincy/rgw/rgw_multisite.yaml
 tests:
-
-  # Cluster deployment stage
 
   - test:
       abort-on-fail: true
@@ -29,30 +20,13 @@ tests:
       clusters:
         ceph-pri:
           config:
-            roles:
-              - rgw
-            rule: root netem delay 30ms 6ms distribution normal
-        ceph-sec:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 20ms 5ms distribution normal
-      desc: Configuring network traffic delay
-      module: configure-tc.py
-      name: apply-net-qos
-      polarion-id: CEPH-83575222
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
             verify_cluster_health: true
             steps:
               - config:
                   command: bootstrap
                   service: cephadm
                   args:
+                    registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
@@ -80,21 +54,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  args:
-                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
-                    - "crush-failure-domain=host crush-device-class=hdd"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool create primary.rgw.buckets.data 32 32"
-                    - "erasure rgwec01"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool application enable"
-                    - "primary.rgw.buckets.data rgw"
-                  command: shell
               - config:
                   command: apply
                   service: rgw
@@ -103,7 +62,7 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node7
+                        - node5
         ceph-sec:
           config:
             verify_cluster_health: true
@@ -112,6 +71,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
+                    registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
@@ -140,21 +100,6 @@ tests:
                   args:
                     all-available-devices: true
               - config:
-                  args:
-                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
-                    - "crush-failure-domain=host crush-device-class=hdd"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
-                    - "erasure rgwec01"
-                  command: shell
-              - config:
-                  args:
-                    - "ceph osd pool application enable"
-                    - "secondary.rgw.buckets.data rgw"
-                  command: shell
-              - config:
                   command: apply
                   service: rgw
                   pos_args:
@@ -162,12 +107,13 @@ tests:
                   args:
                     placement:
                       nodes:
-                        - node7
+                        - node5
       desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83575222
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
-      polarion-id: CEPH-83575222
+
   - test:
       abort-on-fail: true
       clusters:
@@ -229,6 +175,7 @@ tests:
       desc: Add monitoring services using spec file.
       module: test_cephadm.py
       polarion-id: CEPH-83574727
+
   - test:
       abort-on-fail: true
       clusters:
@@ -236,7 +183,7 @@ tests:
           config:
             command: add
             id: client.1
-            node: node8
+            node: node6
             install_packages:
               - ceph-common
             copy_admin_keyring: true
@@ -244,15 +191,16 @@ tests:
           config:
             command: add
             id: client.1
-            node: node8
+            node: node6
             install_packages:
               - ceph-common
             copy_admin_keyring: true
       desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
       destroy-cluster: false
       module: test_client.py
       name: configure client
-      polarion-id: CEPH-83573758
+
   - test:
       abort-on-fail: true
       clusters:
@@ -261,8 +209,8 @@ tests:
             cephadm: true
             commands:
               - "radosgw-admin realm create --rgw-realm india --default"
-              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node7}:80 --master --default"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node7}:80 --master --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
@@ -276,9 +224,9 @@ tests:
             cephadm: true
             commands:
               - "sleep 120"
-              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node7}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
@@ -288,6 +236,7 @@ tests:
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:
@@ -300,11 +249,11 @@ tests:
               - "radosgw-admin realm list"
               - "radosgw-admin zonegroup list"
               - "radosgw-admin zone list"
-              - "ceph osd dump"
       desc: Retrieve the configured environment details
+      polarion-id: CEPH-83575227
       module: exec.py
       name: get shared realm info on primary
-      polarion-id: CEPH-83575227
+
   - test:
       abort-on-fail: true
       clusters:
@@ -317,13 +266,10 @@ tests:
               - "radosgw-admin realm list"
               - "radosgw-admin zonegroup list"
               - "radosgw-admin zone list"
-              - "ceph osd dump"
       desc: Retrieve the configured environment details
+      polarion-id: CEPH-83575227
       module: exec.py
       name: get shared realm info on secondary
-      polarion-id: CEPH-83575227
-
-  # Test work flow
 
   - test:
       clusters:
@@ -335,143 +281,6 @@ tests:
             copy-user-info-to-site: ceph-sec
             timeout: 300
       desc: create non-tenanted user
+      polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
-      polarion-id: CEPH-83575199
-
-  - test:
-      name: listing flat ordered versioned buckets on primary
-      desc: test_bucket_listing_flat_ordered_versionsing on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
-  - test:
-      name: listing flat ordered buckets on primary
-      desc: test_bucket_listing_flat_ordered on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
-  - test:
-      name: listing flat unordered buckets on primary
-      desc: test_bucket_listing_flat_unordered.yaml on secondary
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
-  - test:
-      name: listing pseudo ordered dir only buckets on primary
-      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
-      polarion-id: CEPH-83573651
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
-  - test:
-      name: ordered listing of bucket with pseudo directories and objects
-      desc: measure execution time for ordered listing of bucket with pseudo directories and objects
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered.yaml
-            timeout: 300
-  - test:
-      name: Test Copy of objects with Versioned and non-versionsed buckets on primary
-      desc: test_versioning_copy_objects on secondary
-      polarion-id: CEPH-9221
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_copy_objects.py
-            config-file-name: test_versioning_copy_objects.yaml
-            timeout: 300
-  - test:
-      name: enable bucket versioning on primary
-      desc: test_versioning_enable on secondary
-      polarion-id: CEPH-9178
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_enable.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
-  - test:
-      name: setting acls to versioned objects on primary
-      desc: test_versioning_objects_acls on secondary
-      polarion-id: CEPH-9190
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_acls.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
-  - test:
-      name: reverting object to one of the versions on primary
-      desc: test_versioning_objects_copy on secondary
-      polarion-id: CEPH-14264 # also applies to CEPH-10646
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
-  - test:
-      name: delete versioned objects on primary
-      desc: test_versioning_objects_delete on secondary
-      polarion-id: CEPH-14262
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
-  - test:
-      name: enabling bucket versioning and uploading objects on primary
-      desc: test_versioning_objects_enable on secondary
-      polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_enable.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
-  - test:
-      name: suspend bucket versioning on primary
-      desc: test_versioning_objects_suspend on secondary
-      polarion-id: CEPH-14263
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_suspend.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -61,6 +61,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -97,6 +99,37 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83573713
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   # Basic Bucket Operation Tests
 

--- a/suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml
@@ -31,6 +31,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host
@@ -95,6 +97,37 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Enabling Dashboard  feature in rgw test suites rather than skipping it
Logs:
    Single site 5.3 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-219RQO/RHCS_deploy_cluster_using_cephadm_0.log
    Enabling dashboard after cluster deployment :http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OOXAFE/Enable_the_dashboard_0.log   
    upgrade : 
          Install : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0KLPV6/ceph_ansible_install_rhcs_4.x_from_cdn_0.log
          Upgrade: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0KLPV6/Upgrade_containerized_ceph_to_5.x_latest_0.log
     




<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
