### PR TITLE
Moving RBD mirror tier-2 regression suite to openstack env

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -286,12 +286,11 @@ suites:
       openstack: "conf/inventory/rhel-9-latest.yaml"
       ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
-      - sanity
+      - schedule
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - rbd
-      - stage-1
+      - stage-4
 
   - name: "Basic operation test suite for Cephfs"
     suite: "suites/pacific/cephfs/tier-0_fs.yaml"


### PR DESCRIPTION
Moving RBD mirror tier-2 regression suite to openstack env

Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

# Description

success log for openstack environment : 

https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/1677/consoleFull 
