### PR TITLE
add ms-dbr tests on greenfield deployments

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
@@ -9,197 +9,197 @@ tests:
 
   # Cluster deployment stage
 
-#  - test:
-#      abort-on-fail: true
-#      desc: Install software pre-requisites for cluster deployment.
-#      module: install_prereq.py
-#      name: setup pre-requisites
-#
-#  - test:
-#      abort-on-fail: true
-#      clusters:
-#        ceph-pri:
-#          config:
-#            verify_cluster_health: true
-#            steps:
-#              - config:
-#                  command: bootstrap
-#                  service: cephadm
-#                  args:
-#                    mon-ip: node1
-#                    orphan-initial-daemons: true
-#                    skip-dashboard: true
-#              - config:
-#                  command: add_hosts
-#                  service: host
-#                  args:
-#                    attach_ip_address: true
-#                    labels: apply-all-labels
-#              - config:
-#                  command: apply
-#                  service: mgr
-#                  args:
-#                    placement:
-#                      label: mgr
-#              - config:
-#                  command: apply
-#                  service: mon
-#                  args:
-#                    placement:
-#                      label: mon
-#              - config:
-#                  command: apply
-#                  service: osd
-#                  args:
-#                    all-available-devices: true
-#              - config:
-#                  command: apply
-#                  service: rgw
-#                  pos_args:
-#                    - shared.pri
-#                  args:
-#                    placement:
-#                      nodes:
-#                        - node5
-#        ceph-sec:
-#          config:
-#            verify_cluster_health: true
-#            steps:
-#              - config:
-#                  command: bootstrap
-#                  service: cephadm
-#                  args:
-#                    mon-ip: node1
-#                    orphan-initial-daemons: true
-#                    skip-dashboard: true
-#              - config:
-#                  command: add_hosts
-#                  service: host
-#                  args:
-#                    attach_ip_address: true
-#                    labels: apply-all-labels
-#              - config:
-#                  command: apply
-#                  service: mgr
-#                  args:
-#                    placement:
-#                      label: mgr
-#              - config:
-#                  command: apply
-#                  service: mon
-#                  args:
-#                    placement:
-#                      label: mon
-#              - config:
-#                  command: apply
-#                  service: osd
-#                  args:
-#                    all-available-devices: true
-#              - config:
-#                  command: apply
-#                  service: rgw
-#                  pos_args:
-#                    - shared.sec
-#                  args:
-#                    placement:
-#                      nodes:
-#                        - node5
-#      desc: RHCS cluster deployment using cephadm.
-#      polarion-id: CEPH-83575222
-#      destroy-cluster: false
-#      module: test_cephadm.py
-#      name: deploy cluster
-#  - test:
-#      abort-on-fail: true
-#      clusters:
-#        ceph-pri:
-#          config:
-#            command: add
-#            id: client.1
-#            node: node6
-#            install_packages:
-#              - ceph-common
-#            copy_admin_keyring: true
-#        ceph-sec:
-#          config:
-#            command: add
-#            id: client.1
-#            node: node6
-#            install_packages:
-#              - ceph-common
-#            copy_admin_keyring: true
-#      desc: Configure the RGW client system
-#      destroy-cluster: false
-#      module: test_client.py
-#      name: configure client
-#      polarion-id: CEPH-83573758
-#  - test:
-#      abort-on-fail: true
-#      clusters:
-#        ceph-pri:
-#          config:
-#            cephadm: true
-#            commands:
-#              - "radosgw-admin realm create --rgw-realm india --default"
-#              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
-#              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
-#              - "radosgw-admin period update --rgw-realm india --commit"
-#              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
-#              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-#              - "radosgw-admin period update --rgw-realm india --commit"
-#              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
-#              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
-#              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
-#              - "ceph orch restart {service_name:shared.pri}"
-#        ceph-sec:
-#          config:
-#            cephadm: true
-#            commands:
-#              - "sleep 120"
-#              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
-#              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-#              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-#              - "radosgw-admin period update --rgw-realm india --commit"
-#              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
-#              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
-#              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
-#              - "ceph orch restart {service_name:shared.sec}"
-#      desc: Setting up RGW multisite replication environment
-#      module: exec.py
-#      name: setup multisite
-#      polarion-id: CEPH-10362
-#  - test:
-#      abort-on-fail: true
-#      clusters:
-#        ceph-pri:
-#          config:
-#            cephadm: true
-#            commands:
-#              - "radosgw-admin sync status"
-#              - "ceph -s"
-#              - "radosgw-admin realm list"
-#              - "radosgw-admin zonegroup list"
-#              - "radosgw-admin zone list"
-#      desc: Retrieve the configured environment details
-#      module: exec.py
-#      name: get shared realm info on primary
-#      polarion-id: CEPH-83575227
-#  - test:
-#      abort-on-fail: true
-#      clusters:
-#        ceph-sec:
-#          config:
-#            cephadm: true
-#            commands:
-#              - "radosgw-admin sync status"
-#              - "ceph -s"
-#              - "radosgw-admin realm list"
-#              - "radosgw-admin zonegroup list"
-#              - "radosgw-admin zone list"
-#      desc: Retrieve the configured environment details
-#      module: exec.py
-#      name: get shared realm info on secondary
-#      polarion-id: CEPH-83575227
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83575222
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on primary
+      polarion-id: CEPH-83575227
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on secondary
+      polarion-id: CEPH-83575227
 
   # create user from primary
   - test:

