### PR TITLE
[LibFix] Add check for response keys in `rp_client` script

### DIFF
--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -136,9 +136,10 @@ def get_launch_details(config_file, launch_id):
                 "failed": ts.get("statistics").get("executions").get("failed", 0),
                 "skipped": ts.get("statistics").get("executions").get("skipped", 0),
             }
-            testsuite.update(
-                {"executionTime": int(ts.get("endTime")) - int(ts.get("startTime"))}
-            )
+            if "endTime" in ts.keys() and "startTime" in ts.keys():
+                testsuite.update(
+                    {"executionTime": int(ts.get("endTime")) - int(ts.get("startTime"))}
+                )
             if rp_host_url:
                 testsuite.update(
                     {"url": url.format(rp_host_url, launch_id, ts.get("id"))}


### PR DESCRIPTION
`utility/rp_client.py` fails with an error `TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'` when report portal response doesn't contain `startTime` or `endTime` keys. Add check for respective keys in `response.content` and perform required compution.

Signed-off-by: Vaibhav Mahajan <vamahaja@redhat.com>