### PR TITLE
Adding abort on fail for preflight test case

### DIFF
--- a/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
+++ b/suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml
@@ -166,6 +166,7 @@ tests:
       playbook: cephadm-preflight.yml
       extra-vars:
         ceph_origin: rhcs
+    abort-on-fail: True
 
 - test:
     name: check-ceph-health


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Adding abort on fail for preflight test case.

cephadm-ansible preflight playbook - this test case failed and we have not included abort-on-fail for this test
Due to this all the remaining test cases got executed and rgw - rgw sanity tests - multitenant_user_access test case has not timed out

https://159.23.92.24/blue/organizations/jenkins/rhceph-test-execution-pipeline/detail/rhceph-test-execution-pipeline/409/pipeline/ - One task running for 42 Hours. 