### PR TITLE
Adding abort on failure to bm pipeline

### DIFF
--- a/pipeline/baremetal/6.0.yaml
+++ b/pipeline/baremetal/6.0.yaml
@@ -1,15 +1,18 @@
 ---
 -
-  cluster_conf: "conf/quincy/upi/octo_11_node_env.yaml"
+  cluster_conf: conf/quincy/upi/octo_11_node_env.yaml
   name: "Tier-1: End to End scenarios executed on greenfield deployment"
   os_version: 9.0
   platform: rhel-9
   rhbuild: "6.0"
   scenario: 1
-  suites:
+  stages:
     deploy:
-      - "suites/quincy/e2e/poc/test_cluster_deployment.yaml"
+      abort_on_failure: true
+      suites:
+        - suites/quincy/e2e/poc/test_cluster_deployment.yaml
     baseline:
-      - "suites/quincy/e2e/poc/test-cephfs-core-features.yaml"
-      - "suites/quincy/e2e/poc/test-rbd-core-features.yaml"
-      - "suites/quincy/e2e/poc/test-object-core-features.yaml"
+      suites:
+        - suites/quincy/e2e/poc/test-cephfs-core-features.yaml
+        - suites/quincy/e2e/poc/test-rbd-core-features.yaml
+        - suites/quincy/e2e/poc/test-object-core-features.yaml

--- a/pipeline/vars/bm_send_test_reports.groovy
+++ b/pipeline/vars/bm_send_test_reports.groovy
@@ -63,7 +63,7 @@ def sendEMail(def testResults, def rhBuild, def scenarioName, def rhCephInfo) {
     body +="</table> </body> </html>"
 
     def composeUrl = ""
-    for (compose in rhcephInfo["composes"]){
+    for (compose in rhCephInfo["composes"]){
         composeUrl += compose.key
         composeUrl += " : " + compose.value
         composeUrl += "<br /><br />"
@@ -72,7 +72,7 @@ def sendEMail(def testResults, def rhBuild, def scenarioName, def rhCephInfo) {
     body += "<h3><u>Test Artifacts</h3></u>"
     body += "<table><tr><td>Composes</td><td>${composeUrl}</td></tr>"
     body += "<td>Ceph version</td><td>${cephVer}</td></tr>"
-    body += "<tr><td>Repository</td><td>${rhcephInfo["repository"]}</td></tr>"
+    body += "<tr><td>Repository</td><td>${rhCephInfo["repository"]}</td></tr>"
 
     subject = "[UPI]-[${rhBuild}] Test report of ${scenarioName} - ${cephVer} : ${status}"
     toList = "cephci@redhat.com"

--- a/suites/quincy/e2e/poc/test_cluster_deployment.yaml
+++ b/suites/quincy/e2e/poc/test_cluster_deployment.yaml
@@ -37,12 +37,7 @@ tests:
               args:
                 placement:
                   label: mgr
-          - config:
-              command: apply
-              service: mon
-              args:
-                placement:
-                  label: mon
+
       desc: "Evaluate cluster deployment using CephADM orchestrator."
       destroy-cluster: false
       module: test_cephadm.py


### PR DESCRIPTION
Adding abort on failure to bm pipeline
This will abort all the further stages on failure of current stage.
This happens only when abort_on_failure field is set to true


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
