### PR TITLE
Fixing node id for baremetal

### DIFF
--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -97,7 +97,7 @@ def create_baremetal_ceph_nodes(cluster_conf):
 
     with parallel() as p:
         for n, node in enumerate(nodes):
-            node_id = node.get("id") or f"node{n}"
+            node_id = node.get("id") or f"node{n + 1}"
             params = dict(
                 {
                     "ip": node.get("ip"),


### PR DESCRIPTION
Fixing node id for baremetal
We observe issues while generating node IDs if they are not given as part of the conf file.
Nodes getting ids starting form node0 to nodeN-1
first node is getting id as node0 and when we are referring it it was referred as node1.

so adding +1 for node id generation


Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
