### PR TITLE
Merging config test to Cluster create

### DIFF
--- a/suites/pacific/cephfs/tier-0_fs.yaml
+++ b/suites/pacific/cephfs/tier-0_fs.yaml
@@ -69,29 +69,21 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow with label placement."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
       polarion-id: CEPH-83573777
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/pacific/cephfs/tier-1_fs.yaml
+++ b/suites/pacific/cephfs/tier-1_fs.yaml
@@ -102,22 +102,15 @@ tests:
               args:
                 placement:
                   label: mds
-      destroy-cluster: false
-      abort-on-fail: true
-  - test:
-      name: Add Active Active configuration of MDS
-      desc: Add Active Active configuration of MDS for cephfs
-      module: test_bootstrap.py
-      polarion-id: CEPH-11344
-      config:
-        command: shell
-        args: # arguments to ceph orch
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
       destroy-cluster: false
       abort-on-fail: true
   - test:

--- a/suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml
@@ -106,25 +106,17 @@ tests:
               args:
                 placement:
                   label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
       destroy-cluster: false
       abort-on-fail: true
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml
@@ -80,28 +80,20 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml
@@ -89,28 +89,20 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml
@@ -128,29 +128,21 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
       polarion-id: ~
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
@@ -96,29 +96,21 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
       polarion-id: ~
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/pacific/cephfs/tier-2_fs.yaml
+++ b/suites/pacific/cephfs/tier-2_fs.yaml
@@ -69,29 +69,21 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
       polarion-id: ~
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/quincy/cephfs/tier-0_cephfs_upgrade_5x_to_6x.yaml
+++ b/suites/quincy/cephfs/tier-0_cephfs_upgrade_5x_to_6x.yaml
@@ -84,29 +84,21 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow with label placement."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
       polarion-id: CEPH-83573777
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true

--- a/suites/quincy/cephfs/tier-2_fs_scale.yaml
+++ b/suites/quincy/cephfs/tier-2_fs_scale.yaml
@@ -77,29 +77,21 @@ tests:
               pos_args:
                 - cephfs
               service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow with label placement."
       destroy-cluster: false
       module: test_cephadm.py
       name: "cluster deployment"
       polarion-id: CEPH-83573777
-  -
-    test:
-      abort-on-fail: true
-      config:
-        args:
-          - ceph
-          - fs
-          - set
-          - cephfs
-          - max_mds
-          - "2"
-        command: shell
-      desc: "Add Active Active configuration of MDS for cephfs"
-      destroy-cluster: false
-      module: test_bootstrap.py
-      name: "Add Active Active configuration of MDS"
-      polarion-id: CEPH-11344
   -
     test:
       abort-on-fail: true


### PR DESCRIPTION
Merging config test to Cluster create

Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OJ7626/

As part of this PR, We are removing CEPH-11344 and adding it to cluster create test case
Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
