### PR TITLE
Setting password for baremetal as per conf file

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1417,7 +1417,9 @@ class CephNode(object):
             f"echo '{self.username}:{self.password}' | chpasswd"
         )
         logger.info(stdout.readlines())
-        _, stdout, stderr = self.rssh().exec_command("echo 'root:passwd' | chpasswd")
+        _, stdout, stderr = self.rssh().exec_command(
+            f"echo 'root:{self.root_passwd}' | chpasswd"
+        )
         logger.info(stdout.readlines())
         self.rssh().exec_command("echo 120 > /proc/sys/net/ipv4/tcp_keepalive_time")
         self.rssh().exec_command("echo 60 > /proc/sys/net/ipv4/tcp_keepalive_intvl")


### PR DESCRIPTION
Setting password for baremetal as per conf file
Fixing issue #2159:

Problem : 
In baremetal installation, password is getting set to `**passwd**` even the conf file has the root_password 

solution:
removed hardcoded `**passwd**` and made it as **self.root_password** 

Tested on Vms by constructing conf file
http://magna002.ceph.redhat.com/ceph-qe-logs/amar/tier-0_fs.yaml

Logs : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DSJB2O/

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
