### PR TITLE
Fix suite name in 6.0 metadata file

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -748,7 +748,7 @@ suites:
       - stage-1
 
   - name: "Tier-2 RGW bucket notification on the latest development build"
-    suite: "suites/quincy/rgw/tier-2_rgw_test-bucket-notifications.yaml"
+    suite: "suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml"
     global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"


### PR DESCRIPTION
Signed-off-by: ckulal <ckulal@redhat.com>

Fixing suite name in 6.0 metadata file
existing suite file name is : tier-2_rgw_test_bucket_notifications.yaml

to fix the failure:
2022-11-05 03:29:21,178 - DEBUG - cephci.utility.xunit:110 - Not a supported file: suites/quincy/rgw/tier-2_rgw_test-bucket-notifications.yaml
2022-11-05 03:29:21,178 - DEBUG - cephci.utility.xunit:110 - Found the following valid test suites: []


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
