### PR TITLE
update to new metadata style

### DIFF
--- a/pipeline/metadata/quincy.yaml
+++ b/pipeline/metadata/quincy.yaml
@@ -7,7 +7,7 @@
 # parameter required to create a similar custom file is suite name, suite yaml file, global configuration file,
 # platform, rhbuild, inventory and metadata information like frequency of execution, tier, cloud type, functional group and stage.
 #=====================================================================================
-
+suites:
 - name: "Core Feature Upstream Testing For DMFG"
   suite: "suites/quincy/cephadm/sanity-test.yaml"
   global-conf: "conf/3-node-cluster-with-1-client.yaml"


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

**Issue:**
```
+ /home/jenkins-build/workspace/rhceph-upstream-test-executor/.venv/bin/python getPipelineStages.py --rhcephVersion quincy --tags upstream,stage-1 --overrides '{"build":"upstream","upstream-build":"quincy"}'
Traceback (most recent call last):
  File "getPipelineStages.py", line 163, in <module>
    raise e
  File "getPipelineStages.py", line 161, in <module>
    testStages = fetch_stages(arguments)
  File "getPipelineStages.py", line 69, in fetch_stages
    metadata_overrides = metadata_content.get("overrides", {})
AttributeError: 'list' object has no attribute 'get'
```

**Solution:** update upstream metadata file style

**Results:**
```
❯ python pipeline/scripts/ci/getPipelineStages.py --rhcephVersion quincy --tags upstream,stage-1 --overrides '{"build":"upstream","upstream-build":"quincy"}'
final_stage: false
scripts:
  Core Feature Upstream Testing For CephFS:
    cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
      ci-okrfg --log-level DEBUG
    execute_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
      ci-okrfg --log-level DEBUG --suite suites/quincy/cephfs/test-core-functionality.yaml
      --global-conf conf/6-node-cluster-with-1-client.yaml --platform rhel-8 --rhbuild
      6.0 --inventory conf/inventory/rhel-8-latest.yaml --build upstream --upstream-build
      quincy
    log_dir: /logs/7jdv8-
  Core Feature Upstream Testing For DMFG:
    cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
      ci-uugyq --log-level DEBUG
    execute_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
      ci-uugyq --log-level DEBUG --suite suites/quincy/cephadm/sanity-test.yaml --global-conf
      conf/3-node-cluster-with-1-client.yaml --platform rhel-8 --rhbuild 6.0 --inventory
      conf/inventory/rhel-8-latest.yaml --build upstream --upstream-build quincy
    log_dir: /logs/p0c0l-
  Core Feature Upstream Testing For RBD:
    cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
      ci-xtc59 --log-level DEBUG
    execute_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
      ci-xtc59 --log-level DEBUG --suite suites/quincy/rbd/basic-operations-unit-testing.yaml
      --global-conf conf/5-node-cluster-with-1-client.yaml --platform rhel-8 --rhbuild
      6.0 --inventory conf/inventory/rhel-8-latest.yaml --build upstream --upstream-build
      quincy
    log_dir: /logs/h07ps-
  Core Feature Upstream Testing For RGW:
    cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
      ci-fn3ug --log-level DEBUG
    execute_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
      ci-fn3ug --log-level DEBUG --suite suites/quincy/rgw/test-basic-object-operations.yaml
      --global-conf conf/5-node-cluster-1-client-with-1-rgw.yaml --platform rhel-8
      --rhbuild 6.0 --inventory conf/inventory/rhel-8-latest.yaml --build upstream
      --upstream-build quincy
    log_dir: /logs/5czr7-

```