### PR TITLE
Adding id to ceph node objects

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1281,6 +1281,7 @@ class CephNode(object):
         if kw.get("ceph_vmnode"):
             self.vm_node = kw["ceph_vmnode"]
             self.osd_scenario = self.vm_node.osd_scenario
+        self.id = kw.get("id", None)
 
         self.volume_list = []
         if kw["no_of_volumes"]:

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -1025,6 +1025,9 @@ def get_node_by_id(cluster, node_name):
         for ele in searches:
             if ele == node_name:
                 return node
+        else:
+            if node_name == node.id:
+                return node
 
 
 def get_nodes_by_ids(cluster, node_names):

--- a/run.py
+++ b/run.py
@@ -249,6 +249,7 @@ def create_nodes(
                     private_ip=private_ip,
                     hostname=node.hostname,
                     ceph_vmnode=node,
+                    id=node.id,
                 )
                 ceph_nodes.append(ceph)
 


### PR DESCRIPTION
Adding id to ceph node objects
With this attribute, we can uniquely identify and reference the nodes anywhere.
This attribute can be set using conf file. if not given will get with node{idx}

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C7OB7M/


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
