### PR TITLE
[Automation] Bootstrap with custom ssh and support for manage services

### DIFF
--- a/playbooks/bootstrap-cluster-custom-ssh.yml
+++ b/playbooks/bootstrap-cluster-custom-ssh.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Test 'cephadm_bootstrap' module
+  hosts: admin
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+
+  tasks:
+    - name: Bootstrap with dashboard set to `true` without credenatials
+      cephadm_bootstrap:
+        mon_ip: "{{ mon_ip }}"
+        dashboard: true
+        monitoring: false
+        firewalld: false
+        ssh_user: cephuser

--- a/playbooks/restart-mgr-service.yml
+++ b/playbooks/restart-mgr-service.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Restart mon.0 service
+  hosts: bootstrap
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+  tasks:
+    - name: Restart the mgr service
+      ceph_orch_daemon:
+        state: restarted
+        daemon_id: mgr.0
+        daemon_type: mgr

--- a/playbooks/stop-osd-service.yml
+++ b/playbooks/stop-osd-service.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Stop mon.0 service
+  hosts: bootstrap
+  gather_facts: false
+  become: true
+  any_errors_fatal: true
+  tasks:
+    - name: Stop the osd service
+      ceph_orch_daemon:
+        state: stopped
+        daemon_id: osd.0
+        daemon_type: osd

--- a/suites/pacific/cephadm/test_cephadm_bootstrap_custom_ssh.yaml
+++ b/suites/pacific/cephadm/test_cephadm_bootstrap_custom_ssh.yaml
@@ -1,0 +1,57 @@
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: test_cephadm_ansible_wrapper.yaml
+# Test-Case: Perform cephadm operations using cephadm ansible modules
+#
+# Cluster Configuration:
+#    conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml
+#
+#    4-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
+#     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
+#     Node3 - Mon, OSD, MDS, RGW, node-exporter
+#     Node4 - Client
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/bootstrap-cluster-custom-ssh.yml' playbook
+      polarion-id: CEPH-83575204
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        args:
+          custom_repo: "cdn"
+          registry-url: registry.redhat.io
+          mon-ip: node1
+        ansible_wrapper:
+          module: "cephadm_bootstrap"
+          playbook: playbooks/bootstrap-cluster-custom-ssh.yml
+          module_args:
+            mon_node: node1
+
+  - test:
+      name: Stop 'osd' service using cephadm-ansible module 'ceph_orch_daemon'
+      desc: Execute 'playbooks/stop-osd-service.yml' playbook
+      polarion-id: CEPH-83575211
+      module: test_cephadm_ansible_manage_services.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_daemon"
+          playbook: playbooks/stop-osd-service.yml
+
+  - test:
+      name: Restart mgr service using cephadm-ansible module 'ceph_orch_daemon'
+      desc: Execute 'playbooks/restart-mgr-service.yml' playbook
+      polarion-id: CEPH-83575212
+      module: test_cephadm_ansible_manage_services.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_daemon"
+          playbook: playbooks/restart-mgr-service.yml


### PR DESCRIPTION
Signed-off-by: Pranav <prprakas@redhat.com>


TC's included
CEPH-83575205 Bootstrap a cluster using cephadm-ansible module 'cephadm_bootstrap' with overriding existing ceph keys
CEPH-83575215 Get 'mgr' config using cephadm-ansible module 'ceph_config'
CEPH-83575214 Set 'osd' config using cephadm-ansible module 'ceph_config'

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
