### PR TITLE
Adapted EC pool changes for rbd_snap_clone_imported_image

### DIFF
--- a/tests/rbd/rbd_snap_clone_imported_image.py
+++ b/tests/rbd/rbd_snap_clone_imported_image.py
@@ -1,13 +1,12 @@
 from tests.rbd.exceptions import RbdBaseException
-from tests.rbd.rbd_utils import Rbd
+from tests.rbd.rbd_utils import Rbd, initial_rbd_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
-    """Verification of snap and clone on an imported image.
-
+def test_snap_clone(rbd, pool_type, **kw):
+    """
     This module verifies snapshot and cloning operations on an imported image
 
     Args:
@@ -29,6 +28,7 @@ def run(**kw):
     2. Create a dummy file, import it as an image
     3. Create snapshot of it and protect the snapshot
     4. Create a clone
+    5. perform same test on EC pool
     """
     log.info("Running snap and clone operations on imported image")
     rbd = Rbd(**kw)
@@ -37,23 +37,52 @@ def run(**kw):
     snap = rbd.random_string()
     dir_name = rbd.random_string()
     clone = rbd.random_string()
-
     rbd.exec_cmd(cmd="mkdir {}".format(dir_name))
     try:
         if not rbd.create_pool(poolname=pool):
-            # create pool does not catch exceptions, it returns true/false.
-            # so we are returning 1 instead of raising exception
+            log.error(f"Pool creation failed for pool {pool}")
             return 1
-
         rbd.create_file_to_import(filename="dummy_file")
         rbd.import_file("dummy_file", pool, image)
         rbd.snap_create(pool, image, snap)
         snap_name = f"{pool}/{image}@{snap}"
         rbd.protect_snapshot(snap_name)
         rbd.create_clone(snap_name, pool, clone)
+        return 0
+
     except RbdBaseException as error:
-        print(error.message)
+        log.error(error)
+        return 1
 
     finally:
-        rbd.clean_up(pools=[pool])
-        return rbd.flag
+        if not kw.get("config").get("do_not_cleanup_pool"):
+            rbd.clean_up(pools=[pool])
+
+
+def run(**kw):
+    """
+    This module verifies snapshot and cloning operations on an imported image
+    on EC pool and Replicated pool.
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+    """
+    rbd_obj = initial_rbd_config(**kw)
+    if rbd_obj:
+        # To run test on EC pool config
+        log.info(
+            "Running snapshot and cloning operations on an imported image in EC pool"
+        )
+        if test_snap_clone(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+            return 1
+
+        # To run test on replicated pool
+        log.info(
+            "Running snapshot and cloning operations on an imported image in replicated pool"
+        )
+        if test_snap_clone(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+            return 1
+        return 0

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -192,7 +192,7 @@ class Rbd:
         Returns:  True -> pass, False -> fail
         """
         cmd = f"dd if=/dev/urandom of={filename} bs=4 count=5M"
-        if not self.exec_cmd(cmd, long_running=True):
+        if self.exec_cmd(cmd=cmd, long_running=True):
             raise CreateFileError("Creating a file to import failed")
 
     def import_file(self, filename="dummy", pool_name="dummy", image_name="dummy"):
@@ -206,7 +206,7 @@ class Rbd:
         Note: run create_file_to_import before this module in positive scenarios
         """
         cmd = f"rbd import {filename} {pool_name}/{image_name}"
-        if not self.exec_cmd(cmd, long_running=True):
+        if self.exec_cmd(cmd=cmd, long_running=True):
             raise ImportFileError("Importing the file failed")
 
     def snap_create(self, pool_name, image_name, snap_name):


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>

# Description
Fixes RHCEPHQE-6732
Adapted rbd_snap_clone_imported_image.py to test for both ecpools and replicated pools
Test results: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4N86CR


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
