### PR TITLE
Adding fs info command to basic tests

### DIFF
--- a/tests/cephfs/cephfs_basic_tests.py
+++ b/tests/cephfs/cephfs_basic_tests.py
@@ -19,6 +19,10 @@ def run(ceph_cluster, **kw):
         clients = ceph_cluster.get_ceph_objects("client")
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
+        if not build.startswith(("3", "4", "5")):
+            if not fs_util.validate_fs_info(clients[0], "cephfs"):
+                log.error("FS info Validation failed")
+                return 1
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -106,6 +106,26 @@ class FsUtils(object):
                 output_dict["data_pool_name"] = fs["data_pools"][0]
         return output_dict
 
+    def validate_fs_info(self, client, fs_name="cephfs"):
+        """
+        Validates fs info command.
+        ceph fs volume info
+        if fs_name not given.it fetches the default cephfs info
+        Checks the mon Ips based on Cluster configuration in CI
+        Args:
+            client:
+            fs_name:
+        """
+        out, rc = client.exec_command(
+            sudo=True, cmd=f"ceph fs volume info {fs_name} --format json"
+        )
+        fs_info = json.loads(out)
+        mon_ips = self.get_mon_node_ips()
+        if not set([f"{i}:6789" for i in mon_ips]).issubset(fs_info["mon_addrs"]):
+            log.error("Mon IPs are not matching with FS Info IPs")
+            return False
+        return True
+
     def get_fs_details(self, client, **kwargs):
         """
         Gets all filesystems information


### PR DESCRIPTION
Adding fs info command to basic tests

Ceph fs info command is added to tier-0 test cases

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C0ZU6E/ 

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
