### PR TITLE
Adding cephfs IOs to upgrade suites

### DIFF
--- a/conf/pacific/upgrades/upgrades.yaml
+++ b/conf/pacific/upgrades/upgrades.yaml
@@ -11,10 +11,12 @@ globals:
        role:
          - mon
          - mgr
+         - mds
      node3:
        role:
          - mon
          - mgr
+         - mds
      node4:
        role:
          - osd

--- a/suites/pacific/upgrades/tier-1_upgrade_4x-to-5x-baremetal-without-dashboard.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_4x-to-5x-baremetal-without-dashboard.yaml
@@ -162,6 +162,15 @@ tests:
     desc: Perform export during read/write,resizing,flattening,lock operations
 
 - test:
+    abort-on-fail: false
+    config:
+        timeout: 600
+    desc: Runs cephfs IOs
+    module: cephfs_upgrade.cephfs_io.py
+    name: "cephfs-io"
+    polarion-id: CEPH-83575315
+
+- test:
     name: rgw sanity tests
     module: sanity_rgw.py
     config:

--- a/suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml
@@ -197,6 +197,14 @@ tests:
               io-total: 100M
             desc: Perform export during read/write,resizing,flattening,lock operations
         - test:
+            abort-on-fail: false
+            config:
+                timeout: 600
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "cephfs-io"
+            polarion-id: CEPH-83575315
+        - test:
             name: Upgrade ceph
             desc: Upgrade cluster to latest version
             module: test_cephadm_upgrade.py

--- a/suites/pacific/upgrades/tier-1_upgrade_cephadm_without_rgw.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_cephadm_without_rgw.yaml
@@ -173,6 +173,14 @@ tests:
               io-total: 100M
             desc: Perform export during read/write,resizing,flattening,lock operations
         - test:
+            abort-on-fail: false
+            config:
+                timeout: 600
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "cephfs-io"
+            polarion-id: CEPH-83575315
+        - test:
             name: Upgrade ceph
             desc: Upgrade cluster to latest version
             module: test_cephadm_upgrade.py

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml
@@ -6,7 +6,7 @@
 # Test configuration needs atleast one non mon node to exist to test the test case - test_cephadm_shell_run
 # --------------------------------------------------------------------------
 # Nodes:
-#   - 3 MONS, 3 MGRs, 3 OSDs, 2 RGW, 2 ISCSIGW's, 1 MDS's, 1 CLIENT, 1 GRAFANA, 1 CLIENT
+#   - 3 MONS, 3 MGRs, 3 OSDs, 2 RGW, 2 ISCSIGW's, 3 MDS's, 1 CLIENT, 1 GRAFANA, 1 CLIENT
 #
 # Test steps:
 # ---------------------------------------------------------------------
@@ -96,6 +96,14 @@ tests:
              io-total: 100M
              cleanup: false
            desc: Perform export during read/write,resizing,flattening,lock operations
+       - test:
+           abort-on-fail: false
+           config:
+               timeout: 600
+           desc: Runs IOs in parallel with upgrade process
+           module: cephfs_upgrade.cephfs_io.py
+           name: "cephfs-io"
+           polarion-id: CEPH-83575315
        - test:
            name: Upgrade containerized ceph to 5.x latest
            polarion-id: CEPH-83573680

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container_custom_name.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container_custom_name.yaml
@@ -83,6 +83,14 @@ tests:
              cleanup: false
            desc: Perform export during read/write,resizing,flattening,lock operations
        - test:
+           abort-on-fail: false
+           config:
+               timeout: 600
+           desc: Runs IOs in parallel with upgrade process
+           module: cephfs_upgrade.cephfs_io.py
+           name: "cephfs-io"
+           polarion-id: CEPH-83575315
+       - test:
            name: Upgrade containerized ceph to 5.x latest
            polarion-id: CEPH-83575198
            module: test_ansible_upgrade.py

