### PR TITLE
Adding krbd io handler to handle krbd associated IO tasks

### DIFF
--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -1,6 +1,6 @@
 from tests.rbd.rbd_utils import Rbd
 from utility.log import Log
-from utility.utils import run_fio
+from utility.utils import run_fio, run_mkfs
 
 log = Log(__name__)
 
@@ -15,14 +15,19 @@ def krbd_io_handler(**kw):
         config:
           operations:
             map: true
-            # TBD:
-            # mount and different options of mount command
+            mount: true
+            fs: ext4/xfs
             io: true
             fsck: true
             nounmap: false
           image_spec:
-            - image_name/pool_name
-            # TBD: options to provide images with different size, IO
+            - pool_name/image_name
+          runtime: 30
+          file_size: 100M
+        Note:
+        1) if mount is set to true, a mount point will be created and fs will be created on the device by default
+        2) Required pool needs to be created.
+        3) Run time is per image
     """
 
     rbd = Rbd(**kw)
@@ -30,29 +35,58 @@ def krbd_io_handler(**kw):
 
     operations = config["operations"]
     device_names = []
+    mount_points = []
+    return_flag = 0
 
-    # TBD: parallelism among images
     for image_spec in config["image_spec"]:
         pool_name = image_spec.split("/")[0]
         image_name = image_spec.split("/")[1]
-    try:
-        rbd.create_image(pool_name, image_name, config.get("size", "1G"))
-        # TBD: skip map option
-        if operations.get("map"):
-            device_names.append(rbd.image_map(pool_name, image_name)[:-1])
+        try:
+            rbd.create_image(pool_name, image_name, config.get("size", "1G"))
 
-        if operations.get("io"):
-            run_fio(
-                client_node=rbd.ceph_client,
-                device_name=device_names[-1],
-                runtime=config.get("runtime", 30),
-            )
+            if operations.get("map"):
+                device_names.append(rbd.image_map(pool_name, image_name)[:-1])
 
-        if operations.get("fsck"):
-            rbd.exec_cmd(cmd=f"fsck -N {device_names[-1]}")
+            if operations.get("mount"):
+                run_mkfs(
+                    client_node=rbd.ceph_client,
+                    device_name=device_names[-1],
+                    type=operations.get("fs"),
+                )
+                # Creating mount directory and mouting device
+                mount_points.append(f"/tmp/mp_{device_names[-1].split('/')[-1]}")
+                rbd.exec_cmd(
+                    cmd=f"mkdir {mount_points[-1]}; mount {device_names[-1]} {mount_points[-1]}",
+                    sudo=True,
+                )
 
-    finally:
-        for device_name in device_names:
-            rbd.image_unmap(device_name)
+            if operations.get("io"):
+                if operations.get("mount"):
+                    run_fio(
+                        client_node=rbd.ceph_client,
+                        filename=mount_points[-1],
+                        runtime=config.get("runtime", 30),
+                        file_size=config.get("file_size", "100M"),
+                    )
+                else:
+                    run_fio(
+                        client_node=rbd.ceph_client,
+                        device_name=device_names[-1],
+                        runtime=config.get("runtime", 30),
+                    )
 
-    return 0
+            if operations.get("fsck"):
+                if rbd.exec_cmd(cmd=f"fsck -n {device_names[-1]}"):
+                    log.debug("fsck failed")
+                    return_flag = 1
+
+        finally:
+            if not operations.get("nounmap"):
+                for device_name in device_names:
+                    rbd.exec_cmd(
+                        cmd=f"umount /tmp/mp_{device_names[-1].split('/')[-1]}",
+                        sudo=True,
+                    )
+                    rbd.image_unmap(device_name)
+
+    return return_flag

--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -1,0 +1,58 @@
+from tests.rbd.rbd_utils import Rbd
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def run(**kw):
+    return krbd_io_handler(**kw)
+
+
+def krbd_io_handler(**kw):
+    """krbd io handler.
+    Usage:
+        config:
+          operations:
+            map: true
+            # TBD:
+            # mount and different options of mount command
+            io: true
+            fsck: true
+            nounmap: false
+          image_spec:
+            - image_name/pool_name
+            # TBD: options to provide images with different size, IO
+    """
+
+    rbd = Rbd(**kw)
+    config = kw.get("config")
+
+    operations = config["operations"]
+    device_names = []
+
+    # TBD: parallelism among images
+    for image_spec in config["image_spec"]:
+        pool_name = image_spec.split("/")[0]
+        image_name = image_spec.split("/")[1]
+    try:
+        rbd.create_image(pool_name, image_name, config.get("size", "1G"))
+        # TBD: skip map option
+        if operations.get("map"):
+            device_names.append(rbd.image_map(pool_name, image_name)[:-1])
+
+        if operations.get("io"):
+            run_fio(
+                client_node=rbd.ceph_client,
+                device_name=device_names[-1],
+                runtime=config.get("runtime", 30),
+            )
+
+        if operations.get("fsck"):
+            rbd.exec_cmd(cmd=f"fsck -N {device_names[-1]}")
+
+    finally:
+        for device_name in device_names:
+            rbd.image_unmap(device_name)
+
+    return 0

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -44,7 +44,7 @@ class Rbd:
         exec_command wrapper for rbd functions
         Args:
             pool_name: configs along with `cmd` - command
-
+            output: True if command output needs to be returned
 
         Returns:  0 -> pass, 1 -> fail
         """
