### PR TITLE
[Pipeline Failure 6.0] - test_rbd_mirror_snapshot_cluster/test_rbd_mirror_snapshot_pool

### DIFF
--- a/tests/rbd_mirror/test-image-delete-from-secondary.py
+++ b/tests/rbd_mirror/test-image-delete-from-secondary.py
@@ -51,6 +51,7 @@ def run(**kw):
             io_total=config.get("io-total", "1G"),
             mode="image",
             mirrormode="snapshot",
+            **kw,
         )
 
         # promote and demote images

--- a/tests/rbd_mirror/test-image-delete-primary-site.py
+++ b/tests/rbd_mirror/test-image-delete-primary-site.py
@@ -46,6 +46,7 @@ def run(**kw):
             imagename=imagename,
             imagesize=config.get("imagesize", "1G"),
             mode="pool",
+            **kw,
         )
 
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))

--- a/tests/rbd_mirror/test_9470.py
+++ b/tests/rbd_mirror/test_9470.py
@@ -28,6 +28,7 @@ def run(**kw):
             imagesize=config.get("imagesize", "1G"),
             io_total=config.get("io-total", "1G"),
             mode="pool",
+            **kw,
         )
 
         hard_reboot(osd_cred, name="ceph-rbd1")

--- a/tests/rbd_mirror/test_9471.py
+++ b/tests/rbd_mirror/test_9471.py
@@ -27,6 +27,7 @@ def run(**kw):
             imagesize=config.get("imagesize", "1G"),
             io_total=config.get("io-total", "1G"),
             mode="pool",
+            **kw,
         )
 
         mirror2.wait_for_replay_complete(imagespec=imagespec)

--- a/tests/rbd_mirror/test_9474.py
+++ b/tests/rbd_mirror/test_9474.py
@@ -27,6 +27,7 @@ def run(**kw):
             imagename=imagename,
             imagesize=config.get("imagesize", "1G"),
             mode="pool",
+            **kw,
         )
 
         with parallel() as p:

--- a/tests/rbd_mirror/test_9475.py
+++ b/tests/rbd_mirror/test_9475.py
@@ -25,6 +25,7 @@ def run(**kw):
             imagename=imagename,
             imagesize=config.get("imagesize", "1G"),
             mode="pool",
+            **kw,
         )
 
         with parallel() as p:

--- a/tests/rbd_mirror/test_9500_shrink_img_at_secondary.py
+++ b/tests/rbd_mirror/test_9500_shrink_img_at_secondary.py
@@ -41,6 +41,7 @@ def run(**kw):
             imagename=imagename,
             imagesize=config.get("imagesize", "1G"),
             mode="pool",
+            **kw,
         )
 
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))

--- a/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
+++ b/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
@@ -61,6 +61,7 @@ def run(**kw):
             imagesize=config.get("imagesize", "1G"),
             mode="image",
             mirrormode="journal",
+            **kw,
         )
 
         # Create image and enable snapshot mirroring"

--- a/tests/rbd_mirror/test_rbd_mirror_daemon_status.py
+++ b/tests/rbd_mirror/test_rbd_mirror_daemon_status.py
@@ -36,6 +36,7 @@ def run(**kw):
             imagename=imagename,
             imagesize=config.get("imagesize", "1G"),
             mode="pool",
+            **kw,
         )
 
         # Check rbd-daemon runing status

--- a/tests/rbd_mirror/test_rbd_mirror_rename_image.py
+++ b/tests/rbd_mirror/test_rbd_mirror_rename_image.py
@@ -39,6 +39,7 @@ def run(**kw):
             io_total=config.get("io-total", "1G"),
             mode="image",
             mirrormode="snapshot",
+            **kw,
         )
 
         # Rename primary image and check on secondary

--- a/tests/rbd_mirror/test_rbd_mirror_snapshot.py
+++ b/tests/rbd_mirror/test_rbd_mirror_snapshot.py
@@ -35,6 +35,7 @@ def run(**kw):
             io_total=config.get("io-total", "1G"),
             mode="image",
             mirrormode="snapshot",
+            **kw,
         )
 
         # check if snapshots are created for image created above


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Changes has been done to overcome the pipeline failure caused by recent changes done for RBD-Mirror to add manual peer for clusters (https://github.com/red-hat-storage/cephci/pull/1929).