--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
@@ -4,7 +4,7 @@
 # Cluster configuration: (conf/pacific/upgrades/upgrades.yaml)
 # --------------------------------------------------------------------------
 # Nodes:
-#   - 3 MONS, 3 MGRs, 3 OSDs, 2 RGW, 2 ISCSIGW's, 1 MDS's, 1 CLIENT, 1 GRAFANA, 1 CLIENT
+#   - 3 MONS, 3 MGRs, 3 OSDs, 2 RGW, 2 ISCSIGW's, 3 MDS's, 1 CLIENT, 1 GRAFANA, 1 CLIENT
 #
 # Test steps:
 # ---------------------------------------------------------------------
@@ -116,6 +116,14 @@ tests:
             io-total: 100M
             cleanup: false
           desc: Perform export during read/write,resizing,flattening,lock operations
+      - test:
+          abort-on-fail: false
+          config:
+              timeout: 600
+          desc: Runs IOs in parallel with upgrade process
+          module: cephfs_upgrade.cephfs_io.py
+          name: "cephfs-io"
+          polarion-id: CEPH-83575315
       - test:
           name: Upgrade containerized ceph to 5.x latest
           polarion-id: CEPH-83573679

--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml
@@ -106,6 +106,14 @@ tests:
            cleanup: False
          desc: Perform export during read/write,resizing,flattening,lock operations
      - test:
+         abort-on-fail: false
+         config:
+             timeout: 600
+         desc: Runs IOs in parallel with upgrade process
+         module: cephfs_upgrade.cephfs_io.py
+         name: "cephfs-io"
+         polarion-id: CEPH-83575315
+     - test:
          name: Upgrade containerized ceph to 5.x latest
          module: test_ansible_upgrade.py
          config:

--- a/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
+++ b/suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml
@@ -213,6 +213,14 @@ tests:
               io-total: 100M
             desc: Perform export during read/write,resizing,flattening,lock operations
         - test:
+            abort-on-fail: false
+            config:
+                timeout: 600
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "cephfs-io"
+            polarion-id: CEPH-83575315
+        - test:
             name: Upgrade ceph
             desc: Upgrade cluster to latest version
             module: test_cephadm_upgrade.py

--- a/suites/pacific/upgrades/tier-2_upgrade_skip-tag_ceph_infra.yaml
+++ b/suites/pacific/upgrades/tier-2_upgrade_skip-tag_ceph_infra.yaml
@@ -4,7 +4,7 @@
 # Cluster configuration: (conf/pacific/upgrades/upgrades.yaml)
 # --------------------------------------------------------------------------
 # Nodes:
-#   - 3 MONS, 3 MGRs, 3 OSDs, 2 RGW, 2 ISCSIGW's, 1 MDS's, 1 CLIENT, 1 GRAFANA, 1 CLIENT
+#   - 3 MONS, 3 MGRs, 3 OSDs, 2 RGW, 2 ISCSIGW's, 3 MDS's, 1 CLIENT, 1 GRAFANA, 1 CLIENT
 #
 # Test steps:
 # ---------------------------------------------------------------------
@@ -71,6 +71,14 @@ tests:
              pg_num: '128'
              pool_type: 'normal'
            desc: run rados bench for 360 - normal profile
+       - test:
+           abort-on-fail: false
+           config:
+               timeout: 600
+           desc: Runs IOs in parallel with upgrade process
+           module: cephfs_upgrade.cephfs_io.py
+           name: "cephfs-io"
+           polarion-id: CEPH-83575315
        - test:
            name: Upgrade containerized ceph to 5.x latest
            polarion-id: CEPH-83575130


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
Adding logs for 2 suites as fix is just adding cephfs IOs

Logs for suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-container.yaml - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-THYA6J 
tier-1_upgrade_cephadm_without_rgw.yaml  - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C6QCNN/Upgrade_along_with_IOs_0.log