### PR TITLE
Fixing fs script 

### DIFF
--- a/suites/pacific/cephfs/tier-0_fs.yaml
+++ b/suites/pacific/cephfs/tier-0_fs.yaml
@@ -128,7 +128,7 @@ tests:
       abort-on-fail: false
   - test:
       name: Increase and Decrease of MDS
-      module: mds_Inc_dec.py
+      module: mds_inc_dec.py
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false

--- a/suites/quincy/cephfs/test-core-functionality.yaml
+++ b/suites/quincy/cephfs/test-core-functionality.yaml
@@ -126,7 +126,7 @@ tests:
       polarion-id: CEPH-11293  # also applies to [CEPH-11296,CEPH-11297,CEPH-11295]
   - test:
       name: Increase and Decrease of MDS
-      module: mds_Inc_dec.py
+      module: mds_inc_dec.py
       desc: Deploy mds using cephadm and increase & decrease number of mds
       polarion-id: CEPH-83574286
       abort-on-fail: false

--- a/suites/quincy/e2e/poc/test-cephfs-core-features.yaml
+++ b/suites/quincy/e2e/poc/test-cephfs-core-features.yaml
@@ -21,6 +21,6 @@ tests:
     test:
       abort-on-fail: false
       desc: "Deploy mds using cephA and increase & decrease number of mds"
-      module: mds_Inc_dec.py
+      module: mds_inc_dec.py
       name: "Evaluate crud operations on MDS daemons"
       polarion-id: CEPH-83574286

--- a/tests/cephfs/mds_inc_dec.py
+++ b/tests/cephfs/mds_inc_dec.py
@@ -37,12 +37,8 @@ def run(ceph_cluster, **kw):
             )
             return 1
         client1 = clients[0]
-        host_list = [
-            client1.node.hostname.replace("node7", "node2"),
-            client1.node.hostname.replace("node7", "node3"),
-            client1.node.hostname.replace("node7", "node4"),
-            client1.node.hostname.replace("node7", "node5"),
-        ]
+        nodes_list = ceph_cluster.get_nodes()
+        host_list = [node.hostname for node in nodes_list[1:5]]
         hosts = " ".join(host_list[:2])
         fs_name = "cephfs_df_fs"
         client1.exec_command(

--- a/tests/cephfs/nfs-ganesha_basics.py
+++ b/tests/cephfs/nfs-ganesha_basics.py
@@ -39,7 +39,7 @@ def run(ceph_cluster, **kw):
         config = kw.get("config")
         build = config.get("build", config.get("rhbuild"))
         rhbuild = config.get("rhbuild")
-        if rhbuild.startswith(("5", "6")):
+        if not rhbuild.startswith(("3", "4")):
             from tests.cephfs.cephfs_utilsV1 import FsUtils
 
             fs_util = FsUtils(ceph_cluster)


### PR DESCRIPTION
Fixing fs script 
The script was failing in Upstream when there were more client nodes.

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-84H67O/

Solution:
We have removed the client node hardcoding and get node details from cluster

Pass logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QMOW0C/ 


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
