### PR TITLE
Workaround to remove failed test from tier-0 suite till we have a fix

### DIFF
--- a/suites/quincy/cephadm/tier-0.yaml
+++ b/suites/quincy/cephadm/tier-0.yaml
@@ -103,14 +103,6 @@ tests:
             name: Test M buckets with N objects
             polarion-id: CEPH-9789
         - test:
-            config:
-              script: cli_generic.sh
-              script_path: qa/workunits/rbd
-            desc: "Executing upstream RBD CLI Generic scenarios"
-            module: test_rbd.py
-            name: 1_rbd_cli_generic
-            polarion-id: CEPH-83574241
-        - test:
             abort-on-fail: false
             desc: "cephfs basic operations"
             module: cephfs_basic_tests.py


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

Workaround to remove this failure from tier-0 will revert the changes once we have a fix

> https://159.23.92.24/job/rhceph-test-execution-pipeline/192/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
