### PR TITLE
[Lib] Add libraries to setup user & ceph SSH keys

### DIFF
--- a/utility/install_prereq.py
+++ b/utility/install_prereq.py
@@ -14,6 +14,21 @@ CEPHADM_ANSIBLE_PATH = "/usr/share/cephadm-ansible"
 CEPHADM_INVENTORY_PATH = f"{CEPHADM_ANSIBLE_PATH}/hosts"
 CEPHADM_PREFLIGHT_PLAYBOOK = "cephadm-preflight.yml"
 
+ETC_HOSTS = "/etc/hosts"
+CEPH_PUB_KEY = "/etc/ceph/ceph.pub"
+
+SSH = "~/.ssh"
+SSH_CONFIG = f"{SSH}/config"
+SSH_ID_RSA_PUB = f"{SSH}/id_rsa.pub"
+SSH_KNOWN_HOSTS = f"{SSH}/known_hosts"
+
+SSH_KEYGEN = f"ssh-keygen -b 2048 -f {SSH}/id_rsa -t rsa -q -N ''"
+SSH_COPYID = "ssh-copy-id -f -i {} {}@{}"
+SSH_KEYSCAN = "ssh-keyscan {}"
+
+CHMOD_CONFIG = f"chmod 600 {SSH_CONFIG}"
+SSHPASS = "sshpass -p {}"
+
 
 class ConfigureCephadmAnsibleInventoryError(Exception):
     pass
@@ -29,6 +44,85 @@ class ConfigureCephToolsRepositoriesError(Exception):
 
 class ConfigureCephadmAnsibleNodeError(Exception):
     pass
+
+
+class SetUpSSHKeys:
+    """Set up SSH keys"""
+
+    @staticmethod
+    def run(installer, nodes):
+        hosts, config = (
+            "",
+            "Host *\n\tStrictHostKeyChecking no\n\tServerAliveInterval 2400\n",
+        )
+        for node in nodes:
+            config += f"\nHost {node.ip_address}"
+            config += f"\n\tHostname {node.hostname}"
+            config += "\n\tUser root"
+
+            hosts += f"\n{node.ip_address}"
+            hosts += f"\t{node.hostname}"
+            hosts += f"\t{node.shortname}"
+
+            node.exec_command(cmd=f"rm -rf {SSH}", check_ec=False)
+            node.exec_command(cmd=SSH_KEYGEN)
+
+            node.exec_command(sudo=True, cmd=f"rm -rf {SSH}", check_ec=False)
+            node.exec_command(sudo=True, cmd=SSH_KEYGEN)
+
+        installer.exec_command(sudo=True, cmd=f"echo -e '{hosts}' >> {ETC_HOSTS}")
+        installer.exec_command(
+            cmd=f"touch {SSH_CONFIG} && echo -e '{config}' > {SSH_CONFIG}"
+        )
+        installer.exec_command(cmd=CHMOD_CONFIG)
+        Package(installer).install("sshpass")
+
+        for node in nodes:
+            installer.exec_command(
+                cmd="{} >> {}".format(
+                    SSH_KEYSCAN.format(node.hostname), SSH_KNOWN_HOSTS
+                ),
+            )
+            installer.exec_command(
+                sudo=True,
+                cmd="{} >> {}".format(
+                    SSH_KEYSCAN.format(node.hostname), SSH_KNOWN_HOSTS
+                ),
+            )
+
+            installer.exec_command(
+                cmd="{} {}".format(
+                    SSHPASS.format(node.password),
+                    SSH_COPYID.format(SSH_ID_RSA_PUB, node.username, node.hostname),
+                ),
+            )
+            installer.exec_command(
+                cmd="{} {}".format(
+                    SSHPASS.format(node.root_passwd),
+                    SSH_COPYID.format(SSH_ID_RSA_PUB, "root", node.hostname),
+                ),
+            )
+            installer.exec_command(
+                sudo=True,
+                cmd="{} {}".format(
+                    SSHPASS.format(node.root_passwd),
+                    SSH_COPYID.format(SSH_ID_RSA_PUB, "root", node.hostname),
+                ),
+            )
+
+
+class CopyCephSshKeyToHost:
+    """Copy ceph.pub to hosts"""
+
+    @staticmethod
+    def run(installer, nodes, user="root", key=CEPH_PUB_KEY):
+        if not isinstance(nodes, list):
+            nodes = [nodes]
+
+        for node in nodes:
+            installer.exec_command(
+                sudo=True, cmd=SSH_COPYID.format(key, user, node.hostname)
+            )
 
 
 class ExecutePreflightPlaybook:


### PR DESCRIPTION
Add below classes to setup user and ceph SSH keys

- class SetUpSSHKeys - Generates root & ceph-user SSH keys and copy to different nodes.
- class CopyCephSshKeyToHost - Copy ceph SSH key to nodes.

Signed-off-by: Vaibhav Mahajan <vamahaja@redhat.com>