### PR TITLE
modifying read_io_info run as long_running to get the live output

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -166,7 +166,7 @@ def run(ceph_cluster, **kw):
     script_dir = DIR[test_version]["script"]
     config_dir = DIR[test_version]["config"]
     lib_dir = DIR[test_version]["lib"]
-    timeout = config.get("timeout", 300)
+    # timeout = config.get("timeout", 300)
 
     if test_config["config"]:
         log.info("creating custom config")
@@ -191,14 +191,16 @@ def run(ceph_cluster, **kw):
 
     if run_io_verify:
         log.info("running io verify script")
-        verify_out, err = exec_from.exec_command(
+        verify_status = exec_from.exec_command(
             cmd=f"sudo {python_cmd} "
             + test_folder_path
             + lib_dir
             + f"read_io_info.py -c {config_file_name}",
-            timeout=timeout,
+            long_running=True,
         )
-        log.info(verify_out)
-        log.error(err)
+        log.info(f"verify io status code is : {verify_status}")
+        if verify_status != 0:
+            log.error(verify_status)
+            return verify_status
 
     return test_status

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -135,7 +135,7 @@ def run(**kw):
     script_dir = TEST_DIR[test_version]["script"]
     config_dir = TEST_DIR[test_version]["config"]
     lib_dir = TEST_DIR[test_version]["lib"]
-    timeout = config.get("timeout", 600)
+    # timeout = config.get("timeout", 600)
 
     log.info("flushing iptables")
     exec_from.exec_command(cmd="sudo iptables -F", check_ec=False)
@@ -192,15 +192,17 @@ def run(**kw):
                         io_info, exec_from, verify_io_on_site_node, io_info
                     )
 
-                verify_out, err = verify_io_on_site_node.exec_command(
+                verify_status = verify_io_on_site_node.exec_command(
                     cmd="sudo venv/bin/python "
                     + test_folder_path
                     + lib_dir
                     + f"read_io_info.py -c {config_file_name}",
-                    timeout=timeout,
+                    long_running=True,
                 )
-                log.info(verify_out)
-                log.error(err)
+                log.info(f"verify io status code is : {verify_status}")
+                if verify_status != 0:
+                    log.error(verify_status)
+                    return verify_status
 
     return test_status
 


### PR DESCRIPTION
Signed-off-by: Hemanth Maheswarla <hmaheswa@hmaheswa.remote.csb>

This PR is to display the live logs of the verify_io while running read_io_info.py instead of dumping the verify_io output at once after the run is completed.
to analyse the failure better when socket timeout exception occurs (refer this http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QU4J38/m_buckets_with_n_objects_0.log)

pass logs:
1. sanity_rgw:  http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/verify_io_long_running/cephci-run-ENQKKC/
2. sanity_rgw_multisite:  http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/verify_io_long_running/cephci-run-K0W3YW/

logs for failure scenarios:
1. rgw url is wrong in read_io_info.yaml
       http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/verify_io_long_running/failure_scenarios/cephci-run-VGHTVH/setting_acls_to_versioned_objects_on_primary_0.log
2. reproducing sockettimeoutexception with timeout given as 1 sec and long_running=True
       http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/verify_io_long_running/failure_scenarios/cephci-run-MJWDEF/setting_acls_to_versioned_objects_on_primary_0.log
3. reproducing sockettimeoutexception with timeout given as 1 sec and long_running=False
       http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/verify_io_long_running/failure_scenarios/cephci-run-19M7ZG/setting_acls_to_versioned_objects_on_primary_0.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
