### PR TITLE
Removing tier-2_rados_test-pool-functionalities test suite from openstack-only pipeline

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -350,7 +350,7 @@ suites:
     metadata:
       - schedule
       - tier-2
-      - openstack-only
+      - openstack
       - ibmc
       - rados
       - stage-2


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Removing tier-2_rados_test-pool-functionalities from openstack-only pipeline.

RADOS test suite executing over more than 1 day - https://jenkins.ceph.redhat.com/blue/organizations/jenkins/rhceph-test-execution-pipeline/detail/rhceph-test-execution-pipeline/1677/pipeline
- Few tests are taking higher execution time compared to previous execution.
- Migration test cases did consume more time here.

The same suite is getting exeuted as part of IBM scheduled runs and also in open stack.
No issues are observed when the suite is run in IBM envt on the same build.
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6479/163715
In PSI environment socket timeout issues are also observed for the same suite
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/5/6522/165072
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6389/160174

Removing the suite from psi environment for now.


