### PR TITLE
Fix reimage failures due to single quote escape in Jenkins

### DIFF
--- a/pipeline/scripts/ci/reimage-octo-node.sh
+++ b/pipeline/scripts/ci/reimage-octo-node.sh
@@ -48,15 +48,15 @@ echo "Initiating reimage of nodes"
 ${REIMAGE_CMD} --os-type rhel --os-version ${OS_VER} ${NODES}
 
 for node in ${NODES} ; do
-    ssh ${node} "echo 'passwd' | sudo passwd --stdin root; \
-    grep -qxF 'PermitRootLogin yes' /etc/ssh/sshd_config || \
-    echo 'PermitRootLogin yes' | sudo tee -a /etc/ssh/sshd_config"
+    ssh ${node} 'echo "passwd" | sudo passwd --stdin root; \
+    grep -qxF "PermitRootLogin yes" /etc/ssh/sshd_config || \
+    echo "PermitRootLogin yes" | sudo tee -a /etc/ssh/sshd_config'
     ssh ${node} 'sudo systemctl restart sshd &'
     sleep 2
 
     echo "Wipe all data disks clean."
     disks=$(ssh ${node} 'lsblk -o NAME -d | tail -n +2')
-    root_disk=$(ssh ${node} "lsblk -oPKNAME,MOUNTPOINT | grep -e '^[a-z].*' | cut -d ' ' -f 1 | uniq")
+    root_disk=$(ssh ${node} 'lsblk -oPKNAME,MOUNTPOINT | grep -e "^[a-z].*" | cut -d " " -f 1 | uniq')
 
     for disk in ${disks} ; do
         if [ "${disk}" != "${root_disk}" ] ; then


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes the issue wherein Jenkins introduced single quotes which in turn led us to wipe out the root disk of the target systems.

__Error__
```
++ ssh cali015 'lsblk -oPKNAME,MOUNTPOINT | grep -e '\''^[a-z].*'\'' | cut -d '\'' '\'' -f 1 | uniq'
+ root_disk='sdc
nvme0n1
sde
sdb
sda
sdd
sdf
sdg'
```

__Fixed snippet__
```
++ ssh cali015 'lsblk -oPKNAME,MOUNTPOINT | grep -e "^[a-z].*" | cut -d " " -f 1 | uniq'
+ root_disk=sdc
+ for disk in ${disks}
```

__Log__
https://jenkins.ceph.redhat.com/job/rhceph-upi-pipeline-executor/13/console