### PR TITLE
Fixing node error issue when VM creation fails

### DIFF
--- a/compute/openstack.py
+++ b/compute/openstack.py
@@ -437,7 +437,7 @@ class CephVMNodeV2:
                 msg = (
                     "Unknown Error"
                     if not node.extra
-                    else node.extra.get("fault").get("message")
+                    else node.extra.get("fault", {}).get("message", "Unknown Error")
                 )
                 raise NodeError(msg)
 


### PR DESCRIPTION
Fixing node error issue when VM creation fails
When VM creation fails in OpenStack.
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-deploy-cluster/70/console 


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
