### PR TITLE
Fix newline character for haproxy cfg

### DIFF
--- a/tests/misc_env/haproxy.py
+++ b/tests/misc_env/haproxy.py
@@ -73,7 +73,7 @@ backend app
     balance     roundrobin
 {% for item in data %}
     server      rgw{{loop.index}} {{item}} check
-{%- endfor %}
+{% endfor %}
 """
 
 


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

# Description

This PR fixes an issue encountered with rendering of Jinja2 template.

__Error__
```
Oct 10 09:08:11 cali019 haproxy[52618]: [ALERT]    (52618) : parsing [/etc/haproxy/haproxy.cfg:52]: Missing LF on last line, file might have been truncated at position 42.
Oct 10 09:08:11 cali019 haproxy[52618]: [ALERT]    (52618) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
Oct 10 09:08:11 cali019 haproxy[52618]: [ALERT]    (52618) : Fatal errors found in configuration.
Oct 10 09:08:11 cali019 systemd[1]: haproxy.service: Control process exited, code=exited, status=1/FAILURE
```
