### PR TITLE
added multiple snapshot scheduler

### DIFF
--- a/tests/rbd_mirror/test_rbd_mirror_snapshot.py
+++ b/tests/rbd_mirror/test_rbd_mirror_snapshot.py
@@ -41,11 +41,17 @@ def run(**kw):
         snapshot_schedule_level = config.get("snapshot_schedule_level")
         if not snapshot_schedule_level or snapshot_schedule_level == "cluster":
             mirror1.mirror_snapshot_schedule_add()
+            mirror1.mirror_snapshot_schedule_add(interval="1h")
         elif snapshot_schedule_level == "pool":
             mirror1.mirror_snapshot_schedule_add(poolname=poolname)
+            mirror1.mirror_snapshot_schedule_add(poolname=poolname, interval="1h")
         else:
             mirror1.mirror_snapshot_schedule_add(poolname=poolname, imagename=imagename)
-        mirror1.verify_snapshot_schedule(imagespec)
+            mirror1.mirror_snapshot_schedule_add(
+                poolname=poolname, imagename=imagename, interval="1h"
+            )
+        # this is the verification of interval 1h
+        mirror1.verify_snapshot_schedule(imagespec, interval=40)
         mirror1.mirror_snapshot_schedule_list(poolname=poolname, imagename=imagename)
         mirror1.mirror_snapshot_schedule_status(poolname=poolname, imagename=imagename)
 
@@ -66,12 +72,17 @@ def run(**kw):
 
         # snapshot schedule should be removed at the level (cluster, pool, image) at which it was added
         if not snapshot_schedule_level or snapshot_schedule_level == "cluster":
+            mirror1.mirror_snapshot_schedule_remove(interval="1h")
             mirror1.mirror_snapshot_schedule_remove()
             mirror1.verify_snapshot_schedule_remove()
         elif snapshot_schedule_level == "pool":
+            mirror1.mirror_snapshot_schedule_remove(poolname=poolname, interval="1h")
             mirror1.mirror_snapshot_schedule_remove(poolname=poolname)
             mirror1.verify_snapshot_schedule_remove(poolname=poolname)
         else:
+            mirror1.mirror_snapshot_schedule_remove(
+                poolname=poolname, imagename=imagename, interval="1h"
+            )
             mirror1.mirror_snapshot_schedule_remove(
                 poolname=poolname, imagename=imagename
             )


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Fixes RHCEPHQE-6248
Added multiple snapshot scheduler as one scheduler as daily basis i.e 1h and removed the same as well in test.
Pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NFJEWB/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
