### PR TITLE
RGW: avoid return of duplicate interfaces

### DIFF
--- a/tests/misc_env/configure-tc.py
+++ b/tests/misc_env/configure-tc.py
@@ -25,7 +25,9 @@ def exec_command(
 def get_network_device(node: CephNode) -> str:
     """Return the interface configured for default route."""
     out, _ = exec_command(
-        node=node, sudo=True, command="ip route show | awk '/default/ { print $5 }'"
+        node=node,
+        sudo=True,
+        command="ip route show | awk '/default/ { print $5 }' | uniq",
     )
     return out.strip()
 


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

**Issue:**
Duplicates  were returned from the command `ip route show`. 
> 2022-12-01 20:43:57,232 - INFO - cephci.ceph.ceph.py:1513 - Running command ip route show | awk '/default/ { print $5 }' on 10.245.7.200 timeout 600
> 2022-12-01 20:43:57,251 - INFO - cephci.ceph.ceph.py:1546 - Command completed successfully
> 2022-12-01 20:43:57,251 - DEBUG - cephci.tests.misc_env.configure-tc.py:19 - Output: eth0
> eth0
> 
> 2022-12-01 20:43:57,252 - DEBUG - cephci.tests.misc_env.configure-tc.py:20 - Error: 
> 2022-12-01 20:43:57,252 - INFO - cephci.ceph.ceph.py:1513 - Running command tc qdisc add dev eth0 
> eth0 root netem delay 30ms 6ms distribution normal on 10.245.7.200 timeout 600
> 2022-12-01 20:43:57,282 - ERROR - cephci.ceph.ceph.py:1548 - Error 127 during cmd, timeout 600
> 2022-12-01 20:43:57,283 - ERROR - cephci.ceph.ceph.py:1549 - Error: Handle cannot be zero.
> bash: line 2: eth0: command not found


**Solution:**

> [sunnagar@ceph-qe-jump-01 ~]$ ip route show | awk '/default/ { print $5 }'
> eth0
> eth0
> [sunnagar@ceph-qe-jump-01 ~]$ ip route show | awk '/default/ { print $5 }' | uniq
> eth0


All test logs located here: /tmp/cephci-run-AMF7Z7

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
pre-req                          install ceph pre requisites                                    0:16:21.730830                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm.                         0:27:12.844196                   Pass                             
Monitoring Services deployment   Add monitoring services using spec file.                       0:19:24.780286                   Pass                             
configure client                 Configure the RGW client system                                0:00:45.583793                   Pass                             
create user                      create non-tenanted user                                       0:02:47.327786                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects on primary(single site)            0:00:02.366539                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects_compression on primary(single si   0:00:02.308671                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects_aws4 on primary(single site)       0:00:02.342766                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects_delete on primary(single site)     0:00:02.315919                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects_download on primary(single site)   0:00:02.308763                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects_enc on primary(single site)        0:00:02.321735                   Failed                           
Buckets and Objects test         test_Mbuckets_with_Nobjects_multipart on primary(single site   0:00:02.309276                   Failed                           
Bucket listing test              test_bucket_listing_flat_ordered_versionsing on primary(sing   0:00:02.312596                   Failed                           
Bucket listing test              test_bucket_listing_flat_unordered.yaml on primary(single si   0:00:02.309388                   Failed                           
Buckets Versioning test          test_versioning_objects_acls on on primary(single site)        0:04:40.636882                   Pass                             
setup multisite                  Setting up RGW multisite replication environment               0:03:18.247514                   Pass                             
get shared realm info on prima   Retrieve the configured environment details                    0:00:10.975680                   Pass                             
get shared realm info on secon   Retrieve the configured environment details                    0:00:12.208510                   Pass                             
**apply-net-qos                    Configuring network traffic delay                              0:00:00.738673                   Pass**                             
create user                      create tenanted user                                           0:03:38.164786                   Failed                           
Bucket policy tests              test_bucket_policy_modify.yaml on secondary                    0:01:07.349092                   Failed                           
Bucket policy tests              test_bucket_policy_delete.yaml on secondary                    0:01:05.161176                   Failed                           
Bucket policy tests              test_bucket_policy_replace on secondary                        0:01:05.060823                   Failed                           
2022-12-15 10:29:00,439 - INFO - cephci.run.py:1078 - final rc of test run 1
