### PR TITLE
Moving mail section as a part of final block

### DIFF
--- a/pipeline/upstream_test_executor.groovy
+++ b/pipeline/upstream_test_executor.groovy
@@ -18,6 +18,9 @@ def overrides = [
     "report-portal": "",
     "workspace": "${env.WORKSPACE}"
 ]
+def status = "STABLE"
+def upstreamArtifact =  [:]
+def failureReason
 
 // Pipeline script entry point
 node('ceph-qe-ci || rhel-8-medium') {
@@ -53,6 +56,9 @@ node('ceph-qe-ci || rhel-8-medium') {
         }
 
         stage('Fetch Test-suites for Execution') {
+            yamlData = readYaml file: "/ceph/cephci-jenkins/latest-rhceph-container-info/${buildType}.yaml"
+            cephVersion = yamlData[upstreamVersion]["ceph-version"]
+            currentBuild.description = "${upstreamVersion} - ${currentStage} - ${cephVersion}"
             fetchStages = sharedLib.fetchStages(tags, overrides, testResults, null, null, upstreamVersion)
             testStages = fetchStages["testStages"]
             if ( testStages.isEmpty() ) {
@@ -60,27 +66,20 @@ node('ceph-qe-ci || rhel-8-medium') {
                 error "Test suites were not found for execution"
             }
             print("Stages fetched: ${fetchStages}")
-            yamlData = readYaml file: "/ceph/cephci-jenkins/latest-rhceph-container-info/${buildType}.yaml"
-            cephVersion = yamlData[upstreamVersion]["ceph-version"]
-            currentBuild.description = "${upstreamVersion} - ${currentStage} - ${cephVersion}"
         }
 
         parallel testStages
 
         stage('publish result') {
-            def upstreamArtifact = ["composes": yamlData[upstreamVersion]["composes"],
+            upstreamArtifact = ["composes": yamlData[upstreamVersion]["composes"],
                                     "product": "Ceph Storage",
                                     "ceph_version": cephVersion,
                                     "repository": yamlData[upstreamVersion]["image"],
                                     "upstreamVersion": upstreamVersion]
-            def status = "STABLE"
             if ( "FAIL" in sharedLib.fetchStageStatus(testResults) ) {
                 currentBuild.result = "FAILURE"
                 status = "UNSTABLE"
             }
-            sharedLib.sendEmail(buildType, testResults, upstreamArtifact, null, currentStage)
-            def msg = "Upstream test report status of ${currentStage} ceph version:${cephVersion}-${upstreamVersion} is ${status} .Log:${env.BUILD_URL}"
-            googlechatnotification(url: "id:rhcephCIGChatRoom", message: msg)
         }
 
         stage('Post Build Action') {
@@ -97,11 +96,17 @@ node('ceph-qe-ci || rhel-8-medium') {
                 ])
             }
         }
-
     } catch(Exception err) {
         // notify about failure
         currentBuild.result = "FAILURE"
-        def failureReason = err.getMessage()
+        failureReason = err.getMessage()
         echo failureReason
+    } finally {
+        sharedLib.sendEmail(buildType, testResults, upstreamArtifact, null, currentStage)
+        def msg = "Upstream test report status of ${currentStage} ceph version:${cephVersion}-${upstreamVersion} is ${status} .Log:${env.BUILD_URL}"
+        if (currentBuild.result != "SUCCESS") {
+            msg = msg + ", ${currentBuild.result} Reason: ${failureReason}"
+        }
+        googlechatnotification(url: "id:rhcephCIGChatRoom", message: msg)
     }
 }


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Send email on execution of upstream test executor on pass and fail
![Screenshot from 2023-02-01 12-15-48](https://user-images.githubusercontent.com/83442624/215971937-2570dd88-39ed-45b4-861b-ecb9594a8979.png)

Gchat on failure
Downstream Ceph Jenkins, App, Now
Upstream test report status of stage-2 ceph version:6.0-quincy is UNSTABLE .Log:https://jenkins.ceph.redhat.com/job/rhceph-upstream-test-executor/37/, FAILURE Reason: Test suites were not found for execution


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
