### PR TITLE
[quincy][pipeline][cephadm] metadata change

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -1087,8 +1087,7 @@ suites:
     metadata:
       - sanity
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - dmfg
       - stage-5
 


### PR DESCRIPTION
[quincy][pipeline][cephadm] metadata change

Remove ibm cloud run for suite "tier-2_multiple_subnet_openstack_only.yaml"