### PR TITLE
Included caller module name in the logs.

### DIFF
--- a/utility/log.py
+++ b/utility/log.py
@@ -26,8 +26,7 @@ from typing import Any, Dict
 
 from .config import TestMetaData
 
-LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
-# EX: 2022-11-15 11:37:00,346 - DEBUG  - Completed log configuration
+LOG_FORMAT = "%(asctime)s (%(name)s) [%(levelname)s] - %(message)s"
 magna_server = "http://magna002.ceph.redhat.com"
 magna_url = f"{magna_server}/cephci-jenkins/"
 


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Including main caller information in Log record to identify the Log records based on the module which called.

`<time> (<caller-module>) [<LEVEL>] - <Message>`
> 2023-01-17 21:48:34,553 (cephci.exec) [DEBUG] - cephci.utility.log.py:237 - Completed log configuration
> 2023-01-17 21:48:34,554 (cephci.sanity_rgw) [INFO] - cephci.run.py:792 - Running test sanity_rgw.py
> 2023-01-17 21:48:34,555 (cephci.sanity_rgw) [INFO] - cephci.tests.rgw.sanity_rgw.py:78 - Running RGW test version: v2
> 2023-01-17 21:48:34,556 (cephci.sanity_rgw) [INFO] - cephci.ceph.ceph.py:1540 - Running command cat /etc/os-release on 10.0.211.240 timeout 600

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7SL2HF/rgw_sanity_tests_0.log