### PR TITLE
Fix metadata remove non-existing test suite

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -761,22 +761,6 @@
     - rgw
     - stage-2
 
-- name: "test-empty-bucket-notification"
-  suite: "suites/pacific/rgw/tier-2_rgw_test-empty-bucket-notifcations.yaml"
-  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-  platform: "rhel-9"
-  rhbuild: "6.0"
-  inventory:
-    openstack: "conf/inventory/rhel-9-latest.yaml"
-    ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-  metadata:
-    - schedule
-    - tier-2
-    - openstack
-    - ibmc
-    - rgw
-    - stage-3
-
 - name: "test-rgw-quota-management"
   suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
   global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

As per PR: https://github.com/red-hat-storage/cephci/pull/1795/files
tier-2_rgw_test-empty-bucket-notifcations.yaml was renamed to tier-2_rgw_test_5.3_specific_fixes.yaml

tier-2_rgw_test_5.3_specific_fixes.yaml is already present in 6.0 metadata file,
hence removing entry for suite tier-2_rgw_test-empty-bucket-notifcations.yaml from metada file 6.0


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