--- a/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
@@ -1,0 +1,272 @@
+# Objective: Testing RadosGW bucket basic operationswith dynamic bucket resharding enabled.
+# Cluster: Requires a minimum of one RGW daemon
+# conf: rgw_multisite.yaml
+#
+#
+# This suite deploys multisite cluster and performs bucket and user related operations
+---
+tests:
+
+  # Cluster deployment stage
+
+#  - test:
+#      abort-on-fail: true
+#      desc: Install software pre-requisites for cluster deployment.
+#      module: install_prereq.py
+#      name: setup pre-requisites
+#
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-pri:
+#          config:
+#            verify_cluster_health: true
+#            steps:
+#              - config:
+#                  command: bootstrap
+#                  service: cephadm
+#                  args:
+#                    mon-ip: node1
+#                    orphan-initial-daemons: true
+#                    skip-dashboard: true
+#              - config:
+#                  command: add_hosts
+#                  service: host
+#                  args:
+#                    attach_ip_address: true
+#                    labels: apply-all-labels
+#              - config:
+#                  command: apply
+#                  service: mgr
+#                  args:
+#                    placement:
+#                      label: mgr
+#              - config:
+#                  command: apply
+#                  service: mon
+#                  args:
+#                    placement:
+#                      label: mon
+#              - config:
+#                  command: apply
+#                  service: osd
+#                  args:
+#                    all-available-devices: true
+#              - config:
+#                  command: apply
+#                  service: rgw
+#                  pos_args:
+#                    - shared.pri
+#                  args:
+#                    placement:
+#                      nodes:
+#                        - node5
+#        ceph-sec:
+#          config:
+#            verify_cluster_health: true
+#            steps:
+#              - config:
+#                  command: bootstrap
+#                  service: cephadm
+#                  args:
+#                    mon-ip: node1
+#                    orphan-initial-daemons: true
+#                    skip-dashboard: true
+#              - config:
+#                  command: add_hosts
+#                  service: host
+#                  args:
+#                    attach_ip_address: true
+#                    labels: apply-all-labels
+#              - config:
+#                  command: apply
+#                  service: mgr
+#                  args:
+#                    placement:
+#                      label: mgr
+#              - config:
+#                  command: apply
+#                  service: mon
+#                  args:
+#                    placement:
+#                      label: mon
+#              - config:
+#                  command: apply
+#                  service: osd
+#                  args:
+#                    all-available-devices: true
+#              - config:
+#                  command: apply
+#                  service: rgw
+#                  pos_args:
+#                    - shared.sec
+#                  args:
+#                    placement:
+#                      nodes:
+#                        - node5
+#      desc: RHCS cluster deployment using cephadm.
+#      polarion-id: CEPH-83575222
+#      destroy-cluster: false
+#      module: test_cephadm.py
+#      name: deploy cluster
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-pri:
+#          config:
+#            command: add
+#            id: client.1
+#            node: node6
+#            install_packages:
+#              - ceph-common
+#            copy_admin_keyring: true
+#        ceph-sec:
+#          config:
+#            command: add
+#            id: client.1
+#            node: node6
+#            install_packages:
+#              - ceph-common
+#            copy_admin_keyring: true
+#      desc: Configure the RGW client system
+#      destroy-cluster: false
+#      module: test_client.py
+#      name: configure client
+#      polarion-id: CEPH-83573758
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-pri:
+#          config:
+#            cephadm: true
+#            commands:
+#              - "radosgw-admin realm create --rgw-realm india --default"
+#              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+#              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+#              - "radosgw-admin period update --rgw-realm india --commit"
+#              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+#              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+#              - "radosgw-admin period update --rgw-realm india --commit"
+#              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+#              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+#              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+#              - "ceph orch restart {service_name:shared.pri}"
+#        ceph-sec:
+#          config:
+#            cephadm: true
+#            commands:
+#              - "sleep 120"
+#              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+#              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+#              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+#              - "radosgw-admin period update --rgw-realm india --commit"
+#              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+#              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+#              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+#              - "ceph orch restart {service_name:shared.sec}"
+#      desc: Setting up RGW multisite replication environment
+#      module: exec.py
+#      name: setup multisite
+#      polarion-id: CEPH-10362
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-pri:
+#          config:
+#            cephadm: true
+#            commands:
+#              - "radosgw-admin sync status"
+#              - "ceph -s"
+#              - "radosgw-admin realm list"
+#              - "radosgw-admin zonegroup list"
+#              - "radosgw-admin zone list"
+#      desc: Retrieve the configured environment details
+#      module: exec.py
+#      name: get shared realm info on primary
+#      polarion-id: CEPH-83575227
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-sec:
+#          config:
+#            cephadm: true
+#            commands:
+#              - "radosgw-admin sync status"
+#              - "ceph -s"
+#              - "radosgw-admin realm list"
+#              - "radosgw-admin zonegroup list"
+#              - "radosgw-admin zone list"
+#      desc: Retrieve the configured environment details
+#      module: exec.py
+#      name: get shared realm info on secondary
+#      polarion-id: CEPH-83575227
+
+  # create user from primary
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create tenanted user
+      module: sanity_rgw_multisite.py
+      name: create tenanted user
+      polarion-id: CEPH-83574433
+
+  #  Dynamic resharding tests
+  - test:
+      name: Verify DBR feature enabled on greenfield cluster
+      desc: Check DBR feature enabled on greenfield cluster
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      polarion-id: CEPH-83573596
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_check_sharding_enabled.py
+            config-file-name: test_check_sharding_enabled_greenfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
+            timeout: 300
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
+            timeout: 300
+      desc: Test dynamic resharding on greenfield deployment
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      name: Dynamic Resharding tests on Primary cluster
+      polarion-id: CEPH-83574737
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_multisite_manual_resharding_greenfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
+            timeout: 300
+      desc: Test manual resharding on greenfield deployment
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      name: Manual Resharding tests on Primary cluster
+      polarion-id: CEPH-83574734
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+            script-name: test_dynamic_bucket_resharding.py
+            timeout: 300
+            verify-io-on-site: ["ceph-pri", "ceph-sec" ]
+      desc: Resharding test - dynamic resharding on versioned bucket
+      name: Dynamic Resharding on versioned buckets
+      polarion-id: CEPH-83571740
+      module: sanity_rgw_multisite.py


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Add support to test multisite DBR tests on Greenfield(fresh) deployments with tenanted users. Currently we have the scenario covered only in upgrade suites.

Polarion testcase - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574433 

Pass logs:
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-03IUQU/ 
RHCS 6.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JOZZKX

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
