### PR TITLE
Adding validation for cluster health status

### DIFF
--- a/suites/quincy/integrations/ocs.yaml
+++ b/suites/quincy/integrations/ocs.yaml
@@ -105,6 +105,12 @@ tests:
 
   - test:
       abort-on-fail: true
+      desc: "Check Ceph health"
+      module: test_cluster_health.py
+      name: "Get ceph cluster details."
+
+  - test:
+      abort-on-fail: true
       desc: "Retrieve the deployed cluster information."
       module: gather_cluster_info.py
       name: "Get ceph cluster details."

--- a/tests/misc_env/test_cluster_health.py
+++ b/tests/misc_env/test_cluster_health.py
@@ -1,0 +1,28 @@
+import json
+
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def run(ceph_cluster, **kwargs) -> int:
+    """
+    Validate the Ceph Helath Status
+    Returns:
+        0 -> on success
+        1 -> on failure
+
+    Raises:
+        CommandError
+    """
+    LOG.info("Validating Ceph Health")
+    clients = ceph_cluster.get_ceph_objects("client")
+    out, rc = clients[0].exec_command(sudo=True, cmd="ceph -s -f json")
+    cluster_info = json.loads(out)
+    if cluster_info.get("health").get("status") != "HEALTH_OK":
+        LOG.error(f"Cluster helath is in : {cluster_info.get('health').get('status')}")
+        out, rc = clients[0].exec_command(sudo=True, cmd="ceph health detail -f json")
+        error_summary = json.loads(out)
+        LOG.error(f"{error_summary}")
+        return 1
+    return 0


### PR DESCRIPTION
This is to address OCS-CI issue.
We are validating only ceph services. As this was used by odf team, cluster should be in **HELATH_OK** state.
So added a test case to validate ceph health

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ERSR5L/


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
