### PR TITLE
[Probot/stale] Is closing stale issues/PRs really a good idea?

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,60 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 * * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+        # STALE
+        # Duration of inactivity before making PRs stale
+        days-before-pr-stale: 15
+
+        # Stale Comment
+        stale-pr-message: >
+            This Pull request has been automatically marked as STALE due to inactivity for 15 days
+            and will be CLOSED on further inactivity on the PR for another 15 days.
+
+        # stale label
+        stale-pr-label: 'stale-warning-on-inactivity'
+
+        # remove stale label when updated.
+        remove-stale-when-updated: true
+
+        # CLOSE
+        # Duration of inactivity before closing stale PRs
+        days-before-pr-close: 15
+
+        # closing Comment on the staled PRs
+        close-pr-message: >
+            This pull request has been automatically CLOSED,
+            because there has been no activity for 15 days after marking PR as STALE.
+
+        # close pr label
+        close-pr-label: "closed-due-to-inactivity"
+
+        # Change the order used to fetch the issues and pull requests
+        # So we now start with the oldest PRs and work our way backwards
+        ascending: true
+
+        # labels to exempt from stale action
+        exempt-pr-labels: "pinned,need-help"
+
+        # Maximum number of operations per run
+        operations-per-run: 100


### PR DESCRIPTION
# Description

[Probot/stale] Is closing stale issues/PRs really a good idea?

> This bot closes stale issues and pull requests. Really handy if you have large contributors working on your repository and receive many issues and pull request.

> This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.

Reference: https://github.com/actions/stale

**Important information on CephCI stale action**

|Attribute| Values | Actions|
|-------------|-----------|------------|
|name| `Mark stale issues and pull requests ` |Name of the GitHub action|
|schedule| `0 * * * *' ` |Scheduled every hour|
|**STALE**|||
|days-before-pr-stale| 15 |PR would be marked as stale after 15 days of inactivity.|
|stale-pr-message|   This Pull request has been automatically marked as stale due to inactivity for 15 day and will be closed on further inactivity on the PR for another 15 day. |stale PR will updated with this message.|
|stale-pr-label| `stale-warning-on-inactivity` |If PR is stale, this label would be added.|
|remove-stale-when-updated| true |Once PR is active, this would remove stale PR label|
|**CLOSE**|||
|days-before-pr-close| 15  |PR would be closed after 15 days of inactivity from the date of PR marked as stale. |
|close-pr-message:| This pull request has been automatically closed because there has been no activity for 15 days.    |Close PR message|
|close-pr-label| `closed-due-to-inactivity` |label would be added on closing PR|
|exempt-pr-labels| `pinned` |label to exempt from stale, not to be misused.|
