### PR TITLE
Send consolidated email when stages are aborted for a particular build

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -15,6 +15,8 @@ def composeInfo
 def metaData = [:]
 def rp_base_link = "https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com"
 def launch_id = ""
+def testStatus
+def date
 
 node("rhel-8-medium || ceph-qe-ci") {
 
@@ -58,6 +60,8 @@ node("rhel-8-medium || ceph-qe-ci") {
             println("emailLib : ${emailLib}")
             reportLib = load("${env.WORKSPACE}/pipeline/vars/upload_results.groovy")
             println("reportLib : ${reportLib}")
+            testStatus = msgMap["test"]["result"]
+            date = sh(returnStdout: true, script: "date")
         }
 
         stage('updatePipelineMetadata'){
@@ -74,162 +78,30 @@ node("rhel-8-medium || ceph-qe-ci") {
             }
         }
 
-        stage('configureReportPortalWorkDir') {
-            println("Stage configureReportPortalWorkDir")
-            (rpPreprocDir, credsRpProc) = reportLib.configureRpPreProc(sharedLib)
-        }
-
-        stage('uploadTestResultToReportPortal'){
-            println("Stage uploadTestResultToReportPortal")
-            composeInfo = msgMap["recipe"]
-
-            def resultDir = msgMap["test"]["object-prefix"]
-            println("Test results are available at ${resultDir}")
-
-            def tmpDir = sh(returnStdout: true, script: "mktemp -d").trim()
-            tags_list = msgMap["pipeline"]["tags"].split(',') as List
-            if ('ibmc' in tags_list) {
-                sh script: "rclone sync ${remoteName}://${reportBucket} ${tmpDir} --progress --create-empty-src-dirs"
-            } else {
-                sh "sudo cp -r /ceph/cephci-jenkins/${resultDir} ${tmpDir}"
-            }
-
-            metaData = readYaml file: "${tmpDir}/${resultDir}/metadata.yaml"
-            println("metadata: ${metaData}")
-            def copyFiles = "sudo cp -a ${tmpDir}/${resultDir}/results ${rpPreprocDir}/payload/"
-            def copyAttachments = "sudo cp -a ${tmpDir}/${resultDir}/attachments ${rpPreprocDir}/payload/"
-            def rmTmpDir = "sudo rm -rf ${tmpDir}"
-
-            // Modifications to reuse methods
-            metaData["ceph_version"] = metaData["ceph-version"]
-            if ( metaData["stage"] == "latest" ) { metaData["stage"] = "Tier-0" }
-
-            sh script: "${copyFiles} && ${copyAttachments} && ${rmTmpDir}"
-
-            if ( composeInfo ){
-                metaData["buildArtifacts"] = composeInfo
-            }
-
-            if (metaData["results"]) {
-                launch_id = reportLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData, stageLevel, run_type)
-                println("launch_id: ${launch_id}")
-                if (launch_id) {
-                    metaData["rp_link"] = "${rp_base_link}/ui/#cephci/launches/all/${launch_id}"
-                }
-            }
-
-            // Remove the sync results folder
-            if ('ibmc' in tags_list) {
-                sh script: "rclone purge ${remoteName}:${reportBucket}/${resultDir}"
-            } else {
-                sh "sudo rm -r /ceph/cephci-jenkins/${resultDir}"
-            }
-        }
-
-        stage('notifyTier-0Failure'){
-            println("Stage notifyTier-0Failure")
-            if (msgMap["test"]["result"] == "FAILURE" && tierLevel == "tier-0") {
-                metaData.put("version", msgMap["artifact"]["nvr"])
-                println("version")
-                println(msgMap["artifact"]["nvr"])
-                emailLib.sendEmail(
-                    sharedLib,
-                    run_type,
-                    metaData['results'],
-                    metaData,
-                    tierLevel,
-                    stageLevel,
-                    msgMap["artifact"]["nvr"]
-                )
-
-                emailLib.sendGChatNotification(
-                    run_type, metaData["results"], tierLevel, stageLevel, build_url
-                )
-            }
-        }
-
-        stage('updateRecipeFile'){
-            println("Stage updateRecipeFile")
-            if ( composeInfo != null ) {
-                if ( run_type == "Sanity Run") {
-                    if ( tierLevel == null ) {
-                        tierLevel = msgMap["pipeline"]["name"]
-                    }
-                    def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
-                    majorVersion = rhcsVersion["major_version"]
-                    minorVersion = rhcsVersion["minor_version"]
-                    minorVersion = "${minorVersion}"
-
-                    def latestContent = sharedLib.readFromReleaseFile(
-                        majorVersion, minorVersion
-                    )
-                    println("latestContentBefore: ${latestContent}")
-
-                    if ( latestContent.containsKey(tierLevel) ) {
-                        latestContent[tierLevel] = composeInfo
-                    }
-                    else {
-                        def updateContent = ["${tierLevel}": composeInfo]
-                        latestContent += updateContent
-                    }
-                    println("latestContent: ${latestContent}")
-                    sharedLib.writeToReleaseFile(
-                        majorVersion, minorVersion, latestContent
-                    )
-                }
-            }
-        }
-
-        stage('updateResultsFile'){
-            println("Stage updateResultsFile")
-            if (composeInfo != null){
-                println("Fetching rp_launch_details")
-                def rp_launch_details = [:]
-                if (launch_id){
-                    sh "sleep 60"
-                    rp_launch_details = reportLib.fetchTestItemIdForLaunch(
-                        launch_id,
-                        rp_base_link,
-                        rpPreprocDir,
-                        credsRpProc,
-                        metaData,
-                        stageLevel,
-                        run_type
-                    )
-                }
-                reportLib.writeToResultsFile(
-                    msgMap["artifact"]["version"],
-                    run_type,
-                    tierLevel,
-                    stageLevel,
-                    metaData['results'],
-                    msgMap['run']['url'],
-                    metaData['rp_link'],
-                    rp_launch_details
-                )
-            }
-        }
-
-        stage('sendConsolidatedReport'){
-            println("Stage sendConsolidatedReport")
-            if (msgMap["pipeline"]["final_stage"] && tierLevel == "tier-2") {
+        if (testStatus == 'ABORTED' && msgMap["pipeline"]["final_stage"]) {
+            stage('sendConsolidatedReport'){
                 def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
                 majorVersion = rhcsVersion["major_version"]
                 minorVersion = rhcsVersion["minor_version"]
-                minorVersion = "${minorVersion}"
 
                 def testResults = sharedLib.readFromResultsFile(
                     msgMap["artifact"]["version"]
                 )
-                
-                reportLib.updateConfluencePage(
-                    sharedLib,
-                    majorVersion,
-                    minorVersion,
-                    msgMap["artifact"]["version"],
-                    run_type,
-                    testResults
+
+                def recipeMap = sharedLib.readFromReleaseFile(
+                    majorVersion, minorVersion, lockFlag=false
                 )
+                println("recipeMap ---- ${recipeMap}")
+                metaData = recipeMap['tier-0']
+                metaData["product"] = "Red Hat Ceph Storage"
+                metaData["version"] = "RHCEPH-${majorVersion}.${minorVersion}"
+                metaData["date"] = date
+                metaData["ceph_version"] = msgMap["artifact"]["version"]
+                metaData["buildArtifacts"] = msgMap["recipe"]
+                metaData["log"] = env.RUN_DISPLAY_URL
+                metaData["stage"] = tierLevel
+                metaData["results"] = testResults
+
                 emailLib.sendConsolidatedEmail(
                     run_type,
                     metaData,
@@ -237,30 +109,198 @@ node("rhel-8-medium || ceph-qe-ci") {
                     minorVersion,
                     msgMap["artifact"]["version"]
                 )
-                sharedLib.sendGChatNotification(
-                    run_type, metaData["results"], tierLevel, stageLevel, build_url
-                )
             }
         }
+        else
+        {
+            stage('configureReportPortalWorkDir') {
+                println("Stage configureReportPortalWorkDir")
+                (rpPreprocDir, credsRpProc) = reportLib.configureRpPreProc(sharedLib)
+            }
 
-        stage('sendUMBFortier0RC'){
-            // This stage is to send UMB message for OSP interop team
-            // everytime an RC build passes sanity tier-0
-            println("Stage sendUMBFortier0RC")
-            if (
-                tags_list.contains("rc") && tierLevel == "tier-0"
-                && msgMap.containsKey("pipeline") && msgMap["pipeline"]["final_stage"]
-                && msgMap.containsKey("test") && msgMap["test"]["result"] == "SUCCESS"
-            ){
-                def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
-                majorVersion = rhcsVersion["major_version"]
-                minorVersion = rhcsVersion["minor_version"]
-                minorVersion = "${minorVersion}"
-                def recipeMap = sharedLib.readFromReleaseFile(
-                    majorVersion, minorVersion, lockFlag=false
-                )
-                umbLib = load("${env.WORKSPACE}/pipeline/vars/umb.groovy")
-                umbLib.postUMBTestQueue(msgMap["artifact"]["nvr"], recipeMap, "false")
+            stage('uploadTestResultToReportPortal'){
+                println("Stage uploadTestResultToReportPortal")
+                composeInfo = msgMap["recipe"]
+
+                def resultDir = msgMap["test"]["object-prefix"]
+                println("Test results are available at ${resultDir}")
+
+                def tmpDir = sh(returnStdout: true, script: "mktemp -d").trim()
+                tags_list = msgMap["pipeline"]["tags"].split(',') as List
+                if ('ibmc' in tags_list) {
+                    sh script: "rclone sync ${remoteName}://${reportBucket} ${tmpDir} --progress --create-empty-src-dirs"
+                } else {
+                    sh "sudo cp -r /ceph/cephci-jenkins/${resultDir} ${tmpDir}"
+                }
+
+                metaData = readYaml file: "${tmpDir}/${resultDir}/metadata.yaml"
+                println("metadata: ${metaData}")
+                def copyFiles = "sudo cp -a ${tmpDir}/${resultDir}/results ${rpPreprocDir}/payload/"
+                def copyAttachments = "sudo cp -a ${tmpDir}/${resultDir}/attachments ${rpPreprocDir}/payload/"
+                def rmTmpDir = "sudo rm -rf ${tmpDir}"
+
+                // Modifications to reuse methods
+                metaData["ceph_version"] = metaData["ceph-version"]
+                if ( metaData["stage"] == "latest" ) { metaData["stage"] = "Tier-0" }
+
+                sh script: "${copyFiles} && ${copyAttachments} && ${rmTmpDir}"
+
+                if ( composeInfo ){
+                    metaData["buildArtifacts"] = composeInfo
+                }
+
+                if (metaData["results"]) {
+                    launch_id = reportLib.uploadTestResults(rpPreprocDir, credsRpProc, metaData, stageLevel, run_type)
+                    println("launch_id: ${launch_id}")
+                    if (launch_id) {
+                        metaData["rp_link"] = "${rp_base_link}/ui/#cephci/launches/all/${launch_id}"
+                    }
+                }
+
+                // Remove the sync results folder
+                if ('ibmc' in tags_list) {
+                    sh script: "rclone purge ${remoteName}:${reportBucket}/${resultDir}"
+                } else {
+                    sh "sudo rm -r /ceph/cephci-jenkins/${resultDir}"
+                }
+            }
+
+            stage('notifyTier-0Failure'){
+                println("Stage notifyTier-0Failure")
+                if (msgMap["test"]["result"] == "FAILURE" && tierLevel == "tier-0") {
+                    metaData.put("version", msgMap["artifact"]["nvr"])
+                    println("version")
+                    println(msgMap["artifact"]["nvr"])
+                    emailLib.sendEmail(
+                        sharedLib,
+                        run_type,
+                        metaData['results'],
+                        metaData,
+                        tierLevel,
+                        stageLevel,
+                        msgMap["artifact"]["nvr"]
+                    )
+
+                    emailLib.sendGChatNotification(
+                        run_type, metaData["results"], tierLevel, stageLevel, build_url
+                    )
+                }
+            }
+
+            stage('updateRecipeFile'){
+                println("Stage updateRecipeFile")
+                if ( composeInfo != null ) {
+                    if ( run_type == "Sanity Run") {
+                        if ( tierLevel == null ) {
+                            tierLevel = msgMap["pipeline"]["name"]
+                        }
+                        def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
+                        majorVersion = rhcsVersion["major_version"]
+                        minorVersion = rhcsVersion["minor_version"]
+                        minorVersion = "${minorVersion}"
+
+                        def latestContent = sharedLib.readFromReleaseFile(
+                            majorVersion, minorVersion
+                        )
+                        println("latestContentBefore: ${latestContent}")
+
+                        if ( latestContent.containsKey(tierLevel) ) {
+                            latestContent[tierLevel] = composeInfo
+                        }
+                        else {
+                            def updateContent = ["${tierLevel}": composeInfo]
+                            latestContent += updateContent
+                        }
+                        println("latestContent: ${latestContent}")
+                        sharedLib.writeToReleaseFile(
+                            majorVersion, minorVersion, latestContent
+                        )
+                    }
+                }
+            }
+
+            stage('updateResultsFile'){
+                println("Stage updateResultsFile")
+                if (composeInfo != null){
+                    println("Fetching rp_launch_details")
+                    def rp_launch_details = [:]
+                    if (launch_id){
+                        sh "sleep 60"
+                        rp_launch_details = reportLib.fetchTestItemIdForLaunch(
+                            launch_id,
+                            rp_base_link,
+                            rpPreprocDir,
+                            credsRpProc,
+                            metaData,
+                            stageLevel,
+                            run_type
+                        )
+                    }
+                    reportLib.writeToResultsFile(
+                        msgMap["artifact"]["version"],
+                        run_type,
+                        tierLevel,
+                        stageLevel,
+                        metaData['results'],
+                        msgMap['run']['url'],
+                        metaData['rp_link'],
+                        rp_launch_details
+                    )
+                }
+            }
+
+            stage('sendConsolidatedReport'){
+                println("Stage sendConsolidatedReport")
+                if (msgMap["pipeline"]["final_stage"] && tierLevel == "tier-2") {
+                    def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
+                    majorVersion = rhcsVersion["major_version"]
+                    minorVersion = rhcsVersion["minor_version"]
+                    minorVersion = "${minorVersion}"
+
+                    def testResults = sharedLib.readFromResultsFile(
+                        msgMap["artifact"]["version"]
+                    )
+
+                    reportLib.updateConfluencePage(
+                        sharedLib,
+                        majorVersion,
+                        minorVersion,
+                        msgMap["artifact"]["version"],
+                        run_type,
+                        testResults
+                    )
+                    emailLib.sendConsolidatedEmail(
+                        run_type,
+                        metaData,
+                        majorVersion,
+                        minorVersion,
+                        msgMap["artifact"]["version"]
+                    )
+                    sharedLib.sendGChatNotification(
+                        run_type, metaData["results"], tierLevel, stageLevel, build_url
+                    )
+                }
+            }
+
+            stage('sendUMBFortier0RC'){
+                // This stage is to send UMB message for OSP interop team
+                // everytime an RC build passes sanity tier-0
+                println("Stage sendUMBFortier0RC")
+                if (
+                    tags_list.contains("rc") && tierLevel == "tier-0"
+                    && msgMap.containsKey("pipeline") && msgMap["pipeline"]["final_stage"]
+                    && msgMap.containsKey("test") && msgMap["test"]["result"] == "SUCCESS"
+                ){
+                    def rhcsVersion = sharedLib.getRHCSVersionFromArtifactsNvr()
+                    majorVersion = rhcsVersion["major_version"]
+                    minorVersion = rhcsVersion["minor_version"]
+                    minorVersion = "${minorVersion}"
+                    def recipeMap = sharedLib.readFromReleaseFile(
+                        majorVersion, minorVersion, lockFlag=false
+                    )
+                    umbLib = load("${env.WORKSPACE}/pipeline/vars/umb.groovy")
+                    umbLib.postUMBTestQueue(msgMap["artifact"]["nvr"], recipeMap, "false")
+                }
             }
         }
     } catch(Exception err) {

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -156,6 +156,59 @@ node(nodeName) {
             println "recipeFile ceph-version : ${content['ceph-version']}"
             println "buildArtifacts ceph-version : ${buildArtifacts['ceph-version']}"
             if ( buildArtifacts['ceph-version'] != content['ceph-version']) {
+                 def msgMap = [
+                    "artifact": [
+                        "type": "product-build",
+                        "name": "Red Hat Ceph Storage",
+                        "version": buildArtifacts["ceph-version"],
+                        "nvr": rhcephVersion,
+                        "phase": "testing",
+                        "build": "tier-0",
+                    ],
+                    "contact": [
+                        "name": "Downstream Ceph QE",
+                        "email": "cephci@redhat.com",
+                    ],
+                    "system": [
+                        "os": "centos-7",
+                        "label": "agent-01",
+                        "provider": "IBM-Cloud",
+                    ],
+                    "pipeline": [
+                        "name": tierLevel,
+                        "id": currentBuild.number,
+                        "tags": tags,
+                        "overrides": overrides,
+                        "run_type": run_type,
+                        "final_stage": true,
+                    ],
+                    "run": [
+                        "url": env.RUN_DISPLAY_URL,
+                        "additional_urls": [
+                            "doc": "https://docs.engineering.redhat.com/display/rhcsqe/RHCS+QE+Pipeline",
+                            "repo": "https://github.com/red-hat-storage/cephci",
+                            "report": "https://reportportal-rhcephqe.apps.ocp4.prod.psi.redhat.com/",
+                            "tcms": "https://polarion.engineering.redhat.com/polarion/",
+                        ],
+                    ],
+                    "test": [
+                        "type": buildType,
+                        "category": "functional",
+                        "result": "ABORTED",
+                        "object-prefix": dirName,
+                    ],
+                    "recipe": buildArtifacts,
+                    "generated_at": env.BUILD_ID,
+                    "version": "3.0.0",
+                ]
+
+                def msgType = "Custom"
+
+                sharedLib.SendUMBMessage(
+                    msgMap,
+                    "VirtualTopic.qe.ci.rhcephqe.product-build.test.complete",
+                    msgType,
+                )
                 currentBuild.result = "ABORTED"
                 error "Aborting the execution as new builds are available.."
             }


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Send consolidated email when stages are aborted for a particular build.

logs:

executor - https://159.23.92.24/job/rhcs-tintu/4/console
                   https://159.23.92.24/job/rhcs-tintu/5/console

post-results - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/post_res_tintu/1/console
                         https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/post_res_tintu/2/console

umb-messages - https://datagrepper.engineering.redhat.com/id?id=ID:6f0790e24143-46239-1673849317111-367:1:1:1:1&is_raw=true&size=extra-large
                              https://datagrepper.engineering.redhat.com/id?id=ID:6f0790e24143-46239-1673849317111-371:1:1:1:1&is_raw=true&size=extra-large

report portal - https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/6541

[email_screenshots.odt](https://github.com/red-hat-storage/cephci/files/10459513/email_screenshots.odt)
[log2_post_res.txt](https://github.com/red-hat-storage/cephci/files/10459514/log2_post_res.txt)
[log1_post_res.txt](https://github.com/red-hat-storage/cephci/files/10459515/log1_post_res.txt)
[log2_executor.txt](https://github.com/red-hat-storage/cephci/files/10459516/log2_executor.txt)
[log1_executor.txt](https://github.com/red-hat-storage/cephci/files/10459517/log1_executor.txt)
