### PR TITLE
Fixing aborted pipeline failure

### DIFF
--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -195,7 +195,7 @@ node(nodeName) {
                         "type": buildType,
                         "category": "functional",
                         "result": "ABORTED",
-                        "object-prefix": dirName,
+                        "object-prefix": null,
                     ],
                     "recipe": buildArtifacts,
                     "generated_at": env.BUILD_ID,


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for aborted pipeline when ceph version mismatched

recipeFile ceph-version : 16.2.10-115
[Pipeline] echo
buildArtifacts ceph-version : 16.2.10-113
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
groovy.lang.MissingPropertyException: No such property: dirName for class: groovy.lang.Binding
	at groovy.lang.Binding.getVariable(Binding.java:63)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onGetProperty(SandboxInterceptor.java:266)
	at org.kohsuke.groovy.sandbox.impl.Checker$7.call(Checker.java:375)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:379)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:355)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedGetProperty(Checker.java:355)
	at com.cloudbees.groovy.cps.sandbox.SandboxInvoker.getProperty(SandboxInvoker.java:29)
	at com.cloudbees.groovy.cps.impl.PropertyAccessBlock.rawGet(PropertyAccessBlock.java:20)
	at WorkflowScript.run(WorkflowScript:198)