### PR TITLE
rgw s3cmd suites execute from rgw-node

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -140,6 +140,7 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
         timeout: 300
+        run-on-rgw: true
 
   - test:
       name: S3CMD large object download with GC
@@ -150,6 +151,7 @@ tests:
         script-name: ../s3cmd/test_large_object_gc.py
         config-file-name: ../../s3cmd/configs/test_large_object_gc.yaml
         timeout: 300
+        run-on-rgw: true
 
   - test:
       name: S3CMD bucket stats consistency
@@ -160,6 +162,7 @@ tests:
         script-name: ../s3cmd/test_bucket_stats.py
         config-file-name: ../../s3cmd/configs/test_bucket_stats.yaml
         timeout: 300
+        run-on-rgw: true
 
   - test:
       name: S3CMD object header size check
@@ -170,6 +173,7 @@ tests:
         script-name: ../s3cmd/test_header_size.py
         config-file-name: ../../s3cmd/configs/test_header_size.yaml
         timeout: 300
+        run-on-rgw: true
 
   - test:
       name: S3CMD tests
@@ -180,6 +184,7 @@ tests:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_opslog.yaml
         timeout: 300
+        run-on-rgw: true
 
   - test:
       name: Test single delete marker for versioned object using s3cmd
@@ -190,3 +195,4 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
         timeout: 300
+        run-on-rgw: true


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

1. enabling tier-2_rgw_test-using-s3cmd.yaml to be executed from rgw node,
    by default it is trying to execute from client node, but required changes to execute from client node is not yet present in
    https://github.com/red-hat-storage/ceph-qe-scripts/tree/master/rgw/v2/tests/s3cmd
    hence making this changes to avoid pipeline failures.
    
    Once the required changes are available under https://github.com/red-hat-storage/ceph-qe- 
    scripts/tree/master/rgw/v2/tests/s3cmd will revert this change

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W4JWKQ/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
