### PR TITLE
Moving Snapshot suite to PSI only environment

### DIFF
--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -545,8 +545,7 @@ suites:
     metadata:
       - schedule
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - cephfs
       - stage-1
   - name: "test-cephfs-volume-mgmt"

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -894,8 +894,7 @@ suites:
     metadata:
       - sanity
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - cephfs
       - stage-5
 

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -952,8 +952,7 @@ suites:
     metadata:
       - sanity
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - cephfs
       - stage-5
 

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -440,8 +440,7 @@ suites:
     metadata:
       - sanity
       - tier-2
-      - openstack
-      - ibmc
+      - openstack-only
       - cephfs
       - stage-5
 


### PR DESCRIPTION
Moving Snapshot suite to PSI only environment
As we are seeing issues in IBM-C environment, moving this suite to PSI only.

We tried to fence the failures by adding sufficient timeouts but suite is still failing (4 out of 10 times)

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
