### PR TITLE
Removing rgw testcase from tier-0

### DIFF
--- a/suites/pacific/cephadm/tier-0.yaml
+++ b/suites/pacific/cephadm/tier-0.yaml
@@ -93,15 +93,15 @@ tests:
       desc: Run object, block and filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
-            desc: test to create "M" no of buckets and "N" no of objects
-            module: sanity_rgw.py
-            name: Test M buckets with N objects
-            polarion-id: CEPH-9789
+#        - test:
+#            config:
+#              script-name: test_Mbuckets_with_Nobjects.py
+#              config-file-name: test_Mbuckets_with_Nobjects.yaml
+#              timeout: 300
+#            desc: test to create "M" no of buckets and "N" no of objects
+#            module: sanity_rgw.py
+#            name: Test M buckets with N objects
+#            polarion-id: CEPH-9789
         - test:
             config:
               branch: v16.2.8

--- a/suites/quincy/cephadm/tier-0.yaml
+++ b/suites/quincy/cephadm/tier-0.yaml
@@ -93,15 +93,15 @@ tests:
       desc: Run object, block and filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
-            desc: test to create "M" no of buckets and "N" no of objects
-            module: sanity_rgw.py
-            name: Test M buckets with N objects
-            polarion-id: CEPH-9789
+#        - test:
+#            config:
+#              script-name: test_Mbuckets_with_Nobjects.py
+#              config-file-name: test_Mbuckets_with_Nobjects.yaml
+#              timeout: 300
+#            desc: test to create "M" no of buckets and "N" no of objects
+#            module: sanity_rgw.py
+#            name: Test M buckets with N objects
+#            polarion-id: CEPH-9789
         - test:
             abort-on-fail: false
             desc: "cephfs basic operations"


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Removing rgw testcase from tier-0, will add this back once we have tescase passed in tier-1

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
