### PR TITLE
Correcting flow of single site to multisite and CEPH-83575355 automation.

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -2,10 +2,14 @@
 # The test  will create a primary site 'ceph-pri', write IOs on the first site, indeuce delay of 10ms on first site and second site, and then convert it to a multisite and test sync.
 # ceph-pri is master/primary site
 # ceph-sec is slave/secondary site
+# CEPH-83575355 - [single-site to multi-site conversion] Test no recovering shards are seen ( Bug 2026101)
 
 tests:
+
+  # Cluster deployment stage
+
   - test:
-      name: pre-req
+      name: setup pre-requisites
       module: install_prereq.py
       abort-on-fail: true
       desc: install ceph pre requisites
@@ -197,6 +201,29 @@ tests:
   # Test work flow before migration
 
   - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+      desc: Setting up only primary site first
+      module: exec.py
+      name: setup only primary site
+      polarion-id: CEPH-10362
+
+  - test:
       name: create user
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
@@ -328,21 +355,6 @@ tests:
   - test:
       abort-on-fail: true
       clusters:
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "radosgw-admin realm create --rgw-realm india --default"
-              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
-              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
-              - "radosgw-admin period update --rgw-realm india --commit"
-              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
-              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
-              - "radosgw-admin period update --rgw-realm india --commit"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
-              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
-              - "ceph orch restart {service_name:shared.pri}"
         ceph-sec:
           config:
             cephadm: true
@@ -360,6 +372,7 @@ tests:
       module: exec.py
       name: setup multisite
       polarion-id: CEPH-10362
+
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -236,6 +236,44 @@ tests:
             config-file-name: non_tenanted_user.yaml
             timeout: 300
 
+  #  Dynamic resharding tests
+  - test:
+      name: Verify DBR feature enabled on greenfield cluster
+      desc: Check DBR feature enabled on greenfield cluster
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      polarion-id: CEPH-83573596
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_check_sharding_enabled.py
+            config-file-name: test_check_sharding_enabled_greenfield.yaml
+            timeout: 300
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
+            timeout: 300
+      desc: Test dynamic resharding on greenfield deployment
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      name: Dynamic Resharding tests on Primary cluster
+      polarion-id: CEPH-83574737
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+            script-name: test_dynamic_bucket_resharding.py
+            timeout: 300
+      desc: Resharding test - dynamic resharding on versioned bucket
+      name: Dynamic Resharding on versioned buckets
+      polarion-id: CEPH-83571740
+      module: sanity_rgw_multisite.py
+
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects on primary(single site)
@@ -438,6 +476,19 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
+            timeout: 300
+
+  - test:
+      name: Verify DBR feature enabled on single to multisite cluster
+      desc: Check DBR feature enabled on single to multisite cluster
+      abort-on-fail: true
+      module: sanity_rgw_multisite.py
+      polarion-id: CEPH-83573596
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_check_sharding_enabled.py
+            config-file-name: test_check_sharding_enabled_brownfield.yaml
             timeout: 300
 
   - test:


### PR DESCRIPTION
Have created 2 commits for clarity.

**commit 1: Correcting the flow of single site to multisite conversion.**

The flow should be to 
- create the primary site with the realm "India", zonegroup "shared" and zone "primary"
- write IOs
- establish a multisite to the above realm at zone level with realm "India", zonegroup "shared" and zone "secondary."

**commit 2: Addresses test automation of CEPH-83575355 and bug-2026101**

[Bug 2026101](https://bugzilla.redhat.com/show_bug.cgi?id=2026101) verification. [rgw/multisite-reshard] : radosgw-admin sync status repots 56 recovering shards on the slave after converting singlesite to multisite.

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3PGFND/

Signed-off-by: viduship <vimishra@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
