### PR TITLE
Add support to run 5.3 rgw suites on rhel-9 platform

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -465,11 +465,11 @@ suites:
   - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
     suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
     global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-8"
+    platform: "rhel-9"
     rhbuild: "5.3"
     inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+      openstack: "conf/inventory/rhel-9-latest.yaml"
+      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - sanity
       - tier-1
@@ -481,11 +481,11 @@ suites:
   - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
     suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
     global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-8"
+    platform: "rhel-9"
     rhbuild: "5.3"
     inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+      openstack: "conf/inventory/rhel-9-latest.yaml"
+      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - sanity
       - tier-1
@@ -689,11 +689,11 @@ suites:
   - name: "RGW STS functionality testing"
     suite: "suites/pacific/rgw/tier-1-extn_rgw.yaml"
     global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
+    platform: "rhel-9"
     rhbuild: "5.3"
     inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+      openstack: "conf/inventory/rhel-9-latest.yaml"
+      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
       - sanity
       - tier-2


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Single site:
       tier-1-extn_rgw.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K6YUHP/
Multi site:
        tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UD76K6
        tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SI5KNM

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
