### PR TITLE
verify images in trash after force remove on images in trash

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -105,3 +105,10 @@ tests:
       module: rbd_trash.py
       name: Disable Trash and Delete images and check if they are not moved to trash automatically
       polarion-id: CEPH-83573296
+
+  - test:
+      desc: Verify force remove on trash images
+      destroy-cluster: false
+      module: rbd_trash_remove.py
+      name: Test force remove on trash images
+      polarion-id: CEPH-83573289

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -106,3 +106,10 @@ tests:
       module: rbd_trash.py
       name: Disable Trash and Delete images and check if they are not moved to trash automatically
       polarion-id: CEPH-83573296
+
+  - test:
+      desc: Verify force remove on trash images
+      destroy-cluster: false
+      module: rbd_trash_remove.py
+      name: Test force remove on trash images
+      polarion-id: CEPH-83573289

--- a/tests/rbd/rbd_clonev2.py
+++ b/tests/rbd/rbd_clonev2.py
@@ -44,11 +44,7 @@ def run(**kw):
     size = "1G"
 
     try:
-        if not rbd.create_pool(poolname=pool):
-            # create pool does not catch exceptions, it returns true/false.
-            # so we are returning 1 instead of raising exception
-            return 1
-        rbd.create_image(pool_name=pool, image_name=image, size=size)
+        rbd.initial_rbd_config(rbd, pool, image, size=size)
         rbd.snap_create(pool, image, snap)
         snap_name = f"{pool}/{image}@{snap}"
         cmd = "ceph osd set-require-min-compat-client mimic"

--- a/tests/rbd/rbd_trash.py
+++ b/tests/rbd/rbd_trash.py
@@ -48,12 +48,7 @@ def run(**kw):
     size = "10G"
 
     try:
-        if not rbd.create_pool(poolname=pool):
-            # create pool does not catch exceptions, it returns true/false.
-            # so we are returning 1 instead of raising exception
-            return 1
-
-        rbd.create_image(pool_name=pool, image_name=image, size=size)
+        rbd.initial_rbd_config(rbd, pool, image, size=size)
         client = kw["ceph_cluster"].get_nodes(role="client")[0]
         run_fio(image_name=image, pool_name=pool, client_node=client)
         if config["enable"]:

--- a/tests/rbd/rbd_trash_remove.py
+++ b/tests/rbd/rbd_trash_remove.py
@@ -1,0 +1,58 @@
+from tests.rbd.exceptions import ImageFoundError, RbdBaseException
+from tests.rbd.rbd_utils import Rbd
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """Verify the trash functionality.
+
+    This module verifies trash operations
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Pre-requisites :
+    We need atleast one client node with ceph-common package,
+    conf and keyring files
+
+    Test cases covered -
+    1) CEPH-83573289 - Move images to trash, apply force remove on some of the images
+    and check them, if they are removed from trash
+    Test Case Flow
+    1. Create a pool and an Image
+    2. generate IO in images
+    3. Move images to trash
+    4. Remove/Delete image from trash and verify that images is deleted from trash
+    """
+    log.info("Running Trash image remove test")
+    rbd = Rbd(**kw)
+    pool = rbd.random_string()
+    image = rbd.random_string()
+    size = "10G"
+    client = kw["ceph_cluster"].get_nodes(role="client")[0]
+    try:
+        # create rep pool and execute the test work flow
+        rbd.initial_rbd_config(rbd, pool, image, size=size)
+        client = kw["ceph_cluster"].get_nodes(role="client")[0]
+        run_fio(image_name=image, pool_name=pool, client_node=client)
+        rbd.move_image_trash(pool, image)
+        image_id = rbd.get_image_id(pool, image)
+        log.info(f"image id is {image_id}")
+        rbd.remove_image_trash(pool, image_id)
+        if rbd.trash_exist(pool, image):
+            raise ImageFoundError(" Image is found in the Trash")
+        else:
+            return 0
+
+    except RbdBaseException as error:
+        print(error.message)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[pool])


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Automation - CEPH-83573289 - Move images to trash, apply force purge on some of the images and check them
Polarion Link - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573289

Logs : 
5.3 : https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/1828/console 
6.0 : https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/1829/consoleFull

