### PR TITLE
[CephAdm] [Tier1] Add test cases for OS tuning profile.

### DIFF
--- a/suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml
+++ b/suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml
@@ -1,0 +1,289 @@
+#===============================================================================================
+#
+# Tier-level: 1
+# Test-Suite: tier-1_os_tuning_profiles.yaml.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml
+#
+#    4-Node cluster
+#    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
+#     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
+#     Node3 - Mon, OSD, MDS, RGW, node-exporter
+#     Node4 - RGW
+#     Node5 - Client
+#
+#===============================================================================================
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      name: Cephadm Bootstrap
+      desc: cephadm cluster bootstrap
+      module: test_bootstrap.py
+      polarion-id: CEPH-83573720
+      config:
+        command: bootstrap
+        base_cmd_args:
+          verbose: true
+        args:
+          skip-monitoring-stack: true
+          orphan-initial-daemons: true
+          registry-json: registry.redhat.io
+          custom_image: true
+          mon-ip: node1
+          fsid: f64f341c-655d-11eb-8778-fa163e914bcc
+      destroy-cluster: false
+      abort-on-fail: true
+  - test:
+      name: Host addition with spec file
+      desc: add hosts using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574726
+      config:
+        steps:
+        - config:
+            service: host
+            command: set_address
+            args:
+              node: node1
+        - config:
+            service: host
+            command: label_add
+            args:
+              node: node1
+              labels: apply-all-labels
+        - config:
+            command: apply_spec
+            service: orch
+            specs:
+             - service_type: host
+               address: true
+               labels: apply-all-labels
+               nodes:
+                 - node2
+                 - node3
+             - service_type: host
+               address: true
+               labels: apply-all-labels
+               nodes:
+                 - node4
+      abort-on-fail: true
+  - test:
+      name: Service deployment with spec
+      desc: Add services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+        - config:
+            command: apply_spec
+            service: orch
+            specs:
+            - service_type: mon
+              placement:
+                nodes:
+                - node1
+                - node2
+                - node3
+            - service_type: mgr
+              placement:
+                label: mgr
+            - service_type: prometheus
+              placement:
+                count: 1
+                nodes:
+                  - node1
+            - service_type: grafana
+              placement:
+                nodes:
+                  - node1
+            - service_type: alertmanager
+              placement:
+                count: 2
+                label: alertmanager
+            - service_type: node-exporter
+              placement:
+                host_pattern: "*"
+            - service_type: crash
+              placement:
+                host_pattern: "*"
+        - config:
+            command: shell
+            args:                 # sleep to get all services deployed
+              - sleep
+              - "300"
+  - test:
+      name: Service deployment with spec
+      desc: Add services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      config:
+        steps:
+        - config:
+            command: apply_spec
+            service: orch
+            specs:
+            - service_type: osd
+              service_id: all-available-devices
+              placement:
+                host_pattern: "*"
+              spec:
+                data_devices:
+                  all: "true"                         # boolean as string
+                encrypted: "true"                     # boolean as string
+        - config:
+            command: shell
+            args:                 # sleep to get all services deployed
+              - sleep
+              - "300"
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args:               # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+          - config:
+              command: shell
+              args:              # sleep to get all services deployed
+                - sleep
+                - "120"
+  - test:
+      name: NFS Service deployment with spec
+      desc: Add NFS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574729
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: nfs
+                  service_id: nfs-rgw-service
+                  placement:
+                    nodes:
+                      - node4
+                  spec:
+                    port: 2049
+  - test:
+      name: RGW Service deployment with spec
+      desc: Add RGW services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574640
+      config:
+        steps:                # create realm, zone group and zone
+          - config:
+              command: shell
+              args:
+                - "radosgw-admin realm create --rgw-realm=east --default"
+          - config:
+              command: shell
+              args:
+                - "radosgw-admin zonegroup create --rgw-zonegroup=asia --master --default"
+          - config:
+              command: shell
+              args:
+                - "radosgw-admin zone create --rgw-zonegroup=asia --rgw-zone=india --master --default"
+          - config:
+              command: shell
+              args:
+                - "radosgw-admin period update --rgw-realm=east --commit"
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: my-rgw
+                  placement:
+                    count_per_host: 2
+                    nodes:
+                      - node4
+                      - node3
+                  spec:
+                    rgw_frontend_port: 8080
+                    rgw_realm: east
+                    rgw_zone: india
+          - config:
+              command: shell
+              args:              # sleep to get all services deployed
+                - sleep
+                - "120"
+  - test:
+      name: create_tuning_profile
+      desc: Verify tuning profile created successfully using cephadm
+      polarion-id: CEPH-83575318
+      module: test_os_tuning_profile.py
+      config:
+        command: apply
+        specs:
+          profile_name: test-mon-host-profile
+          placement:
+            hosts:
+              - node1
+              - node2
+          settings:
+            fs.file-max: 100000
+            vm.swappiness: 14
+        apply_result: Saved tuned profile test-mon-host-profile
+        ls_result: "profile_name: test-mon-host-profile"
+  - test:
+      name: modify_tuning_profile
+      desc: Verify users are able to modify tuning profiles settings using cephadm command.
+      polarion-id: CEPH-83575322
+      module: test_os_tuning_profile.py
+      config:
+        command: modify
+        profile_name: test-mon-host-profile
+        settings: vm.swappiness
+        value: 15
+        result: Added setting vm.swappiness with value 15 to tuned profile test-mon-host-profile
+  - test:
+      name: modify_tuning_profile_using_re-apply_yaml_spec
+      desc: Verify users are able to modify tuning profiles settings using re-applying YAML spec.
+      polarion-id: CEPH-83575323
+      module: test_os_tuning_profile.py
+      config:
+        command: re-apply
+        specs:
+          profile_name: test-mon-host-profile
+          placement:
+            hosts:
+              - node1
+              - node2
+          settings:
+            fs.file-max: 110000
+            vm.swappiness: 15
+        apply_result: Saved tuned profile test-mon-host-profile
+        ls_result: "profile_name: test-mon-host-profile"
+  - test:
+      name: remove_tuning_profile
+      desc: Verify users are able to remove tuning profiles  using cephadm command.
+      polarion-id: CEPH-83575321
+      module: test_os_tuning_profile.py
+      config:
+        command: remove
+        profile_name: test-mon-host-profile
+        result:  Removed tuned profile test-mon-host-profile

