### PR TITLE
[FS]Fixing the mutlifs issue 1924

### DIFF
--- a/tests/cephfs/multifs/multifs_multiplefs.py
+++ b/tests/cephfs/multifs/multifs_multiplefs.py
@@ -66,7 +66,10 @@ def run(ceph_cluster, **kw):
             )
             fuse_mounting_dir = f"/mnt/cephfs_fuse{mounting_dir}_{i}/"
             fs_util.fuse_mount(
-                [clients[0]], fuse_mounting_dir, extra_params=f"--client_fs cephfs_{i}"
+                [clients[0]],
+                fuse_mounting_dir,
+                extra_params=f"--client_fs cephfs_{i}",
+                wait_for_mount=True,
             )
             client1.exec_command(
                 sudo=True,


### PR DESCRIPTION
Problem:
Fuse mount was failing for the newly created Filesystems with Laggy MDS #1924 

Fix:
We are retrying the fuse mount operation for every 1 minute until it succeeds. this timeouts after 5 min.
Even then if mount fails after 5 retries we decalre it as failure and will raise Error

Logs dir : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XIA6J3/

As part of this PR we have also added fix for 1923
problem:
After reboot command, the VM is taking time to start reboot command
Before that script is trying to reconnect which was successful and later commands are failing

solution:
We have added sleep right after reboot and reconnect so that there will gap for reboot to get initiated and wait to reconnect

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-144K09
Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
