### PR TITLE
[Report Poratl] Launch name change for upstream builds

### DIFF
--- a/run.py
+++ b/run.py
@@ -450,10 +450,11 @@ def run(args):
 
     platform = args["--platform"]
     build = args.get("--build")
+    upstream_build = args.get("--upstream-build", None)
 
     if build and build not in ["released"] and not ignore_latest_nightly_container:
         base_url, docker_registry, docker_image, docker_tag = fetch_build_artifacts(
-            build, rhbuild, platform, args.get("--upstream-build", None)
+            build, rhbuild, platform, upstream_build
         )
 
     store = args.get("--store") or False
@@ -557,7 +558,7 @@ def run(args):
 
     distro = ", ".join(list(set(distro)))
     if not ceph_version and build == "upstream":
-        ceph_version.append(args.get("--upstream-build", None))
+        ceph_version.append(upstream_build)
     ceph_version = ", ".join(list(set(ceph_version)))
     ceph_ansible_version = ", ".join(list(set(ceph_ansible_version)))
 
@@ -576,7 +577,11 @@ def run(args):
         suite_file_name = " ".join(suite_file_name.split("_"))
         _log = run_dir.replace("/ceph/", "http://magna002.ceph.redhat.com/")
 
-        launch_name = f"RHCS {rhbuild} - {suite_file_name}"
+        launch_name = (
+            f"Upstream {upstream_build} - {suite_file_name}"
+            if build == "upstream"
+            else f"RHCS {rhbuild} - {suite_file_name}"
+        )
         launch_desc = textwrap.dedent(
             """
             "jenkin-url": {jenkin_job_url},


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
[Report Poratl] Launch name change for upstream builds
When buils is not "upstream": https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/-1/6078
when build is upstream : https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/-1/6105
"Upstream 6.0 - test-basic-object-operations"

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
