### PR TITLE
Adding missing RBD test suite for RHCS 6.0 Pipeline

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -597,6 +597,38 @@ suites:
       - rgw
       - stage-3
 
+  - name: "tier-2_rbd_cli_regression"
+    suite: "suites/quincy/rbd/tier-2_rbd_cli_regression.yaml"
+    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+    platform: "rhel-9"
+    rhbuild: "6.0"
+    inventory:
+      openstack: "conf/inventory/rhel-9-latest.yaml"
+      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+    metadata:
+      - sanity
+      - tier-2
+      - openstack
+      - ibmc
+      - rgw
+      - stage-4
+
+  - name: "tier-2_rbd_mirror_snapshot_regression"
+    suite: "suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
+    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+    platform: "rhel-9"
+    rhbuild: "6.0"
+    inventory:
+      openstack: "conf/inventory/rhel-9-latest.yaml"
+      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+    metadata:
+      - sanity
+      - tier-2
+      - openstack
+      - ibmc
+      - rgw
+      - stage-4
+
   # schedule RGW
   - name: "test-rgw-lc-expiration-multiple-bucket"
     suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"

--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -8,6 +8,8 @@
 # The following tests are covered
 #   - CEPH-9230 - verification snap and clone on an imported image
 #   - CEPH-83573308, CEPH-83573307 - clones creation with v2clone format and deletion
+#   - CEPH-83573289 - Verify force remove on trash images
+#   - CEPH-83573298 - Move images to trash, restore them and verify
 
 tests:
 
@@ -112,3 +114,10 @@ tests:
       module: rbd_trash_remove.py
       name: Test force remove on trash images
       polarion-id: CEPH-83573289
+
+  - test:
+      desc: Move images to trash, restore them and verify
+      destroy-cluster: false
+      module: trash_restore.py
+      name: Check trash restore functionality
+      polarion-id: CEPH-83573298

--- a/suites/quincy/rbd/tier-2_rbd_cli_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_cli_regression.yaml
@@ -1,0 +1,105 @@
+# Tier2: RBD CLI regression test cases
+#
+# This test suite runs addition test scripts to evaluate the existing
+# functionality of Ceph RBD component.
+#
+# Conf File - cephci/conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#
+# The following tests are covered
+#   - CEPH-10247 - CLI Validation(+ve cases) rbd mirror image enable
+#   - CEPH-10249 - CLI Validation(+ve cases) rbd mirror pool enable
+#   - CEPH-10250 - CLI Validation(+ve cases) rbd mirror pool disable
+
+tests:
+
+  # Setup the cluster
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  # Test cases to be executed
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      desc: CLI Validation(+ve cases) rbd mirror image enable
+      destroy-cluster: false
+      module: rbd_system.py
+      name: CEPH-10247
+      config:
+        test_name: cli/rbd_cli_testcase_handler.py
+        test_case_name: mirror_image_enable
+      polarion-id: CEPH-10247
+
+  - test:
+      desc: CLI Validation(+ve cases) rbd mirror pool enable
+      destroy-cluster: false
+      module: rbd_system.py
+      name: CEPH-10249
+      config:
+        test_name: cli/rbd_cli_testcase_handler.py
+        test_case_name: mirror_pool_enable
+      polarion-id: CEPH-10249
+
+  - test:
+      desc: CLI Validation(+ve cases) rbd mirror pool disable
+      destroy-cluster: false
+      module: rbd_system.py
+      name: CEPH-10250
+      config:
+        test_name: cli/rbd_cli_testcase_handler.py
+        test_case_name: mirror_pool_disable
+      polarion-id: CEPH-10250

--- a/suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml
@@ -1,0 +1,165 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_snapshot_regression.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+  - test:
+      name: test_rbd_mirror_snapshot_pool
+      module: test_rbd_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            snapshot_schedule_level: "pool" #snapshots can be scheduled at pool, image or cluster(default) level
+      polarion-id: CEPH-83575375
+      desc: Create snapshot based RBD mirrored pools, schedule snapshots at pool level and verify
+  - test:
+      name: test_rbd_mirror_snapshot_cluster
+      module: test_rbd_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            snapshot_schedule_level: "cluster" #snapshots can be scheduled at pool, image or cluster(default) level
+      polarion-id: CEPH-83575376
+      desc: Create snapshot based RBD mirrored pools, schedule snapshots at cluster level and verify


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Goal is to add new test suite to RHCS 6.0 pipeline.
Test case/ test suite added : 
**Quincy** :
1)  **tier-2_rbd_mirror_snapshot_regression**
     success log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0CUSJ3/
2)  **tier-2_rbd_cli_regression**
     success log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-J9DKY7/
Note : changes is required in https://github.com/red-hat-storage/ceph-qe-scripts/blob/master/rbd/utils/utils.py#L22 to run this test suite for 6.0. changes are ready and will be raising PR for the same.


**Pacific** : 
1) Added new test case to tier-2_rbd_regression
        CEPH-83573298 - Move images to trash, restore them and verify
        success log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4N0E2Q/

