### PR TITLE
RADOS: add ssd tests

### DIFF
--- a/ceph/ceph_admin/device.py
+++ b/ceph/ceph_admin/device.py
@@ -44,7 +44,7 @@ class Device(Orch):
         pos_args = config["pos_args"]
         node = pos_args[0]
         host_id = get_node_by_id(self.cluster, node)
-        host = host_id.shortname
+        host = host_id.hostname
         assert host
         base_cmd.append(host)
         base_cmd.extend(pos_args[1:])

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1033,3 +1033,19 @@ class RadosOrchestrator:
         except Exception as er:
             log.error(f"Exception hit while command execution. {er}")
         return log_lines
+
+    def set_mclock_profile(self, profile, osd="osd"):
+        """Set OSD MClock Profile.
+
+        ceph config set osd_mclock_profile <profile_name>
+
+        profile names:
+        - balanced
+        - high_recovery_ops
+        - high_client_ops
+
+        Args:
+            profile: mclock profile name
+            osd: "osd" service by default or "osd.<Id>"
+        """
+        return self.node.shell([f"ceph config set {osd} osd_mclock_profile {profile}"])

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -5,6 +5,8 @@
     3. Set osd out
     3. Zap device path
 """
+from json import loads
+
 from ceph.ceph_admin.daemon import Daemon
 from ceph.ceph_admin.device import Device
 from ceph.ceph_admin.osd import OSD
@@ -13,22 +15,124 @@ from utility.log import Log
 log = Log(__name__)
 
 
-def set_osd_devices_unamanged(ceph_cluster, unmanaged):
-    """
-    Sets osd device unmanaged as true/false
+def set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged):
+    """Sets osd device unmanaged as true/false.
+
     Args:
         ceph_cluster: ceph cluster
+        osd_id: OSD id
         unmanaged: true/false
     """
     config = {
         "command": "apply",
         "service": "osd",
-        "args": {"all-available-devices": True, "unmanaged": unmanaged},
         "verify": False,
     }
-    log.info(f"Executing OSD {config.pop('command')} service")
     osd = OSD(cluster=ceph_cluster, **config)
-    osd.apply(config)
+    osd_dmns, _ = osd.ps(
+        {"base_cmd_args": {"format": "json"}, "args": {"daemon_type": "osd"}}
+    )
+
+    # fetch service name using osd.id
+    service_name = None
+    for daemon in loads(osd_dmns):
+        if daemon["daemon_id"] == str(osd_id):
+            if daemon.get("service_name") == "osd":
+                return
+            service_name = daemon["service_name"]
+            break
+
+    if not service_name:
+        return
+    log.info(f"Setting OSD service {service_name} to unmanaged={unmanaged}")
+
+    # fetch OSD service information
+    out, err = osd.ls(
+        {"base_cmd_args": {"format": "json"}, "args": {"service_name": service_name}}
+    )
+
+    # return if no services found
+    if "No services reported" in out + err:
+        log.warning(out)
+        return
+    svc = loads(out)[0]
+
+    # return if it is at required state
+    if svc.get("unmanaged") == unmanaged:
+        log.info(f"{service_name} is already set to unmanaged={unmanaged}")
+        return
+
+    # apply to required "unmanaged" state
+    svc_spec = {
+        "service_type": "osd",
+        "service_id": svc["service_id"],
+        "unmanaged": unmanaged,
+        "spec": svc["spec"],
+        "placement": svc["placement"],
+    }
+
+    if svc_spec["placement"].get("hosts"):
+        svc_spec["placement"]["nodes"] = svc_spec["placement"]["hosts"]
+
+    osd.apply_spec({"specs": [svc_spec]})
+
+
+def get_containers(host, role=None):
+    """Return all containers.
+
+    Args:
+        host: CephNode object
+        role: ceph role type (example: mon, osd, mgr)
+    Returns:
+        list of all containers or by role
+    """
+    out, _ = host.exec_command(sudo=True, cmd="podman ps --format json")
+    containers = loads(out)
+    if not role:
+        return containers
+
+    ceph_roles = {
+        "mon": "/usr/bin/ceph-mon",
+        "mgr": "/usr/bin/ceph-mgr",
+        "node_exporter": "/bin/node_exporter",
+        "alert_manager": "/bin/alertmanager",
+        "prometheus": "/bin/prometheus",
+        "osd": "/usr/bin/ceph-osd",
+        "crash": "/usr/bin/ceph-crash",
+    }
+
+    if role not in ceph_roles.keys():
+        return list()
+
+    _containers = []
+    for container in containers:
+        inspect, _ = host.exec_command(
+            sudo=True,
+            cmd="podman inspect %s --format {{.Config.Entrypoint}}" % container["Id"],
+            check_ec=False,
+        )
+        if ceph_roles[role] in inspect:
+            _containers.append(container)
+
+    return _containers
+
+
+def podman_exec(host, container, cmd, shell="bash"):
+    """Podman exec operation with command
+
+    Args:
+        host: host where podman execution
+        container: container id or name
+        cmd: command to be executed
+        shell: executor (default: bash)
+
+    Returns:
+        podman exec response
+    """
+    response, _ = host.exec_command(
+        sudo=True, cmd=f"podman exec {container} {shell} -c {repr(cmd)}"
+    )
+    return response
 
 
 def set_osd_out(ceph_cluster, osd_id):

