### PR TITLE
Add arg post result and report portal to upstream executor

### DIFF
--- a/pipeline/upstream_test_executor.groovy
+++ b/pipeline/upstream_test_executor.groovy
@@ -11,7 +11,7 @@ def buildType = "upstream"
 def yamlData
 def cephVersion
 def tags = "${buildType},${currentStage}"
-def overrides = [build:buildType,"upstream-build":upstreamVersion]
+def overrides = [build:buildType, "upstream-build":upstreamVersion, "post-results": "", "report-portal": ""]
 
 // Pipeline script entry point
 node('ceph-qe-ci || rhel-8-medium') {


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
As per the pr: https://github.com/red-hat-storage/cephci/pull/1917/files ,for PSI jenkins pipeline posts to report portal only on demand
So including posts to report portal as a part of upstream executor pipeline

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
