### PR TITLE
[post result] Report portal launch name to have run_type and stage

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -97,7 +97,7 @@ node("rhel-8-medium || ceph-qe-ci") {
                         metaData["results"], metaData, metaData["stage"]
                     )
                 }
-                sharedLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData)
+                sharedLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData, stageLevel, run_type)
 
             }
             testStatus = msgMap["test"]["result"]

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -437,7 +437,7 @@ def configureRpPreProc(
     }
 }
 
-def uploadTestResults(def sourceDir, def credPreproc, def runProperties) {
+def uploadTestResults(def sourceDir, def credPreproc, def runProperties, def stageLevel=null, def runType=null) {
     /*
         upload Xunit Xml file to report portal and polarion
 
@@ -465,6 +465,9 @@ def uploadTestResults(def sourceDir, def credPreproc, def runProperties) {
             "tier": runProperties["stage"],
         ]
     ]
+    if ( stageLevel ) {
+        launchConfig["name"] = runType.split(" ")[0] + " " + launchConfig["name"] + " " + stageLevel
+    }
     credPreproc["reportportal"]["launch"] = launchConfig
     writeJSON file: credFile, json: credPreproc
 


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
[post result] Report portal launch name to have run_type and stage
ex: Schedule RHCEPH-5.3 - tier-2 stage-3 <launch id>
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/5552
https://jenkins.ceph.redhat.com/job/rhceph-post-results/2368/console

![report_portal](https://user-images.githubusercontent.com/83442624/196598325-00eb409a-bc84-442b-826e-cfc870c1e774.png)

![report_portal_email](https://user-images.githubusercontent.com/83442624/196888117-a4a88eff-7e1e-4775-9674-83d24fa491a7.png)


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
