### PR TITLE
Fixing failure of seen in upstream RGW

### DIFF
--- a/pipeline/metadata/quincy.yaml
+++ b/pipeline/metadata/quincy.yaml
@@ -134,7 +134,7 @@ suites:
     - upstream
     - openstack
     - rados
-    - stage-2
+    - stage-3
 - name: "Upstream Testing For CephFS Regression"
   suite: "suites/quincy/cephfs/tier-1_cephfs_upstream-core-functionality.yaml"
   global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"

--- a/suites/quincy/cephadm/sanity-test.yaml
+++ b/suites/quincy/cephadm/sanity-test.yaml
@@ -20,6 +20,8 @@ tests:
               service: cephadm
               args:
                 mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
           - config:
               command: add_hosts
               service: host

--- a/suites/quincy/rgw/test-basic-object-operations.yaml
+++ b/suites/quincy/rgw/test-basic-object-operations.yaml
@@ -33,6 +33,8 @@ tests:
                 mon-ip: node1
                 initial-dashboard-password: admin@123
                 dashboard-password-noupdate: true
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
           - config:
               command: add_hosts
               service: host
@@ -57,37 +59,6 @@ tests:
       polarion-id: CEPH-83573713
       module: test_cephadm.py
       name: RHCS deploy cluster using cephadm
-
-  - test:
-      name: Monitoring Services deployment
-      desc: Add monitoring services using spec file.
-      module: test_cephadm.py
-      polarion-id: CEPH-83574727
-      config:
-        steps:
-          - config:
-              command: apply_spec
-              service: orch
-              validate-spec-services: true
-              specs:
-                - service_type: prometheus
-                  placement:
-                    count: 1
-                    nodes:
-                      - node1
-                - service_type: grafana
-                  placement:
-                    nodes:
-                      - node1
-                - service_type: alertmanager
-                  placement:
-                    count: 1
-                - service_type: node-exporter
-                  placement:
-                    host_pattern: "*"
-                - service_type: crash
-                  placement:
-                    host_pattern: "*"
 
   - test:
       abort-on-fail: true

--- a/suites/quincy/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/quincy/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -120,68 +120,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: apply_spec
-                  service: orch
-                  validate-spec-services: true
-                  specs:
-                    - service_type: prometheus
-                      placement:
-                        count: 1
-                        nodes:
-                          - node1
-                    - service_type: grafana
-                      placement:
-                        nodes:
-                          - node1
-                    - service_type: alertmanager
-                      placement:
-                        count: 1
-                    - service_type: node-exporter
-                      placement:
-                        host_pattern: "*"
-                    - service_type: crash
-                      placement:
-                        host_pattern: "*"
-        ceph-sec:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: apply_spec
-                  service: orch
-                  validate-spec-services: true
-                  specs:
-                    - service_type: prometheus
-                      placement:
-                        count: 1
-                        nodes:
-                          - node1
-                    - service_type: grafana
-                      placement:
-                        nodes:
-                          - node1
-                    - service_type: alertmanager
-                      placement:
-                        count: 1
-                    - service_type: node-exporter
-                      placement:
-                        host_pattern: "*"
-                    - service_type: crash
-                      placement:
-                        host_pattern: "*"
-      name: Monitoring Service deployment
-      desc: Add monitoring services using spec file.
-      module: test_cephadm.py
-      polarion-id: CEPH-83574727
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
             command: add
             id: client.1
             node: node6

--- a/suites/quincy/upstream/tier-1_rgw_and_lc.yaml
+++ b/suites/quincy/upstream/tier-1_rgw_and_lc.yaml
@@ -64,36 +64,6 @@ tests:
       module: test_cephadm.py
       name: Deploy RHCS cluster using cephadm
   - test:
-      name: Monitoring Services deployment
-      desc: Add monitoring services using spec file.
-      module: test_cephadm.py
-      polarion-id: CEPH-83574727
-      config:
-        steps:
-          - config:
-              command: apply_spec
-              service: orch
-              validate-spec-services: true
-              specs:
-                - service_type: prometheus
-                  placement:
-                    count: 1
-                    nodes:
-                      - node1
-                - service_type: grafana
-                  placement:
-                    nodes:
-                      - node1
-                - service_type: alertmanager
-                  placement:
-                    count: 1
-                - service_type: node-exporter
-                  placement:
-                    host_pattern: "*"
-                - service_type: crash
-                  placement:
-                    host_pattern: "*"
-  - test:
       name: enable bucket versioning
       desc: Basic versioning test, also called as test to enable bucket versioning
       polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652


### PR DESCRIPTION
Signed-off-by: Anuchaithra Rao <anrao@redhat.com>

# Description
Issue : seen "prometheus" package issue which result in crash
when we have used bellow config during bootstrap, monitoring deployment is not required. 
                orphan-initial-daemons: true
                skip-monitoring-stack: true

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8in08/Executes_RGW_and_FS_operations_0.log
its afarallel run failure seen is of cephfs_basictest
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

