### PR TITLE
Adopt to new black(23.1.0)

### DIFF
--- a/ceph/ceph_admin/client_keyring.py
+++ b/ceph/ceph_admin/client_keyring.py
@@ -15,11 +15,9 @@ class ClientKeyringOpFailure(Exception):
 
 
 class ClientKeyring(Orch):
-
     SERVICE_NAME = "client-keyring"
 
     def ls(self, config):
-
         """
         List the client keyrings available
         Args:
@@ -39,7 +37,6 @@ class ClientKeyring(Orch):
         return self.shell(args=cmd)
 
     def rm(self, config):
-
         """
         Remove client-keyring from cluster
         Args:

--- a/ceph/ceph_admin/dashboard.py
+++ b/ceph/ceph_admin/dashboard.py
@@ -154,7 +154,6 @@ def enable_alertmanager(cls, config):
     daemon_obj = loads(out)
 
     if daemon_obj:
-
         # To get hostname in which daemon got deployed
         for daemon in daemon_obj:
             host = daemon["hostname"]

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1040,7 +1040,6 @@ class RadosOrchestrator:
         return True
 
     def get_cluster_date(self):
-
         """
         Used to get the osd parameter value
         Args:

--- a/ceph/rados/rados_scrub.py
+++ b/ceph/rados/rados_scrub.py
@@ -61,7 +61,6 @@ class RadosScrubber(RadosOrchestrator):
             return 1
 
     def get_pg_dump(self, *args):
-
         """
         Used to get the pg dump logs
 

