### PR TITLE
metadata updates for fixing psi pipeline failure

### DIFF
--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -346,12 +346,10 @@ suites:
     rhbuild: "5.2"
     inventory:
       openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - schedule
-      - tier-3
-      - openstack
-      - ibmc
+      - tier-2
+      - openstack-only
       - rados
       - stage-1
 

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -346,12 +346,10 @@ suites:
     rhbuild: "5.3"
     inventory:
       openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - schedule
-      - tier-3
+      - tier-2
       - openstack-only
-      - ibmc
       - rados
       - stage-1
 

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -42,8 +42,8 @@ suites:
       - stage-1
 
   - name: "Testing RADOS basic regression scenarios"
-    suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
-    global-conf: "conf/pacific/rados/7-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+    global-conf: "conf/quincy/rados/7-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -58,8 +58,8 @@ suites:
       - stage-3
 
   - name: "Testing RADOS EC Pool recovery"
-    suite: "suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -74,8 +74,8 @@ suites:
       - stage-2
 
   - name: "Testing RADOS robust osd rebalance scenarios"
-    suite: "suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -90,8 +90,8 @@ suites:
       - stage-2
 
   - name: "RADOS regression testing for stretched Clusters"
-    suite: "suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -106,8 +106,8 @@ suites:
       - stage-4
 
   - name: "RADOS regression for testing various pool functionalities"
-    suite: "suites/pacific/rados/tier-3_rados_test-pool-functionalities.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-pool-functionalities.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -122,24 +122,22 @@ suites:
       - stage-2
 
   - name: "RADOS regression testing for Scrubbing scenarios"
-    suite: "suites/pacific/rados/tier-3_rados_test-scrubbing.yaml"
-    global-conf: "conf/pacific/rados/7-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-scrubbing.yaml"
+    global-conf: "conf/quincy/rados/7-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
       openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - schedule
-      - tier-3
+      - tier-2
       - openstack-only
-      - ibmc
       - rados
       - stage-1
 
   - name: "Testing RADOS regression for ec pool osd rebalance"
-    suite: "suites/pacific/rados/tier-3_rados_test-ecpool-osd-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-ecpool-osd-rebalance.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -154,8 +152,8 @@ suites:
       - stage-2
 
   - name: "Testing RADOS regression for in-progress osd rebalance"
-    suite: "suites/pacific/rados/tier-3_rados_test-osd-inprogress-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-osd-inprogress-rebalance.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -170,8 +168,8 @@ suites:
       - stage-2
 
   - name: "Testing RADOS regression for Stretch mode upgrade"
-    suite: "suites/pacific/rados/tier-3_rados_test-stretch-mode-upgrade.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-stretch-mode-upgrade.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
@@ -186,24 +184,22 @@ suites:
       - stage-1
 
   - name: "RADOS regression testing for Mon DB trimming"
-    suite: "suites/pacific/rados/tier-3_rados_test-mon-db-trimming.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-mon-db-trimming.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:
       openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - sanity
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - rados
       - stage-4
 
   - name: "RADOS regression testing osd rebalance with many pools"
-    suite: "suites/pacific/rados/tier-3_rados_test-osd-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+    suite: "suites/quincy/rados/tier-3_rados_test-osd-rebalance.yaml"
+    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "6.0"
     inventory:


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Updated 5.2, 5.3 and 6.0 metadata files fixing psi pipeline execution failures.

