### PR TITLE
Changing the metadata file format to a more readable one

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -7,1283 +7,1028 @@
 # parameter required to create a similar custom file is suite name, suite yaml file, global configuration file,
 # platform, rhbuild, inventory and metadata information like frequency of execution, tier, cloud type, functional group and stage.
 #=====================================================================================
-suites:
-  - name: "Smoke test of RH Ceph build"
-    suite: "suites/pacific/cephadm/tier-0.yaml"
-    global-conf: "conf/pacific/cephadm/tier-0.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-0
-      - cvp
-      - rc
-      - live
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-1
+overrides:
+  rhbuild: "5.3"
+  # log_dir: "" #other override parameters common to cloud can also be specified here.
+
+pipelines:
+  sanity:
+    tier-0:
+      stage-1:
+        - name: "Smoke test of RH Ceph build"
+          execution_time: "28m 21s"
+          suite: "suites/pacific/cephadm/tier-0.yaml"
+          global-conf: "conf/pacific/cephadm/tier-0.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "51m 31s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Upgrade cluster from 5x GA to 5x latest"
+          execution_time: "55m 54s"
+          suite: "suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          global-conf: "conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+        - name: "Tier-1 test suite for 5x for RBD functionality"
+          execution_time: "43m 47s"
+          suite: "suites/pacific/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-0 Fs"
+          execution_time: "35m 48s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+      stage-2:
+        - name: "Tier-0 test suite for 5x for RGW sanity"
+          execution_time: "1h 16m 25s"
+          suite: "suites/pacific/rgw/tier-0_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Deploy all services at 5x using a spec file"
+          execution_time: "1h 18m 12s"
+          suite: "suites/pacific/cephadm/test-container-cli-args.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy 5x cluster and apply services through cli"
+          execution_time: "1h 9m 19s"
+          suite: "suites/pacific/cephadm/tier-0_5-1_cephadm.yaml"
+          global-conf: "conf/pacific/cephadm/sanity-cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Tier-1 test suite for 5x for RBD-mirror functionality"
+          execution_time: "1h 9m 55s"
+          suite: "suites/pacific/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+      stage-3:
+        - name: "Tier-1 Fs"
+          execution_time: "2h 22m 34s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 59m 25s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+    tier-2:
+      stage-1:
+        - name: "Tier-2 Cephfs test clients"
+          execution_time: "26m 34s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "RADOS regression testing osd rebalance with many pools"
+          execution_time: "32m 39s"
+          suite: "suites/pacific/rados/tier-2_rados_test-osd-rebalance-many-pools.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 Cephfs test Multifs"
+          execution_time: "32m 44s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Tier-2 RGW secure MultiSite RHCS 5 GA to the latest development build"
+          execution_time: "32m 47s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS robust osd rebalance scenarios"
+          execution_time: "33m 45s"
+          suite: "suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rados
+      stage-2:
+        - name: "Tier-2 Cephfs test Volume Management"
+          execution_time: "39m 25s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Tier-2 Cephfs test Nfs"
+          execution_time: "40m 14s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "test-5.3-specific-fixes"
+          execution_time: "41m 40s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RGW multi-realm deployment"
+          execution_time: "43m 33s"
+          suite: "suites/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RGW testing using S3CMD CLI commands"
+          execution_time: "45m 21s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
+          execution_time: "48m 37s"
+          suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-lc-process-single-bucket"
+          execution_time: "57m 49s"
+          suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing extended RGW multisite bucket granular sync policy from primary"
+          execution_time: "1h 0m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test mds pinning"
+          execution_time: "1h 7m 50s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing RADOS EC Pool recovery"
+          execution_time: "1h 11m 4s"
+          suite: "suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rados
+      stage-4:
+        - name: "Testing RADOS basic regression scenarios"
+          execution_time: "1h 13m 5s"
+          suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
+          global-conf: "conf/pacific/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Upgrade cluster from 4x RPM to 5x containerised"
+          execution_time: "1h 35m 17s"
+          suite: "suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml"
+          global-conf: "conf/pacific/upgrades/upgrades.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+        - name: "Tier-2 RGW bucket notification on the latest development build"
+          execution_time: "1h 39m 47s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test quota"
+          execution_time: "1h 42m 55s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
+          execution_time: "1h 54m 39s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+      stage-5:
+        - name: "RADOS regression testing for stretched Clusters"
+          execution_time: "2h 4m 34s"
+          suite: "suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 RGW multisite test async data notifications on 5.3"
+          execution_time: "2h 14m 43s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing extended RGW multisite secondary to primary"
+          execution_time: "2h 21m 51s"
+          suite: "suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RGW STS functionality testing"
+          execution_time: "2h 26m 55s"
+          suite: "suites/pacific/rgw/tier-1-extn_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-6:
+        - name: "test-rgw-ms-bilog-crash-on-primary"
+          execution_time: "2h 47m 38s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-ecpool-ms-bucket-objects-gc-policy-on-secondary"
+          execution_time: "2h 58m 35s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 RGW single site upgrade from 5.x GA to latest developmet build"
+          execution_time: "2h 58m 22s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+  schedule:
+    tier-1:
+      stage-1:
+        - name: "test-rgw-lc-expiration-multiple-bucket"
+          execution_time: "38m 4s"
+          suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test to validate dashboard alerts"
+          execution_time: "45m 8s"
+          suite: "suites/pacific/dashboard/tier-1_dashboard_alerts.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "test-rgw-ms-upgrade-4-to-latest"
+          execution_time: "1h 43m 44s"
+          suite: "suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-upgrade-5-to-latest"
+          execution_time: "1h 45m 14s"
+          suite: "suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+      stage-2:
+        - name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
+          execution_time: "3h 16m 59s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-upgrade-4-to-latest"
+          execution_time: "3h 35m 59s"
+          suite: "suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/upgrades.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for Stretch mode upgrade"
+          execution_time: "3h 39m 11s"
+          suite: "suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
+          execution_time: "3h 51m 55s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
+          execution_time: "4h 15m 13s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ms-upgrade-5-to-latest"
+          execution_time: "4h 52m 14s"
+          suite: "suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-upgrade-4-to-latest"
+          execution_time: "5h 2m 8s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
+          global-conf: "conf/pacific/rgw/upgrades.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
+          execution_time: "5h 10m 58s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rbd-mirror-upgrade-4-to-latest"
+          execution_time: ""
+          suite: "suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-4-to-latest.yaml"
+          global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+            - again
+    tier-2:
+      stage-1:
+        - name: "Tier-2 test suite for 5x - RBD CLI regression"
+          execution_time: "23m 11s"
+          suite: "suites/pacific/rbd/tier-2_rbd_cli_regression.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-tech-preview"
+          execution_time: "28m 55s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for in-progress osd rebalance"
+          execution_time: "41m 41s"
+          suite: "suites/pacific/rados/tier-2_rados_test-osd-inprogress-rebalance.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 test suite for 5x - RBD functionality"
+          execution_time: "42m 41s"
+          suite: "suites/pacific/rbd/tier-2_rbd_regression.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-quota-management"
+          execution_time: "46m 42s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+      stage-2:
+        - name: "Bootstrap cluster with custom ssl dashboard port and apply-spec"
+          execution_time: "52m 0s"
+          suite: "suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip dashboard and custom ceph directory testing"
+          execution_time: "1h 29m 8s"
+          suite: "suites/pacific/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "test-rgw-singlesite-with-archive"
+          execution_time: "1h 36m 24s"
+          suite: "suites/pacific/rgw/tier-2_rgw_archive.yaml"
+          global-conf: "conf/pacific/rgw/rgw_archive.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing scale up and scale down functionality after upgrade from 5x cdn to 5x latest"
+          execution_time: "1h 42m 24s"
+          suite: "suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml"
+          global-conf: "conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+        - name: "test-rgw-ms-dynamic-bucket-resharding"
+          execution_time: "1h 48m 22s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "test-rgw-ms-with-archive"
+          execution_time: "2h 18m 17s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ms-archive.yaml"
+          global-conf: "conf/pacific/rgw/rgw_ms_archive.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+          execution_time: "2h 20m 45s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-singlesite-to-multisite-tier-2"
+          execution_time: "3h 10m 1s"
+          suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
+          execution_time: "3h 20m 34s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RADOS regression for testing various pool functionalities"
+          execution_time: "3h 22m 56s"
+          suite: "suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rados
+      stage-4:
+        - name: "Tier-2 test suite for 5x - RBD Snapshot mirroring functionality"
+          execution_time: "3h 56m 3s"
+          suite: "suites/pacific/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
+          global-conf: "conf/pacific/rbd/tier-2_rbd_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "RGW Regression testing"
+          execution_time: "4h 49m 28s"
+          suite: "suites/pacific/rgw/tier-2_rgw_regression.yaml"
+          global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing scale up and scale down functionality after upgrade from 4x cdn to 5x latest"
+          execution_time: ""
+          suite: "suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml"
+          global-conf: "conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+            - again
+        - name: "test-cephfs-upgrade-4-to-latest"
+          execution_time: ""
+          suite: "suites/pacific/cephfs/tier-2_cephfs_upgrade_4x_5x.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_upgrade.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+            - upgrades
+            - again
+        - name: "Testing RADOS regression for ec pool osd rebalance"
+          execution_time: ""
+          suite: "suites/pacific/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+            - again
+  sanity_openstack_only:
+    tier-1:
+      stage-1:
+        - name: "Tier-0 test suite for 5x for RBD sanity"
+          execution_time: "36m 53s"
+          suite: "suites/pacific/rbd/tier-0_rbd.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 Cephfs test Snapshot Clone"
+          execution_time: "1h 18m 39s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+    tier-2:
+      stage-1:
+        - name: "S3Tests against Red Hat RGW with SSL"
+          execution_time: "1h 46m 37s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml"
+          global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RADOS regression testing for Mon DB trimming"
+          execution_time: "2h 6m 51s"
+          suite: "suites/pacific/rados/tier-2_rados_test-mon-db-trimming.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+          metadata:
+            - rados
+  schedule_openstack_only:
+    tier-2:
+      stage-1:
+        - name: "Test multiple path upgrade to 5x latest"
+          execution_time: ""
+          suite: "suites/pacific/upgrades/tier-2_upgrade_test-multi-path-upgrade-to-5.2-latest.yaml"
+          global-conf: "conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+            - again
+        - name: "RADOS regression testing for Scrubbing scenarios"
+          execution_time: "6h 59m 45s"
+          suite: "suites/pacific/rados/tier-2_rados_test-scrubbing.yaml"
+          global-conf: "conf/pacific/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Testing RADOS regression for slow op requests"
+          execution_time: "1h 40m 1s"
+          suite: "suites/pacific/rados/tier-2_rados_test-slow-op-requests.yaml"
+          global-conf: "conf/pacific/rados/11-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+          metadata:
+            - rados
+        - name: "test cephadm cluster bootstrap with mutiple public network"
+          execution_time: "29m 34s"
+          suite: "suites/pacific/cephadm/customer_bz/tier-2_multiple_subnet_openstack_only.yaml"
+          global-conf: "conf/pacific/cephadm/5-node-cluster-multiple-subnet-openstack-only.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "test-rgw-ingress-with-and-without-ssl-tier-2"
+          execution_time: ""
+          suite: "suites/pacific/rgw/tier-2_rgw_ingress_with_ssl.yaml"
+          global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+          metadata:
+            - rgw
+  rc:
+    tier-0:
+      stage-1:
+        - name: "Smoke test of RH Ceph build"
+          execution_time: "28m 21s"
+          suite: "suites/pacific/cephadm/tier-0.yaml"
+          global-conf: "conf/pacific/cephadm/tier-0.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "51m 31s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Upgrade cluster from 5x GA to 5x latest"
+          execution_time: "55m 54s"
+          suite: "suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          global-conf: "conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+        - name: "Tier-1 test suite for 5x for RBD functionality"
+          execution_time: "43m 47s"
+          suite: "suites/pacific/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-0 Fs"
+          execution_time: "35m 48s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+      stage-2:
+        - name: "Tier-0 test suite for 5x for RGW sanity"
+          execution_time: "1h 16m 25s"
+          suite: "suites/pacific/rgw/tier-0_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Deploy all services at 5x using a spec file"
+          execution_time: "1h 18m 12s"
+          suite: "suites/pacific/cephadm/test-container-cli-args.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy 5x cluster and apply services through cli"
+          execution_time: "1h 9m 19s"
+          suite: "suites/pacific/cephadm/tier-0_5-1_cephadm.yaml"
+          global-conf: "conf/pacific/cephadm/sanity-cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Tier-1 test suite for 5x for RBD-mirror functionality"
+          execution_time: "1h 9m 55s"
+          suite: "suites/pacific/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+      stage-3:
+        - name: "Tier-1 Fs"
+          execution_time: "2h 22m 34s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 59m 25s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+    tier-2:
+      stage-1:
+        - name: "Upgrade cluster from 4x RPM to 5x containerised"
+          execution_time: "1h 35m 17s"
+          suite: "suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml"
+          global-conf: "conf/pacific/upgrades/upgrades.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+  live:
+    tier-0:
+      stage-1:
+        - name: "Smoke test of RH Ceph build"
+          execution_time: "28m 21s"
+          suite: "suites/pacific/cephadm/tier-0.yaml"
+          global-conf: "conf/pacific/cephadm/tier-0.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Upgrade cluster from 5x GA to 5x latest"
+          execution_time: "55m 54s"
+          suite: "suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          global-conf: "conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+    tier-2:
+      stage-1:
+        - name: "Upgrade cluster from 4x RPM to 5x containerised"
+          execution_time: "1h 35m 17s"
+          suite: "suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml"
+          global-conf: "conf/pacific/upgrades/upgrades.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - upgrades
+            - dmfg
+  cvp:
+    tier-0:
+      stage-1:
+        - name: "Smoke test of RH Ceph build"
+          execution_time: "28m 21s"
+          suite: "suites/pacific/cephadm/tier-0.yaml"
+          global-conf: "conf/pacific/cephadm/tier-0.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
 
