### PR TITLE
Adding ec pool inclusion to RBD mirroring test cases

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -20,6 +20,7 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
       abort-on-fail: true
       clusters:
@@ -217,6 +218,17 @@ tests:
             io-total: 200M
       polarion-id: CEPH-9471
       desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of abrupt failure of secondary cluster
+      module: test_9474.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9474
+      desc: Recovery of abrupt failure of secondary cluster
 
   - test:
       name: Recovery of shutdown secondary cluster

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -14,6 +14,7 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
       abort-on-fail: true
       clusters:
@@ -211,6 +212,17 @@ tests:
             io-total: 200M
       polarion-id: CEPH-9471
       desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of abrupt failure of secondary cluster
+      module: test_9474.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9474
+      desc: Recovery of abrupt failure of secondary cluster
 
   - test:
       name: Recovery of shutdown secondary cluster

--- a/tests/rbd_mirror/test_9470.py
+++ b/tests/rbd_mirror/test_9470.py
@@ -1,41 +1,28 @@
 import time
 
 from ceph.utils import hard_reboot
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
+def test_9470(rbd_mirror, pool_type, **kw):
     try:
-        log.info("Starting CEPH-9470")
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
         osd_cred = config.get("osp_cred")
-        poolname = mirror1.random_string() + "9470pool"
-        imagename = mirror1.random_string() + "9470image"
-        imagespec = poolname + "/" + imagename
         state_after_demote = "up+stopped" if mirror1.ceph_version < 3 else "up+unknown"
-
-        mirror1.initial_mirror_config(
-            mirror2,
-            poolname=poolname,
-            imagename=imagename,
-            imagesize=config.get("imagesize", "1G"),
-            io_total=config.get("io-total", "1G"),
-            mode="pool",
-            **kw,
-        )
 
         hard_reboot(osd_cred, name="ceph-rbd1")
 
         mirror2.promote(imagespec=imagespec, force=True)
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
-        mirror2.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+        mirror2.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
         time.sleep(60)
         mirror1.demote(imagespec=imagespec)
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+error")
@@ -49,11 +36,56 @@ def run(**kw):
         mirror1.promote(imagespec=imagespec)
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
-        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+        mirror1.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+
+def run(**kw):
+    """
+    DR Use case verification - Local/Primary cluster failure - Abrupt failure - Recovery of cluster
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9470 - DR Use case verification - Local/Primary cluster failure - Abrupt failure - Recovery of cluster
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. 3 monitors
+        2. Atleast 9 osds
+        3. Atleast 1 Client
+
+    Test Case Flow:
+    1. Follow the latest official Block device Doc to configure RBD Mirroring - For Both Pool and Image Based Mirroring.
+        VMs should be running on the images that get mirrored.
+        With IOs running on these images, carry on the mirroring for an hour+ (with heavy IOs).
+    2. Shutdown the primary cluster.
+        Follow the latest official Block device Doc for failover After a Non-Orderly Shutdown.
+    3. Restart the IOs on secondary images. Carry on the IOs for an hour+.
+    4. While IO is going on remote/secondary cluster, bring up the local/primary cluster.
+    5. Halt the IOs. Follow the latest official Block device Doc for Failback After a Non-Orderly Shutdown.
+    6. After resync, demote the remote/secondary images and then promote local/primary images.
+    7. Run IOs run from it and make sure mirroring is successfully being done in remote/secondary cluster.
+    """
+    log.info("Starting CEPH-9470")
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_9470(mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_9470(mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw):
+            return 1
+
+    return 0

--- a/tests/rbd_mirror/test_9471.py
+++ b/tests/rbd_mirror/test_9471.py
@@ -1,34 +1,21 @@
 import time
 
 from ceph.parallel import parallel
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
+def test_9471(rbd_mirror, pool_type, **kw):
     try:
-        log.info("Starting CEPH-9471")
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
-        poolname = mirror1.random_string() + "9471pool"
-        imagename = mirror1.random_string() + "9471image"
-        imagespec = poolname + "/" + imagename
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
         state_after_demote = "up+stopped" if mirror1.ceph_version < 3 else "up+unknown"
-
-        mirror1.initial_mirror_config(
-            mirror2,
-            poolname=poolname,
-            imagename=imagename,
-            imagesize=config.get("imagesize", "1G"),
-            io_total=config.get("io-total", "1G"),
-            mode="pool",
-            **kw,
-        )
 
         mirror2.wait_for_replay_complete(imagespec=imagespec)
         mirror1.demote(imagespec=imagespec)
@@ -44,18 +31,63 @@ def run(**kw):
                     check_ec=False,
                 )
         mirror2.promote(imagespec=imagespec)
-        mirror2.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+        mirror2.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
         time.sleep(30)
         mirror2.check_data(peercluster=mirror1, imagespec=imagespec)
         mirror2.demote(imagespec=imagespec)
         mirror2.wait_for_status(imagespec=imagespec, state_pattern=state_after_demote)
         mirror1.wait_for_status(imagespec=imagespec, state_pattern=state_after_demote)
         mirror1.promote(imagespec=imagespec)
