### PR TITLE
Adding test 9470, 9471, 9475 to quincy and pacific rbd-mirorr suites

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -183,3 +183,36 @@ tests:
             value: pong
       polarion-id: CEPH-9524
       desc: Verify removal of image meta gets mirrored
+
+  - test:
+      name: Recovery of abrupt failure of primary cluster
+      module: test_9470.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9470
+      desc: Test unplanned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown primary cluster
+      module: test_9471.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9471
+      desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown secondary cluster
+      module: test_9475.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9475
+      desc: Testing secondary cluster unplanned failover test

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -177,3 +177,36 @@ tests:
             value: pong
       polarion-id: CEPH-9524
       desc: Verify removal of image meta gets mirrored
+
+  - test:
+      name: Recovery of abrupt failure of primary cluster
+      module: test_9470.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9470
+      desc: Test unplanned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown primary cluster
+      module: test_9471.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9471
+      desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown secondary cluster
+      module: test_9475.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9475
+      desc: Testing secondary cluster unplanned failover test

--- a/tests/rbd_mirror/test_9470.py
+++ b/tests/rbd_mirror/test_9470.py
@@ -1,6 +1,7 @@
 import time
 
 from ceph.utils import hard_reboot
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
 
 log = Log(__name__)
@@ -9,9 +10,11 @@ log = Log(__name__)
 def run(**kw):
     try:
         log.info("Starting CEPH-9470")
-        mirror1 = kw.get("test_data")["mirror1"]
-        mirror2 = kw.get("test_data")["mirror2"]
         config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
         osd_cred = config.get("osp_cred")
         poolname = mirror1.random_string() + "9470pool"
         imagename = mirror1.random_string() + "9470image"

--- a/tests/rbd_mirror/test_9471.py
+++ b/tests/rbd_mirror/test_9471.py
@@ -1,6 +1,7 @@
 import time
 
 from ceph.parallel import parallel
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
 
 log = Log(__name__)
@@ -9,9 +10,11 @@ log = Log(__name__)
 def run(**kw):
     try:
         log.info("Starting CEPH-9471")
-        mirror1 = kw.get("test_data")["mirror1"]
-        mirror2 = kw.get("test_data")["mirror2"]
         config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
         poolname = mirror1.random_string() + "9471pool"
         imagename = mirror1.random_string() + "9471image"
         imagespec = poolname + "/" + imagename

--- a/tests/rbd_mirror/test_9474.py
+++ b/tests/rbd_mirror/test_9474.py
@@ -2,6 +2,7 @@ import time
 
 from ceph.parallel import parallel
 from ceph.utils import hard_reboot
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
 
 log = Log(__name__)
@@ -10,9 +11,11 @@ log = Log(__name__)
 def run(**kw):
     try:
         log.info("Starting CEPH-9474")
-        mirror1 = kw.get("test_data")["mirror1"]
-        mirror2 = kw.get("test_data")["mirror2"]
         config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
         osd_cred = config.get("osp_cred")
         poolname = mirror1.random_string() + "9474pool"
         imagename = mirror1.random_string() + "9474image"

--- a/tests/rbd_mirror/test_9475.py
+++ b/tests/rbd_mirror/test_9475.py
@@ -1,6 +1,7 @@
 import time
 
 from ceph.parallel import parallel
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
 
 log = Log(__name__)
@@ -9,9 +10,11 @@ log = Log(__name__)
 def run(**kw):
     try:
         log.info("Starting CEPH-9475")
-        mirror1 = kw.get("test_data")["mirror1"]
-        mirror2 = kw.get("test_data")["mirror2"]
         config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
         poolname = mirror1.random_string() + "9475pool"
         imagename = mirror1.random_string() + "9475image"
         imagespec = poolname + "/" + imagename


### PR DESCRIPTION
# Description
Adding test 9470, 9471, 9475 to quincy and pacific rbd-mirror suites and tweking modules to adopt to the suites.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
