### PR TITLE
Fix for IBM status failure when cleanup fails.

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -278,6 +278,13 @@ node(nodeName) {
             writeYaml file: "${env.WORKSPACE}/${dirName}/metadata.yaml", data: content
             sharedLib.uploadResults(dirName, "${env.WORKSPACE}/${dirName}")
 
+            testStatus = "SUCCESS"
+            if ("FAIL" in sharedLib.fetchStageStatus(testResults)) {
+                currentBuild.result = "FAILED"
+                buildStatus = "fail"
+                testStatus = "FAILURE"
+            }
+
             def msgMap = [
                 "artifact": [
                     "type": "product-build",
@@ -316,7 +323,7 @@ node(nodeName) {
                 "test": [
                     "type": buildType,
                     "category": "functional",
-                    "result": currentBuild.currentResult,
+                    "result": testStatus,
                     "object-prefix": dirName,
                 ],
                 "recipe": buildArtifacts,
@@ -361,10 +368,6 @@ node(nodeName) {
             }
             overrides = writeJSON returnText: true, json: overrides
 
-            if ("FAIL" in sharedLib.fetchStageStatus(testResults)) {
-                currentBuild.result = "FAILED"
-                buildStatus = "fail"
-            }
             // Do not trigger next stage of execution
             // 1) if the current tier executed is tier-0 and it failed
             // 2) if the current stage was final_stage of a particular tier and tier is greater than 2


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for IBM status failure when cleanup fails.

test failed log - https://159.23.92.24/job/rhcs-tintu/29/console
tests passed log - https://159.23.92.24/job/rhcs-tintu/28/console

In IBM pipeline even after the successful execution of testcases/testsuites, sometimes the cleanup script fails. Due to this the overall status of the pipeline execution will be failure. To fix this we will check for any test failures in the test results and will determine the pipline execution status.
https://159.23.92.24/job/rhcs-tintu/32/console
