### PR TITLE
Fix test-basic-object-operations.yaml to be run from rgw nodes

### DIFF
--- a/suites/quincy/rgw/test-basic-object-operations.yaml
+++ b/suites/quincy/rgw/test-basic-object-operations.yaml
@@ -119,6 +119,7 @@ tests:
               config-file-name: test_Mbuckets_with_Nobjects.yaml
               timeout: 300
               install_common: false
+              run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects
             module: sanity_rgw.py
             name: Test M buckets with N objects
@@ -130,6 +131,7 @@ tests:
               config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
               timeout: 300
               install_common: false
+              run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with delete
             module: sanity_rgw.py
             name: Test delete using M buckets with N objects
@@ -141,6 +143,7 @@ tests:
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
               timeout: 300
               install_common: false
+              run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with download
             module: sanity_rgw.py
             name: Test download with M buckets with N objects
@@ -152,6 +155,7 @@ tests:
               config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
               timeout: 300
               install_common: false
+              run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with multipart upload
             module: sanity_rgw.py
             name: Test multipart upload of M buckets with N objects
@@ -163,6 +167,7 @@ tests:
               config-file-name: test_swift_basic_ops.yaml
               timeout: 300
               install_common: false
+              run-on-rgw: true
             desc: Test object operations with swift
             module: sanity_rgw.py
             name: Swift based tests


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>
Fix test-basic-object-operations.yaml to be run from rgw nodes to avoid pipeline failure

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5GWIST/Parallel_run_0.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
