### PR TITLE
Report portal updates for PSI environment

### DIFF
--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -45,7 +45,7 @@ node("rhel-8-medium || ceph-qe-ci") {
         def rhcephVersion = ciMap.artifact.nvr
         def buildType = "tier-0"
         def tags = "openstack-only,tier-1,stage-1"
-        def overrides = ["build": "tier-0", "post-results": "", "report-portal": ""]
+        def overrides = ["build": "tier-0"]
         def overridesStr = writeJSON returnText: true, json: overrides
         def buildArtifacts = "${params.CI_MESSAGE}"
 

--- a/pipeline/scripts/ci/getPipelineStages.py
+++ b/pipeline/scripts/ci/getPipelineStages.py
@@ -112,12 +112,12 @@ def fetch_stages(args):
         execute_cli += " --log-level DEBUG"
         logdir = f"{workspace}/logs/{generate_random_string(5)}-{build_number}"
 
+        execute_cli += " --xunit-results"
+        os.makedirs(logdir)
+        execute_cli += f" --log-dir {logdir}"
         if "ibmc" in tags:
             cloud_type = "ibmc"
-            execute_cli += " --xunit-results"
             execute_cli += " --cloud ibmc"
-            os.makedirs(logdir)
-            execute_cli += f" --log-dir {logdir}"
             cleanup_cli += f" --cloud {cloud_type}"
 
         script.update({"inventory": script["inventory"][cloud_type]})

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -19,6 +19,7 @@ def nodeName = "rhel-8-medium || ceph-qe-ci"
 def tags = ""
 def majorVersion
 def minorVersion
+def buildStatus = "pass"
 
 def branch='origin/master'
 def repo='https://github.com/red-hat-storage/cephci.git'
@@ -134,6 +135,10 @@ node(nodeName) {
             )
             println("releaseContent")
             println(releaseContent)
+            def workspace = "${env.WORKSPACE}"
+            def build_number = "${currentBuild.number}"
+            overrides.put("workspace", workspace.toString())
+            overrides.put("build_number", build_number.toInteger())
         }
 
         if("ibmc" in tags_list) {
@@ -171,55 +176,125 @@ node(nodeName) {
 
     if ("openstack" in tags_list || "openstack-only" in tags_list){
         stage('Publish Results') {
-        /* Publish results through E-mail to user who started the run*/
-            build_url = env.BUILD_URL
+
+            // Copy all the results into one folder before upload
+            def dirName = "psi_${currentBuild.projectName}_${currentBuild.number}"
+            def targetDir = "${env.WORKSPACE}/${dirName}/results"
+            def attachDir = "${env.WORKSPACE}/${dirName}/attachments"
+
+            sh (script: "mkdir -p ${targetDir} ${attachDir}")
+            print(testResults)
+            testResults.each { key, value ->
+                def fileName = key.replaceAll(" ", "-")
+                def logDir = value["logdir"]
+                sh "find ${logDir} -maxdepth 1 -type f -name xunit.xml -exec cp '{}' ${targetDir}/${fileName}.xml \\;"
+                sh "tar -zcvf ${logDir}/${fileName}.tar.gz ${logDir}/*.log"
+                sh "mkdir -p ${attachDir}/${fileName}"
+                sh "cp ${logDir}/${fileName}.tar.gz ${attachDir}/${fileName}/"
+                sh "find ${logDir} -maxdepth 1 -type f -not -size 0 -name '*.err' -exec cp '{}' ${attachDir}/${fileName}/ \\;"
+            }
+
+            println("directories created..")
+
+            // Adding metadata information
+            def recipeMap = sharedLib.readFromReleaseFile(
+                majorVersion, minorVersion, lockFlag=false
+            )
+            println("recipeMap : ${recipeMap}")
+            println("tierLevel : ${tierLevel}")
+
+            // Using only Tier-0 as pipeline progresses even if intermediate stages fail.
+            def tier = "latest"
+            if(tierLevel != "tier-0"){
+                tier = "tier-0"
+            }
+            println("tier: ${tier}")
+            def content = recipeMap[tier]
+            content["product"] = "Red Hat Ceph Storage"
+            content["version"] = rhcephVersion
+            content["date"] = sh(returnStdout: true, script: "date")
+            content["log"] = env.RUN_DISPLAY_URL
+            content["stage"] = tierLevel
+            content["results"] = testResults
+
+            writeYaml file: "${env.WORKSPACE}/${dirName}/metadata.yaml", data: content
+            sh "sudo cp -r ${env.WORKSPACE}/${dirName} /ceph/cephci-jenkins"
+
             run_type = "Manual Run"
             if ("openstack-only" in tags_list){
-                run_type = "PSI Only Run"
-            }
-            if (testResults && run_type != "Manual Run") {
-
-                testStatus = "SUCCESS"
-                if ("FAIL" in sharedLib.fetchStageStatus(testResults)) {
-                    currentBuild.result = "FAILED"
-                    buildStatus = "fail"
-                    testStatus = "FAILURE"
-                }
-                sharedLib.writeToResultsFile(
-                    ceph_version,
-                    tierLevel,
-                    currentStageLevel,
-                    testStatus,
-                    run_type,
-                    env.RUN_DISPLAY_URL
-                )
-                if(final_stage && tierLevel == "tier-2"){
-
-                    def testConsolidatedResults = sharedLib.readFromResultsFile(ceph_version)
-                    sharedLib.updateConfluencePage(
-                        majorVersion,
-                        minorVersion,
-                        ceph_version,
-                        run_type,
-                        testConsolidatedResults
-                    )
-                    sharedLib.sendConsolidatedEmail(
-                        run_type,
-                        testConsolidatedResults,
-                        sharedLib.buildArtifactsDetails(releaseContent, rhcephVersion, overrides.get("build")),
-                        majorVersion,
-                        minorVersion,
-                        ceph_version
-                    )
+                if ("schedule" in tags_list){
+                    run_type = "PSI-Only Schedule Run"
+                } else {
+                    run_type = "PSI-Only Sanity Run"
                 }
             }
+
+            testStatus = "SUCCESS"
+            if ("FAIL" in sharedLib.fetchStageStatus(testResults)) {
+                currentBuild.result = "FAILED"
+                buildStatus = "fail"
+                testStatus = "FAILURE"
+            }
+
+            def msgMap = [
+                "artifact": [
+                    "type": "product-build",
+                    "name": "Red Hat Ceph Storage",
+                    "version": content["ceph-version"],
+                    "nvr": rhcephVersion,
+                    "phase": "testing",
+                    "build": "tier-0",
+                ],
+                "contact": [
+                    "name": "Downstream Ceph QE",
+                    "email": "cephci@redhat.com",
+                ],
+                "system": [
+                    "os": "centos-7",
+                    "label": "agent-01",
+                    "provider": "IBM-Cloud",
+                ],
+                "pipeline": [
+                    "name": tierLevel,
+                    "id": currentBuild.number,
+                    "tags": tags,
+                    "overrides": overrides,
+                    "run_type": run_type,
+                    "final_stage": final_stage,
+                ],
+                "run": [
+                    "url": env.RUN_DISPLAY_URL,
+                    "additional_urls": [
+                        "doc": "https://docs.engineering.redhat.com/display/rhcsqe/RHCS+QE+Pipeline",
+                        "repo": "https://github.com/red-hat-storage/cephci",
+                        "report": "https://reportportal-rhcephqe.apps.ocp4.prod.psi.redhat.com/",
+                        "tcms": "https://polarion.engineering.redhat.com/polarion/",
+                    ],
+                ],
+                "test": [
+                    "type": buildType,
+                    "category": "functional",
+                    "result": testStatus,
+                    "object-prefix": dirName,
+                ],
+                "recipe": buildArtifacts['recipe'],
+                "generated_at": env.BUILD_ID,
+                "version": "3.0.0",
+            ]
+
+            def msgType = "Custom"
+
+            sharedLib.SendUMBMessage(
+                msgMap,
+                "VirtualTopic.qe.ci.rhcephqe.product-build.test.complete",
+                msgType,
+            )
         }
 
         stage('postBuildAction') {
             println("Inside post build action")
             buildArtifacts = writeJSON returnText: true, json: buildArtifacts
             def nextbuildType = buildType
-            def buildStatus = "pass"
             if (final_stage){
                 def tierValue = tierLevel.split("-")
                 Increment_tier= tierValue[1].toInteger()+1
@@ -243,10 +318,6 @@ node(nodeName) {
             }
             overrides = writeJSON returnText: true, json: overrides
 
-            if ("FAIL" in sharedLib.fetchStageStatus(testResults)) {
-                currentBuild.result = "FAILED"
-                buildStatus = "fail"
-            }
             // Execute post tier based on run execution
             // Do not trigger next stage of execution
             // if the current stage was final_stage of a particular tier and tier is greater than 2

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -478,7 +478,7 @@ def uploadTestResults(def sourceDir, def credPreproc, def runProperties, def sta
         ]
     ]
     if ( stageLevel ) {
-        launchConfig["name"] = runType.split(" ")[0] + " " + launchConfig["name"] + " " + stageLevel
+        launchConfig["name"] = runType + " " + launchConfig["name"] + " " + stageLevel
     }
     credPreproc["reportportal"]["launch"] = launchConfig
     writeJSON file: credFile, json: credPreproc

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -475,7 +475,7 @@ def create_run_dir(run_id, log_dir=""):
 
     print(f"log directory - {base_dir}")
     try:
-        os.makedirs(base_dir)
+        os.makedirs(base_dir, exist_ok=True)
     except OSError:
         if "jenkins" in getpass.getuser():
             raise


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Report portal updates for PSI environment.

These changes were required to match IBM report portal launch creation and PSI environment report portal launch creation.

logs: 
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/post_res_tintu/
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhcs-tintu-new/
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-execute-psi-only-suites/2056/console
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6292
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6291

Results file output:
PSI-Only_Sanity_Run:
  tier-1:
    stage-1:
      result: SUCCESS
      build_url: https://jenkins.ceph.redhat.com/job/rhcs-tintu-new/3/display/redirect
  tier-2:
    stage-1:
      result: SUCCESS
      build_url: https://jenkins.ceph.redhat.com/job/rhcs-tintu-new/4/display/redirect

![con_psi_email](https://user-images.githubusercontent.com/83664366/209044781-c9a162ef-c58c-42e4-bdef-cc2b63f350f3.jpg)

![rp_con](https://user-images.githubusercontent.com/83664366/209044967-894ccc51-22ad-425b-bcde-e8c61c47df18.jpg)

