### PR TITLE
RHCEPHQE-6394:[Pipeline failure]:RBD 6.0 failure with configure clients

### DIFF
--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -64,7 +64,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node6
+        node: node4
         install_packages:
           - ceph-common
           - fio


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Node4 is set wrongly as Node6 which causing to failure for pipeline job,  as per the conf file correcting the Node as node4.

successful run  : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ymxlj/ 