### PR TITLE
Fix pipeline failure

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -447,7 +447,6 @@ node(nodeName) {
             println("Inside post build action")
             buildArtifacts = writeJSON returnText: true, json: buildArtifacts
             def nextbuildType = buildType
-            def buildStatus = "pass"
             if (final_stage){
                 def tierValue = tierLevel.split("-")
                 Increment_tier= tierValue[1].toInteger()+1


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for pipeline failure.
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 450: The current scope already contains a variable of the name buildStatus
 @ line 450, column 17.
               def buildStatus = "pass"
                   ^

1 error
