### PR TITLE
Updating Polarian ID in cephci suites

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw.yaml
+++ b/suites/pacific/rgw/tier-1_rgw.yaml
@@ -100,7 +100,7 @@ tests:
   - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
-      polarion-id: CEPH-83571740 # also applies to ceph-11479
+      polarion-id: CEPH-83571740 # also applies to ceph-11479, ceph-11477
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py

--- a/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml
@@ -82,7 +82,7 @@ tests:
   - test:
       name: Dynamic Resharding tests with version pre upgrade
       desc: Resharding test - dynamic
-      polarion-id: CEPH-83571740
+      polarion-id: CEPH-83571740 # also applies to ceph-11479, ceph-11477
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py

--- a/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml
@@ -104,7 +104,7 @@ tests:
   - test:
       name: Dynamic Resharding tests pre upgrade
       desc: Resharding test - dynamic
-      polarion-id: CEPH-83571740
+      polarion-id: CEPH-83571740 # also applies to ceph-11479, ceph-11477
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py


### PR DESCRIPTION

TC "CEPH-83571740" provides automation coverage to the TCs ceph-11479 and ceph-11477.

Hence, mentioning these 2 TCs (11479 and -11477) in cephci, before updating their automation status in the Polarian.

Signed-off-by: viduship <vimishra@redhat.com>

