### PR TITLE
[RHEL Interop] Update RHCS Release version to 5.3

### DIFF
--- a/pipeline/scripts/interop/test-ceph-features.sh
+++ b/pipeline/scripts/interop/test-ceph-features.sh
@@ -77,7 +77,7 @@ for suite in "${!TEST_SUITES[@]}" ; do
     if [[ $TEST_SUITE =~ "nautilus" ]]; then
       RHCS_VERSION="4.2"
     elif [[ $TEST_SUITE =~ "pacific" ]]; then
-      RHCS_VERSION="5.2"
+      RHCS_VERSION="5.3"
     fi
 
     random_string=$(cat /dev/urandom | tr -cd 'a-z0-9' | head -c 5)


### PR DESCRIPTION
Update `RHCS_VERSION` for test suite `TEST_SUITE` to latest GAed version `5.3`