### PR TITLE
Adding rp link to results 

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -114,8 +114,10 @@ node("rhel-8-medium || ceph-qe-ci") {
                         metaData["results"], metaData, metaData["stage"]
                     )
                 }
-                sharedLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData, stageLevel, run_type)
-
+                def launch_id = sharedLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData, stageLevel, run_type)
+                if (launch_id) {
+                metaData["rp_link"] = "https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/${launch_id}"
+                }
             }
             testStatus = msgMap["test"]["result"]
 

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -99,6 +99,9 @@ def sendEmail(
     if (artifactDetails.repository) {
         body += "<tr><td>Container Image</td><td>${artifactDetails.repository}</td></tr>"
     }
+    if (artifactDetails.rp_link) {
+        body += "<tr><td>Report Portal</td><td>${artifactDetails.rp_link}</td></tr>"
+    }
     if (artifactDetails.log) {
         body += "<tr><td>Log</td><td>${artifactDetails.log}</td></tr>"
     } else {
@@ -225,6 +228,9 @@ def sendConsolidatedEmail(
     }
     if (artifactDetails.repository) {
         body += "<tr><td>Container Image</td><td>${artifactDetails.repository}</td></tr>"
+    }
+    if (artifactDetails.rp_link) {
+        body += "<tr><td>Report Portal</td><td>${artifactDetails.rp_link}</td></tr>"
     }
     if (artifactDetails.log) {
         body += "<tr><td>Log</td><td>${artifactDetails.log}</td></tr>"
@@ -478,8 +484,7 @@ def uploadTestResults(def sourceDir, def credPreproc, def runProperties, def sta
     writeJSON file: credFile, json: credPreproc
 
     // Upload xml file to report portal
-    sh(script: ".venv/bin/python utility/rp_client.py -c ${credFile} -d ${sourceDir}/payload")
-
+    rp_launch_id = sh(returnStdout: true, script: ".venv/bin/python utility/rp_client.py -c ${credFile} -d ${sourceDir}/payload")
     // Upload test result to polarion using xUnit Xml file
     withCredentials([
         usernamePassword(
@@ -500,6 +505,10 @@ def uploadTestResults(def sourceDir, def credPreproc, def runProperties, def sta
             sh script: "${localCmd}"
         }
     }
+    def launch_rgex = (rp_launch_id =~ /launch id: (\d+)/)
+	if(launch_rgex){
+	return launch_rgex[0][1]
+	}
 }
 
 def fetchStageStatus(def testResults) {

--- a/run.py
+++ b/run.py
@@ -158,6 +158,7 @@ Options:
 """
 log = Log()
 test_names = []
+run_summary = {}
 
 
 @retry(LibcloudError, tries=5, delay=15)
@@ -971,6 +972,7 @@ def run(args):
 
     if post_to_report_portal:
         rp_logger.finish_launch()
+        run_summary["rp_link"] = rp_logger.client.get_launch_ui_url()
 
     if xunit_results:
         create_xunit_results(suite_name, tcs, test_run_metadata)
@@ -986,6 +988,8 @@ def run(args):
         "total": f"{int(duration[0])} mins, {int(duration[1])} secs",
     }
     info = {"status": "Pass"}
+    with open(f"{run_dir}/run_summary.json", "w", encoding="utf-8") as f:
+        json.dump(run_summary, f, ensure_ascii=False, indent=4)
     test_res = {
         "result": tcs,
         "run_id": run_id,

--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -109,6 +109,8 @@ def upload_logs(args):
         launch.finish()
     return_obj["launches"] = rportal.launches.list
     log.info("RETURN OBJECT: %s", return_obj)
+    # Do not Remove this print statement as it is consumed in groovy file
+    print(f"launch id: {launch.launch_id}")
     tfacon(launch.launch_id)
     return return_obj
 


### PR DESCRIPTION
Adding rp link to results 
As part of this PR, we are Collecting the Report Portal Url from the Upload results function and populating it as part of Test Artifacts in the Email Notification for IBM-C

For PSI,
We are going to populate the Report portal URL as a separate file in run_summary.json inside the logs_dir

Unit Test logs for IBM-C : 
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-post-results_amk/27/console

PSI:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VX6XAF/

![image](https://user-images.githubusercontent.com/80021994/205906668-de60231f-0289-48cf-8773-0b0dea413cb5.png)


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
