### PR TITLE
Include gitclone support in test_client to support parallel execution…

### DIFF
--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -5,6 +5,7 @@ from typing import Dict
 from ceph.ceph_admin.orch import Orch
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
+from utility import utils
 from utility.log import Log
 
 log = Log(__name__)
@@ -80,6 +81,12 @@ def add(cls, config: Dict) -> None:
                     node.exec_command(
                         cmd=f"yum install -y --nogpgcheck {pkg}", sudo=True
                     )
+            if config.get("git_clone", False):
+                log.info("perform cloning operation")
+                role = config.get("git_node_role", "client")
+                ceph_object = cls.cluster.get_ceph_object(role)
+                node_value = ceph_object.node
+                utils.perform_env_setup(config, node_value, cls.cluster)
 
             out, _ = node.exec_command(cmd="ls -ltrh /etc/ceph/", sudo=True)
             log.info(out)


### PR DESCRIPTION
… in RGW

Signed-off-by: ckulal <ckulal@redhat.com>

Include gitclone support in test_client to support parallel execution in RGW,
logic is included with adding two config parameter to test_client.py
1) git_clone: default value set to False, so that there would be no changes to the existing suite which is currently using 
    test_client.py,
    only for for those test-case where we need git-clone has to be performed need to pass config, git_clone: true
2) git_node_role: on which node cloning has to be done, defaulted to client,
    currently for rgw cases need to pass config git_node_role: rgw

Logs:
parallel execution: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-89R27O/
for existing suite: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VNQZIY/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FTQSZ2/ 
(failure is not due to this changes, it's a script issue in ceph-qe-script team is working on it)

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
