### PR TITLE
fix upstream pipeline

### DIFF
--- a/pipeline/upstream_test_executor.groovy
+++ b/pipeline/upstream_test_executor.groovy
@@ -11,7 +11,13 @@ def buildType = "upstream"
 def yamlData
 def cephVersion
 def tags = "${buildType},${currentStage}"
-def overrides = [build:buildType, "upstream-build":upstreamVersion, "post-results": "", "report-portal": ""]
+def overrides = [
+    "build": buildType,
+    "upstream-build": upstreamVersion,
+    "post-results": "",
+    "report-portal": "",
+    "workspace": "${env.WORKSPACE}"
+]
 
 // Pipeline script entry point
 node('ceph-qe-ci || rhel-8-medium') {


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

**Issue:**

> + /home/jenkins-build/workspace/rhceph-upstream-test-executor/.venv/bin/python getPipelineStages.py --rhcephVersion quincy --tags upstream,stage-1 --overrides '{"build":"upstream","upstream-build":"quincy","post-results":"","report-portal":""}'
> Traceback (most recent call last):
>   File "getPipelineStages.py", line 163, in <module>
>     raise e
>   File "getPipelineStages.py", line 161, in <module>
>     testStages = fetch_stages(arguments)
>   File "getPipelineStages.py", line 116, in fetch_stages
>     os.makedirs(logdir)
>   File "/usr/lib64/python3.6/os.py", line 210, in makedirs
>     makedirs(head, mode, exist_ok)
>   File "/usr/lib64/python3.6/os.py", line 220, in makedirs
>     mkdir(name, mode)
> PermissionError: [Errno 13] Permission denied: '/logs'

**Solution:**
Add workspace in the overrides.

> ❯ python getPipelineStages.py --rhcephVersion quincy --tags upstream,stage-1 --overrides '{"build":"upstream","upstream-build":"quincy","post-results":"","report-portal":"", "workspace": "/home/sunil/test"}'
> final_stage: false
> scripts:
>   Basic Regression Upstream Testing For DMFG:
>     cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
>       ci-5p69k --log-level DEBUG
>     execute_cli: '.venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
>       ci-5p69k --log-level DEBUG --xunit-results --log-dir /home/sunil/test/logs/2xbn6-
>       --suite suites/quincy/upstream/tier-1-cephadm-basic-regression.yaml --global-conf
>       conf/quincy/upstream/4-node-cluster-with-1-client.yaml --platform rhel-9 --rhbuild
>       6.0 --inventory conf/inventory/rhel-8-latest.yaml --build upstream --upstream-build
>       quincy --post-results  --report-portal '
>     log_dir: /home/sunil/test/logs/2xbn6-
>   Core Feature Upstream Testing For CephFS:
>     cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
>       ci-g8mov --log-level DEBUG
>     execute_cli: '.venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
>       ci-g8mov --log-level DEBUG --xunit-results --log-dir /home/sunil/test/logs/n5ko6-
>       --suite suites/quincy/cephfs/test-core-functionality.yaml --global-conf conf/6-node-cluster-with-1-client.yaml
>       --platform rhel-8 --rhbuild 6.0 --inventory conf/inventory/rhel-8-latest.yaml
>       --build upstream --upstream-build quincy --post-results  --report-portal '
>     log_dir: /home/sunil/test/logs/n5ko6-
>   Core Feature Upstream Testing For DMFG:
>     cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
>       ci-t7gf8 --log-level DEBUG
>     execute_cli: '.venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
>       ci-t7gf8 --log-level DEBUG --xunit-results --log-dir /home/sunil/test/logs/j3us2-
>       --suite suites/quincy/cephadm/sanity-test.yaml --global-conf conf/3-node-cluster-with-1-client.yaml
>       --platform rhel-8 --rhbuild 6.0 --inventory conf/inventory/rhel-8-latest.yaml
>       --build upstream --upstream-build quincy --post-results  --report-portal '
>     log_dir: /home/sunil/test/logs/j3us2-
>   Core Feature Upstream Testing For RBD:
>     cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
>       ci-7m59l --log-level DEBUG
>     execute_cli: '.venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
>       ci-7m59l --log-level DEBUG --xunit-results --log-dir /home/sunil/test/logs/v3z7w-
>       --suite suites/quincy/rbd/basic-operations-unit-testing.yaml --global-conf conf/5-node-cluster-with-1-client.yaml
>       --platform rhel-8 --rhbuild 6.0 --inventory conf/inventory/rhel-8-latest.yaml
>       --build upstream --upstream-build quincy --post-results  --report-portal '
>     log_dir: /home/sunil/test/logs/v3z7w-
>   Core Feature Upstream Testing For RGW:
>     cleanup_cli: .venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --cleanup
>       ci-xdxx4 --log-level DEBUG
>     execute_cli: '.venv/bin/python run.py --osp-cred $HOME/osp-cred-ci-2.yaml --instances-name
>       ci-xdxx4 --log-level DEBUG --xunit-results --log-dir /home/sunil/test/logs/u6vh8-
>       --suite suites/quincy/rgw/test-basic-object-operations.yaml --global-conf conf/5-node-cluster-1-client-with-1-rgw.yaml
>       --platform rhel-8 --rhbuild 6.0 --inventory conf/inventory/rhel-8-latest.yaml
>       --build upstream --upstream-build quincy --post-results  --report-portal '
>     log_dir: /home/sunil/test/logs/u6vh8-

