### PR TITLE
Switch to RHEL-8.7 nightly image

### DIFF
--- a/conf/inventory/rhel-8.7-server-x86_64-large.yaml
+++ b/conf/inventory/rhel-8.7-server-x86_64-large.yaml
@@ -3,7 +3,7 @@ version_id: 8.7
 id: rhel
 instance:
   create:
-    image-name: RHEL-8.7.0-x86_64-ga-latest
+    image-name: RHEL-8.7.0-x86_64-nightly-latest
     vm-size: ci.m1.large
 
   setup: |

--- a/conf/inventory/rhel-8.7-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.7-server-x86_64.yaml
@@ -3,7 +3,7 @@ version_id: 8.7
 id: rhel
 instance:
   create:
-    image-name: RHEL-8.7.0-x86_64-ga-latest
+    image-name: RHEL-8.7.0-x86_64-nightly-latest
     vm-size: ci.m1.medium
 
   setup: |


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Found none or more than one image resource with name: RHEL-8.7.0-x86_64-ga-latest, so swtiching to Nightly build. 