--- a/conf/pacific/rados/4-node-baremetal.yaml
+++ b/conf/pacific/rados/4-node-baremetal.yaml
@@ -1,0 +1,75 @@
+# Cluster for Baremetal environment.
+# The below defined cluster has 11 nodes.
+# Cluster configuration:
+#      3 MONS, 2 MGR, 6 OSD, 2 MDS, 1 RGW service daemon(s)
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.8.128.0/21']
+      nodes:
+        -
+          hostname: cali003.ceph.redhat.com
+          id: node1
+          ip: 10.8.130.3
+          root_password: passwd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+        -
+          hostname: cali004.ceph.redhat.com
+          id: node2
+          ip: 10.8.130.4
+          root_password: passwd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+          role:
+            - mon
+            - mgr
+            - osd
+        -
+          hostname: cali005.ceph.redhat.com
+          id: node3
+          ip: 10.8.130.5
+          root_password: passwd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/nvme0n1
+          role:
+            - osd
+            - mon
+            - client
+        -
+          hostname: clara015.ceph.redhat.com
+          id: node4
+          ip: 10.8.129.15
+          root_password: passwd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+          role:
+            - osd

--- a/suites/pacific/rados/tier-3_rados_ssd-tests.yaml
+++ b/suites/pacific/rados/tier-3_rados_ssd-tests.yaml
@@ -1,0 +1,191 @@
+# Suite contains tests related to OSD(s) on SSDs
+# Picking Cali and Clara systems, since it has SSDs, HDDs and NVmes
+# - ADD SSD OSDs
+# - Perform IO with replicated and EC pool
+# - ADD or remove OSDs.
+# - Remove replicated EC pool and verify the re-balance
+# - ADD HDD OSDs and perform IOS
+tests:
+  - test:
+      name: setup install pre-requisites
+      desc: deploy pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+  - test:
+      name: OSD deployment on SSDs with spec
+      desc: Add OSD services on SSDs using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-11686
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: ssd_nodes
+                  placement:
+                    nodes:
+                      - node1
+                      - node2
+                      - node3
+                  spec:
+                    data_devices:
+                      rotational: 0
+
+  - test:
+      name: SSDs OSDs replacement with replicated and EC pools
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration from the pools
+      polarion-id: CEPH-9269
+      abort-on-fail: true
+      config:
+        mclock_profile: high_recovery_ops
+        timeout: unlimited                # provide "unlimited" or "<time in seconds>"
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 16
+              pool_type: replicated
+              size: 2
+              min_size: 2
+              rados_write_duration: 30
+              rados_read_duration: 15
+              byte_size: 256
+          - create_pool:
+              create: true
+              pool_name: ecpool_1
+              pool_type: erasure
+              pg_num: 16
+              byte_size: 256
+              k: 4
+              m: 2
+              plugin: jerasure
+              rados_write_duration: 30
+              rados_read_duration: 15
+              crush-failure-domain: osd
+        delete_pools:
+          - ecpool_1
+          - rpool_1
+
+  - test:
+      name: OSD deployment on SSDs and HDDs with spec
+      desc: Add OSD on SSDs and HDDs using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-9264
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: hdd_nodes
+                  placement:
+                    nodes:
+                      - node1
+                      - node2
+                      - node3
+                  spec:
+                    data_devices:
+                      rotational: 1
+
+  - test:
+      name: Rebalancing on SSDs HDDs osd with replicate pools
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration
+      polarion-id: CEPH-9210
+      abort-on-fail: true
+      config:
+        timeout: unlimited
+        mclock_profile: high_recovery_ops
+        create_pools:
+          - create_pool:
+              pool_name: rpool_01
+              pg_num: 16
+              rados_write_duration: 60
+              rados_read_duration: 30
+              byte_size: 256
+              pool_type: replicated
+        delete_pools:
+          - rpool_01
+
+  - test:
+      name: OSD deployment on single SSD
+      desc: Add OSD services on single SSD.
+      module: test_daemon.py
+      polarion-id: CEPH-9268
+      config:
+        steps:
+          - config:
+              command: add
+              service: osd
+              pos_args:
+                - node4
+                - "/dev/sdc"
+          - config:
+              command: add
+              service: osd
+              pos_args:
+                - node4
+                - "/dev/sdd"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id:
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 16
+          k: 4
+          m: 2
+          plugin: jerasure
+          rados_write_duration: 60
+          rados_read_duration: 30
+          crush-failure-domain: osd
+      desc: Create pools and run IO

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -55,7 +55,7 @@ def run(ceph_cluster, **kw):
         log.debug(
             f"osd1 device path  : {dev_path}, osd_id : {osd_id}, host.hostname : {host.hostname}"
         )
-        utils.set_osd_devices_unamanged(ceph_cluster, unmanaged=True)
+        utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
         method_should_succeed(utils.set_osd_out, ceph_cluster, osd_id)
         method_should_succeed(wait_for_clean_pg_sets, rados_obj)
         utils.osd_remove(ceph_cluster, osd_id)
@@ -83,7 +83,7 @@ def run(ceph_cluster, **kw):
 
         if pool.get("rados_put", False):
             do_rados_get(client_node, pool["pool_name"], 1)
-        utils.set_osd_devices_unamanged(ceph_cluster, unmanaged=False)
+        utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
         rados_obj.change_recover_threads(config=pool, action="rm")
         if config.get("delete_pools"):
             for name in config["delete_pools"]:


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Automated tier-3 SSD test cases.
- polarion test cases: CEPH-9264, CEPH-9269, CEPH-9276, CEPH-9268, CEPH-11686

During this automation, Added/Fixed below things
- updated `Osd container and device validation` in the rebalance test script.
- Get all containers and specific to `role` like osd(tested with OSD).
- podman exec command.
- Introduced unlimited timeout for `wait_for_pg_active_clean_state`.
- Introduced MCLOCK_Profile setting.
- `set_osd_service_unamanged` now sets unmanaged flag on right OSD service where OSD.ID belongs.