### PR TITLE
Including rgw testcase as a part of tier-0 build validation

### DIFF
--- a/suites/pacific/cephadm/tier-0.yaml
+++ b/suites/pacific/cephadm/tier-0.yaml
@@ -93,15 +93,15 @@ tests:
       desc: Run object, block and filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
-#        - test:
-#            config:
-#              script-name: test_Mbuckets_with_Nobjects.py
-#              config-file-name: test_Mbuckets_with_Nobjects.yaml
-#              timeout: 300
-#            desc: test to create "M" no of buckets and "N" no of objects
-#            module: sanity_rgw.py
-#            name: Test M buckets with N objects
-#            polarion-id: CEPH-9789
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects.yaml
+              timeout: 300
+            desc: test to create "M" no of buckets and "N" no of objects
+            module: sanity_rgw.py
+            name: Test M buckets with N objects
+            polarion-id: CEPH-9789
         - test:
             config:
               branch: v16.2.8

--- a/suites/quincy/cephadm/tier-0.yaml
+++ b/suites/quincy/cephadm/tier-0.yaml
@@ -93,15 +93,15 @@ tests:
       desc: Run object, block and filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
-#        - test:
-#            config:
-#              script-name: test_Mbuckets_with_Nobjects.py
-#              config-file-name: test_Mbuckets_with_Nobjects.yaml
-#              timeout: 300
-#            desc: test to create "M" no of buckets and "N" no of objects
-#            module: sanity_rgw.py
-#            name: Test M buckets with N objects
-#            polarion-id: CEPH-9789
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects.yaml
+              timeout: 300
+            desc: test to create "M" no of buckets and "N" no of objects
+            module: sanity_rgw.py
+            name: Test M buckets with N objects
+            polarion-id: CEPH-9789
         - test:
             abort-on-fail: false
             desc: "cephfs basic operations"


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
**Tested In IBM environment:** 
**5.3: All test logs located here: /tmp/cephci-run-M2H9F6 : PASS**
python run.py -osp-cred osp/osp-cred-ci-2.yaml --instances-name ci-anrao --log-level DEBUG --xunit-results **--cloud ibmc --suite suites/pacific/cephadm/tier-0.yaml --global-conf conf/pacific/cephadm/tier-0.yaml --platform rhel-8 --rhbuild 5.3 --inventory conf/inventory/ibm-vpc-rhel-8-latest.yaml** --build latest

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
**setup pre-requisites**             Install software pre-requisites for cluster deployment.        0:11:47.016336                   **Pass**                             
**Deploy cluster using cephadm**     bootstrap and deploy services.                                 0:10:41.423773                   **Pass**                             
**configure client**                 Configure the RGW,RBD client system                            0:00:22.809638                   **Pass**                             
**Executes RGW, RBD and FS opera**   Run object, block and filesystem basic operations parallelly   0:17:23.907058                   **Pass**                             
2022-11-17 13:40:27,003 - INFO - cephci.cephfs_basic_tests:110 - final rc of test run 0
(17nov) [root@ceph-qe-jenkins-agent-01 cephci]# 

 
**6.0: All test logs located here: /tmp/cephci-run-31QMSH: PASS**
python run.py -osp-cred osp/osp-cred-ci-2.yaml --instances-name ci-60-anrao --log-level DEBUG --xunit-results **--cloud ibmc -suite suites/quincy/cephadm/tier-0.yaml --global-conf conf/quincy/cephadm/tier-0.yaml --platform rhel-9 --rhbuild 6.0 --inventory conf/inventory/ibm-vpc-rhel-9-latest.yaml** --custom-config grafana_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/grafana:ceph-6.0-rhel-9-containers-candidate-99494-20221026123006 --custom-config promtail_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/promtail:ceph-6.0-rhel-9-containers-candidate-10191-20221026120801 --custom-config haproxy_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/haproxy:ceph-6.0-rhel-9-containers-candidate-53939-20221026121907 --custom-config keepalived_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/keepalived:ceph-6.0-rhel-9-containers-candidate-18945-20221026120854 --custom-config snmp_gateway_image=ceph-qe-registry.syd.qe.rhceph.local/rh-osbs/snmp-notifier:ceph-6.0-rhel-9-containers-candidate-15559-20221026120853 --build latest

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
**setup pre-requisites**             Install software pre-requisites for cluster deployment.        0:08:13.966438                   **Pass**                             
**Deploy cluster using cephadm**     bootstrap and deploy services.                                 0:10:43.337890                   **Pass**                             
**configure client**                 Configure the RGW,RBD client system                            0:00:22.714862                   **Pass**                             
**Executes RGW, RBD and FS opera**   Run object, block and filesystem basic operations parallelly   0:03:26.489946                   **Pass**                             
2022-11-17 14:23:02,511 - INFO - cephci.cephfs_basic_tests:110 - final rc of test run 0
(17nov) [root@ceph-qe-jenkins-agent-01 cephci]# 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
