### PR TITLE
Fix parallel.py

### DIFF
--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -73,6 +73,7 @@ def execute(test, args, results: dict):
     file_name = test.get("module")
     mod_file_name = os.path.splitext(file_name)[0]
     test_mod = importlib.import_module(mod_file_name)
+    testcase_name = test.get("name", "Test Case Unknown")
 
     rc = test_mod.run(
         ceph_cluster=args["ceph_cluster"],
@@ -83,5 +84,5 @@ def execute(test, args, results: dict):
         clients=args["clients"],
     )
 
-    file_string = f"{test_mod}"
+    file_string = f"{testcase_name}"
     results.update({file_string: rc})


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

previously we used consider module name for updating test result dictionary in parallel run, 
which was causing an issue when we have same test module name in the test-cases, then it used to replace an result each time and only result for last testcase used to present in result dictionary.

hence changing to test-case name instead of module name since we have unique test-case name

Pass log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6RRB17/Parallel_run_0.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
