### PR TITLE
Converting registry_credentials from dict to list of dicts

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -6,7 +6,7 @@ from typing import Dict
 from ceph.ceph_admin.cephadm_ansible import CephadmAnsible
 from ceph.utils import get_node_by_id, get_public_network, setup_repos
 from utility.log import Log
-from utility.utils import fetch_build_artifacts, get_cephci_config
+from utility.utils import fetch_build_artifacts, get_cephci_config, get_registry_creds
 
 from ..ceph import ResourceNotFoundError
 from .common import config_dict_to_string
@@ -42,9 +42,10 @@ def construct_registry(cls, registry: str, json_file: bool = False):
     """
     # Todo: Retrieve credentials based on registry name
     _config = get_cephci_config()
-    cdn_cred = _config.get("registry_credentials", _config["cdn_credentials"])
+    creds = get_registry_creds(registry)
+    cdn_cred = creds if creds else _config["cdn_credentials"]
     reg_args = {
-        "registry-url": cdn_cred.get("registry", registry),
+        "registry-url": registry,
         "registry-username": cdn_cred.get("username"),
         "registry-password": cdn_cred.get("password"),
     }

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -879,6 +879,22 @@ def get_cephci_config():
     return cfg
 
 
+def get_registry_creds(registry):
+    """
+    Fetches the registry details from cephci.yaml file
+    Args:
+        registry:
+
+    Returns:
+        None if the registry details not specified
+    """
+    registries = get_cephci_config().get("registry_credentials")
+    if not (registries or registries.get(registry)):
+        log.error(f"Did not find the {registry} details in cephci.yaml")
+        return
+    return registries.get(registry)
+
+
 def get_run_status(results_list):
     """
     Returns overall run status either Pass or Fail.


### PR DESCRIPTION
Converting registry_credentials from dict to list of dicts

This is to support multiple registry as part of cephci.yaml.
currently we are supporting only 1 registry.

with this changes we are going to add all the registrys specified as part of .cephci.yaml

```
old style:
registry_credentials:
  registry: cp.icr.io
  username: cp
  password: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```
New style :

```
registry_credentials:
    cp.icr.io:
      username: cp
      password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    registry.redhat.io:
      username: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@redhat.com
      password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


```

config.json on IBM 
```
[root@ceph-ci-uceg4-umz8hf-node1-installer ~]# cat ~/.docker/config.json 
{
    "auths": {
        "registry.redhat.io": {
            "auth": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
        },
        "ceph-qe-registry.syd.qe.rhceph.local": {
            "auth": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
        }
    }
}
```
IBM Log : https://159.23.92.24/job/Custom%20Test%20Run/15/console
PSI Log: https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/2474/
Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-k3k55/
Signed-off-by: Amarnath K <amk@amk.remote.csb>

Latest Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YYWMXD/
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