-  - name: "Deploy 5x cluster and apply services through cli"
-    suite: "suites/pacific/cephadm/tier-0_5-1_cephadm.yaml"
-    global-conf: "conf/pacific/cephadm/sanity-cephadm.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-2
-
-  - name: "Deploy all services at 5x using a spec file"
-    suite: "suites/pacific/cephadm/test-container-cli-args.yaml"
-    global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-1
-
-  - name: "Upgrade cluster from 5x GA to 5x latest"
-    suite: "suites/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
-    global-conf: "conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - rc
-      - live
-      - openstack
-      - ibmc
-      - upgrades
-      - dmfg
-      - stage-1
-
-  - name: "Upgrade cluster from 4x RPM to 5x containerised"
-    suite: "suites/pacific/upgrades/tier-1_upgrade_test-4x-to-5x-rpm.yaml"
-    global-conf: "conf/pacific/upgrades/upgrades.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - rc
-      - live
-      - openstack
-      - ibmc
-      - upgrades
-      - dmfg
-      - stage-4
-
-  - name: "Bootstrap cluster with skip dashboard and custom ceph directory testing"
-    suite: "suites/pacific/cephadm/tier-1_skip_dashboard.yaml"
-    global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-1
-
-  - name: "Bootstrap cluster with custom ssl dashboard port and apply-spec"
-    suite: "suites/pacific/cephadm/tier-1_ssl_dashboard_port.yaml"
-    global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-1
-
-  - name: "Test multiple path upgrade to 5x latest"
-    suite: "suites/pacific/upgrades/tier-2_upgrade_test-multi-path-upgrade-to-5-latest.yaml"
-    global-conf: "conf/pacific/upgrades/tier-1_upgrade_cephadm.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - upgrades
-      - dmfg
-      - stage-1
-
-  - name: "Testing scale up and scale down functionality after upgrade from 4x cdn to 5x latest"
-    suite: "suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-4-cdn-to-5-latest.yaml"
-    global-conf: "conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - upgrades
-      - dmfg
-      - stage-1
-
-  - name: "Testing scale up and scale down functionality after upgrade from 5x cdn to 5x latest"
-    suite: "suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml"
-    global-conf: "conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - upgrades
-      - dmfg
-      - stage-1
-
-  - name: "Tier-0 test suite for 5x for RBD sanity"
-    suite: "suites/pacific/rbd/tier-0_rbd.yaml"
-    global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - rc
-      - openstack-only
-      - rbd
-      - stage-1
-
-  - name: "Tier-1 test suite for 5x for RBD-mirror functionality"
-    suite: "suites/pacific/rbd/tier-1_rbd_mirror.yaml"
-    global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rbd
-      - stage-2
-
-  - name: "Tier-1 test suite for 5x for RBD functionality"
-    suite: "suites/pacific/rbd/tier-1_rbd.yaml"
-    global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rbd
-      - stage-1
-
-  - name: "Tier-2 test suite for 5x - RBD functionality"
-    suite: "suites/pacific/rbd/tier-2_rbd_regression.yaml"
-    global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rbd
-      - stage-2
-
-  - name: "Tier-2 test suite for 5x - RBD CLI regression"
-    suite: "suites/pacific/rbd/tier-2_rbd_cli_regression.yaml"
-    global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rbd
-      - stage-2
-
-  - name: "Testing RADOS basic regression scenarios"
-    suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
-    global-conf: "conf/pacific/rados/7-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-3
-
-  - name: "Tier-2 test suite for 5x - RBD Snapshot mirroring functionality"
-    suite: "suites/pacific/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
-    global-conf: "conf/pacific/rbd/tier-2_rbd_mirror.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rbd
-      - stage-3
-
-  - name: "Testing RADOS EC Pool recovery"
-    suite: "suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS robust osd rebalance scenarios"
-    suite: "suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "RADOS regression testing for stretched Clusters"
-    suite: "suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-4
-
-  - name: "RADOS regression for testing various pool functionalities"
-    suite: "suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "RADOS regression testing for Scrubbing scenarios"
-    suite: "suites/pacific/rados/tier-2_rados_test-scrubbing.yaml"
-    global-conf: "conf/pacific/rados/7-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-1
-
-  - name: "Testing RADOS regression for ec pool osd rebalance"
-    suite: "suites/pacific/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS regression for in-progress osd rebalance"
-    suite: "suites/pacific/rados/tier-2_rados_test-osd-inprogress-rebalance.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS regression for Stretch mode upgrade"
-    suite: "suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rados
-      - stage-1
-
-  - name: "Testing RADOS regression for slow op requests"
-    suite: "suites/pacific/rados/tier-2_rados_test-slow-op-requests.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-3
-
-  - name: "RADOS regression testing for Mon DB trimming"
-    suite: "suites/pacific/rados/tier-2_rados_test-mon-db-trimming.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-4
-
-  - name: "RADOS regression testing osd rebalance with many pools"
-    suite: "suites/pacific/rados/tier-2_rados_test-osd-rebalance-many-pools.yaml"
-    global-conf: "conf/pacific/rados/11-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-5
-
-  - name: "Tier-0 test suite for 5x for RGW sanity"
-    suite: "suites/pacific/rgw/tier-0_rgw.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - rc
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-sse-s3-encryption-tech-preview"
-    suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "Testing Rgw Single site"
-    suite: "suites/pacific/rgw/tier-1_rgw.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-ssl-ecpool-ms-bucket-objects-gc-policy-on-secondary"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "Testing RGW multi-realm deployment"
-    suite: "suites/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-5
-
-  - name: "test-rgw-ms-bilog-crash-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "Testing extended RGW multisite secondary to primary"
-    suite: "suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "Testing extended RGW multisite bucket granular sync policy from primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "RGW Regression testing"
-    suite: "suites/pacific/rgw/tier-2_rgw_regression.yaml"
-    global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "S3Tests against Red Hat RGW with SSL"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml"
-    global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - rgw
-      - stage-1
-
-  - name: "RGW STS functionality testing"
-    suite: "suites/pacific/rgw/tier-1-extn_rgw.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
-    suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "RGW testing using S3CMD CLI commands"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Tier-2 RGW bucket notification on the latest development build"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Tier-2 RGW secure MultiSite RHCS 5 GA to the latest development build"
-    suite: "suites/pacific/rgw/tier-1_rgw_ssl_multisite_test-upgrade-5-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "Tier-2 RGW single site upgrade from 5.x GA to latest developmet build"
-    suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "Tier-2 RGW multisite test async data notifications on 5.3"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "Tier-0 Fs"
-    suite: "suites/pacific/cephfs/tier-0_fs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - rc
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "Tier-1 Fs"
-    suite: "suites/pacific/cephfs/tier-1_fs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-1 Cephfs Mirror"
-    suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
-    global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-2
-
-  - name: "Tier-2 Cephfs test clients"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "Tier-2 Cephfs test Multifs"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-2 Cephfs test Nfs"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test quota"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-2 Cephfs test Snapshot Clone"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test Volume Management"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test mds pinning"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "test-lc-process-single-bucket"
-    suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "test-rgw-ms-upgrade-4-to-latest"
-    suite: "suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ms-upgrade-5-to-latest"
-    suite: "suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ssl-upgrade-4-to-latest"
-    suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-4-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/upgrades.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-upgrade-4-to-latest"
-    suite: "suites/pacific/rgw/tier-1_rgw_test-upgrade-4-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/upgrades.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-upgrade-5-to-latest"
-    suite: "suites/pacific/rgw/tier-1_rgw_test_upgrade-5-to-latest.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-lc-expiration-multiple-bucket"
-    suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-5.3-specific-fixes"
-    suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-singlesite-to-multisite-tier-2"
-    suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ingress-with-and-without-ssl-tier-2"
-    suite: "suites/pacific/rgw/tier-2_rgw_ingress_with_ssl.yaml"
-    global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rgw
-      - stage-1
-
-  - name: "test cephadm cluster bootstrap with mutiple public network"
-    suite: "suites/pacific/cephadm/customer_bz/tier-2_multiple_subnet_openstack_only.yaml"
-    global-conf: "conf/pacific/cephadm/5-node-cluster-multiple-subnet-openstack-only.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - dmfg
-      - stage-7
-
-  - name: "test to validate dashboard alerts"
-    suite: "suites/pacific/dashboard/tier-1_dashboard_alerts.yaml"
-    global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-
-  - name: "test-rgw-quota-management"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-6
-
-  - name: "test-cephfs-upgrade-4-to-latest"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_upgrade_4x_5x.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_upgrade.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - upgrades
-      - stage-1
-
-  - name: "test-rgw-singlesite-with-archive"
-    suite: "suites/pacific/rgw/tier-2_rgw_archive.yaml"
-    global-conf: "conf/pacific/rgw/rgw_archive.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ms-dynamic-bucket-resharding"
-    suite: "suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-7
-
-  - name: "test-rgw-ms-with-archive"
-    suite: "suites/pacific/rgw/tier-2_rgw_ms-archive.yaml"
-    global-conf: "conf/pacific/rgw/rgw_ms_archive.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-7
-
-  - name: "test-rbd-mirror-upgrade-4-to-latest"
-    suite: "suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-4-to-latest.yaml"
-    global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rbd
-      - stage-2

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -22,1168 +22,1088 @@ overrides:
       - "haproxy_image=registry-proxy.engineering.redhat.com/rh-osbs/haproxy:ceph-6.0-rhel-9-containers-candidate-53939-20221026121907"
       - "keepalived_image=registry-proxy.engineering.redhat.com/rh-osbs/keepalived:ceph-6.0-rhel-9-containers-candidate-18945-20221026120854"
       - "snmp_gateway_image=registry-proxy.engineering.redhat.com/rh-osbs/snmp-notifier:ceph-6.0-rhel-9-containers-candidate-15559-20221026120853"
