### PR TITLE
Removing msgrv2 compression modes from pcific suite

### DIFF
--- a/suites/pacific/rados/tier-2_rados_basic_regression.yaml
+++ b/suites/pacific/rados/tier-2_rados_basic_regression.yaml
@@ -170,31 +170,6 @@ tests:
       desc: Verify config changes for section & masks like device class, host etc
 
   - test:
-      name: Monitor configuration - msgrv2 compression modes
-      module: rados_prep.py
-      polarion-id: CEPH-83574961
-      config:
-        Verify_config_parameters:
-          configurations:
-            - config-1:
-                section: "mon"
-                name: "ms_osd_compress_mode"
-                value: "snappy"
-            - config-2:
-                section: "mon"
-                name: "ms_osd_compress_min_size"
-                value: "512"
-            - config-3:
-                section: "mon"
-                name: "ms_osd_compress_mode"
-                value: "none"
-            - config-4:
-                section: "mon"
-                name: "ms_osd_compress_min_size"
-                value: "1024"
-      desc: Verify the health status of the cluster by randomly changing the compression configuration values
-
-  - test:
       name: Replicated pool LC
       module: rados_prep.py
       polarion-id: CEPH-83571632


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Removing msgrv2 compression modes from pcific suite.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GW7UVA/