### PR TITLE
Migrate listener agent node to execute on new rhel-9-medium openstack agent

### DIFF
--- a/pipeline/upstream_listener.groovy
+++ b/pipeline/upstream_listener.groovy
@@ -5,7 +5,7 @@
 def sharedLib
 
 // Pipeline script entry point
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-9-medium") {
     try {
         timeout(unit: "MINUTES", time: 30) {
             stage('prepareNode') {


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Execute the listener job to execute on new rhel-9-medium openstack client.

**Results:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil/upstream-listener.jenkins.log