-        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total"))
+        mirror1.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
-        return 1
+    return 1
+
+
+def run(**kw):
+    """
+    DR Use case verification - Local/Primary cluster failure - Ordered shutdown of cluster - Recovery of cluster
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9471 - DR Use case verification - Local/Primary cluster failure - Ordered shutdown of cluster -
+                Recovery of cluster
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. 3 monitors
+        2. Atleast 9 osds
+        3. Atleast 1 Client
+
+    Test Case Flow:
+    1. Follow the latest official Block device Doc to configure RBD Mirroring -
+        For Both Pool and Image Based Mirroring. VMs should be running on the images that get mirrored.
+        With IOs running on these images, carry on the mirroring for an hour+ (with heavy IOs).
+    2. Stop the IOs. Follow the latest official Block device Doc for Failover - Orderly Shutdown.
+        Shutdown the primary cluster.
+    3. Restart the IOs on secondary images.
+    4. While IO is going on on remote/secondary cluster, bring up the local/primary cluster.
+    5. Halt the IOs. Promote the local/primary images and demote the secondary images.
+    6. Run IOs run from it and make sure mirroring is successfully being done in remote/secondary cluster.
+    """
+    log.info("Starting CEPH-9471")
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_9471(mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_9471(mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw):
+            return 1
+
+    return 0

--- a/tests/rbd_mirror/test_9474.py
+++ b/tests/rbd_mirror/test_9474.py
@@ -2,42 +2,74 @@ import time
 
 from ceph.parallel import parallel
 from ceph.utils import hard_reboot
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
+def test_9474(rbd_mirror, pool_type, **kw):
     try:
-        log.info("Starting CEPH-9474")
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
         osd_cred = config.get("osp_cred")
-        poolname = mirror1.random_string() + "9474pool"
-        imagename = mirror1.random_string() + "9474image"
-        imagespec = poolname + "/" + imagename
-
-        mirror1.initial_mirror_config(
-            mirror2,
-            poolname=poolname,
-            imagename=imagename,
-            imagesize=config.get("imagesize", "1G"),
-            mode="pool",
-            **kw,
-        )
 
         with parallel() as p:
-            p.spawn(mirror1.benchwrite, imagespec=imagespec, io=config.get("io-total"))
+            p.spawn(
+                mirror1.benchwrite,
+                imagespec=imagespec,
+                io=config[pool_type].get("io_total"),
+            )
             p.spawn(hard_reboot, osd_cred, name="ceph-rbd2")
         time.sleep(60)
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+
+def run(**kw):
+    """
+    Secondary cluster failure - Abrupt Failure - Recovery of failed Cluster
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9474 - Secondary cluster failure - Abrupt Failure - Recovery of failed Cluster
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. 3 monitors
+        2. Atleast 9 osds
+        3. Atleast 1 Client
+
+    Test Case Flow:
+    1. Follow the latest official Block device Doc to configure RBD Mirroring -
+        For Both Pool and Image Based Mirroring:-
+    2. Start the IOs on the primary image. Fail the secondary cluster machines abruptly (power supply failure)
+    3. Bring back the secondary machines.
+    4. Check the data integrity and size of the primary and secondary images.
+    """
+    log.info("Starting CEPH-9474")
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_9474(mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_9474(mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw):
+            return 1
+
+    return 0

--- a/tests/rbd_mirror/test_9475.py
+++ b/tests/rbd_mirror/test_9475.py
@@ -1,32 +1,20 @@
 import time
 
 from ceph.parallel import parallel
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
+def test_9475(rbd_mirror, pool_type, **kw):
     try:
-        log.info("Starting CEPH-9475")
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
-        poolname = mirror1.random_string() + "9475pool"
-        imagename = mirror1.random_string() + "9475image"
-        imagespec = poolname + "/" + imagename
-
-        mirror1.initial_mirror_config(
-            mirror2,
-            poolname=poolname,
-            imagename=imagename,
-            imagesize=config.get("imagesize", "1G"),
-            mode="pool",
-            **kw,
-        )
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
 
         with parallel() as p:
             for node in mirror2.ceph_nodes:
@@ -37,12 +25,55 @@ def run(**kw):
                     node=node,
                     check_ec=False,
                 )
-            p.spawn(mirror1.benchwrite, imagespec=imagespec, io=config.get("io-total"))
+            p.spawn(
+                mirror1.benchwrite,
+                imagespec=imagespec,
+                io=config[pool_type].get("io_total"),
+            )
         time.sleep(30)
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+
+def run(**kw):
+    """
+    Secondary cluster failure - Ordered Shutdown - Recovery of shutdown cluster.
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9475 - Secondary cluster failure - Ordered Shutdown - Recovery of shutdown cluster.
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. 3 monitors
+        2. Atleast 9 osds
+        3. Atleast 1 Client
+
+    Test Case Flow:
+    1. Do an orderly shutdown of all the machines on the slave cluster.
+    2. Write some IOs on the primary image.
+    3. Bring back the secondary cluster.
+    4. Verify that both primary and secondary image has same data
+    """
+    log.info("Starting CEPH-9475")
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_9475(mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_9475(mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw):
+            return 1
+
+    return 0


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

Added a method (rbd_mirror_config) to adopt ec pool inclusion for RBD mirroring which can be reused for all test modules to adopt ec pool inclusion.

RHCS 5.3
test_9470 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ae78a/Recovery_of_abrupt_failure_of_primary_cluster_0.log
test_9471 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ae78a/Recovery_of_shutdown_primary_cluster_0.log 
test_9474 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6qxo7/test_9474_0.log (Failure is not because of the changes in PR, its because of a connection issue, so i think this PR can still be merged)
test_9475 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ae78a/Recovery_of_shutdown_secondary_cluster_0.log

RHCS 6.0
test_9470 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6gfal/Recovery_of_abrupt_failure_of_primary_cluster_0.log
test_9471 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6gfal/Recovery_of_shutdown_primary_cluster_0.log (Failure is not because of the changes in PR, its because of a connection issue, so i think this PR can still be merged)
test_9474 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6gfal/test_9474_0.log
test_9475 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6gfal/Recovery_of_shutdown_secondary_cluster_0.log
