### PR TITLE
Fix for osd rebalance test suite failure.

### DIFF
--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -134,7 +134,7 @@ def wait_for_device(host, osd_id, action: str) -> bool:
         container = [
             item["Names"][0]
             for item in json.loads(out)
-            if item.get["Command"] and "ceph" in item["Command"]
+            if item.get("Command") and "ceph" in item["Command"]
         ]
         if not container:
             log.error("Failed to retrieve container ids")


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for osd rebalance test suite failure.
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6154/152745

2022-12-14 21:46:06,377 - INFO - cephci.ceph.ceph.py:1513 - Running command podman ps --format json on 10.245.5.59 timeout 600
2022-12-14 21:46:06,558 - INFO - cephci.ceph.ceph.py:1546 - Command completed successfully
2022-12-14 21:46:06,559 - ERROR - cephci.run.py:889 - 'builtin_function_or_method' object is not subscriptable
Traceback (most recent call last):
  File "run.py", line 886, in run
    clients=clients,
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline/tests/rados/test_osd_rebalance.py", line 101, in run
    method_should_succeed(wait_for_device, host, osd_id, action="remove")
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline/utility/utils.py", line 1315, in method_should_succeed
    rc = function(*args, **kwargs)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline/tests/rados/test_osd_rebalance.py", line 136, in wait_for_device
    for item in json.loads(out)
  File "/data/jenkins/workspace/rhceph-test-execution-pipeline/tests/rados/test_osd_rebalance.py", line 137, in <listcomp>
    if item.get["Command"] and "ceph" in item["Command"]
TypeError: 'builtin_function_or_method' object is not subscriptable