### PR TITLE
T2 automation of CEPH-83574449

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -156,6 +156,15 @@ tests:
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
         timeout: 500
   - test:
+      name: STS test with invalid principal in the role's policy
+      desc: STS test with invalid principal in the role's policy
+      polarion-id: CEPH-83574537
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto.py
+        config-file-name: test_sts_invalid_principal.yaml
+        timeout: 500
+  - test:
       name: reshard cancel command
       desc: reshard cancel command
       polarion-id: CEPH-11474

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -162,6 +162,15 @@ tests:
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
         timeout: 500
   - test:
+      name: STS test with invalid principal in the role's policy
+      desc: STS test with invalid principal in the role's policy
+      polarion-id: CEPH-83574537
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto.py
+        config-file-name: test_sts_invalid_principal.yaml
+        timeout: 500
+  - test:
       name: reshard cancel command
       desc: reshard cancel command
       polarion-id: CEPH-11474


### PR DESCRIPTION
T2 automation of CEPH-83574449.

Test invalid principal in the policy rule, it should fail.

logs:  http://pastebin.test.redhat.com/1090318

Signed-off-by: viduship <vimishra@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