--- a/compute/ibmcloud.py
+++ b/compute/ibmcloud.py
@@ -116,7 +116,6 @@ class CephVMNodeV2:
         """
         LOG.info("Starting to create VM with name %s", node_name)
         try:
-
             ibmcloud_client = SoftLayer.VSManager(self.driver)
             keys = SoftLayer.SshKeyManager(self.driver).list_keys()
             key_ids = [d["id"] for d in keys if d["label"] == "Amarnath"]

--- a/pipeline/scripts/ci/cos_cli.py
+++ b/pipeline/scripts/ci/cos_cli.py
@@ -119,7 +119,6 @@ OPS = {
 }
 
 if __name__ == "__main__":
-
     _args = docopt(usage, help=True, version=None, options_first=False)
     logging.basicConfig(
         handlers=[logging.StreamHandler(sys.stdout)],

--- a/pipeline/scripts/ci/getPipelineStages.py
+++ b/pipeline/scripts/ci/getPipelineStages.py
@@ -126,7 +126,7 @@ def fetch_stages(args):
         script.update(metadata_overrides)
         script.update(overrides)
 
-        for (k, v) in script.items():
+        for k, v in script.items():
             if isinstance(v, list):
                 for item in v:
                     execute_cli += f" --{k} {item}"

--- a/pipeline/scripts/ci/upstream_cli.py
+++ b/pipeline/scripts/ci/upstream_cli.py
@@ -178,7 +178,6 @@ OPS = {
 }
 
 if __name__ == "__main__":
-
     _args = docopt(usage, help=True, version=None, options_first=False)
     logging.basicConfig(
         handlers=[logging.StreamHandler(sys.stdout)],

--- a/run.py
+++ b/run.py
@@ -363,7 +363,6 @@ def get_html_page(url: str) -> str:
 
 
 def run(args):
-
     import urllib3
 
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -519,7 +518,6 @@ def run(args):
             distro.append(inventory.get("instance").get("create").get("image-name"))
 
     for cluster in conf.get("globals"):
-
         if cluster.get("ceph-cluster").get("inventory"):
             cluster_inventory_path = os.path.abspath(
                 cluster.get("ceph-cluster").get("inventory")

--- a/tests/ceph_ansible/docker_to_podman.py
+++ b/tests/ceph_ansible/docker_to_podman.py
@@ -5,7 +5,6 @@ log = Log(__name__)
 
 
 def run(**kw):
-
     log.info("Running exec test")
     ceph_nodes = kw.get("ceph_nodes")
     config = kw.get("config")

--- a/tests/ceph_ansible/filestore_to_bluestore.py
+++ b/tests/ceph_ansible/filestore_to_bluestore.py
@@ -5,7 +5,6 @@ log = Log(__name__)
 
 
 def run(**kw):
-
     log.info("Running Filestore to bluestore migrations test")
     ceph_nodes = kw.get("ceph_nodes")
     ansible_dir = "/usr/share/ceph-ansible"

--- a/tests/ceph_ansible/shrink_daemon.py
+++ b/tests/ceph_ansible/shrink_daemon.py
@@ -9,7 +9,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     ansible_dir = "/usr/share/ceph-ansible"
     ceph_installer = ceph_cluster.get_ceph_object("installer")
     config = kw.get("config")

--- a/tests/ceph_ansible/switch_rpm_to_container.py
+++ b/tests/ceph_ansible/switch_rpm_to_container.py
@@ -31,7 +31,6 @@ def ceph_repository_type_cdn(ansible_dir, installer_node):
 
 
 def run(**kw):
-
     log.info("Running exec test")
     ceph_nodes = kw.get("ceph_nodes")
     config = kw.get("config")

--- a/tests/ceph_ansible/test_ansible_upgrade.py
+++ b/tests/ceph_ansible/test_ansible_upgrade.py
@@ -204,7 +204,6 @@ def run(ceph_cluster, **kw):
     client = ceph_cluster.get_ceph_object("mon")
 
     if build.startswith("5"):
-
         cmd = (
             "cd {};"
             "ANSIBLE_STDOUT_CALLBACK=debug;"

--- a/tests/cephfs/CEPH-11220.py
+++ b/tests/cephfs/CEPH-11220.py
@@ -124,7 +124,6 @@ def run(ceph_cluster, **kw):
         return 1
 
     except Exception as e:
-
         log.info(e)
 
         log.info(traceback.format_exc())

--- a/tests/cephfs/CEPH-11221.py
+++ b/tests/cephfs/CEPH-11221.py
@@ -56,7 +56,6 @@ def run(ceph_cluster, **kw):
             raise CommandFailed("kernel mount failed")
 
         while c1:
-
             with parallel() as p:
                 p.spawn(
                     fs_util.read_write_IO,

--- a/tests/cephfs/CEPH-11222.py
+++ b/tests/cephfs/CEPH-11222.py
@@ -239,7 +239,6 @@ def run(ceph_cluster, **kw):
             )
         return 1
     except Exception as e:
-
         log.info(e)
 
         log.info(traceback.format_exc())

--- a/tests/cephfs/CEPH-11262.py
+++ b/tests/cephfs/CEPH-11262.py
@@ -99,7 +99,6 @@ def run(ceph_cluster, **kw):
             )
 
         for node in client_info["mds_nodes"]:
-
             rc = fs_util.heartbeat_map(node)
             if rc == 0:
                 log.info("heartbeat_map entry not found")

--- a/tests/cephfs/active_active_mdsfailover_test.py
+++ b/tests/cephfs/active_active_mdsfailover_test.py
@@ -140,7 +140,6 @@ def run(**kw):
     log.info("Execution of Test case 11230 started:")
     tc = "11130"
     with parallel() as p:
-
         p.spawn(
             utils.mkdir_pinning,
             fuse_clients,
@@ -160,7 +159,6 @@ def run(**kw):
         )
 
     with parallel() as p:
-
         p.spawn(
             utils.pinned_dir_io,
             kernel_clients,

--- a/tests/cephfs/ceph-83574186.py
+++ b/tests/cephfs/ceph-83574186.py
@@ -10,7 +10,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     """
     Test operation:
     1. Generate random name fo subvolume creation
@@ -21,7 +20,6 @@ def run(ceph_cluster, **kw):
     6. Verify if trash directory is empty
     """
     try:
-
         tc = "CEPH-83574186"
         log.info(f"Running CephFS tests for BZ-{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_clientsIO_test.py
+++ b/tests/cephfs/cephfs_clientsIO_test.py
@@ -59,7 +59,6 @@ def run(**kw):
     print(md5sum_file_lock)
 
     if md5sum_file_lock[0] == md5sum_file_lock[1]:
-
         log.info(
             "File Locking mechanism is working,data is not corrupted,test case CEPH-10529 passed"
         )

--- a/tests/cephfs/cephfs_utils.py
+++ b/tests/cephfs/cephfs_utils.py
@@ -874,7 +874,6 @@ class FsUtils(object):
     @staticmethod
     def file_locking(clients, mounting_dir):
         for client in clients:
-
             to_lock_file = """
 import fcntl
 import subprocess
@@ -1533,7 +1532,6 @@ os.system('sudo systemctl start  network')
                 )
 
     def standby_rank(self, mds_nodes, mon_nodes, **kwargs):
-
         host_names = []
         for mds in mds_nodes:
             host_names.append(mds.node.hostname)
@@ -2251,7 +2249,6 @@ mds standby for rank = 1
             return self.result_vals, 0
 
     def setfattr(self, clients, ops, val, mounting_dir, file_name):
