### PR TITLE
RBD pipeline issue fix

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -291,7 +291,8 @@ class RbdMirror:
             kw["peer_mode"] = kw.get("peer_mode", "bootstrap")
             kw["rbd_client"] = kw.get("rbd_client", "client.admin")
             self.config_mirror(mirror2, poolname=poolname, **kw)
-        if kw.get("mirrormode"):
+        # Enable image level mirroring only when mode is image type
+        if kw.get("mirrormode") and kw.get("mode") == "image":
             mirrormode = kw.get("mirrormode")
             self.enable_mirror_image(poolname, imagename, mirrormode)
 


### PR DESCRIPTION
Signed-off-by: Sunil Angadi <sangadi@redhat.com>
Fixes RHCEPHQE-7066
Fix: Enable image level mirroring only if mirroring is enabled of type mode **image**

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
