### PR TITLE
Send email only when test stages are available

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -174,13 +174,15 @@ node(nodeName) {
             if ("openstack-only" in tags_list){
                 run_type = "PSI Only Run"
             }
-            sharedLib.sendEmail(
-                run_type,
-                testResults,
-                sharedLib.buildArtifactsDetails(releaseContent, rhcephVersion, overrides.get("build")),
-                tierLevel.capitalize(),
-                currentStageLevel.capitalize()
-            )
+            if (testResults) {
+                sharedLib.sendEmail(
+                    run_type,
+                    testResults,
+                    sharedLib.buildArtifactsDetails(releaseContent, rhcephVersion, overrides.get("build")),
+                    tierLevel.capitalize(),
+                    currentStageLevel.capitalize()
+                )
+            }
         }
 
         stage('postBuildAction') {


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Emails where getting triggered when the stages don't have any suites available for execution. This fix will check for testresults before triggering the email.

logs: https://jenkins.ceph.redhat.com/job/rhcs-test1/2/console

[psi_logs.txt](https://github.com/red-hat-storage/cephci/files/10072109/psi_logs.txt)

