### PR TITLE
[LibFix] Add different classes in `install_prereq.py` to configure CephAdm Ansible node

### DIFF
--- a/utility/install_prereq.py
+++ b/utility/install_prereq.py
@@ -1,19 +1,18 @@
-from ceph.utils import setup_repos
+from cli.cephadm.ansible import Ansible
 from cli.utilities.packages import Package, SubscriptionManager
-from cli.utilities.utils import get_custom_repo_url, os_major_version
-from utility.log import Log
-from utility.utils import fetch_build_artifacts
+from cli.utilities.utils import get_builds_by_rhbuild, get_custom_repo_url
 
-RHEL8_EPEL_RELESE_RPM = (
-    "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
-)
-RHCEPH5_TOOLS_REPO = "rhceph-5-tools-for-rhel-{}-x86_64-rpms"
 RHEL8_ANSIBLE_REPO = "ansible-2.9-for-rhel-8-x86_64-rpms"
+
+RHCS5_REPOS = {
+    "rhel-8": "rhceph-5-tools-for-rhel-8-x86_64-rpms",
+    "rhel-9": "rhceph-5-tools-for-rhel-9-x86_64-rpms",
+}
+RHCS6_REPOS = {"rhel-9": "rhceph-6-tools-for-rhel-9-x86_64-rpms"}
 
 CEPHADM_ANSIBLE_PATH = "/usr/share/cephadm-ansible"
 CEPHADM_INVENTORY_PATH = f"{CEPHADM_ANSIBLE_PATH}/hosts"
-
-log = Log(__name__)
+CEPHADM_PREFLIGHT_PLAYBOOK = "cephadm-preflight.yml"
 
 
 class ConfigureCephadmAnsibleInventoryError(Exception):
@@ -24,6 +23,55 @@ class EnableToolsRepositoriesError(Exception):
     pass
 
 
+class ConfigureCephToolsRepositoriesError(Exception):
+    pass
+
+
+class ConfigureCephadmAnsibleNodeError(Exception):
+    pass
+
+
+class ExecutePreflightPlaybook:
+    """Execute cephadm-preflight.yaml playbook"""
+
+    @staticmethod
+    def run(installer, base_url, cloud_type, build_type):
+        base_url = get_custom_repo_url(base_url, cloud_type)
+        extra_vars = {"ceph_origin": "rhcs"}
+        if build_type not in ["ga", "ga-async"]:
+            extra_vars = {
+                "ceph_origin": "custom",
+                "gpgcheck": "no",
+                "custom_repo_url": base_url,
+            }
+
+        Ansible(installer).run_playbook(
+            playbook=CEPHADM_PREFLIGHT_PLAYBOOK,
+            extra_vars=extra_vars,
+        )
+
+
+class ConfigureCephadmAnsibleNode:
+    """Install cephadm-ansible and configure node"""
+
+    @staticmethod
+    def run(installer, nodes, build_type, base_url, rhbuild, cloud_type):
+        base_url = get_custom_repo_url(base_url, cloud_type)
+
+        ConfigureCephToolsRepositories().run(installer, build_type, base_url, rhbuild)
+
+        _, rhel = get_builds_by_rhbuild(rhbuild)
+        if rhel == "rhel-8" and SubscriptionManager(installer).repos.enable(
+            RHEL8_ANSIBLE_REPO
+        ):
+            raise ConfigureCephadmAnsibleNodeError(
+                f"Failed to enable ansible repo '{RHEL8_ANSIBLE_REPO}' on node '{installer}'"
+            )
+
+        Package(installer).install("cephadm-ansible", nogpgcheck=True)
+        ConfigureCephadmAnsibleInventory().run(nodes)
+
+
 class ConfigureCephadmAnsibleInventory:
     """Configures cephadm ansible inventory."""
 
@@ -31,10 +79,17 @@ class ConfigureCephadmAnsibleInventory:
     def run(nodes):
         nodes = nodes if isinstance(nodes, list) else [nodes]
 
-        _admins, _clients, _others, _installer = "[admin]", "[client]", "", None
+        installer = None
+        _admins, _clients, _installer, _others = (
+            "[admin]",
+            "[client]",
+            "[installer]",
+            "",
+        )
         for node in nodes:
             if node.role == "installer":
-                _installer = node
+                installer = node
+                _installer += f"\n{node.shortname}"
 
             _roles = node.role.role_list
             if "_admin" in _roles:
@@ -49,77 +104,44 @@ class ConfigureCephadmAnsibleInventory:
                 "Admin(_admin) nodes not found..."
             )
 
