### PR TITLE
Pipeline Failure 6.0- Mirroring of cloned image for tier-2_rbd_mirror_regression

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -232,11 +232,19 @@ tests:
   - test:
       name: Mirroring of cloned image
       module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-9521
       desc: Testing mirroring of cloned image
 
   - test:
       name: Mirroring from journal to snapshot
       module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-83573618
       desc: Testing journal mirroring to snapshot mirroring

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -226,11 +226,19 @@ tests:
   - test:
       name: Mirroring of cloned image
       module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-9521
       desc: Testing mirroring of cloned image
 
   - test:
       name: Mirroring from journal to snapshot
       module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
       polarion-id: CEPH-83573618
       desc: Testing journal mirroring to snapshot mirroring

--- a/tests/rbd_mirror/test_rbd_clone_mirror.py
+++ b/tests/rbd_mirror/test_rbd_clone_mirror.py
@@ -1,4 +1,3 @@
-from tests.rbd.exceptions import RbdBaseException
 from tests.rbd.rbd_utils import Rbd
 from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
@@ -105,9 +104,13 @@ def run(**kw):
         mirror1.delete_image(imagespec2)
         mirror1.delete_image(imagespec)
         mirror1.clean_up(peercluster=mirror2, pools=[poolname])
-
         return 0
 
-    except RbdBaseException as error:
-        print(error.message)
+    except ValueError as ve:
+        log.error(
+            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
+        )
+        log.exception(ve)
+    except Exception as e:
+        log.exception(e)
         return 1

--- a/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
+++ b/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
@@ -1,5 +1,4 @@
 from ceph.parallel import parallel
-from tests.rbd.exceptions import RbdBaseException
 from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
 
@@ -71,9 +70,13 @@ def run(**kw):
 
         # Cleans up the configuration
         mirror1.clean_up(peercluster=mirror2, pools=[poolname])
-
         return 0
 
-    except RbdBaseException as error:
-        print(error.message)
+    except ValueError:
+        log.error(
+            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
+        )
+
+    except Exception as e:
+        log.error(e)
         return 1


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

This is pipeline issue observed while monitoring TFA.
issue : Test case is running twice on both the cluster as we are not mentioning the cluster on which test case to be run.
solution : Adding cluster details in test suite resolved the issue.

success log: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-tp8e7/