### PR TITLE
[Fix] Update CephAdm Ansible test module to support boostraping using any builds

### DIFF
--- a/playbooks/bootstrap-cluster.yml
+++ b/playbooks/bootstrap-cluster.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Test 'cephadm_bootstrap' module
-  hosts: admin
+  hosts: installer
   gather_facts: false
   become: true
   any_errors_fatal: true
@@ -9,6 +9,7 @@
   tasks:
     - name: Bootstrap with dashboard set to `true` without credenatials
       cephadm_bootstrap:
+        image: "{{ image | default(False) }}"
         mon_ip: "{{ mon_ip }}"
         dashboard: true
         monitoring: false

--- a/suites/quincy/cephadm/test_cephadm_ansible_wrapper.yaml
+++ b/suites/quincy/cephadm/test_cephadm_ansible_wrapper.yaml
@@ -1,0 +1,34 @@
+#===============================================================================================
+# Tier-level: 1
+# Test-Suite: test_cephadm_ansible_wrapper.yaml
+# Test-Case: Perform cephadm operations using cephadm ansible modules
+#
+# Cluster Configuration:
+#    conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml
+#
+#    4-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MDS, 1 MGR, 3 OSD and 2 RGW service daemon(s)
+#     Node1 - Mon, Mgr, Installer, OSD, alertmanager, grafana, prometheus, node-exporter
+#     Node2 - Mon, Mgr, OSD, MDS, RGW, alertmanager, node-exporter
+#     Node3 - Mon, OSD, MDS, RGW, node-exporter
+#     Node4 - Client
+#
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/bootstrap-cluster.yaml' playbook
+      polarion-id: CEPH-83575201
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "cephadm_bootstrap"
+          playbook: playbooks/bootstrap-cluster.yml
+          module_args:
+            mon_node: node1

--- a/tests/cephadm/test_cephadm_ansible_wrapper.py
+++ b/tests/cephadm/test_cephadm_ansible_wrapper.py
@@ -3,18 +3,57 @@ import os
 from cli.cephadm.ansible import Ansible
 from cli.cephadm.cephadm import CephAdm
 from cli.cephadm.exceptions import CephadmOpsExecutionError, ConfigNotFoundError
-from cli.utilities.packages import Package, Rpm, RpmError
+from cli.utilities.packages import Rpm, RpmError
 from cli.utilities.utils import get_node_ip, put_cephadm_ansible_playbook
-from utility.install_prereq import (
-    ConfigureCephadmAnsibleInventory,
-    EnableToolsRepositories,
-)
-from utility.log import Log
+from utility.install_prereq import ConfigureCephadmAnsibleNode, ExecutePreflightPlaybook
 
-log = Log(__name__)
 
-CEPHADM_PREFLIGHT_PLAYBOOK = "cephadm-preflight.yml"
-CEPHADM_PREFLIGHT_VARS = {"ceph_origin": "rhcs"}
+def validate_configs(config):
+    aw = config.get("ansible_wrapper")
+    if not aw:
+        raise ConfigNotFoundError("Mandatory parameter 'ansible_wrapper' not found")
+
+    playbook = aw.get("playbook")
+    if not playbook:
+        raise ConfigNotFoundError("Mandatory resource 'playbook' not found")
+
+    mon_node = aw.get("module_args", {}).get("mon_node")
+    module = aw.get("module")
+    if module == "cephadm_bootstrap" and not mon_node:
+        raise ConfigNotFoundError(
+            "'cephadm_bootstrap' module requires 'mon_node' parameter"
+        )
+
+
+def setup_cluster(ceph_cluster, config):
+    installer = ceph_cluster.get_ceph_object("installer")
+    nodes = ceph_cluster.get_nodes()
+
+    base_url = config.get("base_url")
+    rhbuild = config.get("rhbuild")
+    cloud_type = config.get("cloud-type")
+    build_type = config.get("build_type")
+
+    try:
+        Rpm(installer).query("cephadm-ansible")
+    except RpmError:
+        ceph_cluster.setup_ssh_keys()
+        ConfigureCephadmAnsibleNode.run(
+            installer, nodes, build_type, base_url, rhbuild, cloud_type
+        )
+        ExecutePreflightPlaybook.run(installer, base_url, cloud_type, build_type)
+
+
+def validate_cephadm_ansible_module(installer, playbook, extra_vars, extra_args):
+    put_cephadm_ansible_playbook(installer, playbook)
+    Ansible(installer).run_playbook(
+        playbook=os.path.basename(playbook),
+        extra_vars=extra_vars,
+        extra_args=extra_args,
+    )
+
+    if not CephAdm(installer).ceph.status():
+        raise CephadmOpsExecutionError("Failed to bootstrap cluster")
 
 
 def run(ceph_cluster, **kwargs):
