### PR TITLE
Fix for nautilus:unable to find a keyring on /etc/ceph/ceph.client.ad…

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -149,7 +149,7 @@ def verify_sync_status(verify_io_on_site_node, retry=10, delay=60):
     """
     verify RGW multisite sync status
     """
-    ceph_version = verify_io_on_site_node.exec_command(cmd="ceph version")
+    ceph_version = verify_io_on_site_node.exec_command(cmd="sudo ceph version")
     ceph_version = ceph_version[0].split()[4]
     if ceph_version == "pacific":
         out = verify_io_on_site_node.exec_command(cmd="ceph orch ps | grep rgw")


### PR DESCRIPTION
…min.keyring

Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Issue : 
23:12:04,559 - ERROR - cephci.ceph.ceph.py:1548 - Error 13 during cmd, timeout 600
2022-12-07 23:12:04,560 - ERROR - cephci.ceph.ceph.py:1549 - 2022-12-07 18:12:04.541 7f9ebac92700 -1 auth: unable to find a keyring on /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,: (2) No such file or directory
2022-12-07 18:12:04.541 7f9ebac92700 -1 AuthRegistry(0x7f9eb40c2448) no keyring found at /etc/ceph/ceph.client.admin.keyring,/etc/ceph/ceph.keyring,/etc/ceph/keyring,/etc/ceph/keyring.bin,, disabling cephx

https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6056/149919


log: : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X5KJ4A

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
