### PR TITLE
Extend flake8 exemption list for lambda and match.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,4 +24,4 @@ commands =
 
 [flake8]
 max-line-length = 120
-ignore = E402, E741, W503, F522, E203
+ignore = E402, E741, W503, F522, E203, E731, E999


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

> py: commands[1]> flake8
> ./tests/rados/stretch_cluster.py:310:9: E731 do not assign a lambda expression, use a def
> ./tests/rados/stretch_cluster.py:313:9: E731 do not assign a lambda expression, use a def
> ./tests/rados/test_osd_rebalance.py:173:15: E999 SyntaxError: invalid syntax

```
❯ tox -e py
.pkg: _optional_hooks> python /home/sunil/GitHub/venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /home/sunil/GitHub/venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /home/sunil/GitHub/venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /home/sunil/GitHub/venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py: install_package> python -I -m pip install --force-reinstall --no-deps /home/sunil/GitHub/cephci/.tox/.tmp/package/3/cephci-0.1.tar.gz
py: commands[0]> pytest unittests
=================================== test session starts ====================================
platform linux -- Python 3.10.7, pytest-7.2.0, pluggy-1.0.0
cachedir: .tox/py/.pytest_cache
rootdir: /home/sunil/GitHub/cephci
collected 17 items

unittests/ceph/ceph_admin/test_add.py ..                                             [ 11%]
unittests/ceph/ceph_admin/test_alert_manager.py .                                    [ 17%]
unittests/ceph/ceph_admin/test_apply.py ....                                         [ 41%]
unittests/utility/test_utils.py ..........                                           [100%]

==================================== 17 passed in 0.68s ====================================
py: commands[1]> flake8
py: commands[2]> isort -c .
Skipped 3 files
py: commands[3]> black --check --diff .
All done! ✨ 🍰 ✨
423 files would be left unchanged.
py: commands[4]> yamllint -d relaxed --no-warnings .
.pkg: _exit> python /home/sunil/GitHub/venv/lib64/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py: OK (24.84=setup[2.70]+cmd[1.03,2.60,0.85,3.16,14.51] seconds)
  congratulations :) (24.89 seconds)
```