### PR TITLE
add support for kafka broker with rgw ssl

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -1091,3 +1091,19 @@ suites:
       - ibmc
       - dmfg
       - stage-5
+
+  - name: "test-rgw-ssl-bucket-notifications"
+    suite: "suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml"
+    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+    platform: "rhel-9"
+    rhbuild: "6.0"
+    inventory:
+      openstack: "conf/inventory/rhel-9-latest.yaml"
+      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+    metadata:
+      - sanity
+      - tier-2
+      - openstack
+      - ibmc
+      - rgw
+      - stage-3

--- a/suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml
@@ -1,0 +1,81 @@
+# Tier 2: RGW kafka tests with ssl
+
+# The primary objective of the test suite is to evaluate the notification functionality with kafka endpoint
+
+# Requires a 5 node cluster layout having only one node with RGW role with SSL
+
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-dashboard: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgw.ssl
+                  placement:
+                    nodes:
+                      - node5
+                  spec:
+                    ssl: true
+                    rgw_frontend_ssl_certificate: create-cert
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+      polarion-id: CEPH-83573777
+
+
+  # kafka broker type broker with persistent flag enabled
+  - test:
+      name: notify put,delete events with kafka_broker_persistent with rgw ssl
+      desc: notify put,delete events with kafka_broker_persistent with rgw ssl
+      module: sanity_rgw.py
+      polarion-id: CEPH-83574489
+      config:
+        run-on-rgw: true
+        extra-pkgs:
+          - java
+        install_start_kafka: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
+        timeout: 300


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Add support to test bucket notification with kafka broker with rgw with ssl.
Polarion - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574489 

logs- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-dczpm

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