@@ -264,6 +264,10 @@ class Rbd:
     def image_map(self, pool_name, image_name):
         """Map provided rbd image."""
         return self.exec_cmd(cmd=f"rbd map {pool_name}/{image_name}", output=True)
+
+    def image_unmap(self, device_name):
+        """UnMap provided rbd image."""
+        return self.exec_cmd(cmd=f"rbd unmap {device_name}", output=True)
 
     def clean_up(self, **kw):
         if kw.get("dir_name"):

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1406,7 +1406,21 @@ def perform_env_setup(config, node, ceph_cluster):
         )
 
 
-def run_fio(**kw):
+def run_mkfs(**kw):
+    """Create fs on a raw device using mkfs.
+
+    Args:
+        type: ext4/xfs
+        device_name: name of the device on which fs needs to be created.
+    """
+
+    long_running = kw.get("long_running", True)
+    cmd = f"mkfs -t {kw.get('type', 'xfs')} {kw.get('device_name')}"
+
+    return kw["client_node"].exec_command(cmd=cmd, long_running=long_running, sudo=True)
+
+
+def run_fio(**fio_args):
     """Run IO using fio tool on given target.
 
     Args:
@@ -1417,29 +1431,31 @@ def run_fio(**kw):
         runtime: fio runtime
         long_running(bool): True for long running required
         client_node: node where fio needs to be run
-
+        file_size: 'size' for file size
     Prerequisite: fio package must have been installed on the client node.
     One of device_name, filename, (rbdname,pool) is required.
     """
+    log.debug(f"Config Recieved for fio: {fio_args}")
 
-    if kw.get("filename"):
-        opt_args = f"--filename={kw['filename']}"
+    if fio_args.get("filename"):
+        opt_args = f"--filename={fio_args['filename']}/file --size={fio_args.get('file_size', '100M')}"
 
-    if kw.get("device_name"):
-        opt_args = f"--ioengine=libaio --filename={kw['device_name']}"
+    elif fio_args.get("device_name"):
+        opt_args = f"--ioengine=libaio --filename={fio_args['device_name']}"
+
     else:
-        opt_args = (
-            f"--ioengine=rbd --rbdname={kw['image_name']} --pool={kw['pool_name']}"
-        )
+        opt_args = f"--ioengine=rbd --rbdname={fio_args['image_name']} --pool={fio_args['pool_name']}"
 
-    long_running = kw.get("long_running", False)
+    long_running = fio_args.get("long_running", False)
     cmd = (
         "fio --name=test-1  --numjobs=1 --rw=write"
-        " --bs=1M --iodepth=8 --fsync=32  --time_based"
-        f" --group_reporting --runtime={kw.get('runtime', 120)} {opt_args}"
+        " --iodepth=8 --fsync=32  --time_based"
+        f" --group_reporting --runtime={fio_args.get('runtime', 120)} {opt_args}"
     )
 
-    return kw["client_node"].exec_command(cmd=cmd, long_running=long_running, sudo=True)
+    return fio_args["client_node"].exec_command(
+        cmd=cmd, long_running=long_running, sudo=True
+    )
 
 
 def fetch_image_tag(rhbuild):


### PR DESCRIPTION
Adding a module to handle
> image map
> io using fio
> using fsck to check filesystem
> finally unmap the device

tests/rbd/krbd_io_handler.py
Module to handle the krbdio

Usage:
> config:
> operations:
>        map: true
>        io: true
>        fsck: true
>        nounmap: false
>      image_spec:
>        - image_name/pool_name

tests/rbd/rbd_utils.py
Added method to unmap device

utility/utils.py
Tuned run_fio method with more doc and improvements
Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
