### PR TITLE
Fixing the repo subscription for upgrade suite

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -212,6 +212,7 @@ class BootstrapMixin:
             ] = f"{_details[1]}/{_details[2]}:{_details[3]}"
             self.cluster.rhcs_version = _rhcs_version
             rhbuild = f"{_rhcs_version}-{_platform}"
+            base_url = _details[0]
 
         if build_type == "upstream":
             self.setup_upstream_repository()


### PR DESCRIPTION
Fixing the repo subscription for upgrade suite
Upgrade suite is failng when tried with 5.x
it is fetching the builds properly with config data provided in rhcs-version: 5.2, release: ga
but while setting the repos it is still setting the --rhbuild repos.
Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-70W89G/
Planning to add below inside 
base_url = self.config.get("base_url") at line no : 217 in ceph/ceph_admin/bootstrap.py 
Logs with the above line : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-A9PXHI/
fix is inside if _rhcs_release and _rhcs_version:


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
