### PR TITLE
Adapt rbd_trash_remove.py to test for both ecpools and replicated pools

### DIFF
--- a/tests/rbd/rbd_trash_remove.py
+++ b/tests/rbd/rbd_trash_remove.py
@@ -1,9 +1,39 @@
 from tests.rbd.exceptions import ImageFoundError, RbdBaseException
-from tests.rbd.rbd_utils import Rbd
+from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.utils import run_fio
 
 log = Log(__name__)
+
+
+def rbd_trash_remove(rbd, pool_type, **kw):
+    """
+    Run trash and force remove operation on images
+    Args:
+        rbd: rbd object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: Test data
+    """
+    pool = kw["config"][pool_type]["pool"]
+    image = kw["config"][pool_type]["image"]
+    try:
+        client = kw["ceph_cluster"].get_nodes(role="client")[0]
+        run_fio(image_name=image, pool_name=pool, client_node=client)
+        rbd.move_image_trash(pool, image)
+        image_id = rbd.get_image_id(pool, image)
+        log.info(f"image id is {image_id}")
+        rbd.remove_image_trash(pool, image_id)
+        if rbd.trash_exist(pool, image):
+            raise ImageFoundError(" Image is found in the Trash")
+        else:
+            return 0
+
+    except RbdBaseException as error:
+        log.error(error.message)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
 
 
 def run(**kw):
@@ -29,30 +59,16 @@ def run(**kw):
     2. generate IO in images
     3. Move images to trash
     4. Remove/Delete image from trash and verify that images is deleted from trash
+    5. Repeat the above steps for EC-pool.
     """
     log.info("Running Trash image remove test")
-    rbd = Rbd(**kw)
-    pool = rbd.random_string()
-    image = rbd.random_string()
-    size = "10G"
-    client = kw["ceph_cluster"].get_nodes(role="client")[0]
-    try:
-        # create rep pool and execute the test work flow
-        rbd.initial_rbd_config(rbd, pool, image, size=size)
-        client = kw["ceph_cluster"].get_nodes(role="client")[0]
-        run_fio(image_name=image, pool_name=pool, client_node=client)
-        rbd.move_image_trash(pool, image)
-        image_id = rbd.get_image_id(pool, image)
-        log.info(f"image id is {image_id}")
-        rbd.remove_image_trash(pool, image_id)
-        if rbd.trash_exist(pool, image):
-            raise ImageFoundError(" Image is found in the Trash")
-        else:
-            return 0
-
-    except RbdBaseException as error:
-        print(error.message)
-        return 1
-
-    finally:
-        rbd.clean_up(pools=[pool])
+    rbd_obj = initial_rbd_config(**kw)
+    rc = 1
+    if rbd_obj:
+        log.info("Ecexuting test on Replication pool")
+        rc = rbd_trash_remove(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw)
+        if rc:
+            return rc
+        log.info("Executing test on EC pool")
+        rc = rbd_trash_remove(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw)
+    return rc


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Goal is to change the Rbd_trash_remove.py module to execute for both Replicated pools as well as EC pools configuration.

success Log : 
5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-d0gi7/ 
6.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9ihbd/