+  rhbuild: "6.0"
   # log_dir: "" #other override parameters common to cloud can also be specified here.
 
-suites:
-  - name: "Smoke Test of RH Ceph build"
-    suite: "suites/quincy/cephadm/tier-0.yaml"
-    global-conf: "conf/quincy/cephadm/tier-0.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-0
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-1
-      - rc
-
-  - name: "Testing RADOS basic regression scenarios"
-    suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
-    global-conf: "conf/quincy/rados/7-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-3
-
-  - name: "Testing RADOS EC Pool recovery"
-    suite: "suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS robust osd rebalance scenarios"
-    suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "RADOS regression testing for stretched Clusters"
-    suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-4
-
-  - name: "RADOS regression for testing various pool functionalities"
-    suite: "suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "RADOS regression testing for Scrubbing scenarios"
-    suite: "suites/quincy/rados/tier-2_rados_test-scrubbing.yaml"
-    global-conf: "conf/quincy/rados/7-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-1
-
-  - name: "Testing RADOS regression for ec pool osd rebalance"
-    suite: "suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS regression for in-progress osd rebalance"
-    suite: "suites/quincy/rados/tier-2_rados_test-osd-inprogress-rebalance.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS regression for Stretch mode upgrade"
-    suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rados
-      - stage-1
-      - rc
-
-  - name: "RADOS regression testing for Mon DB trimming"
-    suite: "suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-4
-
-  - name: "RADOS regression testing osd rebalance with many pools"
-    suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance-many-pools.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-5
-
-  - name: "Basic operation test suite for 6x for RGW sanity"
-    suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-      - rc
-
-  - name: "test-rgw-sse-s3-encryption-GA"
-    suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-      - rc
-
-  - name: "Testing RBD basic regression scenarios"
-    suite: "suites/quincy/rbd/tier-1_rbd.yaml"
-    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack-only
-      - rbd
-      - stage-1
-      - rc
-
-  - name: "Testing RBD tier-2 regression scenarios"
-    suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
-    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rbd
-      - stage-1
-
-  - name: "Testing RBD-mirror tier-1 regression scenarios"
-    suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
-    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rbd
-      - stage-1
-      - rc
-
-  - name: "Testing RBD-mirror tier-2 regression scenarios"
-    suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
-    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rbd
-      - stage-1
-
-  - name: "Basic operation test suite for Cephfs"
-    suite: "suites/pacific/cephfs/tier-0_fs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - rc
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "FS Scenario based coversion subvolume-snapshot-quota features"
-    suite: "suites/pacific/cephfs/tier-1_fs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-      - rc
-
-  - name: "Tier-1 Cephfs Mirror"
-    suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
-    global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-2
-      - rc
-
-  - name: "Tier-2 Cephfs test clients"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "Tier-2 Cephfs test Multifs"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-2 Cephfs test Nfs"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test quota"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-2 Cephfs test Snapshot Clone"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test Volume Management"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test mds pinning"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "Tier-2 cephfs upgrade 5.3 to 6.0"
-    suite: "suites/quincy/cephfs/tier-0_cephfs_upgrade_53_to_6x.yaml"
-    global-conf: "conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - upgrades
-      - stage-1
-
-  - name: "Testing Rgw Single site"
-    suite: "suites/pacific/rgw/tier-1_rgw.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-      - rc
-
-  - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-      - rc
-
-  - name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-      - rc
-
-  - name: "RGW STS functionality testing"
-    suite: "suites/quincy/rgw/tier-1-extn_rgw.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "RGW Regression testing"
-    suite: "suites/quincy/rgw/tier-2_rgw_regression.yaml"
-    global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "RGW testing using S3CMD CLI commands"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "Tier-2 RGW multisite test async data notifications"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "Tier-2 RGW cloud transitions"
-    suite: "suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml"
-    global-conf: "conf/quincy/rgw/cloud_transition.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-7
-
-  - name: "tier-2-rgw-test-fixes"
-    suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "tier-2_rbd_cli_regression"
-    suite: "suites/quincy/rbd/tier-2_rbd_cli_regression.yaml"
-    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "tier-2_rbd_mirror_snapshot_regression"
-    suite: "suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
-    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  # schedule RGW
-  - name: "test-rgw-lc-expiration-multiple-bucket"
-    suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Testing RGW multi-realm deployment"
-    suite: "suites/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-ms-bilog-crash-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-ssl-ecpool-ms-bucket-objects-gc-policy-on-secondary"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Testing extended RGW multisite secondary to primary"
-    suite: "suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Testing RGW multisite Bucket granular sync policy from primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
-    suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Tier-2 RGW bucket notification on the latest development build"
-    suite: "suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-lc-process-single-bucket"
-    suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-singlesite-to-multisite-tier-2"
-    suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-quota-management"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "tier-2_rgw_test-multisite-metadata-sync"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "S3Tests against Red Hat RGW with SSL"
-    suite: "suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml"
-    global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rgw
-      - stage-3
-
-  - name: "tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "tier-1_rgw_upgrade_5-2GA_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-2GA_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "tier-1_rgw_upgrade_5-3_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "tier-1_rgw_ms_upgrade_5-3latest_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-3_latest_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ms-dynamic-bucket-resharding"
-    suite: "suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Deploy all services using a spec file option"
-    suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
-    suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Execute os tuning profiles test cases"
-    suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Execute purge cluster using rm-cluster commands"
-    suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Deploy all services using a spec file option"
-    suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-5
-      - rc
-
-  - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
-    suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-5
-      - rc
-
-  - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
-    suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-5
-      - rc
-
-  - name: "cephadm cluster bootstrap with mutiple public network."
-    suite: "suites/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
-    global-conf: "conf/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - dmfg
-      - stage-5
-
-  - name: "test-rgw-ssl-bucket-notifications"
-    suite: "suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.0"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
+pipelines:
+  sanity:
+    tier-0:
+      stage-1:
+        - name: "Smoke Test of RH Ceph build"
+          execution_time: "26m 32s"
+          suite: "suites/quincy/cephadm/tier-0.yaml"
+          global-conf: "conf/quincy/cephadm/tier-0.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Basic operation test suite for 6x for RGW sanity"
+          execution_time: "32m 41s"
+          suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RBD basic regression scenarios"
+          execution_time: "36m 36s"
+          suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-GA"
+          execution_time: "26m 13s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Basic operation test suite for Cephfs"
+          execution_time: "30m 13s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+      stage-2:
+        - name: "Testing RBD-mirror tier-1 regression scenarios"
+          execution_time: "1h 6m 0s"
+          suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "43m 43s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "FS Scenario based coversion subvolume-snapshot-quota features"
+          execution_time: "1h 28m 58s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 19m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "Execute os tuning profiles test cases"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Execute purge cluster using rm-cluster commands"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-4:
+        - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-2:
+      stage-1:
+        - name: "tier-2_rbd_cli_regression"
+          execution_time: "18m 15s"
+          suite: "suites/quincy/rbd/tier-2_rbd_cli_regression.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test clients"
+          execution_time: "23m 4s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing RADOS robust osd rebalance scenarios"
+          execution_time: "29m 39s"
+          suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 Cephfs test Multifs"
+          execution_time: "29m 12s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "RADOS regression testing osd rebalance with many pools"
+          execution_time: "29m 39s"
+          suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance-many-pools.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+      stage-2:
+        - name: "Testing RBD tier-2 regression scenarios"
+          execution_time: "37m 6s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 Cephfs test Nfs"
+          execution_time: "33m 49s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Tier-2 Cephfs test Volume Management"
+          execution_time: "33m 26s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "tier-2-rgw-test-fixes"
+          execution_time: "38m 22s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RGW testing using S3CMD CLI commands"
+          execution_time: "41m 19s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "Tier-2 RGW cloud transitions"
+          execution_time: "47m 35s"
+          suite: "suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml"
+          global-conf: "conf/quincy/rgw/cloud_transition.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 RGW multisite test async data notifications"
+          execution_time: "1h 55m 51s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS basic regression scenarios"
+          execution_time: "1h 15m 45s"
+          suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+          global-conf: "conf/quincy/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-ms-dynamic-bucket-resharding"
+          execution_time: "1h 21m 25s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test quota"
+          execution_time: "1h 36m 20s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+      stage-4:
+        - name: "Testing RADOS EC Pool recovery"
+          execution_time: "2h 36m 59s"
+          suite: "suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "RGW STS functionality testing"
+          execution_time: "2h 41m 38s"
+          suite: "suites/quincy/rgw/tier-1-extn_rgw.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RGW Regression testing"
+          execution_time: "2h 54m 12s"
+          suite: "suites/quincy/rgw/tier-2_rgw_regression.yaml"
+          global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-bucket-notifications"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test mds pinning"
+          execution_time: ""
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+  schedule:
+    tier-1:
+      stage-1:
+        - name: "test-rgw-lc-expiration-multiple-bucket"
+          execution_time: "34m 51s"
+          suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RGW multi-realm deployment"
+          execution_time: "39m 59s"
+          suite: "suites/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
+          execution_time: "1h 26m 11s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ms-bilog-crash-on-primary"
+          execution_time: "2h 18m 51s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-2:
+        - name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
+          execution_time: "3h 50m 55s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
+          execution_time: "4h 16m 54s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for Stretch mode upgrade"
+          execution_time: "4h 17m 41s"
+          suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
+          execution_time: "4h 23m 34s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
+          execution_time: "4h 27m 3s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-1_rgw_upgrade_5-2GA_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-2GA_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-1_rgw_upgrade_5-3_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-1_rgw_ms_upgrade_5-3latest_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-3_latest_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+    tier-2:
+      stage-1:
+        - name: "test-lc-process-single-bucket"
+          execution_time: "33m 3s"
+          suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for in-progress osd rebalance"
+          execution_time: "38m 4s"
+          suite: "suites/quincy/rados/tier-2_rados_test-osd-inprogress-rebalance.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-quota-management"
+          execution_time: "39m 30s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for ec pool osd rebalance"
+          execution_time: "50m 57s"
+          suite: "suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 RGW bucket notification on the latest development build"
+          execution_time: "52m 12s"
+          suite: "suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-2:
+        - name: "Testing extended RGW multisite secondary to primary"
+          execution_time: "1h 31m 6s"
+          suite: "suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-2_rgw_test-multisite-metadata-sync"
+          execution_time: "1h 21m 12s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
+          execution_time: "2h 3m 55s"
+          suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-singlesite-to-multisite-tier-2"
+          execution_time: "2h 7m 12s"
+          suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+          execution_time: "2h 14m 3s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "test-rgw-ssl-ecpool-ms-bucket-objects-gc-policy-on-secondary"
+          execution_time: "2h 45m 4s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
+          execution_time: "2h 51m 12s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RADOS regression testing for stretched Clusters"
+          execution_time: "3h 15m 14s"
+          suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "tier-2_rbd_mirror_snapshot_regression"
+          execution_time: "3h 29m 42s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-4:
+        - name: "RADOS regression for testing various pool functionalities"
+          execution_time: ""
+          suite: "suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Testing RGW multisite Bucket granular sync policy from primary"
+          execution_time: ""
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 cephfs upgrade 5.3 to 6.0"
+          execution_time: ""
+          suite: "suites/quincy/cephfs/tier-0_cephfs_upgrade_53_to_6x.yaml"
+          global-conf: "conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+            - upgrades
+  sanity_openstack_only:
+    tier-2:
+      stage-1:
+        - name: "RADOS regression testing for Mon DB trimming"
+          execution_time: "1h 18m 55s"
+          suite: "suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 Cephfs test Snapshot Clone"
+          execution_time: "1h 17m 8s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "cephadm cluster bootstrap with mutiple public network."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
+          global-conf: "conf/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+  schedule_openstack_only:
+    tier-2:
+      stage-1:
+        - name: "RADOS regression testing for Scrubbing scenarios"
+          execution_time: ""
+          suite: "suites/quincy/rados/tier-2_rados_test-scrubbing.yaml"
+          global-conf: "conf/quincy/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Testing RBD-mirror tier-2 regression scenarios"
+          execution_time: "2h 9m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "S3Tests against Red Hat RGW with SSL"
+          execution_time: "56m 4s"
+          suite: "suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml"
+          global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rgw
+  rc:
+    tier-0:
+      stage-1:
+        - name: "Smoke Test of RH Ceph build"
+          execution_time: "26m 32s"
+          suite: "suites/quincy/cephadm/tier-0.yaml"
+          global-conf: "conf/quincy/cephadm/tier-0.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Basic operation test suite for 6x for RGW sanity"
+          execution_time: "32m 41s"
+          suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RBD basic regression scenarios"
+          execution_time: "36m 36s"
+          suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-GA"
+          execution_time: "26m 13s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Basic operation test suite for Cephfs"
+          execution_time: "30m 13s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-2:
+        - name: "Testing RBD-mirror tier-1 regression scenarios"
+          execution_time: "1h 6m 0s"
+          suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "43m 43s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "FS Scenario based coversion subvolume-snapshot-quota features"
+          execution_time: "1h 28m 58s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 19m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-3:
+        - name: "Execute os tuning profiles test cases"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Execute purge cluster using rm-cluster commands"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+  live:
+    tier-0:
+      stage-1:
+        - name: "Smoke Test of RH Ceph build"
+          execution_time: "26m 32s"
+          suite: "suites/quincy/cephadm/tier-0.yaml"
+          global-conf: "conf/quincy/cephadm/tier-0.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Basic operation test suite for 6x for RGW sanity"
+          execution_time: "32m 41s"
+          suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RBD basic regression scenarios"
+          execution_time: "36m 36s"
+          suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-GA"
+          execution_time: "26m 13s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Basic operation test suite for Cephfs"
+          execution_time: "30m 13s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-2:
+        - name: "Testing RBD-mirror tier-1 regression scenarios"
+          execution_time: "1h 6m 0s"
+          suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "43m 43s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "FS Scenario based coversion subvolume-snapshot-quota features"
+          execution_time: "1h 28m 58s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 19m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-3:
+        - name: "Execute os tuning profiles test cases"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Execute purge cluster using rm-cluster commands"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+  stage:

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -1,5 +1,5 @@
 #=====================================================================================
