### PR TITLE
[Automation] Bootstrap cluster using cephadm-ansible wrapper modules,…

### DIFF
--- a/cli/cephadm/exceptions.py
+++ b/cli/cephadm/exceptions.py
@@ -1,2 +1,6 @@
 class CephadmOpsExecutionError(Exception):
     pass
+
+
+class ConfigNotFoundError(Exception):
+    pass

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -1,4 +1,11 @@
+import os
 import re
+
+from utility.log import Log
+
+log = Log(__name__)
+
+CEPHADM_ANSIBLE_PATH = "/usr/share/cephadm-ansible"
 
 
 def get_disk_list(node, expr=None, **kw):
@@ -178,3 +185,17 @@ def build_cmd_from_args(seperator="=", **kw):
             else:
                 cmd += f" --{k} {v}"
     return cmd
+
+
+def put_cephadm_ansible_playbook(
+    node, playbook, cephadm_ansible_path=CEPHADM_ANSIBLE_PATH
+):
+    """Put playbook to cephadm ansible location.
+    Args:
+        playbook (str): Playbook need to be copied to cephadm ansible path
+        cephadm_ansible_path (str): Path to where the playbook has to be copied
+    """
+    dst = os.path.join(cephadm_ansible_path, os.path.basename(playbook))
+
+    node.upload_file(sudo=True, src=playbook, dst=dst)
+    log.info(f"Uploaded playbook '{playbook}' to '{dst}' on node.")

--- a/playbooks/bootstrap-cluster-overide-exisitng-keys.yml
+++ b/playbooks/bootstrap-cluster-overide-exisitng-keys.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Test 'cephadm_bootstrap' module
+  hosts: admin
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+
+  tasks:
+    - name: Bootstrap cluster overriding existing keys
+      cephadm_bootstrap:
+        mon_ip: "{{ mon_ip }}"
+        dashboard: true
+        allow_overwrite: true

--- a/playbooks/get-mgr-config.yml
+++ b/playbooks/get-mgr-config.yml
@@ -1,0 +1,16 @@
+- name: Get `osd` config  `osd_memory_target_autotune`
+  hosts: admin
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+  tasks:
+    - name: Validate `osd_memory_target_autotune` of `osd`
+      ceph_config:
+        action: get
+        who: osd
+        option: osd_memory_target_autotune
+      register: osd_memory_target_autotune
+
+    - name: DEBUG. Get `osd_memory_target_autotune` value
+      debug:
+        msg: "{{ osd_memory_target_autotune.stdout }}"

--- a/playbooks/set-osd-config.yml
+++ b/playbooks/set-osd-config.yml
@@ -1,0 +1,23 @@
+- name: Set `osd` config  `osd_memory_target_autotune` to `true`
+  hosts: admin
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+  tasks:
+    - name: Set ceph config `osd_memory_target_autotune` on `osd` with `true`
+      ceph_config:
+        action: set
+        who: osd
+        option: osd_memory_target_autotune
+        value: true
+
+    - name: Validate `osd_memory_target_autotune` of `osd`
+      ceph_config:
+        action: get
+        who: osd
+        option: osd_memory_target_autotune
+      register: osd_memory_target_autotune
+
+    - name: DEBUG. Get `osd_memory_target_autotune` value
+      debug:
+        msg: "{{ osd_memory_target_autotune.stdout }}"

--- a/suites/pacific/cephadm/test_cephadm_bootstrap_with_overriding_exisiting_ceph_keys.yaml
+++ b/suites/pacific/cephadm/test_cephadm_bootstrap_with_overriding_exisiting_ceph_keys.yaml
@@ -1,0 +1,58 @@
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: test_cephadm_ansible_wrapper.yaml
+# Test-Case: Perform cephadm operations using cephadm ansible modules
+#
+# Cluster Configuration:
+#    conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml
+#
+#    4-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
+#     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
+#     Node3 - Mon, OSD, MDS, RGW, node-exporter
+#     Node4 - Client
+#
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/bootstrap-cluster-custom.yaml' playbook
+      polarion-id: CEPH-83575205
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        args:
+          custom_repo: "cdn"
+          registry-url: registry.redhat.io
+          mon-ip: node1
+        ansible_wrapper:
+          module: "cephadm_bootstrap"
+          playbook: playbooks/bootstrap-cluster-overide-exisitng-keys.yml
+          module_args:
+            mon_node: node1
+
+  - test:
+      name: Get 'mgr' config using cephadm-ansible module 'ceph_config'
+      desc: Execute 'playbooks/get-mgr-config.yml' playbook
+      polarion-id: CEPH-83575215
+      module: test_cephadm_ansible_manage_services.py
+      config:
+        ansible_wrapper:
+          module: "ceph_config"
+          playbook: playbooks/get-mgr-config.yml
+
+  - test:
+      name: Set 'osd' config using cephadm-ansible module 'ceph_config'
+      desc: Execute 'playbooks/set-osd-config.yml' playbook
+      polarion-id: CEPH-83575214
+      module: test_cephadm_ansible_manage_services.py
+      config:
+        ansible_wrapper:
+          module: "ceph_config"
+          playbook: playbooks/set-osd-config.yml

