### PR TITLE
[Scale FS] Creating max subvolumes with 1 gb each

### DIFF
--- a/suites/quincy/cephfs/tier-2_fs_scale.yaml
+++ b/suites/quincy/cephfs/tier-2_fs_scale.yaml
@@ -120,3 +120,15 @@ tests:
       module: cephfs_scale.max_snapshots.py
       name: cephfs Scale test for max Snapshots
       polarion-id: "CEPH-83573520"
+  - test:
+      abort-on-fail: false
+      desc: "Max subvolumess"
+      module: cephfs_scale.max_subvolumes.py
+      name: cephfs Scale test for max subvolumes
+      polarion-id: ~
+  - test:
+      abort-on-fail: false
+      desc: "Max snaps per volume"
+      module: cephfs_scale.max_smallfile_snap.py
+      name: cephfs Scale test for max Snapshots
+      polarion-id: ~

--- a/tests/cephfs/cephfs_scale/max_smallfile_snap.py
+++ b/tests/cephfs/cephfs_scale/max_smallfile_snap.py
@@ -1,0 +1,147 @@
+import json
+import random
+import string
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def get_available_space(client, fs_name="cephfs"):
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"ceph fs status {fs_name} --format json"
+    )
+    output = json.loads(out)
+    return next(
+        (pool["avail"] for pool in output["pools"] if pool["type"] == "data"), None
+    )
+
+
+def collect_ceph_details(client, cmd):
+    out, rc = client.exec_command(sudo=True, cmd=f"{cmd} --format json")
+    output = json.loads(out)
+    log.info(output)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573520	Validate the max snapshot that can be created under a root FS sub volume level.
+
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+    2. creats fs volume create cephfs if the volume is not there
+    3. ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>]
+       [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>]  [--namespace-isolated]
+       Ex: ceph fs subvolume create cephfs subvol_max_snap --size 5368706371 --group_name subvolgroup_1
+    4. Create Data on the subvolume
+        Ex:  python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 --files
+            100 --files-per-dir 10 --dirs-per-dir 2 --top /mnt/cephfs_fuse1baxgbpaia_1/
+
+    Test Script Flow :
+    1. We will set max snapshots to maximum allowed value 4096.
+    2. We create subvolume and write data to subvolume and create snapshot
+    3. For every snapshot we are going to write new file
+
+    Clean up:
+    1. Deletes all the snapshots created
+    2. Deletes snapshot and subvolume created.
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        max_snap = 4096
+        log.info("checking Pre-requisites")
+        if len(clients) < 1:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+        default_fs = "cephfs"
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        client1 = clients[0]
+        fs_details = fs_util.get_fs_info(client1)
+        if not fs_details:
+            fs_util.create_fs(client1, "cephfs")
+        subvolume = {
+            "vol_name": default_fs,
+            "subvol_name": "subvol_max_snap",
+        }
+        fs_util.create_subvolume(client1, **subvolume)
+        log.info("Get the path of sub volume")
+        subvol_path, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume getpath {default_fs} subvol_max_snap",
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph config set mds mds_max_snaps_per_dir {max_snap}",
+        )
+        kernel_mounting_dir_1 = f"/mnt/cephfs_kernel{mounting_dir}_1/"
+        mon_node_ips = fs_util.get_mon_node_ips()
+        fs_util.kernel_mount(
+            [clients[0]],
+            kernel_mounting_dir_1,
+            ",".join(mon_node_ips),
+            sub_dir=f"{subvol_path.strip()}",
+        )
+        available_space = int(get_available_space(client1, default_fs))
+        log.info(available_space)
+        data_size_iter = int(available_space / 1024000000)
+        snapshot_list = [
+            {
+                "vol_name": default_fs,
+                "subvol_name": "subvol_max_snap",
+                "snap_name": f"snap_limit_{x}",
+            }
+            for x in range(0, data_size_iter)
+        ]
+        for snapshot in snapshot_list:
+            try:
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"mkdir -p {kernel_mounting_dir_1}/{snapshot['snap_name']}",
+                )
+
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 "
+                    f"--file-size 512 "
+                    f"--files 20480 --top "
+                    f"{kernel_mounting_dir_1}/{snapshot['snap_name']}",
+                    long_running=True,
+                )
+                fs_util.create_snapshot(clients[0], **snapshot, validate=False)
+            except CommandFailed:
+                log.info(
+                    f"Max Snapshots allowed under a root FS sub volume level is {snapshot}"
+                )
+
+        return 0
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        cmd_list = [
+            "ceph crash ls",
+            "ceph fs status",
+            f"ceph fs subvolume snapshot ls {default_fs} subvol_max_snap",
+        ]
+        map(collect_ceph_details, cmd_list)
+        for cmd in cmd_list:
+            collect_ceph_details(client1, cmd)
+        log.info("Clean Up in progess")
+        for snapshot in snapshot_list:
+            fs_util.remove_snapshot(client1, **snapshot)
+        fs_util.remove_subvolume(client1, **subvolume, check_ec=False)