-# Metadata file for RHCS 6.1 release version.
+# Metadata file for 6.1 RHCS release version.
 # Single file to specify test suites to be executed for all regression (sanity) and schedule tests
 # as per defined in each stages.
 # Each stage will execute in sequential pattern.
@@ -8,1150 +8,1077 @@
 # platform, rhbuild, inventory and metadata information like frequency of execution, tier, cloud type, functional group and stage.
 #=====================================================================================
 overrides:
-
-suites:
-  - name: "Smoke Test of RH Ceph build"
-    suite: "suites/quincy/cephadm/tier-0.yaml"
-    global-conf: "conf/quincy/cephadm/tier-0.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-0
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-1
-      - rc
-
-  - name: "Testing RADOS basic regression scenarios"
-    suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
-    global-conf: "conf/quincy/rados/7-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-3
-
-  - name: "Testing RADOS EC Pool recovery"
-    suite: "suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS robust osd rebalance scenarios"
-    suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "RADOS regression testing for stretched Clusters"
-    suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-4
-
-  - name: "RADOS regression for testing various pool functionalities"
-    suite: "suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "RADOS regression testing for Scrubbing scenarios"
-    suite: "suites/quincy/rados/tier-2_rados_test-scrubbing.yaml"
-    global-conf: "conf/quincy/rados/7-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-1
-
-  - name: "Testing RADOS regression for ec pool osd rebalance"
-    suite: "suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS regression for in-progress osd rebalance"
-    suite: "suites/quincy/rados/tier-2_rados_test-osd-inprogress-rebalance.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-2
-
-  - name: "Testing RADOS regression for Stretch mode upgrade"
-    suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rados
-      - stage-1
-      - rc
-
-  - name: "RADOS regression testing for Mon DB trimming"
-    suite: "suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - rados
-      - stage-4
-
-  - name: "RADOS regression testing osd rebalance with many pools"
-    suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance-many-pools.yaml"
-    global-conf: "conf/quincy/rados/11-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rados
-      - stage-5
-
-  - name: "Basic operation test suite for 6x for RGW sanity"
-    suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-      - rc
-
-  - name: "test-rgw-sse-s3-encryption-GA"
-    suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-      - rc
-
-  - name: "Testing RBD basic regression scenarios"
-    suite: "suites/quincy/rbd/tier-1_rbd.yaml"
-    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack-only
-      - rbd
-      - stage-1
-      - rc
-
-  - name: "Testing RBD tier-2 regression scenarios"
-    suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
-    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rbd
-      - stage-1
-
-  - name: "Testing RBD-mirror tier-1 regression scenarios"
-    suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
-    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rbd
-      - stage-1
-      - rc
-
-  - name: "Testing RBD-mirror tier-2 regression scenarios"
-    suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
-    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rbd
-      - stage-1
-
-  - name: "Basic operation test suite for Cephfs"
-    suite: "suites/pacific/cephfs/tier-0_fs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - rc
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "FS Scenario based coversion subvolume-snapshot-quota features"
-    suite: "suites/pacific/cephfs/tier-1_fs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-      - rc
-
-  - name: "Tier-1 Cephfs Mirror"
-    suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
-    global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-2
-      - rc
-
-  - name: "Tier-2 Cephfs test clients"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "Tier-2 Cephfs test Multifs"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-2 Cephfs test Nfs"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test quota"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-3
-
-  - name: "Tier-2 Cephfs test Snapshot Clone"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
-    global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test Volume Management"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-5
-
-  - name: "Tier-2 Cephfs test mds pinning"
-    suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
-    global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
-    platform: "rhel-8"
-    rhbuild: "5.3"
-    inventory:
-      openstack: "conf/inventory/rhel-8-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - cephfs
-      - stage-1
-
-  - name: "Testing Rgw Single site"
-    suite: "suites/pacific/rgw/tier-1_rgw.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-      - rc
-
-  - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-      - rc
-
-  - name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-      - rc
-
-  - name: "RGW STS functionality testing"
-    suite: "suites/quincy/rgw/tier-1-extn_rgw.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "RGW Regression testing"
-    suite: "suites/quincy/rgw/tier-2_rgw_regression.yaml"
-    global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "RGW testing using S3CMD CLI commands"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "Tier-2 RGW multisite test async data notifications"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "Tier-2 RGW cloud transitions"
-    suite: "suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml"
-    global-conf: "conf/quincy/rgw/cloud_transition.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-7
-
-  - name: "tier-2-rgw-test-fixes"
-    suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "tier-2_rbd_cli_regression"
-    suite: "suites/quincy/rbd/tier-2_rbd_cli_regression.yaml"
-    global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "tier-2_rbd_mirror_snapshot_regression"
-    suite: "suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
-    global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  # schedule RGW
-  - name: "test-rgw-lc-expiration-multiple-bucket"
-    suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Testing RGW multi-realm deployment"
-    suite: "suites/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-ms-bilog-crash-on-primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-ssl-ecpool-ms-bucket-objects-gc-policy-on-secondary"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
-    suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"
-    global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Testing extended RGW multisite secondary to primary"
-    suite: "suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Testing RGW multisite Bucket granular sync policy from primary"
-    suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-4
-
-  - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
-    suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Tier-2 RGW bucket notification on the latest development build"
-    suite: "suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-lc-process-single-bucket"
-    suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "test-rgw-singlesite-to-multisite-tier-2"
-    suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-quota-management"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
-    global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "tier-2_rgw_test-multisite-metadata-sync"
-    suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "S3Tests against Red Hat RGW with SSL"
-    suite: "suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml"
-    global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-2
-      - openstack-only
-      - rgw
-      - stage-3
-
-  - name: "tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "tier-1_rgw_upgrade_5-2GA_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-2GA_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "tier-1_rgw_upgrade_5-3_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-2
-
-  - name: "tier-1_rgw_ms_upgrade_5-3latest_to_6x_latest"
-    suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-3_latest_to_6x_latest.yaml"
-    global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - schedule
-      - tier-1
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
-
-  - name: "test-rgw-ms-dynamic-bucket-resharding"
-    suite: "suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml"
-    global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-1
-
-  - name: "Deploy all services using a spec file option"
-    suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
-    suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Execute os tuning profiles test cases"
-    suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Execute purge cluster using rm-cluster commands"
-    suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-4
-      - rc
-
-  - name: "Deploy all services using a spec file option"
-    suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-5
-      - rc
-
-  - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
-    suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-5
-      - rc
-
-  - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
-    suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
-    global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-1
-      - openstack
-      - ibmc
-      - dmfg
-      - stage-5
-      - rc
-
-  - name: "cephadm cluster bootstrap with mutiple public network."
-    suite: "suites/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
-    global-conf: "conf/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack-only
-      - dmfg
-      - stage-5
-
-  - name: "test-rgw-ssl-bucket-notifications"
-    suite: "suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml"
-    global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
-    platform: "rhel-9"
-    rhbuild: "6.1"
-    inventory:
-      openstack: "conf/inventory/rhel-9-latest.yaml"
-      ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-    metadata:
-      - sanity
-      - tier-2
-      - openstack
-      - ibmc
-      - rgw
-      - stage-3
+  rhbuild: "6.1"
+  # log_dir: "" #other override parameters common to cloud can also be specified here.
+
+pipelines:
+  sanity:
+    tier-0:
+      stage-1:
+        - name: "Smoke Test of RH Ceph build"
+          execution_time: "26m 32s"
+          suite: "suites/quincy/cephadm/tier-0.yaml"
+          global-conf: "conf/quincy/cephadm/tier-0.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Basic operation test suite for 6x for RGW sanity"
+          execution_time: "32m 41s"
+          suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RBD basic regression scenarios"
+          execution_time: "36m 36s"
+          suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-GA"
+          execution_time: "26m 13s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Basic operation test suite for Cephfs"
+          execution_time: "30m 13s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+      stage-2:
+        - name: "Testing RBD-mirror tier-1 regression scenarios"
+          execution_time: "1h 6m 0s"
+          suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "43m 43s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "FS Scenario based coversion subvolume-snapshot-quota features"
+          execution_time: "1h 28m 58s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 19m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "Execute os tuning profiles test cases"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Execute purge cluster using rm-cluster commands"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-4:
+        - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-2:
+      stage-1:
+        - name: "tier-2_rbd_cli_regression"
+          execution_time: "18m 15s"
+          suite: "suites/quincy/rbd/tier-2_rbd_cli_regression.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test clients"
+          execution_time: "23m 4s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing RADOS robust osd rebalance scenarios"
+          execution_time: "29m 39s"
+          suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 Cephfs test Multifs"
+          execution_time: "29m 12s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-multifs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "RADOS regression testing osd rebalance with many pools"
+          execution_time: "29m 39s"
+          suite: "suites/quincy/rados/tier-2_rados_test-osd-rebalance-many-pools.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+      stage-2:
+        - name: "Testing RBD tier-2 regression scenarios"
+          execution_time: "37m 6s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 Cephfs test Nfs"
+          execution_time: "33m 49s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Tier-2 Cephfs test Volume Management"
+          execution_time: "33m 26s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-volume-management.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "tier-2-rgw-test-fixes"
+          execution_time: "38m 22s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RGW testing using S3CMD CLI commands"
+          execution_time: "41m 19s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "Tier-2 RGW cloud transitions"
+          execution_time: "47m 35s"
+          suite: "suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml"
+          global-conf: "conf/quincy/rgw/cloud_transition.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 RGW multisite test async data notifications"
+          execution_time: "1h 55m 51s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS basic regression scenarios"
+          execution_time: "1h 15m 45s"
+          suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+          global-conf: "conf/quincy/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-ms-dynamic-bucket-resharding"
+          execution_time: "1h 21m 25s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test quota"
+          execution_time: "1h 36m 20s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-quota.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+      stage-4:
+        - name: "Testing RADOS EC Pool recovery"
+          execution_time: "2h 36m 59s"
+          suite: "suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "RGW STS functionality testing"
+          execution_time: "2h 41m 38s"
+          suite: "suites/quincy/rgw/tier-1-extn_rgw.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RGW Regression testing"
+          execution_time: "2h 54m 12s"
+          suite: "suites/quincy/rgw/tier-2_rgw_regression.yaml"
+          global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-bucket-notifications"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 Cephfs test mds pinning"
+          execution_time: ""
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+  schedule:
+    tier-1:
+      stage-1:
+        - name: "test-rgw-lc-expiration-multiple-bucket"
+          execution_time: "34m 51s"
+          suite: "suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RGW multi-realm deployment"
+          execution_time: "39m 59s"
+          suite: "suites/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          global-conf: "conf/pacific/rgw/tier-1_rgw_cephadm.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
+          execution_time: "1h 26m 11s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ms-bilog-crash-on-primary"
+          execution_time: "2h 18m 51s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-2:
+        - name: "test-rgw-ms-bucket-listing-versioning-on-secondary"
+          execution_time: "3h 50m 55s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ecpool-ms-bucket-object-gc-policy-on-primary"
+          execution_time: "4h 16m 54s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for Stretch mode upgrade"
+          execution_time: "4h 17m 41s"
+          suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-ms-bucket-object-gc-policy-on-secondary"
+          execution_time: "4h 23m 34s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ecpool-ms-bucket-listing-versioning-on-primary"
+          execution_time: "4h 27m 3s"
+          suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-2GA_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-1_rgw_upgrade_5-2GA_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-2GA_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-1_rgw_upgrade_5-3_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-1_rgw_ms_upgrade_5-3latest_to_6x_latest"
+          execution_time: ""
+          suite: "suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-3_latest_to_6x_latest.yaml"
+          global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+    tier-2:
+      stage-1:
+        - name: "test-lc-process-single-bucket"
+          execution_time: "33m 3s"
+          suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for in-progress osd rebalance"
+          execution_time: "38m 4s"
+          suite: "suites/quincy/rados/tier-2_rados_test-osd-inprogress-rebalance.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "test-rgw-quota-management"
+          execution_time: "39m 30s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RADOS regression for ec pool osd rebalance"
+          execution_time: "50m 57s"
+          suite: "suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 RGW bucket notification on the latest development build"
+          execution_time: "52m 12s"
+          suite: "suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-2:
+        - name: "Testing extended RGW multisite secondary to primary"
+          execution_time: "1h 31m 6s"
+          suite: "suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "tier-2_rgw_test-multisite-metadata-sync"
+          execution_time: "1h 21m 12s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
+          execution_time: "2h 3m 55s"
+          suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-singlesite-to-multisite-tier-2"
+          execution_time: "2h 7m 12s"
+          suite: "suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
+          execution_time: "2h 14m 3s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-3:
+        - name: "test-rgw-ssl-ecpool-ms-bucket-objects-gc-policy-on-secondary"
+          execution_time: "2h 45m 4s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
+          execution_time: "2h 51m 12s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"
+          global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "RADOS regression testing for stretched Clusters"
+          execution_time: "3h 15m 14s"
+          suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "tier-2_rbd_mirror_snapshot_regression"
+          execution_time: "3h 29m 42s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+      stage-4:
+        - name: "RADOS regression for testing various pool functionalities"
+          execution_time: ""
+          suite: "suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Testing RGW multisite Bucket granular sync policy from primary"
+          execution_time: ""
+          suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+  sanity_openstack_only:
+    tier-2:
+      stage-1:
+        - name: "RADOS regression testing for Mon DB trimming"
+          execution_time: "1h 18m 55s"
+          suite: "suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml"
+          global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Tier-2 Cephfs test Snapshot Clone"
+          execution_time: "1h 17m 8s"
+          suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "cephadm cluster bootstrap with mutiple public network."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
+          global-conf: "conf/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+  schedule_openstack_only:
+    tier-2:
+      stage-1:
+        - name: "RADOS regression testing for Scrubbing scenarios"
+          execution_time: ""
+          suite: "suites/quincy/rados/tier-2_rados_test-scrubbing.yaml"
+          global-conf: "conf/quincy/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rados
+        - name: "Testing RBD-mirror tier-2 regression scenarios"
+          execution_time: "2h 9m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "S3Tests against Red Hat RGW with SSL"
+          execution_time: "56m 4s"
+          suite: "suites/quincy/rgw/tier-2_rgw_ssl_s3tests.yaml"
+          global-conf: "conf/pacific/rgw/ec-profile-4+2-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - rgw
+  rc:
+    tier-0:
+      stage-1:
+        - name: "Smoke Test of RH Ceph build"
+          execution_time: "26m 32s"
+          suite: "suites/quincy/cephadm/tier-0.yaml"
+          global-conf: "conf/quincy/cephadm/tier-0.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Basic operation test suite for 6x for RGW sanity"
+          execution_time: "32m 41s"
+          suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RBD basic regression scenarios"
+          execution_time: "36m 36s"
+          suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-GA"
+          execution_time: "26m 13s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Basic operation test suite for Cephfs"
+          execution_time: "30m 13s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-2:
+        - name: "Testing RBD-mirror tier-1 regression scenarios"
+          execution_time: "1h 6m 0s"
+          suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "43m 43s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "FS Scenario based coversion subvolume-snapshot-quota features"
+          execution_time: "1h 28m 58s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 19m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-3:
+        - name: "Execute os tuning profiles test cases"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Execute purge cluster using rm-cluster commands"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+  live:
+    tier-0:
+      stage-1:
+        - name: "Smoke Test of RH Ceph build"
+          execution_time: "26m 32s"
+          suite: "suites/quincy/cephadm/tier-0.yaml"
+          global-conf: "conf/quincy/cephadm/tier-0.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+    tier-1:
+      stage-1:
+        - name: "Basic operation test suite for 6x for RGW sanity"
+          execution_time: "32m 41s"
+          suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Testing RBD basic regression scenarios"
+          execution_time: "36m 36s"
+          suite: "suites/quincy/rbd/tier-1_rbd.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "test-rgw-sse-s3-encryption-GA"
+          execution_time: "26m 13s"
+          suite: "suites/pacific/rgw/tier-2_sse_s3_encryption.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Basic operation test suite for Cephfs"
+          execution_time: "30m 13s"
+          suite: "suites/pacific/cephfs/tier-0_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-0_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Execute cephadm-clients playbook to copy keyring with the same name as specified by the keyring parameter"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_cephadm-clients.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-2:
+        - name: "Testing RBD-mirror tier-1 regression scenarios"
+          execution_time: "1h 6m 0s"
+          suite: "suites/quincy/rbd/tier-1_rbd_mirror.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-1 Cephfs Mirror"
+          execution_time: "43m 43s"
+          suite: "suites/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_cephfs_mirror.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "FS Scenario based coversion subvolume-snapshot-quota features"
+          execution_time: "1h 28m 58s"
+          suite: "suites/pacific/cephfs/tier-1_fs.yaml"
+          global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+        - name: "Testing Rgw Single site"
+          execution_time: "1h 19m 48s"
+          suite: "suites/pacific/rgw/tier-1_rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_service_apply_spec.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+      stage-3:
+        - name: "Execute os tuning profiles test cases"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Execute purge cluster using rm-cluster commands"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_remove_cluster.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Deploy all services using a spec file option"
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_test-container-cli-args.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+          execution_time: ""
+          suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
+  stage:

