### PR TITLE
Automated TC 9225: Delete clones with krbd IO

### DIFF
--- a/suites/quincy/rbd/tier-1_rbd.yaml
+++ b/suites/quincy/rbd/tier-1_rbd.yaml
@@ -88,6 +88,7 @@ tests:
           - ceph-common
           - rbd-nbd
           - jq
+          - fio
         node: node4
       desc: "Configure the client system"
       destroy-cluster: false
@@ -178,3 +179,9 @@ tests:
       module: test_rbd.py
       name: 11_rbd_krbd_exclusive
       polarion-id: CEPH-83574531
+
+  - test:
+      module: delete_clones_with_io.py
+      name: test delete clones with io
+      polarion-id: CEPH-9225
+      Desc: Create clone of an image and delete while krbd IO is running

--- a/tests/rbd/delete_clones_with_io.py
+++ b/tests/rbd/delete_clones_with_io.py
@@ -1,0 +1,94 @@
+import time
+
+from krbd_io_handler import krbd_io_handler
+from rbd.exceptions import RbdBaseException
+
+from ceph.parallel import parallel
+from tests.rbd.rbd_utils import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """Delete Clones while IO is running on parent.
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Pre-requisites :
+    We need atleast one client node with ceph-common package,
+    conf and keyring files
+
+    Test cases covered -
+    1) CEPH-9225 - RBD-Kernel_Client: Delete all Clone at once
+
+    Test Case Flow
+    1. Create a pool, an Image, 10 snapshots, 10 clones.
+    2. generate IO on the Image, in parallel delete the clones.
+
+    """
+    log.info("Running test - delete clones with IOs")
+    config = kw["config"]
+    rbd = Rbd(**kw)
+
+    pool = config.get("pool_name", rbd.random_string())
+    image = config.get("image_name", rbd.random_string())
+    size = "10G"
+
+    try:
+
+        def create_clone(*args):
+            if not rbd.create_pool(poolname=pool):
+                return 1
+
+            rbd.create_image(pool_name=pool, image_name=image, size=size)
+
+            for clone_number in range(0, 10):
+                rbd.snap_create(pool, image, f"snap_{clone_number}")
+                rbd.protect_snapshot(f"{pool}/{image}@snap_{clone_number}")
+                rbd.create_clone(
+                    f"{pool}/{image}@snap_{clone_number}", pool, f"clone_{clone_number}"
+                )
+                time.sleep(5)
+
+        def delete_clone(*args):
+            for clone_number in range(0, 10):
+                rbd.remove_image(pool, f"clone_{clone_number}")
+                time.sleep(3)
+
+        io_config = {
+            "file_size": "100M",
+            "image_spec": [f"{pool}/{image}"],
+            "operations": {
+                "fs": "ext4",
+                "io": True,
+                "map": True,
+                "mount": True,
+                "nounmap": False,
+            },
+            "runtime": 30,
+        }
+        kw["config"].update(io_config)
+
+        log.info("Creating image, snaps, clones with IO")
+        with parallel() as p:
+            p.spawn(create_clone)
+            time.sleep(10)
+            p.spawn(krbd_io_handler, **kw)
+
+        log.info("Deleting image, snaps, clones with IO")
+        with parallel() as p:
+            p.spawn(delete_clone)
+            p.spawn(krbd_io_handler, **kw)
+
+        return 0
+    except RbdBaseException as error:
+        print(error.message)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[pool])

