### PR TITLE
test_client.py : deploy multiple clients with different RHCS and RHEL…

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -148,7 +148,7 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         }
 
         cmd = f"subscription-manager repos --enable={cdn_repo[os_major_version]}"
-        for node in self.cluster.get_nodes():
+        for node in self.cluster.get_nodes(ignore="client"):
             node.exec_command(sudo=True, cmd=cmd)
 
     def setup_upstream_repository(self, repo_url=None):
@@ -193,7 +193,7 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         if kwargs.get("nogpgcheck", True):
             cmd += " --nogpghceck"
 
-        for node in self.cluster.get_nodes():
+        for node in self.cluster.get_nodes(ignore="client"):
             node.exec_command(
                 sudo=True,
                 cmd="yum install cephadm -y --nogpgcheck",

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -212,7 +212,7 @@ def create_ibmc_ceph_nodes(
                     node_params["osd-scenario"] = node_dict.get("osd-scenario")
 
                 if node_dict.get("image-name"):
-                    node_params["image-name"] = node_dict.get("image-name")
+                    node_params["image-name"] = node_dict["image-name"]["ibmc"]
 
                 if node_dict.get("cloud-data"):
                     node_params["cloud-data"] = node_dict.get("cloud-data")
@@ -354,7 +354,7 @@ def create_ceph_nodes(
                     node_params["osd-scenario"] = node_dict.get("osd-scenario")
 
                 if node_dict.get("image-name"):
-                    node_params["image-name"] = node_dict.get("image-name")
+                    node_params["image-name"] = node_dict["image-name"]["openstack"]
 
                 if node_dict.get("cloud-data"):
                     node_params["cloud-data"] = node_dict.get("cloud-data")

--- a/conf/inventory/rhel-7.9-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.9-server-x86_64.yaml
@@ -35,6 +35,8 @@ instance:
         - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
         - subscription-manager clean
         - hostnamectl set-hostname $(hostname -s)
+        - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+        - systemctl restart sshd
         - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
         - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
         - update-ca-trust

--- a/conf/inventory/rhel-8.6-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.6-server-x86_64.yaml
@@ -34,6 +34,8 @@ instance:
       - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
       - subscription-manager clean
       - hostnamectl set-hostname $(hostname -s)
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - systemctl restart sshd
       - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
       - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://password.corp.redhat.com/RH-IT-Root-CA.crt
       - update-ca-trust

--- a/conf/pacific/rados/6-node-cluster-6-clients.yaml
+++ b/conf/pacific/rados/6-node-cluster-6-clients.yaml
@@ -11,11 +11,9 @@ globals:
           - mon
           - mgr
           - installer
-          - node-exporter
           - alertmanager
           - grafana
           - prometheus
-          - crash
       node2:
         networks:
           - provider_net_cci_12
@@ -24,16 +22,11 @@ globals:
           - mgr
           - mds
           - rgw
-          - node-exporter
-          - alertmanager
-          - crash
       node3:
         networks:
           - provider_net_cci_12
         role:
           - osd
-          - node-exporter
-          - crash
         no-of-volumes: 5
         disk-size: 25
       node4:
@@ -41,15 +34,11 @@ globals:
           - provider_net_cci_12
         role:
           - osd
-          - node-exporter
-          - crash
         no-of-volumes: 5
         disk-size: 25
       node5:
         role:
           - osd
-          - node-exporter
-          - crash
         no-of-volumes: 5
         disk-size: 25
       node6:
@@ -60,34 +49,50 @@ globals:
           - mgr
           - mds
           - rgw
-          - node-exporter
-          - crash
       node7:
+        image-name:
+          openstack: RHEL-8.6.0-x86_64-ga-latest
+          ibmc: rhel-86-server-released
         networks:
           - provider_net_cci_8
         role:
           - client
       node8:
+        image-name:
+          openstack: RHEL-8.6.0-x86_64-ga-latest
+          ibmc: rhel-86-server-released
         networks:
           - provider_net_cci_8
         role:
           - client
       node9:
+        image-name:
+          openstack: RHEL-8.6.0-x86_64-ga-latest
+          ibmc: rhel-86-server-released
         networks:
           - provider_net_cci_9
         role:
           - client
       node10:
+        image-name:
+          openstack: rhel-7.9-server-x86_64-released
+          ibmc: rhel-server-79-x86-64-kvm
         networks:
           - provider_net_cci_9
         role:
           - client
       node11:
+        image-name:
+          openstack: RHEL-9.1.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_7
         role:
           - client
       node12:
+        image-name:
+          openstack: RHEL-9.1.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_7
         role:

--- a/run.py
+++ b/run.py
@@ -49,6 +49,7 @@ from utility.utils import (
     generate_unique_id,
     magna_url,
     validate_conf,
+    validate_image,
 )
 from utility.xunit import create_xunit_results
 
@@ -182,6 +183,7 @@ def create_nodes(
         rp_logger.start_test_item(name=name, description=desc, item_type="STEP")
 
     validate_conf(conf)
+    validate_image(conf, cloud_type)
     if cloud_type == "openstack":
         cleanup_ceph_nodes(osp_cred, instances_name)
     elif cloud_type == "ibmc":

--- a/suites/pacific/rados/tier-2_rados_cidr_blocklisting.yaml
+++ b/suites/pacific/rados/tier-2_rados_cidr_blocklisting.yaml
@@ -79,6 +79,7 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
 
+
   - test:
       name: Configure clients
       desc: Configures multiple client nodes on cluster
@@ -93,9 +94,10 @@ tests:
               command: add
               id: client.1                      # client Id (<type>.<Id>)
               nodes:
-                  - node7                       # client node
-                  - node8
-                  - node9
+                  - node8:
+                      release: 5
+                  - node7:
+                      release: 5
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node
@@ -113,13 +115,33 @@ tests:
               command: add
               id: client.2                     # client Id (<type>.<Id>)
               nodes:
-                - node10
-                - node11
-                - node12
+                - node9:
+                    release: 5
+                - node10:
+                    release: 4
+                - node11:
+                    release: 5
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node
               caps: # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+        - test:
+            name: Configure client 3
+            desc: Configures client admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.3                      # client Id (<type>.<Id>)
+              node: node12                       # client node
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
                 mon: "allow *"
                 osd: "allow *"
                 mds: "allow *"
@@ -144,9 +166,5 @@ tests:
           pool-2:
             type: replicated
             conf: sample-pool-2
-# TODO: add support for ec pools as data pools for rbd images, and blocklist the clients
-#          pool-3:
-#            type: erasure
-#            conf: sample-pool-3
         pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
       desc: CIDR Blocklisting of ceph rbd clients


### PR DESCRIPTION
… versions.
```
Provide data regarding the RHEL images in the global conf file and RHCS versions in the suite file. Currently we are supporting only latest GA images in each major RHCS versions. Examples:
Conf file :
      node4:
	networks:
          - provider_net_cci_9
        image-name:
          openstack: RHEL-8.6.0-x86_64-ga-latest
          ibmc: rhel-86-server-released
        role:
          - client

suite:
            config:
              command: add
              id: client.1                      # client Id (<type>.<Id>)
              nodes:
                  - node8:
                      release: 5
                  - node7:
                      release: 5
              install_packages:
                - ceph-common
```
Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>
