### PR TITLE
run pytest unit tests on specific path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   tox:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
       matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36, py37, py36-coverage
 deps =
     -r{toxinidir}/test_requirements.txt
 commands =
-    pytest
+    pytest unittests
     flake8
     isort -c .
     black --check --diff .


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- run unit tests on specific directory.
- run GitHub workflows on ubuntu-20.04. (**result:** https://github.com/sunilkumarn417/cephci/actions/runs/3650160647/jobs/6165790767)

**Results:**

> ❯ tox -e py
> py: install_deps> python -I -m pip install -r /home/sunil/pycharm/cephci/test_requirements.txt
> .pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0' wheel
> .pkg: _optional_hooks> python /home/sunil/pycharm/.venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
> .pkg: get_requires_for_build_sdist> python /home/sunil/pycharm/.venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
> .pkg: prepare_metadata_for_build_wheel> python /home/sunil/pycharm/.venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
> .pkg: build_sdist> python /home/sunil/pycharm/.venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
> py: install_package_deps> python -I -m pip install 'apache-libcloud>=3.3.0' cryptography docopt gevent greenlet htmllistparse ibm-cloud-networking-services 'ibm-cloud-sdk-core; python_version >= "3.7"' 'ibm-cloud-sdk-core==3.15.0; python_version < "3.7"' ibm-cos-sdk ibm-cos-sdk-core ibm-cos-sdk-s3transfer 'ibm-vpc>=0.8.0' jinja-markdown jinja2 junitparser paramiko pyyaml reportportal-client requests softlayer
> py: install_package> python -I -m pip install --force-reinstall --no-deps /home/sunil/pycharm/cephci/.tox/.tmp/package/1/cephci-0.1.tar.gz
> py: commands[0]> pytest unittests
> ===================================================================================== test session starts =====================================================================================
> platform linux -- Python 3.10.7, pytest-7.2.0, pluggy-1.0.0
> cachedir: .tox/py/.pytest_cache
> rootdir: /home/sunil/pycharm/cephci
> collected 17 items
> 
> unittests/ceph/ceph_admin/test_add.py ..                                                                                                                                                [ 11%]
> unittests/ceph/ceph_admin/test_alert_manager.py .                                                                                                                                       [ 17%]
> unittests/ceph/ceph_admin/test_apply.py ....                                                                                                                                            [ 41%]
> unittests/utility/test_utils.py ..........                                                                                                                                              [100%]
> 
> ===================================================================================== 17 passed in 0.99s ======================================================================================
> py: commands[1]> flake8
> py: commands[2]> isort -c .
> Skipped 4 files
> py: commands[3]> black --check --diff .
> All done! ✨ 🍰 ✨
> 414 files would be left unchanged.
> py: commands[4]> yamllint -d relaxed --no-warnings .
> .pkg: _exit> python /home/sunil/pycharm/.venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
>   py: OK (60.23=setup[34.85]+cmd[1.38,2.95,1.36,3.05,16.65] seconds)
>   congratulations :) (60.37 seconds)
> 