### PR TITLE
rgw-ms: async notification tests to be run from rgw nodes

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
@@ -291,6 +291,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            run-on-rgw: true
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
@@ -303,6 +304,7 @@ tests:
       clusters:
         ceph-sec:
           config:
+            run-on-rgw: true
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]


### PR DESCRIPTION
async data notification tests on multisite to be run from rgw nodes.

pipeline-failure: https://issues.redhat.com/browse/RHCEPHQE-5784

successful logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5S2I3O/

Signed-off-by: viduship <vimishra@redhat.com>

