### PR TITLE
fix for RBD cli generic issue for upstream sanity test

### DIFF
--- a/suites/quincy/cephadm/sanity-test.yaml
+++ b/suites/quincy/cephadm/sanity-test.yaml
@@ -83,8 +83,8 @@ tests:
 
   # Testing stage
   - test:
-      name: Executes RGW, RBD and FS operations
-      desc: Run object, block and filesystem basic operations parallelly.
+      name: Executes RGW and FS operations
+      desc: Run object, filesystem basic operations parallelly.
       module: test_parallel.py
       parallel:
         - test:
@@ -97,16 +97,16 @@ tests:
             name: Test M buckets with N objects
             polarion-id: CEPH-9789
         - test:
-            config:
-              script: cli_generic.sh
-              script_path: qa/workunits/rbd
-            desc: "Executing upstream RBD CLI Generic scenarios"
-            module: test_rbd.py
-            name: 1_rbd_cli_generic
-            polarion-id: CEPH-83574241
-        - test:
             abort-on-fail: false
             desc: "cephfs basic operations"
             module: cephfs_basic_tests.py
             name: cephfs-basics
             polarion-id: CEPH-11293  # also applies to [CEPH-11296,CEPH-11297,CEPH-11295]
+  - test:
+      config:
+        script: cli_generic.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD CLI Generic scenarios"
+      module: test_rbd.py
+      name: Executes RBD CLI generic operations
+      polarion-id: CEPH-83574241


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Observing issue while running rbd and cephfs test parallely, so Decoupling the RBD basic test from parallelism and running separately.

success Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-J7EGRA/ 