### PR TITLE
change DBR tests to sanity run in 6.0 pipeline

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -957,7 +957,7 @@ suites:
       openstack: "conf/inventory/rhel-9-latest.yaml"
       ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
     metadata:
-      - schedule
+      - sanity
       - tier-2
       - openstack
       - ibmc


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>
This PR is to change the execution of dynamic resharding tests to sanity runs on rhcs6.0 runs

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
