### PR TITLE
[CephADM] [Tier1]: Add test case for label "no_schedule".

### DIFF
--- a/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
@@ -255,3 +255,11 @@ tests:
               args:              # sleep to get all services deployed
                 - sleep
                 - "120"
+  - test:
+      name: test_label_no_schedule
+      desc: Adding  "__no_schedule" label to a node and verify its functionality in a cluster.
+      polarion-id: CEPH-83574672
+      module: test_label_no_schedule.py
+      config:
+        nodes:
+          - node2

--- a/tests/cephadm/test_label_no_schedule.py
+++ b/tests/cephadm/test_label_no_schedule.py
@@ -1,0 +1,51 @@
+import json
+
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+
+
+class LabelNoScheduleError(Exception):
+    pass
+
+
+def run(ceph_cluster, **kw):
+    """verify "__no_schedule" label
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    installer_node = ceph_cluster.get_nodes(role="installer")
+    config = kw.get("config")
+    # node = ceph_cluster.get_nodes()[1]
+    # daemon_type, node_name, label = "osd", node.hostname, "_no_schedule"
+    daemon_type, label = "osd", "_no_schedule"
+
+    for node in config.get("nodes"):
+        node_name = ceph_cluster.get_nodes()[int(node[-1]) - 1].hostname
+        exp_out = f"Added label _no_schedule to host {node_name}"
+        # Adding "__no_schedule" label and checking daemons to node.
+        result = CephAdm(installer_node).ceph.orch.label.add(node_name, label)
+        result = list(result.values())[0][0].strip()
+        if exp_out != result:
+            raise LabelNoScheduleError("Failed to add _no_schedule label to node")
+        # Verfiy label added to host
+        result = CephAdm(installer_node).ceph.orch.host.ls(
+            format="json", host_pattern=node_name
+        )
+        result = list(result.values())[0][0].strip()
+        if label not in result:
+            raise LabelNoScheduleError("Failed to add _no_schedule label to node")
+        # Checking all the deamons in node.
+        timeout, interval = 60, 5
+        for w in WaitUntil(timeout=timeout, interval=interval):
+            result = CephAdm(installer_node).ceph.orch.ps(
+                hostname=node_name, format="json"
+            )
+            all_running_daemons = [
+                data["daemon_type"]
+                for data in json.loads(result[installer_node[0].hostname][0])
+            ]
+            if all(item == daemon_type for item in all_running_daemons):
+                break
+        if w.expired:
+            raise LabelNoScheduleError("Deamons check failed")
+    return 0


### PR DESCRIPTION
[Automation] [CephADM] : CEPH_83574671:test_label_no_schedule
Test Steps:
1. Bootstrap a cluster with atleast 2 nodes
2. Add label __no_schedule label to node 2 
3. On node 2, check for running daemons
4. Add node3 with __no_schedule label
5. On node 3, check for running daemons

Test Result: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-85NSS4/

Note: Added test for "quincy" since bug related to label "no_schedule" fixed in rhcs 6.x , Not in rhcs 5.x.
rhcs 5.x bug : https://bugzilla.redhat.com/show_bug.cgi?id=2112755
rhcs 6.x bug : https://bugzilla.redhat.com/show_bug.cgi?id=2112768

Signed-off-by: Mohit <mobisht@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