--- a/tests/rbd/delete_clones_with_io.py
+++ b/tests/rbd/delete_clones_with_io.py
@@ -32,63 +32,74 @@ def run(**kw):
 
     """
     log.info("Running test - delete clones with IOs")
-    config = kw["config"]
-    rbd = Rbd(**kw)
 
-    pool = config.get("pool_name", rbd.random_string())
-    image = config.get("image_name", rbd.random_string())
+    scenarios = [Rbd(**kw)]
+
+    kw["config"]["ec-pool-k-m"] = "go_with_default"
+    scenarios.append(Rbd(**kw))
+
+    config = kw["config"]
+
+    pools = ["test_rbd_ec_pool_scenario", "test_rbd_rep_pool"]
+    image = config.get("image_name", "rbd_test_image")
     size = "10G"
 
-    try:
+    for rbd in scenarios:
+        pool = pools.pop()
+        kw["rbd_obj"] = rbd
+        try:
 
-        def create_clone(*args):
-            if not rbd.create_pool(poolname=pool):
-                return 1
+            def create_clone(*args):
+                if not rbd.create_pool(poolname=pool):
+                    return 1
 
-            rbd.create_image(pool_name=pool, image_name=image, size=size)
+                rbd.create_image(pool_name=pool, image_name=image, size=size)
 
-            for clone_number in range(0, 10):
-                rbd.snap_create(pool, image, f"snap_{clone_number}")
-                rbd.protect_snapshot(f"{pool}/{image}@snap_{clone_number}")
-                rbd.create_clone(
-                    f"{pool}/{image}@snap_{clone_number}", pool, f"clone_{clone_number}"
-                )
-                time.sleep(5)
+                for clone_number in range(0, 10):
+                    rbd.snap_create(pool, image, f"snap_{clone_number}")
+                    rbd.protect_snapshot(f"{pool}/{image}@snap_{clone_number}")
+                    rbd.create_clone(
+                        f"{pool}/{image}@snap_{clone_number}",
+                        pool,
+                        f"clone_{clone_number}",
+                    )
+                    time.sleep(5)
 
-        def delete_clone(*args):
-            for clone_number in range(0, 10):
-                rbd.remove_image(pool, f"clone_{clone_number}")
-                time.sleep(3)
+            def delete_clone(*args):
+                for clone_number in range(0, 10):
+                    rbd.remove_image(pool, f"clone_{clone_number}")
+                    time.sleep(3)
 
-        io_config = {
-            "file_size": "100M",
-            "image_spec": [f"{pool}/{image}"],
-            "operations": {
-                "fs": "ext4",
-                "io": True,
-                "map": True,
-                "mount": True,
-                "nounmap": False,
-            },
-            "runtime": 30,
-        }
-        kw["config"].update(io_config)
+            io_config = {
+                "file_size": "100M",
+                "image_spec": [f"{pool}/{image}"],
+                "operations": {
+                    "fs": "ext4",
+                    "io": True,
+                    "map": True,
+                    "mount": True,
+                    "nounmap": False,
+                },
+                "runtime": 30,
+            }
+            kw["config"].update(io_config)
 
-        log.info("Creating image, snaps, clones with IO")
-        with parallel() as p:
-            p.spawn(create_clone)
-            time.sleep(10)
-            p.spawn(krbd_io_handler, **kw)
+            log.info("Creating image, snaps, clones with IO")
+            with parallel() as p:
+                p.spawn(create_clone)
+                time.sleep(10)
+                p.spawn(krbd_io_handler, **kw)
 
-        log.info("Deleting image, snaps, clones with IO")
-        with parallel() as p:
-            p.spawn(delete_clone)
-            p.spawn(krbd_io_handler, **kw)
+            log.info("Deleting image, snaps, clones with IO")
+            with parallel() as p:
+                p.spawn(delete_clone)
+                p.spawn(krbd_io_handler, **kw)
 
-        return 0
-    except RbdBaseException as error:
-        print(error.message)
-        return 1
+        except RbdBaseException as error:
+            print(error.message)
+            return 1
 
-    finally:
-        rbd.clean_up(pools=[pool])
+        finally:
+            rbd.clean_up(pools=[pool])
+
+    return 0

--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -36,6 +36,7 @@ def krbd_io_handler(**kw):
     else:
         rbd = Rbd(**kw)
     config = kw.get("config")
+    log.debug("Config recieved for execution: ", config)
 
     operations = config["operations"]
     device_names = []

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -35,11 +35,18 @@ class Rbd:
                 continue
 
         if self.ceph_version > 2 and self.k_m:
-            self.datapool = self.config.get("ec_pool_config").get("data_pool")
-            self.ec_profile = self.config.get("ec_pool_config").get(
-                "ec_profile", "rbd_ec_profile"
+            self.datapool = (
+                self.config["ec_pool_config"]["data_pool"]
+                if self.config.get("ec_pool_config", {}).get("data_pool")
+                else "rbd_test_data_pool"
             )
-            self.set_ec_profile(profile=self.ec_profile)
+            if "," in self.k_m:
+                self.ec_profile = self.config.get("ec_pool_config", {}).get(
+                    "ec_profile", "rbd_ec_profile"
+                )
+                self.set_ec_profile(profile=self.ec_profile)
+            else:
+                self.ec_profile = ""
 
     def exec_cmd(self, **kw):
         """


### PR DESCRIPTION
Automated 9225: Delete clones with krbd IO

    1. Create a pool, an Image, 10 snapshots, 10 clones.
    2. generate IO on the Image, in parallel delete the clones

Changes:
1. Add test to suite suites/quincy/rbd/tier-1_rbd.yaml
2. Module handling the TC tests/rbd/delete_clones_with_io.py
3. Added a debug message tests/rbd/krbd_io_handler.py
4. Rectified errors in a method tests/rbd/rbd_utils.py


Signed-off-by: Vasishta <vashastr@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
