### PR TITLE
CEPH-83573618 - verify Snap mirroring on journaling based image after disable journaling on image

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -232,10 +232,11 @@ tests:
   - test:
       name: Mirroring of cloned image
       module: test_rbd_clone_mirror.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
       polarion-id: CEPH-9521
       desc: Testing mirroring of cloned image
+
+  - test:
+      name: Mirroring from journal to snapshot
+      module: test_rbd_mirror_journal_to_snap.py
+      polarion-id: CEPH-83573618
+      desc: Testing journal mirroring to snapshot mirroring

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -226,10 +226,11 @@ tests:
   - test:
       name: Mirroring of cloned image
       module: test_rbd_clone_mirror.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
       polarion-id: CEPH-9521
       desc: Testing mirroring of cloned image
+
+  - test:
+      name: Mirroring from journal to snapshot
+      module: test_rbd_mirror_journal_to_snap.py
+      polarion-id: CEPH-83573618
+      desc: Testing journal mirroring to snapshot mirroring

--- a/tests/rbd_mirror/test_rbd_clone_mirror.py
+++ b/tests/rbd_mirror/test_rbd_clone_mirror.py
@@ -77,7 +77,9 @@ def run(**kw):
         ]
         imagespec = poolname + "/" + imagename
         mirror2.create_pool(poolname=poolname)
-        mirror1.config_mirror(mirror2, poolname=poolname, mode="pool")
+        kw["peer_mode"] = kw.get("peer_mode", "bootstrap")
+        kw["rbd_client"] = kw.get("rbd_client", "client.admin")
+        mirror1.config_mirror(mirror2, poolname=poolname, mode="pool", **kw)
         mirror2.wait_for_status(poolname=poolname, images_pattern=2)
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")

--- a/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
+++ b/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
@@ -1,0 +1,79 @@
+from ceph.parallel import parallel
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """verification Snap mirroring on journaling based image after disable journaling on image.
+
+    Args:
+        **kw:
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+
+    Test case flow:
+    1. Create image on cluster-1.
+    2. Enable journal mirroring for created image on cluster-1 and run IOs.
+    3. Ensure mirror image created on cluster-2.
+    4. Disable journal mirroring on image.
+    5. enable snapshot mirroring on same image.
+    6. Verify for snapshot mirroring and run IOs
+    7. cleanup
+    """
+    try:
+        log.info("Starting RBD mirroring test case")
+        config = kw.get("config")
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
+        poolname = mirror1.random_string() + "_tier_2_rbd_mirror_pool"
+        imagename = mirror1.random_string() + "_tier_2_rbd_mirror_image"
+        imagespec = poolname + "/" + imagename
+
+        # initial mirror configuration
+        mirror1.initial_mirror_config(
+            mirror2,
+            poolname=poolname,
+            imagename=imagename,
+            imagesize=config.get("imagesize", "1G"),
+            io_total=config.get("io-total", "1G"),
+            mode="image",
+            mirrormode="journal",
+            **kw,
+        )
+
+        # Disabling journal mirror on image
+        mirror1.disable_mirroring("image", imagespec)
+
+        # enable snapshot mirroring on image
+        mirror1.enable_mirror_image(poolname, imagename, "snapshot")
+        mirror2.wait_for_status(poolname=poolname, images_pattern=1)
+
+        # Verification of mirrored image on cluster
+        mirror2.image_exists(imagespec)
+        if mirror1.get_mirror_mode(imagespec) == "snapshot":
+            log.info("snapshot mirroring is enabled")
+        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
+        with parallel() as p:
+            p.spawn(
+                mirror1.wait_for_status, imagespec=imagespec, state_pattern="up+stopped"
+            )
+            p.spawn(
+                mirror2.wait_for_status,
+                imagespec=imagespec,
+                state_pattern="up+replaying",
+            )
+
+        # Cleans up the configuration
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+
+        return 0
+
+    except RbdBaseException as error:
+        print(error.message)
+        return 1


### PR DESCRIPTION
This PR is to verify the Snapshot based mirroring on image after disabling the Journal mirroring.
Polarion ID : CEPH-83573618 
Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573618

```
Test case flow:
    1. Create image on cluster-1.
    2. Enable journal mirroring for created image on cluster-1 and run IOs.
    3. Ensure mirror image created on cluster-2.
    4. Disable journal mirroring on image.
    5. enable snapshot mirroring on same image.
    6. Verify for snapshot mirroring and run IOs
    7. cleanup
```
    
Success log : 

RHCS 6.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-75fom/Mirroring_from_journal_to_snapshot_0.log 

RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2qgmi/Mirroring_from_journal_to_snapshot_0.log

