### PR TITLE
Adding upgrade suite for cephfs from 5x to 6x

### DIFF
--- a/conf/quincy/cephfs/tier-0_fs.yaml
+++ b/conf/quincy/cephfs/tier-0_fs.yaml
@@ -1,0 +1,39 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
+      node3:
+        role:
+          - osd
+          - mon
+        no-of-volumes: 4
+        disk-size: 15
+      node4:
+        role:
+          - nfs
+          - mds
+      node5:
+        role:
+          - osd
+          - mds
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role:
+          - nfs
+          - mds
+      node7:
+        role:
+          - client

--- a/suites/quincy/cephfs/tier-0_cephfs_upgrade_5x_to_6x.yaml
+++ b/suites/quincy/cephfs/tier-0_cephfs_upgrade_5x_to_6x.yaml
@@ -1,0 +1,175 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-0_fs.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 5.x with below options,
+#       - rhcs-version: 5.2 in this suite, but it can be changed to 5.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                rhcs-version: 5.2
+                release: ga
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        args:
+          - ceph
+          - fs
+          - set
+          - cephfs
+          - max_mds
+          - "2"
+        command: shell
+      desc: "Add Active Active configuration of MDS for cephfs"
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Add Active Active configuration of MDS"
+      polarion-id: CEPH-11344
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Deploy MDS with default values using cephadm"
+      module: mds_default_values.py
+      name: cephfs default values for mds
+      polarion-id: "CEPH-83574284"
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        -
+          test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83573791,CEPH-83573790
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados                      # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+      desc: Running upgrade and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575313


### PR DESCRIPTION
Adding upgrade suite for cephfs from 5x to 6x
This Suite upgrades from 5.2 to 6.x based on the --rhbuild argument provided
Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-31YWY6/

CMD : python3 run.py --osp-cred /home/amk/osp-cred-ci-2.yaml **--rhbuild 6.0 --build latest** --platform rhel-9 --instances-name amk_up_2 --global-conf conf/pacific/cephfs/tier-0_fs.yaml --suite suites/pacific/cephfs/tier-0_cephfs_upgrade_5x_to_5x.yaml --inventory conf/inventory/rhel-9.0-server-x86_64.yaml --store

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
