### PR TITLE
PSI jenkins pipeline posts to report portal only on demand

### DIFF
--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -45,7 +45,7 @@ node("rhel-8-medium || ceph-qe-ci") {
         def rhcephVersion = ciMap.artifact.nvr
         def buildType = "tier-0"
         def tags = "openstack-only,tier-1,stage-1"
-        def overrides = ["build": "tier-0"]
+        def overrides = ["build": "tier-0", "post-results": "", "report-portal": ""]
         def overridesStr = writeJSON returnText: true, json: overrides
         def buildArtifacts = "${params.CI_MESSAGE}"
 

--- a/pipeline/scripts/ci/getPipelineStages.py
+++ b/pipeline/scripts/ci/getPipelineStages.py
@@ -112,8 +112,7 @@ def fetch_stages(args):
             os.makedirs(logdir)
             execute_cli += f" --log-dir {logdir}"
             cleanup_cli += f" --cloud {cloud_type}"
-        else:
-            execute_cli += " --post-results --report-portal"
+
         overrides.pop("workspace", None)
         overrides.pop("build_number", None)
         script.update({"inventory": script["inventory"][cloud_type]})


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

The pipeline execution triggered by the job - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-execution-pipeline/ posts to report portal only when the user passes the following values in **overrides** parameter. If these parameters are not passed, then the results are not posted to the report portal by default

> `{"post-results":"", "report-portal":""}`

> Note: IBM pipeline execution still continues to post to the report portal by default, there is no change with that.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
