### PR TITLE
Domain name fix for interop test suite.

### DIFF
--- a/suites/pacific/interop/test-ceph-sanity.yaml
+++ b/suites/pacific/interop/test-ceph-sanity.yaml
@@ -27,6 +27,7 @@ tests:
               args:
                 registry-url: registry.redhat.io
                 mon-ip: node1
+                allow-fqdn-hostname: true
           - config:
               command: add_hosts
               service: host


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for interop pipeline test execution failure on RHCEPH-5.1 build.

logs - http://magna002.ceph.redhat.com/ceph-qe-logs/tmathew/cephci-run-L2UUAQ-rhel-8.7-nightly/

