### PR TITLE
correcting ceph version in build description

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -161,7 +161,8 @@ node(nodeName) {
         testStages = fetchStages["testStages"]
         final_stage = fetchStages["final_stage"]
         println("final_stage : ${final_stage}")
-        currentBuild.description = "${params.rhcephVersion} - ${tierLevel} - ${currentStageLevel} \n ceph-version : ${buildArtifacts['ceph-version']}"
+        ceph_version = ${buildArtifacts['ceph-version']} ?: ${buildArtifacts['recipe']['ceph-version']}
+        currentBuild.description = "${params.rhcephVersion} - ${tierLevel} - ${currentStageLevel} \n ceph-version : ${ceph_version}"
     }
 
     parallel testStages


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

correcting ceph version in build description of psi environment.

buildArtifacts from psi - {"artifact":{"type":"product-build","name":"Red Hat Ceph Storage","version":"16.2.10-78","nvr":"RHCEPH-5.3","phase":"testing","build":"tier-0"},"contact":{"name":"Downstream Ceph QE","email":"cephci@redhat.com"},"system":{"os":"centos-7","label":"agent-01","provider":"IBM-Cloud"},"pipeline":{"name":"tier-0","id":401,"tags":"sanity,ibmc,stage-1,tier-0","overrides":{"build":"latest","workspace":"/data/jenkins/workspace/rhceph-test-execution-pipeline@2","build_number":401},"run_type":"Sanity Run","final_stage":true},"run":{"url":"https://159.23.92.24/job/rhceph-test-execution-pipeline/401/display/redirect","additional_urls":{"doc":"https://docs.engineering.redhat.com/display/rhcsqe/RHCS+QE+Pipeline","repo":"https://github.com/red-hat-storage/cephci","report":"https://reportportal-rhcephqe.apps.ocp4.prod.psi.redhat.com/","tcms":"https://polarion.engineering.redhat.com/polarion/"}},"test":{"type":"latest","category":"functional","result":"SUCCESS","object-prefix":"ibm_rhceph-test-execution-pipeline_401"},"recipe":{"repository":"registry-proxy.engineering.redhat.com/rh-osbs/rhceph:ceph-5.3-rhel-8-containers-candidate-57142-20221123010635","composes":{"rhel-8":"http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.3-rhel-8/RHCEPH-5.3-RHEL-8-20221123.ci.0","rhel-9":"http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-5.3-rhel-9/RHCEPH-5.3-RHEL-9-20221122.ci.0"},"ceph-version":"16.2.10-78"},"generated_at":"401","version":"3.0.0"}

buildArtifacts from ibm - {"repository":"registry-proxy.engineering.redhat.com/rh-osbs/rhceph:ceph-5.3-rhel-8-containers-candidate-57142-20221123010635","composes":{"rhel-8":"http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.3-rhel-8/RHCEPH-5.3-RHEL-8-20221123.ci.0","rhel-9":"http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-5.3-rhel-9/RHCEPH-5.3-RHEL-9-20221122.ci.0"},"ceph-version":"16.2.10-78"}