### PR TITLE
Adding ceph version to pipeline description

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -161,7 +161,7 @@ node(nodeName) {
         testStages = fetchStages["testStages"]
         final_stage = fetchStages["final_stage"]
         println("final_stage : ${final_stage}")
-        currentBuild.description = "${params.rhcephVersion} - ${tierLevel} - ${currentStageLevel}"
+        currentBuild.description = "${params.rhcephVersion} - ${tierLevel} - ${currentStageLevel} \n ceph-version : ${buildArtifacts['ceph-version']}"
     }
 
     parallel testStages


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Adding ceph version to pipeline description so that from the pipeline execution it will be easy to understand for which build the test stages are triggered.

https://jenkins.ceph.redhat.com/job/rhcs-test1/

[#2](https://jenkins.ceph.redhat.com/job/rhcs-test1/2/)
[Nov 22, 2022, 3:52 PM]
RHCEPH-6.0 - tier-1 - stage-1
ceph-version : 17.2.5-13