-        cmd = f"echo -e '{_others}\n\n{_clients}\n\n{_admins}\n' > {CEPHADM_INVENTORY_PATH}"
-        _installer.exec_command(sudo=True, cmd=cmd)
-        log.info(f"Generated inventory file at '{CEPHADM_INVENTORY_PATH}'.")
+        cmd = f"echo -e '{_others}\n\n{_clients}\n\n{_admins}\n\n{_installer}\n' > {CEPHADM_INVENTORY_PATH}"
+        installer.exec_command(sudo=True, cmd=cmd)
 
 
-class EnableToolsRepositories:
-    """Enables tools repositories."""
-
-    @staticmethod
-    def run(nodes):
-        nodes = nodes if isinstance(nodes, list) else [nodes]
-        for node in nodes:
-            stdout, _ = os_major_version(node)
-            repos = [RHCEPH5_TOOLS_REPO.format(stdout.strip())]
-            if stdout.strip() == "8":
-                repos.append(RHEL8_ANSIBLE_REPO)
-
-            if SubscriptionManager(node).repos.enable(repos):
-                raise EnableToolsRepositoriesError("Failed to enable tools repo.")
-
-        log.info("Enabled tools repos on cluster nodes successfully.")
-
-
-class ConfigureCephadmRepositories:
+class ConfigureCephToolsRepositories:
     """Configures Ceph and Cephadm related repositories."""
 
     @staticmethod
-    def run(nodes, args, config):
+    def run(nodes, build_type, base_url, rhbuild):
         """Install and configure cephadm package.
 
         Args:
-            args (dict): key/value pairs passed from the test case
-            config (dict): key/value pairs passed from the cluster config
+            nodes (CephNode | List ): CephNode or list of CephNode object
+            build_type (str): Build type
+            base_url (str): Custom repo build url
+            rhbuild (str): RHCS build version with RHEL
         """
-        nodes = nodes if isinstance(nodes, list) else [nodes]
-        pkg = Package(nodes)
+        if build_type in ["latest", "tier-0", "tier-1", "tier-2", "rc", "upstream"]:
+            Package(nodes).add_repo(base_url)
 
-        custom_repo = args.get("custom_repo")
-        rhcs_version = args.get("rhcs-version")
-        rhcs_release = args.get("release")
+        elif build_type in ["ga", "ga-async"]:
+            rhcs, rhel = get_builds_by_rhbuild(rhbuild)
+            repos = RHCS5_REPOS
+            if int(float(rhcs)) == 6:
+                repos = RHCS6_REPOS
 
-        build_type = config.get("build_type")
-        rhbuild = config.get("rhbuild")
-        base_url = config.get("base_url")
-        cloud_type = config.get("cloud-type", "openstack")
+            repos = repos.get(rhel)
+            if not repos:
+                raise EnableToolsRepositoriesError(
+                    f"'{rhel}' not supported for RHCS {rhcs}"
+                )
 
-        if rhcs_release and rhcs_version:
-            _platform = "-".join(rhbuild.split("-")[1:])
-            _details = fetch_build_artifacts(rhcs_release, rhcs_version, _platform)
-            config["base_url"] = _details[0]
+            if not SubscriptionManager(nodes).repos.enable(repos):
+                raise EnableToolsRepositoriesError(
+                    f"Failed to enable tools repo '{repos}' on node '{nodes}'"
+                )
 
-        if build_type == "upstream":
-            pkg.add_repo(config.get("base_url"))
-            pkg.install(RHEL8_EPEL_RELESE_RPM)
-            pkg.clean()
-
-            # Enabling cdn tool repo to workaround, due to unavailability of
-            # ceph x86_64 RPM pkgs in upstream builds
-            EnableToolsRepositories.run(nodes)
-        elif build_type == "released" or custom_repo.lower() == "cdn":
-            EnableToolsRepositories.run(nodes)
-        elif custom_repo:
-            base_url = get_custom_repo_url(repo=custom_repo)
-            pkg.add_repo(base_url, nogpgcheck=True)
-            pkg.clean()
-
-            log.info(f"Added repo {base_url} on cluster nodes successfully.")
         else:
-            repos = ["Tools"]
-            for node in nodes:
-                setup_repos(node, base_url=base_url, repos=repos, cloud_type=cloud_type)
+            raise ConfigureCephToolsRepositoriesError("Required repos are not provided")
 
-        log.info("Configured cephadm repositories successfully")
         return True


### PR DESCRIPTION
Fix consists of -

-  `ConfigureCephadmAnsibleNode` class which enables RHCS tools repo &  installs `cephadm-ansible` packages
- `ExecutePreflightPlaybook` class which executes `cephadm-preflight.yaml` playbook
- Update `ConfigureCephToolsRepositories` to configure tools repo based on build type provided

Signed-off-by: Vaibhav Mahajan <vamahaja@redhat.com>