--- a/tests/cephfs/cephfs_scale/max_subvolumes.py
+++ b/tests/cephfs/cephfs_scale/max_subvolumes.py
@@ -1,0 +1,123 @@
+import json
+import random
+import string
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def get_available_space(client, fs_name="cephfs"):
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"ceph fs status {fs_name} --format json"
+    )
+    output = json.loads(out)
+    return next(
+        (pool["avail"] for pool in output["pools"] if pool["type"] == "data"), None
+    )
+
+
+def collect_ceph_details(client, cmd):
+    out, rc = client.exec_command(sudo=True, cmd=f"{cmd} --format json-pretty")
+    output = json.loads(out)
+    log.info(output)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    CEPH-83573520	Validate the max snapshot that can be created under a root FS sub volume level.
+
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+    2. creats fs volume create cephfs if the volume is not there
+    3. ceph fs subvolume create <vol_name> <subvol_name> [--size <size_in_bytes>] [--group_name <subvol_group_name>]
+       [--pool_layout <data_pool_name>] [--uid <uid>] [--gid <gid>] [--mode <octal_mode>]  [--namespace-isolated]
+       Ex: ceph fs subvolume create cephfs subvol_max_snap --size 5368706371 --group_name subvolgroup_1
+    4. Create Data on the subvolume
+        Ex:  python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 400 --files
+            100 --files-per-dir 10 --dirs-per-dir 2 --top /mnt/cephfs_fuse1baxgbpaia_1/
+
+    Test Script Flow :
+    1. We will get the total available space.
+    2. Based on total Available space we create a number of volumes with 1 GB each
+    3. Verify there is no error after that
+
+    Clean up:
+    1. Deletes all the subvolumes created
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        default_fs = "cephfs"
+        client1 = clients[0]
+        available_space = int(get_available_space(client1, default_fs))
+        log.info(available_space)
+        data_size_iter = int(available_space / 1024000000)
+        data_size_iter_20 = data_size_iter - round(data_size_iter * 0.2)
+        subvol_list = [
+            {
+                "vol_name": default_fs,
+                "subvol_name": f"subvol_max_{x}",
+            }
+            for x in range(0, data_size_iter_20)
+        ]
+        log.info(f"Total Sub Volumes that will be created : {data_size_iter_20}")
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(5))
+        )
+        for idx, subvol in enumerate(subvol_list):
+            try:
+                fs_util.create_subvolume(clients[0], **subvol, validate=False)
+                fuse_mounting_dir_1 = f"/mnt/cephfs_fuse{mounting_dir}_{idx}/"
+                subvol_path, rc = clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph fs subvolume getpath {default_fs} {subvol['subvol_name']}",
+                )
+                fs_util.fuse_mount(
+                    [clients[0]],
+                    fuse_mounting_dir_1,
+                    extra_params=f" -r {subvol_path.strip()}",
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 1 "
+                    f"--file-size 1024 "
+                    f"--files 1024 --top "
+                    f"{fuse_mounting_dir_1}",
+                    long_running=True,
+                )
+                cmd = f"fusermount -u {fuse_mounting_dir_1} -z"
+                clients[0].exec_command(sudo=True, cmd=cmd)
+                log.info(f"{'*' * 20} Report for Iteration {idx} {'*' * 20} ")
+                cmd_list = [
+                    "ceph crash ls",
+                    "ceph fs status",
+                    f"ceph fs subvolume ls {default_fs}",
+                    "ceph df",
+                ]
+                for cmd in cmd_list:
+                    collect_ceph_details(clients[0], cmd)
+                log.info(f"{'*' * 20} Iteration {idx} completed {'*' * 20} ")
+            except CommandFailed:
+                log.info(f"Subvolume Create command failed at index: {idx}")
+                break
+        log.info(f"Subvolume creation is successful from {idx} to {idx + 50}")
+        return 0
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Clean Up in progess")
+        for subvol in subvol_list[:-1]:
+            fs_util.remove_subvolume(clients[0], **subvol)
+        return 0


### PR DESCRIPTION
[Scale FS] Creating max subvolumes with 1 gb each
Test Script Flow :
    1. We will get the total available space.
    2. Based on total Available space we create a number of volumes with 1 GB each
    3. Verify there is no error after that

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-E1YZBC/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