--- a/tests/cephadm/test_cephadm_ansible_manage_services.py
+++ b/tests/cephadm/test_cephadm_ansible_manage_services.py
@@ -1,0 +1,44 @@
+from os.path import basename
+
+from cli.cephadm.ansible import Ansible
+from cli.cephadm.cephadm import CephAdm
+from cli.cephadm.exceptions import CephadmOpsExecutionError, ConfigNotFoundError
+from cli.utilities.utils import put_cephadm_ansible_playbook
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kwargs):
+    """Module to execute cephadm-ansible wrapper playbooks
+
+    Example:
+        - test:
+            name: Set 'osd' config using cephadm-ansible module 'ceph_config'
+            desc: Execute 'playbooks/set-osd-config.yml' playbook
+            polarion-id: CEPH-83575214
+            module: test_cephadm_ansible_wrapper_set_osd_config.py
+            config:
+              ansible_wrapper:
+                module: "ceph_config"
+                playbook: playbooks/set-osd-config.yml
+
+    """
+    installer = ceph_cluster.get_ceph_object("installer")
+
+    config = kwargs.get("config")
+    aw = config.get("ansible_wrapper")
+    if not aw:
+        raise ConfigNotFoundError("Mandatory parameter 'ansible_wrapper' not found")
+
+    playbook = aw.get("playbook")
+    if not playbook:
+        raise ConfigNotFoundError("Mandatory resource 'playbook' not found")
+
+    put_cephadm_ansible_playbook(installer, playbook)
+    Ansible(installer).run_playbook(playbook=basename(playbook))
+
+    if not CephAdm(installer).ceph.status():
+        raise CephadmOpsExecutionError("Failed to perform action via cephadm ansible")
+
+    return 0

--- a/tests/cephadm/test_cephadm_ansible_wrapper.py
+++ b/tests/cephadm/test_cephadm_ansible_wrapper.py
@@ -2,9 +2,9 @@ import os
 
 from cli.cephadm.ansible import Ansible
 from cli.cephadm.cephadm import CephAdm
-from cli.cephadm.exceptions import CephadmOpsExecutionError
+from cli.cephadm.exceptions import CephadmOpsExecutionError, ConfigNotFoundError
 from cli.utilities.packages import Package, Rpm, RpmError
-from cli.utilities.utils import get_node_ip
+from cli.utilities.utils import get_node_ip, put_cephadm_ansible_playbook
 from utility.install_prereq import (
     ConfigureCephadmAnsibleInventory,
     EnableToolsRepositories,
@@ -13,24 +13,8 @@ from utility.log import Log
 
 log = Log(__name__)
 
-CEPHADM_ANSIBLE_PATH = "/usr/share/cephadm-ansible"
 CEPHADM_PREFLIGHT_PLAYBOOK = "cephadm-preflight.yml"
 CEPHADM_PREFLIGHT_VARS = {"ceph_origin": "rhcs"}
-
-
-class ConfigNotFoundError(Exception):
-    pass
-
-
-def put_cephadm_ansible_playbook(node, playbook):
-    """Put playbook to cephadm ansible location.
-    Args:
-        playbook (str): Playbook need to be copied to cephadm ansible path
-    """
-    dst = os.path.join(CEPHADM_ANSIBLE_PATH, os.path.basename(playbook))
-
-    node.upload_file(sudo=True, src=playbook, dst=dst)
-    log.info(f"Uploaded playbook '{playbook}' to '{dst}' on node.")
 
 
 def run(ceph_cluster, **kwargs):


### PR DESCRIPTION
… get and set configs

Signed-off-by: Pranav <prprakas@redhat.com>

# Description
Tests included
CEPH-83575205 Bootstrap a cluster using cephadm-ansible module 'cephadm_bootstrap' with overriding existing ceph keys
CEPH-83575215 Get 'mgr' config using cephadm-ansible module 'ceph_config'
CEPH-83575214 Set 'osd' config using cephadm-ansible module 'ceph_config'

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
