### PR TITLE
Changes to run on rgw for nautilus suites

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -86,7 +86,11 @@ def run(ceph_cluster, **kw):
     test_config = {"config": config.get("test-config", {})}
     rgw_node = rgw_ceph_object.node
     client_node = client_ceph_object.node
-    run_on_rgw = config.get("run-on-rgw", False)
+    run_on_rgw = (
+        True
+        if ceph_cluster.rhcs_version.version[0] == 4
+        else config.get("run-on-rgw", False)
+    )
     distro_version_id = rgw_node.distro_info["VERSION_ID"]
 
     if run_on_rgw:

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -84,7 +84,11 @@ def run(**kw):
     primary_client_node = primary_cluster.get_ceph_object("client").node
     secondary_rgw_node = secondary_cluster.get_ceph_object("rgw").node
     secondary_client_node = secondary_cluster.get_ceph_object("client").node
-    run_on_rgw = config.get("run-on-rgw", False)
+    run_on_rgw = (
+        True
+        if primary_cluster.rhcs_version.version[0] == 4
+        else config.get("run-on-rgw", False)
+    )
     if run_on_rgw:
         exec_from = test_site_node
         append_param = ""


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Changes to run nautilus suites on rgw node
4.3 :
Single site(8.6) : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TZ69RM/
singel site(8.7) : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ANYD2G/
Multi site(8.7) : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-70BMGZ/

5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2UG6W3/

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
