### PR TITLE
bootstrap.py: Changing the config setting from global level to mon

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -359,12 +359,10 @@ class BootstrapMixin:
         public_nws = self.cluster.get_public_networks()
         cluster_nws = self.cluster.get_cluster_networks()
         if public_nws:
-            self.shell(
-                args=["ceph", "config", "set", "global public_network", public_nws]
-            )
+            self.shell(args=["ceph", "config", "set", "mon public_network", public_nws])
         if cluster_nws:
             self.shell(
-                args=["ceph", "config", "set", "global cluster_network", cluster_nws]
+                args=["ceph", "config", "set", "mon cluster_network", cluster_nws]
             )
 
         # validate spec file


### PR DESCRIPTION
Changing the configuration set from global to mon levels.

The failure occurs when already the public network is set at both mon and global levels, since preference is 
1. Daemon.ID
2. Daemon
3. Global
fail log when set at global levels: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1FXAXJ/cluster_deployment_0.log

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>
