### PR TITLE
Moving mail section as a part of final block

### DIFF
--- a/pipeline/upstream_test_executor.groovy
+++ b/pipeline/upstream_test_executor.groovy
@@ -95,7 +95,6 @@ node('ceph-qe-ci || rhel-8-medium') {
                 ])
             }
         }
-
     } catch(Exception err) {
         // notify about failure
         currentBuild.result = "FAILURE"


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Send email on execution of upstarem test executor
![Screenshot from 2023-02-01 12-15-48](https://user-images.githubusercontent.com/83442624/215971937-2570dd88-39ed-45b4-861b-ecb9594a8979.png)

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
