### PR TITLE
Fixing cos upload directory

### DIFF
--- a/pipeline/scripts/ci/cos_cli.py
+++ b/pipeline/scripts/ci/cos_cli.py
@@ -10,6 +10,7 @@ import sys
 from docopt import docopt
 
 from storage.ibm_cos import CloudObjectStorage
+from utility.retry import retry
 
 LOG = logging.getLogger(__name__)
 
@@ -83,6 +84,7 @@ def delete_objfile(bucket: str, obj_key: str):
     LOG.info(f"Deleted successfully the file object({obj_key})")
 
 
+@retry(BaseException, tries=5, delay=30)
 def upload_directory(bucket: str, local_dir: str, prefix: str) -> None:
     """
     Uploads the given file to the provided bucket with the mentioned name.


### PR DESCRIPTION
Fixing cos upload directory

Issue : 
We are seeing intermittent issue while uploading the logs files to object store of IBM-C
https://159.23.92.24/job/rhceph-test-execution-pipeline/906/console
```
2023-01-21 11:25:38,308 (ibmcos.aspera) [INFO] - Queue processing thread started
2023-01-21 11:25:39,757 (ibmcos.aspera) [INFO] - ASCP process queue - Max(10) InUse(0) Free(10) New(1)
2023-01-21 11:25:39,870 (ibmcos.aspera) [INFO] - 553ab1bd5220-c8963ec0744c : INIT
2023-01-21 11:25:40,440 (ibmcos.aspera) [INFO] - 553ab1bd5220-c8963ec0744c : ERROR
2023-01-21 11:25:40,440 (ibmcos.aspera) [ERROR] - AsperaTransferFailedError : Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat
2023-01-21 11:25:40,440 (ibmcos.aspera) [INFO] - Remove from processing queue count=1
2023-01-21 11:25:40,440 (ibmcos.aspera) [INFO] - Freeing resources: 094e8b32-f45a-451b-9255-553ab1bd5220
2023-01-21 11:25:41,567 (ibmcos.aspera) [INFO] - Queue processing thread stopped
2023-01-21 11:25:41,568 (__main__) [ERROR] - Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat
```

Solution:
We have added a retry of the upload of logs for 5 times and it has been successful all the time
```
[root@ceph-qe-jenkins-agent-02 rhceph-test-execution-pipeline@2]# /data/jenkins/workspace/rhceph-test-execution-pipeline@2/.venv/bin/python pipeline/scripts/ci/cos_cli.py upload_directory /data/jenkins/workspace/rhceph-test-execution-pipeline@2/ibm_rhceph-test-execution-pipeline_908 ibm_rhceph-test-execution-pipeline_908 qe-ci-reports
/data/jenkins/workspace/rhceph-test-execution-pipeline@2/utility/utils.py:19: CryptographyDeprecationWarning: Python 3.6 is no longer supported by the Python core team. Therefore, support for it is deprecated in cryptography. The next release of cryptography (40.0) will be the last to support Python 3.6.
  from cryptography import x509
/data/jenkins/workspace/rhceph-test-execution-pipeline@2/.venv/lib64/python3.6/site-packages/ibm_s3transfer/aspera/futures.py:28: UserWarning: Using Aspera through the COS SDK is deprecated. Refer to the project readme: https://github.com/IBM/ibm-cos-sdk-python
  warnings.warn("Using Aspera through the COS SDK is deprecated. Refer to the project readme: https://github.com/IBM/ibm-cos-sdk-python")
2023-01-22 12:30:13,623 (ibmcos.aspera) [WARNING] - Using Aspera through the COS SDK is deprecated. Refer to the project readme: https://github.com/IBM/ibm-cos-sdk-python
2023-01-22 12:30:13,625 (ibmcos.aspera) [INFO] - Queue processing thread started
2023-01-22 12:30:14,232 (ibmcos.aspera) [INFO] - ASCP process queue - Max(10) InUse(0) Free(10) New(1)
2023-01-22 12:30:14,344 (ibmcos.aspera) [INFO] - 371b874a9ff1-24977f8d3a38 : INIT
2023-01-22 12:30:14,917 (ibmcos.aspera) [INFO] - 371b874a9ff1-24977f8d3a38 : ERROR
2023-01-22 12:30:14,918 (ibmcos.aspera) [ERROR] - AsperaTransferFailedError : Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat
2023-01-22 12:30:14,918 (ibmcos.aspera) [INFO] - Remove from processing queue count=1
2023-01-22 12:30:14,918 (ibmcos.aspera) [INFO] - Freeing resources: c9d464aa-e4df-460a-b628-371b874a9ff1
2023-01-22 12:30:16,036 (ibmcos.aspera) [INFO] - Queue processing thread stopped
2023-01-22 12:30:16,071 (cephci.utility.utils) [WARNING] - cephci.utility.retry.py:28 - Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat, Retrying in 30 seconds...
2023-01-22 12:30:46,095 (ibmcos.aspera) [INFO] - Queue processing thread started
2023-01-22 12:30:46,952 (ibmcos.aspera) [INFO] - ASCP process queue - Max(10) InUse(0) Free(10) New(1)
2023-01-22 12:30:47,062 (ibmcos.aspera) [INFO] - 2ebd6ad0b868-68e24bf303b2 : INIT
2023-01-22 12:30:48,115 (ibmcos.aspera) [INFO] - 2ebd6ad0b868-68e24bf303b2 : ERROR
2023-01-22 12:30:48,115 (ibmcos.aspera) [ERROR] - AsperaTransferFailedError : Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat
2023-01-22 12:30:48,115 (ibmcos.aspera) [INFO] - Remove from processing queue count=1
2023-01-22 12:30:48,115 (ibmcos.aspera) [INFO] - Freeing resources: 5cafe3e5-99ca-4b5a-a440-2ebd6ad0b868
2023-01-22 12:30:49,249 (ibmcos.aspera) [INFO] - Queue processing thread stopped
2023-01-22 12:30:49,250 (cephci.utility.utils) [WARNING] - cephci.utility.retry.py:28 - Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat, Retrying in 60 seconds...
2023-01-22 12:31:49,295 (ibmcos.aspera) [INFO] - Queue processing thread started
2023-01-22 12:31:49,719 (ibmcos.aspera) [INFO] - ASCP process queue - Max(10) InUse(0) Free(10) New(1)
2023-01-22 12:31:49,830 (ibmcos.aspera) [INFO] - 002a12a574b9-1e09c496b176 : INIT
2023-01-22 12:31:50,482 (ibmcos.aspera) [INFO] - 002a12a574b9-1e09c496b176 : ERROR
2023-01-22 12:31:50,482 (ibmcos.aspera) [ERROR] - AsperaTransferFailedError : Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat
2023-01-22 12:31:50,482 (ibmcos.aspera) [INFO] - Remove from processing queue count=1
2023-01-22 12:31:50,483 (ibmcos.aspera) [INFO] - Freeing resources: 6b1c1ae3-7719-48d9-b00e-002a12a574b9
2023-01-22 12:31:51,592 (ibmcos.aspera) [INFO] - Queue processing thread stopped
2023-01-22 12:31:51,592 (cephci.utility.utils) [WARNING] - cephci.utility.retry.py:28 - Server aborted session: Docroot check failed: Failed to authenticate: : Error getting token from delegated refresh token: aspera.clouds.ibm.icos.oauth.IbmOAuthException: Wrong client id passed to retrieve tokens for a delegated refresh token. (The delegat, Retrying in 120 seconds...
2023-01-22 12:33:51,596 (ibmcos.aspera) [INFO] - Queue processing thread started
2023-01-22 12:33:52,259 (ibmcos.aspera) [INFO] - ASCP process queue - Max(10) InUse(0) Free(10) New(1)
2023-01-22 12:33:52,371 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : INIT
2023-01-22 12:33:55,035 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,149 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,303 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,319 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,323 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,467 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,502 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,531 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,531 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,561 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,561 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : STATS
2023-01-22 12:33:55,864 (ibmcos.aspera) [INFO] - 3103c51f5033-eeb157041a43 : DONE
2023-01-22 12:33:55,864 (ibmcos.aspera) [INFO] - Remove from processing queue count=1
2023-01-22 12:33:55,864 (ibmcos.aspera) [INFO] - Freeing resources: c0711d54-b31a-4884-b757-3103c51f5033
2023-01-22 12:33:56,943 (ibmcos.aspera) [INFO] - Queue processing thread stopped
2023-01-22 12:33:56,943 (storage.ibm_cos) [INFO] - Successfully uploaded contents of /data/jenkins/workspace/rhceph-test-execution-pipeline@2/ibm_rhceph-test-execution-pipeline_908
2023-01-22 12:33:56,944 (__main__) [INFO] - Successfully upload the object to IBM COS !!!
```

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
