### PR TITLE
Support to execute multiple daemon operations.

### DIFF
--- a/ceph/ceph_admin/add.py
+++ b/ceph/ceph_admin/add.py
@@ -39,7 +39,7 @@ class AddMixin:
         pos_args = config["pos_args"]
         node = pos_args[0]
         host_id = get_node_by_id(self.cluster, node)
-        host = host_id.shortname
+        host = host_id.hostname
 
         if service == "osd":
             base_cmd.extend([f"{host}:{','.join(pos_args[1:])}"])


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Support to execute multiple daemon operations.

```
  - test:
      name: OSD deployment on single SSD
      desc: Add OSD services on single SSD.
      module: test_daemon.py
      polarion-id: CEPH-9268
      config:
        steps:
          - config:
              command: add
              service: osd
              pos_args:
                - "cali003.ceph.redhat.com"
                - "/dev/nvme0n1"
          - config:
              command: add
              service: osd
              pos_args:
                - "cali003.ceph.redhat.com"
                - "/dev/sda"
          - config:
              command: add
              service: osd
              pos_args:
                - "cali004.ceph.redhat.com"
                - "/dev/nvme0n1"
```

**Results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0FJLZB/OSD_deployment_on_single_SSD_0.log