### PR TITLE
Fixing None type errors seen because of recent changes to getPipelineStages

### DIFF
--- a/pipeline/scripts/ci/getPipelineStages.py
+++ b/pipeline/scripts/ci/getPipelineStages.py
@@ -67,13 +67,14 @@ def fetch_stages(args):
     metadata_file = f"{metadata_dir}/{args['rhcephVersion']}.yaml"
     metadata_content = yaml.safe_load(open(metadata_file, "r"))
     metadata_overrides = metadata_content.get("overrides", {})
-    ibmc_overrides = metadata_overrides.pop("ibmc", None)
-    openstack_overrides = metadata_overrides.pop("openstack", None)
+    cloud_overrides = {
+        "ibmc": metadata_overrides.pop("ibmc", {}),
+        "openstack": metadata_overrides.pop("openstack", {}),
+    }
     data = metadata_content.get("suites")
     tags = args["tags"].split(",")
     tags_next = args["tags"].split(",")
     overrides = json.loads(args.get("overrides", {}))
-    overrides_log = json.loads(args.get("overrides", {}))
     cloud_type = "openstack"
 
     # filter metadata file for test suites based on tags provided
@@ -107,25 +108,22 @@ def fetch_stages(args):
         execute_cli = ".venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml"
         execute_cli += f" --instances-name {instances_name}"
         execute_cli += " --log-level DEBUG"
-        logdir = ""
-        script.update({"inventory": script["inventory"][cloud_type]})
+        workspace = overrides.pop("workspace", "")
+        build_number = overrides.pop("build_number", "")
+        logdir = f"{workspace}/logs/{generate_random_string(5)}-{build_number}"
+
         if "ibmc" in tags:
             cloud_type = "ibmc"
             execute_cli += " --xunit-results"
             execute_cli += " --cloud ibmc"
-            workspace = overrides_log.get("workspace")
-            build_number = overrides_log.get("build_number")
-            logdir = f"{workspace}/logs/{generate_random_string(5)}-{build_number}"
             os.makedirs(logdir)
             execute_cli += f" --log-dir {logdir}"
             cleanup_cli += f" --cloud {cloud_type}"
-            script.update(ibmc_overrides)
-        else:
-            script.update(openstack_overrides)
+
+        script.update({"inventory": script["inventory"][cloud_type]})
+        script.update(cloud_overrides[cloud_type])
 
         script.update(metadata_overrides)
-        overrides.pop("workspace", None)
-        overrides.pop("build_number", None)
         script.update(overrides)
 
         for (k, v) in script.items():


### PR DESCRIPTION
output of getPipelineStages

when metadata file has overrides
```
(venv) [manasagowri@localhost ci]$ python getPipelineStages.py --rhcephVersion 6.0 --tags sanity,ibmc,stage-1,tier-0 --overrides '{"build":"latest","workspace":"~/data/jenkins/workspace/rhceph-test-execution-pipeline","build_number":240}'
final_stage: true
scripts:
  Smoke Test of RH Ceph build:
    cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
      ci-j1v14 --log-level DEBUG --cloud ibmc
    execute_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
      ci-j1v14 --log-level DEBUG --xunit-results --cloud ibmc --log-dir ~/data/jenkins/workspace/rhceph-test-execution-pipeline/logs/kdg5z-240
      --suite suites/quincy/cephadm/tier-0.yaml --global-conf conf/quincy/cephadm/tier-0.yaml
      --platform rhel-9 --rhbuild 6.0 --inventory conf/inventory/ibm-vpc-rhel-9-latest.yaml
      --custom-config grafana_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/grafana:ceph-6.0-rhel-9-containers-candidate-99494-20221026123006
      --custom-config promtail_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/promtail:ceph-6.0-rhel-9-containers-candidate-10191-20221026120801
      --custom-config haproxy_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/haproxy:ceph-6.0-rhel-9-containers-candidate-53939-20221026121907
      --custom-config keepalived_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/keepalived:ceph-6.0-rhel-9-containers-candidate-18945-20221026120854
      --custom-config snmp_gateway_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/snmp-notifier:ceph-6.0-rhel-9-containers-candidate-15559-20221026120853
      --build latest
    log_dir: ~/data/jenkins/workspace/rhceph-test-execution-pipeline/logs/kdg5z-240

```

when metadata file doesn't have overrides

```
(venv) [manasagowri@localhost ci]$ python getPipelineStages.py --rhcephVersion 5.3 --tags sanity,ibmc,stage-1,tier-0 --overrides '{"build":"latest","workspace":"~/data/jenkins/workspace/rhceph-test-execution-pipeline","build_number":240}'
final_stage: true
scripts:
  Smoke test of RH Ceph build:
    cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
      ci-2bnsj --log-level DEBUG --cloud ibmc
    execute_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
      ci-2bnsj --log-level DEBUG --xunit-results --cloud ibmc --log-dir ~/data/jenkins/workspace/rhceph-test-execution-pipeline/logs/1hzfs-240
      --suite suites/pacific/cephadm/tier-0.yaml --global-conf conf/pacific/cephadm/tier-0.yaml
      --platform rhel-8 --rhbuild 5.3 --inventory conf/inventory/ibm-vpc-rhel-8-latest.yaml
      --build latest
    log_dir: ~/data/jenkins/workspace/rhceph-test-execution-pipeline/logs/1hzfs-240
```


Signed-off-by: mgowri <mgowri@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
