### PR TITLE
CEPH-11417-Pool Mirror-Try deleting the primary on the relationship (which has snaps and clone configured), and observe the behavior

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -161,6 +161,17 @@ tests:
       desc: Verify that image deleted at primary site updated at secondary
 
   - test:
+      name: test mirror on image having snap and clone after restoring from trash
+      module: test_mirror_move_primary_trash_restore.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11417
+      desc: Verify that image is restore and mirroring is intact
+
+  - test:
       name: test image delete from secondary after promote and demote
       module: test-image-delete-from-secondary.py
       clusters:
@@ -232,11 +243,19 @@ tests:
   - test:
       name: Mirroring of cloned image
       module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-9521
       desc: Testing mirroring of cloned image
 
   - test:
       name: Mirroring from journal to snapshot
       module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-83573618
       desc: Testing journal mirroring to snapshot mirroring

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -155,6 +155,17 @@ tests:
       desc: Verify that image deleted at primary site updated at secondary
 
   - test:
+      name: test mirror on image having snap and clone after restoring from trash
+      module: test_mirror_move_primary_trash_restore.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11417
+      desc: Verify that image is restore and mirroring is intact
+
+  - test:
       name: test image delete from secondary after multiple promote and demote
       module: test-image-delete-from-secondary.py
       clusters:
@@ -226,11 +237,19 @@ tests:
   - test:
       name: Mirroring of cloned image
       module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-9521
       desc: Testing mirroring of cloned image
 
   - test:
       name: Mirroring from journal to snapshot
       module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-83573618
       desc: Testing journal mirroring to snapshot mirroring

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -287,6 +287,9 @@ class RbdMirror:
             p.spawn(mirror2.create_pool, poolname=poolname)
 
         self.create_image(imagespec=imagespec, size=imagesize)
+        if kw.get("image_feature"):
+            image_feature = kw.get("image_feature")
+            self.image_feature_enable(imagespec=imagespec, image_feature=image_feature)
         if kw.get("mode"):
             kw["peer_mode"] = kw.get("peer_mode", "bootstrap")
             kw["rbd_client"] = kw.get("rbd_client", "client.admin")
@@ -595,12 +598,32 @@ class RbdMirror:
             self.exec_cmd(cmd="rbd pool init {}".format(kw.get("poolname")))
 
     def create_image(self, **kw):
-        cmd = "rbd create -s {} {} --image-feature exclusive-lock,journaling".format(
-            kw.get("size", "2G"), kw.get("imagespec")
+        """
+        Create image on provided pool with default image feature
+        like exclusive-lock, layering, objectmap, fast-diff, deepflatten
+        Args:
+            **kw:
+                imagespec: pool/image_name
+                size: size of the image
+        """
+        cmd = "rbd create {} --size {}".format(
+            kw.get("imagespec"), kw.get("size", "2G")
         )
-
         if kw.get("datapool", self.datapool):
             cmd = cmd + " --data-pool {}".format(kw.get("datapool", self.datapool))
+        self.exec_cmd(cmd=cmd)
+
+    def image_feature_enable(self, **kw):
+        """
+        enable image features on the existing image
+        Args:
+            **kw:
+                imagespec: pool/image_name on which image features will enable
+                image_features: comma seperated value for image features
+        """
+        cmd = "rbd feature enable {} {}".format(
+            kw.get("imagespec"), kw.get("image_feature")
+        )
         self.exec_cmd(cmd=cmd)
 
     def export_image(self, **kw):

--- a/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
+++ b/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
@@ -1,0 +1,103 @@
+from tests.rbd.rbd_utils import Rbd
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """Verification of trash restore on an image with snap and clone in primary cluster
+    to check that mirror relationship is intact post restore.
+
+    Args:
+        **kw:
+
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+
+    Test case covered -
+    CEPH-11417 - Pool Mirror - verify mirroring is intact after restore primary
+    image having snap and clone configured from trash
+
+    Pre-requisites :
+    1. At least two clusters must be up and running with enough number of OSDs to create pools
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+
+    Test Case Flow:
+    1. Create an image in primary and perform IOs.
+    2. enable pool mirroring on the image.
+    3. verify for the pool mirror mode enabled on secondary.
+    4. Create anapshot and clone from the snapshot on primary.
+    5. Move the primary image to the trash.
+    6. Restore the primary image from the trash.
+    7. Make sure that image is restored and the mirror relationship is intact.
+    """
+    try:
+        log.info("Starting RBD mirroring test case - CEPH-11417")
+        config = kw.get("config")
+
+        mirror1, mirror2 = [
+            rbdmirror.RbdMirror(cluster, config)
+            for cluster in kw.get("ceph_cluster_dict").values()
+        ]
+
+        rbd1, rbd2 = [
+            Rbd(**kw, req_cname=cluster_name)
+            for cluster_name in kw.get("ceph_cluster_dict").keys()
+        ]
+
+        poolname = mirror1.random_string()
+        imagename = mirror1.random_string()
+        imagespec = poolname + "/" + imagename
+        image_feature = "journaling"
+        mirror1.initial_mirror_config(
+            mirror2,
+            poolname=poolname,
+            imagename=imagename,
+            imagesize=config.get("imagesize", "1G"),
+            mode="pool",
+            image_feature=image_feature,
+            **kw,
+        )
+
+        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
+
+        # create snapshot and clone for the primary image
+        snap = rbd1.random_string()
+        clone = rbd1.random_string()
+        rbd1.snap_create(poolname, imagename, snap)
+        snap_name = f"{poolname}/{imagename}@{snap}"
+        rbd1.create_clone(
+            snap_name=snap_name,
+            pool_name=poolname,
+            image_name=clone,
+            clone_version="v2",
+        )
+
+        # Move primary image to trash
+        rbd1.move_image_trash(poolname, imagename)
+        image_id = rbd1.get_image_id(poolname, imagename)
+        log.info(f"image id is {image_id}")
+
+        # restore primary image
+        rbd1.trash_restore(poolname, image_id)
+        mirror1.image_exists(imagespec)
+        mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
+        mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
+        if mirror1.get_mirror_mode(imagespec) == "journal":
+            log.info("mirroring is intact and enabled even post trash restore")
+
+        # write some bench IO after restore
+        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
+        return 0
+
+    except ValueError as ve:
+        log.error(
+            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
+        )
+        log.exception(ve)
+    except Exception as e:
+        log.exception(e)
+        return 1


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Verification of primary image having snap and clone move to trash and restore back and check mirror relationship is intact

Polarion link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11417

    Test Case Flow:
    1. Create an image in primary and perform IOs.
    2. enable pool mirroring on the image.
    3. verify for the pool mirror mode enabled on secondary.
    4. Create anapshot and clone from the snapshot on primary.
    5. Move the primary image to the trash.
    6. Restore the primary image from the trash.
    7. Make sure that image is restored and the mirror relationship is intact.

success log :  
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-tepu5/test_mirror_on_image_having_snap_and_clone_after_restoring_from_trash_0.log
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ggdnn/