-
         if ops == "max_bytes" or ops == "max_files":
             for client in clients:
                 rc = self.check_mount_exists(client)

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -473,7 +473,6 @@ class FsUtils(object):
     def client_clean_up(
         *args, fuse_clients=[], kernel_clients=[], mounting_dir="", **kwargs
     ):
-
         """
         This method cleans up all the client nodes and mount points
         Args:
@@ -1472,7 +1471,6 @@ class FsUtils(object):
         return total_bytes
 
     def file_byte_quota_test(self, client, mounting_dir, quota_attrs):
-
         total_bytes = quota_attrs.get("bytes")
         temp_str = "".join([random.choice(string.ascii_letters) for _ in range(3)])
         bytes_in_dir = int(self.get_total_no_bytes(client, mounting_dir))

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_auto_clean_up.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_auto_clean_up.py
@@ -17,7 +17,6 @@ def run(ceph_cluster, **kw):
     4. Check if number of files in the directory is equal to 0
     """
     try:
-
         tc = "CEPH-83574188"
         log.info(f"Running CephFS tests for BZ-{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_create_vol_component_exist_name.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_create_vol_component_exist_name.py
@@ -9,7 +9,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     """
     pre-requisites:
     1. Create a volume with a name

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_delete_non_exist_subvol_group.py
@@ -7,7 +7,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     """
     Test operation:
     1. Create a subvolume_group name that does not exist
@@ -16,7 +15,6 @@ def run(ceph_cluster, **kw):
     4. Check if the command is failed
     """
     try:
-
         tc = "CEPH-83574168"
         log.info(f"Running CephFS tests for BZ-{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_non_exist_subvol_group.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_non_exist_subvol_group.py
@@ -20,7 +20,6 @@ def run(ceph_cluster, **kw):
     5. If the creation and deletion are failed, return 0
     """
     try:
-
         tc = "CEPH-83574161"
         log.info(f"Running CephFS tests for BZ-{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_non_exist_subvolume.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_non_exist_subvolume.py
@@ -7,7 +7,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     """
     Test operation:
     1. Create a subvolume name that does not exist

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_pool_name_option_test.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_pool_name_option_test.py
@@ -21,7 +21,6 @@ def run(ceph_cluster, **kw):
 
     """
     try:
-
         tc = "CEPH-83573528"
         log.info(f"Running CephFS tests for BZ-{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_gid_uid.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_gid_uid.py
@@ -10,7 +10,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     """
     Test operation:
     1. Create a subvolume

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_group_force.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_group_force.py
@@ -7,7 +7,6 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-
     """
     Test operation:
     1. Create a subvolume_group name that does not exist
@@ -16,7 +15,6 @@ def run(ceph_cluster, **kw):
     4. Check if the command is failed
     """
     try:
-
         tc = "CEPH-83574169"
         log.info(f"Running CephFS tests for BZ-{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
@@ -18,7 +18,6 @@ def run(ceph_cluster, **kw):
     3. Using get_path, check if subvolume path is cleaned up
     """
     try:
-
         tc = "CEPH-83574192"
         log.info(f"Running CephFS tests for Polarion ID -{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_isolated_namespace.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_isolated_namespace.py
@@ -20,7 +20,6 @@ def run(ceph_cluster, **kw):
     4. Remove the subvolume
     """
     try:
-
         tc = "CEPH-83574187"
         log.info(f"Running CephFS tests for Polarion ID -{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_metadata.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_subvolume_metadata.py
@@ -22,7 +22,6 @@ def run(ceph_cluster, **kw):
     5. Check if the metadata key and value are deleted
     """
     try:
-
         fs_util = FsUtils(ceph_cluster)
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
@@ -79,7 +78,6 @@ def run(ceph_cluster, **kw):
         log.info("Metadata CREATION testing is done")
 
         for k1, v1 in key_value.items():
-
             if k1 in metadata_result and metadata_result[k1] == v1:
                 pass
             else:
@@ -115,7 +113,6 @@ def run(ceph_cluster, **kw):
         # Remove Testing
 
         for k1, v1 in key_value.items():
-
             client1.exec_command(
                 sudo=True,
                 cmd=f"ceph fs subvolume metadata rm cephfs {subvol_name} {k1}",

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_volume_with_exist_names.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_volume_with_exist_names.py
@@ -18,7 +18,6 @@ def run(ceph_cluster, **kw):
     5. If the creation and deletion are failed, return 0
     """
     try:
-
         tc = "CEPH-83573428"
         log.info(f"Running CephFS tests{tc}")
         fs_util = FsUtils(ceph_cluster)

--- a/tests/cephfs/snapshot_clone/clone_threads.py
+++ b/tests/cephfs/snapshot_clone/clone_threads.py
@@ -64,7 +64,6 @@ def run(ceph_cluster, **kw):
     3. ceph fs subvolumegroup rm <vol_name> <group_name>
     """
     try:
-
         fs_util = FsUtils(ceph_cluster)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")

--- a/tests/cephfs/test_clone_threads.py
+++ b/tests/cephfs/test_clone_threads.py
@@ -64,7 +64,6 @@ def run(ceph_cluster, **kw):
     3. ceph fs subvolumegroup rm <vol_name> <group_name>
     """
     try:
-
         fs_util = FsUtils(ceph_cluster)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")

--- a/tests/iscsi/CEPH-10451.py
+++ b/tests/iscsi/CEPH-10451.py
@@ -112,7 +112,6 @@ def do_failover(iscsi_initiators, device_list, ceph_nodes):
     print(active_device_status)
     print(active_device)
     if rc == "active":
-
         return 0
     else:
         return 1

--- a/tests/mgr/test_mgr_keyring.py
+++ b/tests/mgr/test_mgr_keyring.py
@@ -4,7 +4,6 @@ log = Log(__name__)
 
 
 def run(**kw):
-
     log.info("Running exec test")
     ceph_nodes = kw.get("ceph_nodes")
     config = kw.get("config")

--- a/tests/misc_env/update-kernel.py
+++ b/tests/misc_env/update-kernel.py
@@ -30,7 +30,6 @@ def run(**kw):
 
 
 def update_kernel_and_reboot(client, repo_url):
-
     kernel_repo_file = """
 [KernelUpdate]
 name=KernelUpdate

--- a/tests/rados/scheduled_scrub_scenarios.py
+++ b/tests/rados/scheduled_scrub_scenarios.py
@@ -44,7 +44,6 @@ def set_default_params(rados_obj):
 
 
 def run(ceph_cluster, **kw):
-
     osd_scrub_min_interval = 1800
     osd_scrub_max_interval = 3600
     osd_deep_scrub_interval = 3600

--- a/tests/rados/test_9281.py
+++ b/tests/rados/test_9281.py
@@ -25,7 +25,6 @@ def prepare_sdata(mon):
     sfd = None
 
     try:
-
         sfd = mon.remote_file(file_name=sdata, file_mode="w+")
         sfd.write(dbuf)
         sfd.flush()

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -15,7 +15,6 @@ log = Log(__name__)
 
 class RbdMirror:
     def __init__(self, cluster, config):
-
         self.ceph_nodes = cluster
         self.k_m = config.get("ec-pool-k-m", None)
         self.ceph_version = int(config.get("rhbuild")[0])
@@ -207,7 +206,6 @@ class RbdMirror:
                     poolname=poolname, cluster_name=secondary_cluster_name
                 )
             else:
-
                 primary_mon = ",".join(
                     [
                         obj.node.ip_address
@@ -682,7 +680,6 @@ class RbdMirror:
 
     # Remove Peer
     def peer_remove(self, **kw):
-
         peer_uuid = self.mirror_info(kw.get("poolname"), "uuid")
         return self.exec_cmd(
             cmd="rbd mirror pool peer remove {} {}".format(

--- a/tests/upgrades/test_upgrade.py
+++ b/tests/upgrades/test_upgrade.py
@@ -119,7 +119,6 @@ def run(ceph_cluster, **kw):
     ceph_cluster_dict = kw.get("ceph_cluster_dict")
 
     for cluster_name, cluster in ceph_cluster_dict.items():
-
         LOG.info(f"Starting Ceph cluster deployment for version: {install_version}")
         if install_version >= 5.0:
             config["steps"] = config["suite_setup"]["steps"]

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -427,7 +427,6 @@ def rc_verify(tc, RC):
     return_codes_set = set(RC)
 
     if len(return_codes_set) == 1:
-
         out = "Test case %s Passed" % (tc)
 
         return out


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

```
Oh no! 💥 💔 💥
45 files would be reformatted, 401 files would be left unchanged.
py: exit 1 (10.57 seconds) /home/runner/work/cephci/cephci> black --check --diff . pid=1979
.pkg: _exit> python /opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py: FAIL code 1 (62.91=setup[42.10]+cmd[1.57,7.21,1.47,10.57] seconds)
  evaluation failed :( (63.02 seconds)
Error: Process completed with exit code 1.
```

Fix black issue with newer version `23.1.0`