### PR TITLE
Adding email notification for tier-0 failure

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -93,6 +93,16 @@ node("rhel-8-medium || ceph-qe-ci") {
                 build_url = msgMap["run"]["url"]
             }
 
+            if (msgMap["test"]["result"] == "FAILURE" && tierLevel == "tier-0") {
+                sharedLib.sendEmail(
+                    run_type,
+                    metaData['results'],
+                    metaData,
+                    tierLevel,
+                    stageLevel
+                )
+            }
+
             if (metaData["results"]) {
                 if ( ! msgMap["pipeline"].containsKey("tags") ) {
                     sharedLib.sendEmail(


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Adding email notification for tier-0 failure.
Jenkins - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/post_res_tintu/12/console
![Screenshot from 2022-10-21 13-52-55](https://user-images.githubusercontent.com/83664366/197149313-7718429a-a68a-4d90-9463-b6d89d5c37a6.png)