--- a/tests/cephadm/test_os_tuning_profile.py
+++ b/tests/cephadm/test_os_tuning_profile.py
@@ -1,0 +1,94 @@
+import tempfile
+
+import yaml
+
+from cli.cephadm.cephadm import CephAdm
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class OsTuningProfileError(Exception):
+    pass
+
+
+def generate_tuned_profile_spec(installler_node, specs):
+    """
+    Generate tuned profile.
+    Args:
+        installler_node: installer node
+        specs: tuned profile specs
+    """
+
+    log.info(f"Spec yaml file content:\n{specs}")
+    # Create tuned profile spec yaml file
+    temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
+    spec_file = installler_node.remote_file(
+        sudo=True, file_name=temp_file.name, file_mode="wb"
+    )
+    spec = yaml.dump(specs, sort_keys=False, indent=2).encode("utf-8")
+    spec_file.write(spec)
+    spec_file.flush()
+    return temp_file.name
+
+
+def run(ceph_cluster, **kw):
+    """Verify tuning profile test cases.
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+        kw: test data
+        e.g:
+        test:
+            name: create_tuning_profile
+            desc: Verify tuning profile created successfully using cephadm
+            polarion-id: CEPH-83575318
+            module: test_os_tuning_profile.py
+            config:
+                command: apply
+                specs:
+                    profile_name: test-mon-host-profile
+                    placement:
+                        hosts:
+                            - node1
+                            - node2
+                settings:
+                    fs.file-max: 100000
+                    vm.swappiness: 14
+                apply_result: Saved tuned profile test-mon-host-profile
+                ls_result: "profile_name: test-mon-host-profile"
+    """
+    installler_node = ceph_cluster.get_nodes(role="installer")[0]
+    config = kw.get("config")
+    mount = "/tmp:/tmp"
+    if config.get("command") in ("apply", "re-apply"):
+        nodes = config.get("specs", {}).get("placement", {}).get("hosts")
+        hosts = [ceph_cluster.get_nodes()[int(node[-1])].hostname for node in nodes]
+        config["specs"]["placement"]["hosts"] = hosts
+        spec_file = generate_tuned_profile_spec(installler_node, config.get("specs"))
+        result = CephAdm(installler_node, mount).ceph.orch.tuned_profile.apply(
+            spec_file
+        )
+        if config.get("apply_result") != result:
+            raise OsTuningProfileError("Fail to apply tuned profile")
+        result = CephAdm(installler_node).ceph.orch.tuned_profile.list().split("\n")[0]
+        if config.get("ls_result") != result:
+            raise OsTuningProfileError("Fail to list tuned profile")
+
+    if config.get("command") == "modify":
+        profile_name, setting, value = (
+            config.get("profile_name"),
+            config.get("settings"),
+            str(config.get("value")),
+        )
+        result = CephAdm(installler_node).ceph.orch.tuned_profile.modify(
+            profile_name, setting, value
+        )
+        if config.get("result") != result:
+            raise OsTuningProfileError("Fail to modify tuned profile")
+
+    if config.get("command") == "remove":
+        profile_name = config.get("profile_name")
+        result = CephAdm(installler_node).ceph.orch.tuned_profile.remove(profile_name)
+        if config.get("result") != result:
+            raise OsTuningProfileError("Fail to list tuned profile")
+    return 0


### PR DESCRIPTION
Automated below test cases.
1. Verify tuning profile created successfully using cephadm
2. Verify users are able to remove tuning profiles  using cephadm command.
3. Verify users are able to modify tuning profiles settings using cephadm command.
4. Verify users are able to modify tuning profiles settings using re-applying YAML spec.
