### PR TITLE
Moving to specific python versions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
       - label!=work-in-progress
       - base=master
       - "approved-reviews-by=@red-hat-storage/cephci-top-level-reviewers"
-      - "check-success=tox (3.6)"
+      - "check-success=tox (3.6.8)"
       - check-success=WIP
     actions:
       merge:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,12 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - '3.6'
-        - '3.8'
+        - '3.6.8'
+        - '3.8.15'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
# Description

Fixing gate failures due to changes in github workflow. The runner cannot be changed from `ubuntu-20.04` as this runner is the last supported one for executing python 3.6.x version.

Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>