--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -44,7 +44,7 @@ node("rhel-8-medium || ceph-qe-ci") {
         ciMap = sharedLib.getCIMessageMap()
         def rhcephVersion = ciMap.artifact.nvr
         def buildType = "tier-0"
-        def tags = "openstack-only,tier-1,stage-1"
+        def tags = "sanity_openstack_only,tier-1,stage-1"
         def overrides = ["build": "tier-0"]
         def overridesStr = writeJSON returnText: true, json: overrides
         def buildArtifacts = "${params.CI_MESSAGE}"

--- a/pipeline/psi-scheduled-pipeline-executor.groovy
+++ b/pipeline/psi-scheduled-pipeline-executor.groovy
@@ -8,7 +8,7 @@ def recipeFileDir = "/ceph/cephci-jenkins/latest-rhceph-container-info"
 // Default job parameters
 def buildType = "${params.buildType}" ? "tier-1" : "${params.buildType}"
 def overrides = "${params.overrides}" ? "{}" : "${params.overrides}"
-def tags = "${params.tags}" ? "schedule,psi,tier-1,stage-1" : "${params.tags}"
+def tags = "${params.tags}" ? "schedule_openstack_only,tier-1,stage-1" : "${params.tags}"
 
 
 // Pipeline script entry point

--- a/pipeline/scripts/ci/getTestsForPipeline.py
+++ b/pipeline/scripts/ci/getTestsForPipeline.py
@@ -1,0 +1,350 @@
+import json
+import logging
+import os
+import random
+import string
+import sys
+
+import yaml
+from docopt import docopt
+
+log = logging.getLogger(__name__)
+doc = """
+This script fetches all the tests to be run for a pipeline based on the RHCS version and overrides
+
+    Usage:
+        getTestsForPipeline.py --rhcephVersion <VER> --tags <tags>
+                  [--overrides <str>]
+
+        getTestsForPipeline.py (-h | --help)
+
+    Options:
+        -h --help          Shows the command usage
+        -v --rhcephVersion VER     The rhcephVersion for which test stages need to be fetched
+        -t --tags <str>    tags to be used for filtering test scripts
+        -o --overrides <str>       Overrides to be considered for execution
+"""
+
+
+def generate_random_string(length):
+    """Generate a random alphanumeric string of given length"""
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
+
+
+def update_overrides(metadata_overrides, cloud_type, overrides, data):
+    """
+    Updates the given dictionary "data" with the overrides provided
+    Args:
+        metadata_overrides: RHCeph version level overrides to be updated,
+        cloud_type: ibmc|openstack
+        overrides: User specified overrides to be updated
+        data: dictionary to which overrides need to be updated
+    """
+    cloud_overrides = {
+        "ibmc": metadata_overrides.pop("ibmc", {}),
+        "openstack": metadata_overrides.pop("openstack", {}),
+    }
+    data.update(cloud_overrides[cloud_type])
+    data.update(metadata_overrides)
+    data.update(overrides)
+
+
+def fetch_from_metadata(rhcephVersion):
+    """
+    Fetches the test data from metadata file for the specified RHCS version
+    Args:
+        rhcephVersion: RHCS version for which metadata needs to be fetched
+    Returns:
+        The fetched test data
+    """
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    metadata_dir = os.path.abspath(f"{current_dir}/../../metadata")
+    metadata_file = f"{metadata_dir}/{rhcephVersion}.yaml"
+    metadata_content = yaml.safe_load(open(metadata_file, "r"))
+    return metadata_content
+
+
+def is_final_stage_or_tier(stage_or_tier, data):
+    """
+    Returns whether the current stage specified in tags is the final stage
+    for the given pipeline
+    Args:
+        stage_or_tier: current test stage
+        data: data containing all the stages/tiers in the required pipeline
+    Returns:
+        Whether the stage mentioned in the tags is the final stage
+        for the given pipeline
+    """
+    curr_t_or_s_num = int(stage_or_tier.split("-")[1])
+    next_t_or_s_in_tier = [
+        s for s in data.keys() if int(s.split("-")[1]) > curr_t_or_s_num
+    ]
+    return not bool(next_t_or_s_in_tier)
+
+
+def construct_cli(
+    data, cloud_type, filters, metadata_overrides, user_overrides, test_data
+):
+    """
+
+    Args:
+        data:
+        cloud_type:
+        filters:
+        metadata_overrides:
+        user_overrides:
+        test_data:
+    Returns:
+
+    """
+    workspace = user_overrides.get("workspace", "")
+    build_number = user_overrides.get("build_number", "")
+    overrides = {
+        k: v
+        for (k, v) in user_overrides.items()
+        if k not in ["workspace", "build_number"]
+    }
+    meta_overrides = {
+        k: v for (k, v) in metadata_overrides.items() if k not in ["ibmc", "openstack"]
+    }
+    cloud_overrides = metadata_overrides.get(cloud_type, {})
+    filtered_data = (
+        filter(lambda d: all(tag in d["metadata"] for tag in filters), data)
+        if filters
+        else data
+    )
+
+    for test_suite in filtered_data:
+        script_name = test_suite.pop("name")
+        test_suite.pop("execution_time")
+        del test_suite["metadata"]
+        instances_name = f"ci-{generate_random_string(5)}"
+        cleanup_cli = ".venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml"
+        cleanup_cli += f" --cleanup {instances_name}"
+        cleanup_cli += " --log-level DEBUG"
+
+        execute_cli = ".venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml"
+        execute_cli += f" --instances-name {instances_name}"
+        execute_cli += " --log-level DEBUG"
+        logdir = f"{workspace}/logs/{generate_random_string(5)}-{build_number}"
+
+        execute_cli += " --xunit-results"
+        # os.makedirs(logdir)
+        execute_cli += f" --log-dir {logdir}"
+        if cloud_type == "ibmc":
+            execute_cli += f" --cloud {cloud_type}"
+            cleanup_cli += f" --cloud {cloud_type}"
+
+        test_suite.update({"inventory": test_suite["inventory"][cloud_type]})
+        test_suite.update(cloud_overrides)
+
+        test_suite.update(meta_overrides)
+        test_suite.update(overrides)
+
+        for k, v in test_suite.items():
+            if isinstance(v, list):
+                for item in v:
+                    execute_cli += f" --{k} {item}"
+            else:
+                execute_cli += f" --{k} {v}"
+
+        test_data.update(
+            {
+                script_name: {
+                    "execute_cli": execute_cli,
+                    "cleanup_cli": cleanup_cli,
+                    "log_dir": logdir,
+                }
+            }
+        )
+
+
+def fetch_test_cli(
+    data, cloud_type, filters, metadata_overrides, user_overrides, test_data
+):
+    """
+
+    Args:
+        data:
+        cloud_type:
+        filters:
+        metadata_overrides:
+        user_overrides:
+        test_data
+    Returns:
+
+    """
+    if isinstance(data, list):
+        construct_cli(
+            data, cloud_type, filters, metadata_overrides, user_overrides, test_data
+        )
+        return
+    for data_key, data_val in data.items():
+        if isinstance(data_val, list):
+            construct_cli(
+                data_val,
+                cloud_type,
+                filters,
+                metadata_overrides,
+                user_overrides,
+                test_data,
+            )
+        else:
+            fetch_test_cli(
+                data_val,
+                cloud_type,
+                filters,
+                metadata_overrides,
+                user_overrides,
+                test_data,
+            )
+
+
+def fetch_tests(args):
+    """
+    Fetch tests to be executed based on the input provided
+    Args:
+        args:
+            Dictionary containing the tier_level, cloud_type and all other necessary override parameters
+            to be used to fetch test stages for execution
+
+            arguments = {
+                "rhcephVersion": <the rhbuild version for which the stages need to be fetched>,
+                "tags": comma separated string containing the tags based on which the stages should be filtered,
+                "overrides": <overrides in json format, all keys accepted by run.py are supported to be overridden
+                            if any key similar to --store which does not have a value it can be passed as "store": ""
+            }
+
+            Example:
+                args = {
+                    "rhcephVersion": 5.1,
+                    "tags": "sanity,tier-1,stage-1,ibmc",
+                    "overrides": {"cloud_type": "openstack", "platform": "rhel-8"}
+
+    Returns:
+        Yaml string containing CLI to be executed for each test suite at every stage
+        Examples:
+            "test-cephfs-core-features":
+                "execute_cli": ".venv/bin/python run.py ......",
+                 "cleanup_cli": "...."
+            .....
+    """
+    is_final_tier = False
+    is_final_stage = False
+    test_data = dict()
+
+    # Fetch the necessary test data
+    metadata_content = fetch_from_metadata(args.get("rhcephVersion"))
+    # RHCS version level overrides
+    metadata_overrides = metadata_content.get("overrides", {})
+    # User specified overrides
+    user_overrides = json.loads(args.get("overrides", {}))
+    # Test suites for a specific RHCS version
+    test_pipelines = metadata_content.get("pipelines")
+
+    # Fetch the pipeline, tier and stage values from tags
+    tags = args["tags"].split(",")
+    cloud_type = "ibmc" if "ibmc" in tags else "openstack"
+    (pipeline, pipeline_data) = next(
+        ((i, test_pipelines[i]) for i in tags if i in test_pipelines.keys()), None
+    )
+    tier = next((i for i in tags if i.startswith("tier-")), None)
+    stage = next((i for i in tags if i.startswith("stage-")), None)
+    filters = [i for i in tags if i not in [pipeline, tier, stage, cloud_type]]
+    if not pipeline_data:
+        log.error(
+            f"The pipeline requested in {tags} is not available for version {args.get('rhcephVersion')}"
+        )
+        is_final_stage = True
+        is_final_tier = True
+        return {
+            "scripts": test_data,
+            "final_tier": is_final_tier,
+            "final_stage": is_final_stage,
+        }
+
+    # If tier is not specified in tags, then fetch suites for all the tiers in the given pipeline
+    if not tier:
+        fetch_test_cli(
+            pipeline_data,
+            cloud_type,
+            filters,
+            metadata_overrides,
+            user_overrides,
+            test_data,
+        )
+        return {
+            "scripts": test_data,
+            "final_tier": is_final_tier,
+            "final_stage": is_final_stage,
+        }
+    elif not pipeline_data.get(tier):
+        log.error(
+            f"The tier for the pipeline requested in {tags} is not available for version {args.get('rhcephVersion')}"
+        )
+        is_final_stage = True
+        return {
+            "scripts": test_data,
+            "final_tier": is_final_tier,
+            "final_stage": is_final_stage,
+        }
+    is_final_tier = is_final_stage_or_tier(tier, pipeline_data)
+
+    # If stage is not specified in tags, then fetch suites for all stages for given tier in given pipeline
+    if not stage:
+        fetch_test_cli(
+            pipeline_data.get(tier),
+            cloud_type,
+            filters,
+            metadata_overrides,
+            user_overrides,
+            test_data,
+        )
+        return {
+            "scripts": test_data,
+            "final_tier": is_final_tier,
+            "final_stage": is_final_stage,
+        }
+    elif not pipeline_data.get(tier).get(stage):
+        log.error(
+            f"The stage for the pipeline requested in {tags} is not available for version {args.get('rhcephVersion')}"
+        )
+        is_final_stage = True
+        return {
+            "scripts": test_data,
+            "final_tier": is_final_tier,
+            "final_stage": is_final_stage,
+        }
+
+    # If tier and stage are specified, then fetch suites for the given tier and stage in given pipeline
+    is_final_stage = is_final_stage_or_tier(stage, pipeline_data.get(tier))
+    fetch_test_cli(
+        pipeline_data.get(tier).get(stage),
+        cloud_type,
+        filters,
+        metadata_overrides,
+        user_overrides,
+        test_data,
+    )
+    return {
+        "scripts": test_data,
+        "final_tier": is_final_tier,
+        "final_stage": is_final_stage,
+    }
+
+
+if __name__ == "__main__":
+    cli_args = docopt(doc)
+    log.info(cli_args)
+    arguments = {
+        "rhcephVersion": cli_args.get("--rhcephVersion"),
+        "tags": cli_args.get("--tags"),
+        "overrides": cli_args.get("--overrides"),
+        "metadata": cli_args.get("--metadata"),
+    }
+    try:
+        testStages = fetch_tests(arguments)
+    except Exception as e:
+        raise e
+    log.info(testStages)
+    sys.stdout.write(yaml.dump(testStages))

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -20,6 +20,7 @@ def tags = ""
 def majorVersion
 def minorVersion
 def buildStatus = "pass"
+def is_openstack_run = false
 
 def branch='origin/master'
 def repo='https://github.com/red-hat-storage/cephci.git'
@@ -124,7 +125,11 @@ node(nodeName) {
             overrides.put("build", "rc")
         }
 
-        if ("openstack" in tags_list || "openstack-only" in tags_list){
+        if (tags_list.findAll{element -> element.contains('openstack')}){
+            is_openstack_run = true
+        }
+
+        if (is_openstack_run){
             (majorVersion, minorVersion) = rhcephVersion.substring(7,).tokenize(".")
             /*
                Read the release yaml contents to get contents,
@@ -227,7 +232,7 @@ node(nodeName) {
 
     parallel testStages
 
-    if ("openstack" in tags_list || "openstack-only" in tags_list){
+    if (is_openstack_run){
         stage('Publish Results') {
 
             // Copy all the results into one folder before upload
@@ -274,8 +279,8 @@ node(nodeName) {
             sh "sudo cp -r ${env.WORKSPACE}/${dirName} /ceph/cephci-jenkins"
 
             run_type = "Manual Run"
-            if ("openstack-only" in tags_list){
-                if ("schedule" in tags_list){
+            if (is_openstack_run){
+                if ("schedule_openstack_only" in tags_list){
                     run_type = "PSI-Only Schedule Run"
                 } else {
                     run_type = "PSI-Only Sanity Run"

--- a/pipeline/unsigned-container-image-listener.groovy
+++ b/pipeline/unsigned-container-image-listener.groovy
@@ -85,7 +85,7 @@ node("rhel-8-medium || ceph-qe-ci") {
                     "name": "Red Hat Ceph Storage",
                     "version": cephVersion,
                     "nvr": "RHCEPH-${versions.major_version}.${versions.minor_version}",
-                    "phase": "tier-0",
+                    "phase": "sanity",
                     "build_action": "latest"
                 ],
                 "contact": [

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -844,6 +844,9 @@ def fetchStages(
         upstreamVersion - ex: pacific | quincy
     */
     println("Inside fetch stages from runner")
+
+    def runnerCLI = "cd ${env.WORKSPACE}/pipeline/scripts/ci;"
+
     def rhcephVersion
     if ( ! upstreamVersion ) {
         def RHCSVersion = [:]
@@ -859,13 +862,15 @@ def fetchStages(
         def majorVersion = RHCSVersion.major_version
         def minorVersion = RHCSVersion.minor_version
         rhcephVersion = "${majorVersion}.${minorVersion}"
+        runnerCLI = "${runnerCLI} ${env.WORKSPACE}/.venv/bin/python getTestsForPipeline.py"
     }
-    else { rhcephVersion = upstreamVersion }
+    else {
+        rhcephVersion = upstreamVersion
+        runnerCLI = "${runnerCLI} ${env.WORKSPACE}/.venv/bin/python getPipelineStages.py"
+    }
 
     def overridesStr = writeJSON returnText: true, json: overrides
 
-    def runnerCLI = "cd ${env.WORKSPACE}/pipeline/scripts/ci;"
-    runnerCLI = "${runnerCLI} ${env.WORKSPACE}/.venv/bin/python getPipelineStages.py"
     runnerCLI = "${runnerCLI} --rhcephVersion ${rhcephVersion}"
     runnerCLI = "${runnerCLI} --tags ${tags}"
     runnerCLI = "${runnerCLI} --overrides '${overridesStr}'"


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

This PR is created to change the metadata file format to a more readable one and to support addition of metadata (suites to be tested) for different pipelines. The changes done in this PR are as given below

1. Change the metadata file format to the one mentioned in Row number 1 of the table in this document - https://docs.google.com/document/d/1955Llm8zgqSse7i28cqkLAzXmwkR7mkPny3iBKv9yVU/edit 
2. Create a python script to fetch the required data from the metadata file. This python module does the following
- Takes comma separated filters called tags as the input to filter test suites to be executed.
- Takes overrides to be applied to the run cli as a json input
- Takes the RHCS version for which metadata needs to be fetched (Metadata file is named after its RHCS version)
- Fetches all the metadata from the file specified. 
- If there is no pipeline name specified in tags parameter, the method returns empty dictionary as shown below and gives out an error message in logs saying the pipeline is not specified.
        {
            "scripts": {},
            "final_tier": false,
            "final_stage": false,
        }

- If a pipeline is specified, then based on whether any tiers or stages are specified or not, it fetches all the test suites necessary to be executed based on the tags specified and returns them in the same dictionary format above. When a tier and stage value is specified in tags, it also returns information about whether the tier and stage specified are final ones in the pipeline.
3. Modify tier_executor.groovy to adhere to the new pipeline names specified in metadata file (sanity, schedule, sanity_openstack_only, schedule_openstack_only, etc.,)
4. Modify openstack triggers for the pipeline psi-only-executor.groovy (which triggers everytime a new build is available) to only trigger sanity_openstack_only suites. And psi-scheduled-pipeline-executor.groovy (which triggers pipeline once every week) to only trigger schedule_openstack_only suites.
5. Modify pipeline/vars/v3.groovy's fetchstages method, to fetch metadata from the newly created python script for the regular pipelines. Upstream pipeline still uses the old metadata format, so the method to fetch is retained to be the older one for this.
6. Value of one of the parameters in the UMB message sent for unsigned-container-image-listener is changed. This is to ensure we handle triggering of both nightly and rc builds properly at the IBM end with the new metadata format changes. Once this PR is merged I will also be raising a PR to change the image listener in IBM to adapt to this new change. 

Few pipeline executions were done to test out the new changes. 
https://159.23.92.24/job/rhceph-pipeline-manasa/19/ 
https://159.23.92.24/job/rhceph-pipeline-manasa/22/

Some of the executions have been logrotated and removed from jenkins pipeline. But all in all, the code changes are working as expected in our pipeline. 