@@ -25,10 +64,6 @@ def run(ceph_cluster, **kwargs):
             name: Bootstrap cluster using cephadm-ansible playbook
             desc: Execute playbooks/bootstrap-cluster.yaml
             config:
-                args:
-                    custom_repo: "cdn"
-                    registry-url: registry.redhat.io
-                    mon_ip: node1
                 ansible_wrapper:
                     module: cephadm_bootstrap
                     playbook: bootstrap-cluster.yaml
@@ -39,52 +74,25 @@ def run(ceph_cluster, **kwargs):
                     extra_args:
                         limit: osds
     """
-    nodes = ceph_cluster.get_nodes()
-    installer = ceph_cluster.get_ceph_object("installer")
-
     config = kwargs.get("config")
+
+    validate_configs(config)
+    setup_cluster(ceph_cluster, config)
+
     aw = config.get("ansible_wrapper")
-    if not aw:
-        raise ConfigNotFoundError("Mandatory parameter 'ansible_wrapper' not found")
 
+    extra_vars, extra_args = aw.get("extra_vars", {}), aw.get("extra_args")
     module = aw.get("module")
-    playbook = aw.get("playbook")
-    if not playbook:
-        raise ConfigNotFoundError("Mandatory resource 'playbook' not found")
     mon_node = aw.get("module_args", {}).get("mon_node")
-    if module == "cephadm_bootstrap" and not mon_node:
-        raise ConfigNotFoundError(
-            "'cephadm_bootstrap' module requires 'mon_node' parameter"
-        )
 
-    try:
-        Rpm(installer).query("cephadm-ansible")
-    except RpmError:
-        ceph_cluster.setup_ssh_keys()
-        EnableToolsRepositories().run(installer)
-
-        Package(installer).install("cephadm-ansible")
-
-        ConfigureCephadmAnsibleInventory().run(nodes)
-        Ansible(installer).run_playbook(
-            playbook=CEPHADM_PREFLIGHT_PLAYBOOK,
-            extra_vars=CEPHADM_PREFLIGHT_VARS,
-        )
-
-    extra_vars = aw.get("extra_vars")
-    extra_args = aw.get("extra_args")
     if module == "cephadm_bootstrap" and mon_node:
-        if not extra_vars:
-            extra_vars = {}
+        nodes = ceph_cluster.get_nodes()
         extra_vars["mon_ip"] = get_node_ip(nodes, mon_node)
-    put_cephadm_ansible_playbook(installer, playbook)
-    Ansible(installer).run_playbook(
-        playbook=os.path.basename(playbook),
-        extra_vars=extra_vars,
-        extra_args=extra_args,
-    )
+        if config.get("build_type") not in ["ga", "ga-async"]:
+            extra_vars["image"] = config.get("container_image")
 
-    if not CephAdm(installer).ceph.status():
-        raise CephadmOpsExecutionError("Failed to bootstrap cluster")
+    installer = ceph_cluster.get_ceph_object("installer")
+    playbook = aw.get("playbook")
+    validate_cephadm_ansible_module(installer, playbook, extra_vars, extra_args)
 
     return 0


### PR DESCRIPTION
Fix consists of -
- Refactoring of test case `tests/cephadm/test_cephadm_ansible_wrapper.py`
- Add test suite `test_cephadm_ansible_wrapper.yaml` for quincy
- Update playbook `bootstrap-cluster.yml` to add `image` parameter for downstream ceph image


Signed-off-by: Vaibhav Mahajan <vamahaja@redhat.com>