### PR TITLE
Adding Max snapshot creation script

### DIFF
--- a/suites/quincy/cephfs/tier-2_fs_scale.yaml
+++ b/suites/quincy/cephfs/tier-2_fs_scale.yaml
@@ -1,0 +1,122 @@
+---
+#=======================================================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_scale.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# options : --cloud baremetal if required to run on baremetal
+# Test-Case Covered:
+#	CEPH-83573520 Validate the max snapshot that can be created under a root FS sub volume level.
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        args:
+          - ceph
+          - fs
+          - set
+          - cephfs
+          - max_mds
+          - "2"
+        command: shell
+      desc: "Add Active Active configuration of MDS for cephfs"
+      destroy-cluster: false
+      module: test_bootstrap.py
+      name: "Add Active Active configuration of MDS"
+      polarion-id: CEPH-11344
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Max allowed snapshots"
+      module: cephfs_scale.max_snapshots.py
+      name: cephfs Scale test for max Snapshots
+      polarion-id: "CEPH-83573520"

--- a/tests/cephfs/cephfs_scale/max_snapshots.py
+++ b/tests/cephfs/cephfs_scale/max_snapshots.py
@@ -1,0 +1,153 @@
+import json
+import random
+import string
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def get_available_space(client, fs_name="cephfs"):
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"ceph fs status {fs_name} --format json"
+    )
+    output = json.loads(out)
+    return next(
+        (pool["avail"] for pool in output["pools"] if pool["type"] == "data"), None
+    )
+
+
+def collect_ceph_details(client, cmd):
+    out, rc = client.exec_command(sudo=True, cmd=f"{cmd} --format json")
+    output = json.loads(out)
+    log.info(output)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573520	Validate the max snapshot that can be created under a root FS sub volume level.
+
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+    2. creats fs volume create cephfs if the volume is not there
+    3. ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>]
+       [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>]  [--namespace-isolated]
+       Ex: ceph fs subvolume create cephfs subvol_max_snap --size 5368706371 --group_name subvolgroup_1
+    4. Create Data on the subvolume
+        Ex:  python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 --files
+            100 --files-per-dir 10 --dirs-per-dir 2 --top /mnt/cephfs_fuse1baxgbpaia_1/
+
+    Test Script Flow :
+    1. We will set max snapshots to maximum allowed value 4096.
+    2. We add data based on max available data divided by 4096 .
+    3. For every snapshot we are going to write new file until 4096
+
+    Clean up:
+    1. Deletes all the snapshots created
+    2. Deletes snapshot and subvolume created.
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        max_snap = 4096
+        log.info("checking Pre-requisites")
+        if len(clients) < 1:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        default_fs = "cephfs"
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        client1 = clients[0]
+        fs_details = fs_util.get_fs_info(client1)
+        if not fs_details:
+            fs_util.create_fs(client1, "cephfs")
+        subvolume = {
+            "vol_name": default_fs,
+            "subvol_name": "subvol_max_snap",
+        }
+        fs_util.create_subvolume(client1, **subvolume)
+        log.info("Get the path of sub volume")
+        subvol_path, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume getpath {default_fs} subvol_max_snap",
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph config set mds mds_max_snaps_per_dir {max_snap}",
+        )
+        kernel_mounting_dir_1 = f"/mnt/cephfs_kernel{mounting_dir}_1/"
+        mon_node_ips = fs_util.get_mon_node_ips()
+        fs_util.kernel_mount(
+            [clients[0]],
+            kernel_mounting_dir_1,
+            ",".join(mon_node_ips),
+            sub_dir=f"{subvol_path.strip()}",
+        )
+        snapshot_list = [
+            {
+                "vol_name": default_fs,
+                "subvol_name": "subvol_max_snap",
+                "snap_name": f"snap_limit_{x}",
+            }
+            for x in range(1, max_snap + 1)
+        ]
+        available_space = int(get_available_space(client1, default_fs))
+        log.info(available_space)
+        data_size_iter = int(available_space / max_snap)
+        bs = int(data_size_iter / 10000)
+        for snapshot in snapshot_list:
+            try:
+                client1.exec_command(
+                    sudo=True,
+                    cmd=f"dd if=/dev/zero "
+                    f"of={kernel_mounting_dir_1}/file_{snapshot['snap_name']}.txt bs={bs} count=1000",
+                    check_ec=False,
+                )
+                fs_util.create_snapshot(clients[0], **snapshot, validate=False)
+            except CommandFailed:
+                log.info(
+                    f"Max Snapshots allowed under a root FS sub volume level is {snapshot}"
+                )
+        snaphot_4097 = {
+            "vol_name": default_fs,
+            "subvol_name": "subvol_max_snap",
+            "snap_name": "snap_limit_4097",
+        }
+        try:
+            fs_util.create_snapshot(clients[0], **snaphot_4097, validate=False)
+            log.error(
+                f"We are able create more than maximum number({max_snap}) of snapshot."
+            )
+            return 1
+        except CommandFailed:
+            log.info("Max Snapshots allowed under a root FS sub volume level is 4096")
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        cmd_list = [
+            "ceph crash ls",
+            "ceph fs status",
+            f"ceph fs subvolume snapshot ls {default_fs} subvol_max_snap",
+        ]
+        map(collect_ceph_details, cmd_list)
+        for cmd in cmd_list:
+            collect_ceph_details(client1, cmd)
+        log.info("Clean Up in progess")
+        for snapshot in snapshot_list:
+            fs_util.remove_snapshot(client1, **snapshot)
+        fs_util.remove_subvolume(client1, **subvolume, check_ec=False)


### PR DESCRIPTION
Adding Max snapshot creation script

1. We will set max snapshots to the maximum allowed value 4096.
2. We add data based on max available data divided by 4096 .
3. For every snapshot we are going to write a new file until 4096
We have used the DD command for writing to files
Log File : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LHATMR/
Total execution time: 7 hrs 25 min
This is executed on VM setup same script can be used on bare metal as well



Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
