### PR TITLE
Fixing logdir error for IBM pipeline and releaseContent not found error for openstack-only executions

### DIFF
--- a/pipeline/scripts/ci/getPipelineStages.py
+++ b/pipeline/scripts/ci/getPipelineStages.py
@@ -97,6 +97,8 @@ def fetch_stages(args):
         final_stage = True
 
     test_scripts = dict()
+    workspace = overrides.pop("workspace", "")
+    build_number = overrides.pop("build_number", "")
     for script in filtered_data:
         script_name = script.pop("name")
         del script["metadata"]
@@ -108,8 +110,6 @@ def fetch_stages(args):
         execute_cli = ".venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml"
         execute_cli += f" --instances-name {instances_name}"
         execute_cli += " --log-level DEBUG"
-        workspace = overrides.pop("workspace", "")
-        build_number = overrides.pop("build_number", "")
         logdir = f"{workspace}/logs/{generate_random_string(5)}-{build_number}"
 
         if "ibmc" in tags:

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -45,7 +45,7 @@ node(nodeName) {
                 branches: [[name: branch]],
                 extensions: [[
                     $class: 'CleanBeforeCheckout',
-                        deleteUntrackedNestedRepositories: true
+                    deleteUntrackedNestedRepositories: true
                 ], [
                     $class: 'WipeWorkspace'
                 ], [
@@ -114,7 +114,7 @@ node(nodeName) {
             overrides.put("build", "rc")
         }
 
-        if ("openstack" in tags_list){
+        if ("openstack" in tags_list || "openstack-only" in tags_list){
             def (majorVersion, minorVersion) = rhcephVersion.substring(7,).tokenize(".")
             /*
                Read the release yaml contents to get contents,
@@ -123,6 +123,7 @@ node(nodeName) {
             releaseContent = sharedLib.readFromReleaseFile(
                 majorVersion, minorVersion, lockFlag=false
             )
+            println("releaseContent")
             println(releaseContent)
         }
 


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

For IBM changes - https://159.23.92.24/job/test-execution-manasa/9/console
For PSI changes - https://jenkins.ceph.redhat.com/job/rhceph-test-execution-pipeline/1090/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
