### PR TITLE
Adapt test-image-delete-from-secondary to test for both ecpools and replicated pools

### DIFF
--- a/tests/rbd_mirror/test-image-delete-from-secondary.py
+++ b/tests/rbd_mirror/test-image-delete-from-secondary.py
@@ -1,58 +1,20 @@
 import datetime
 import time
 
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
-    """verification of removal of failed back images should reflect to secondary.
-
-    this verifies that the deletion of primary images deletes the images on secondary also when we perform multiple
-    promote and demote operation.
-
-    Args:
-        **kw:
-        repeat_count - number of times promote and demote happens before delete image
-    Returns:
-        0 - if test case pass
-        1 - it test case fails
-
-    Test case flow:
-    1. Create image on cluster-1.
-    2. Enable mirroring for created image on cluster-1 and run IOs.
-    3. Ensure mirror image created on cluster-2.
-    4. Force promote image on cluster-2 and run IOs.
-    5. demote image on cluster 1.
-    6. resync the image to cluster 2.
-    7. Demote image on cluster-2 and promote image on cluster-1.
-    8. Delete image on cluster-1.
-    """
+def test_image_delete_from_secondary(rbd_mirror, pool_type, **kw):
     try:
-        log.info("Starting RBD mirroring test case - CEPH-83574741")
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
-
-        # create images and enable snapshot mirroring
-        poolname = mirror1.random_string() + "83574741pool"
-        imagename = mirror1.random_string() + "83574741image"
-        imagespec = poolname + "/" + imagename
-
-        mirror1.initial_mirror_config(
-            mirror2,
-            poolname=poolname,
-            imagename=imagename,
-            imagesize=config.get("imagesize", "1G"),
-            io_total=config.get("io-total", "1G"),
-            mode="image",
-            mirrormode="snapshot",
-            **kw,
-        )
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
 
         # promote and demote images
         # resyncing of images after demote
@@ -98,3 +60,47 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+
+def run(**kw):
+    log.info("Starting RBD mirroring test case - CEPH-83574741")
+
+    """verification of removal of failed back images should reflect to secondary.
+
+    this verifies that the deletion of primary images deletes the images on secondary also when we perform multiple
+    promote and demote operation.
+
+    Args:
+        **kw:
+        repeat_count - number of times promote and demote happens before delete image
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+
+    Test case flow:
+    1. Create image on cluster-1.
+    2. Enable mirroring for created image on cluster-1 and run IOs.
+    3. Ensure mirror image created on cluster-2.
+    4. Force promote image on cluster-2 and run IOs.
+    5. demote image on cluster 1.
+    6. resync the image to cluster 2.
+    7. Demote image on cluster-2 and promote image on cluster-1.
+    8. Delete image on cluster-1.
+    """
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_image_delete_from_secondary(
+            mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+        ):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_image_delete_from_secondary(
+            mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+        ):
+            return 1
+
+    return 0


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Goal is to verify test case execution on both Replication pool as well as on EC pool.

success log: 
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-vor9d/