### PR TITLE
Include build type from job parameter

### DIFF
--- a/pipeline/rhcs_deploy.groovy
+++ b/pipeline/rhcs_deploy.groovy
@@ -73,11 +73,12 @@ node ("rhel-8-medium || ceph-qe-ci") {
 
         majorVersion = ciMap.build.substring(0,1)
         clusterName = ciMap["cluster_name"]
+        def buildType = "${ciMap.build}" ?: "tier-0"
 
         // Prepare the CLI arguments
-        cliArgs += "--rhbuild ${ciMap.build}"
+        cliArgs += "--rhbuild ${ciMap.rhbuild}"
         cliArgs += " --platform ${argsMap[majorVersion]['platform']}"
-        cliArgs += " --build tier-0"
+        cliArgs += " --build ${buildType}"
         cliArgs += " --skip-sos-report"
         cliArgs += " --inventory ${argsMap[majorVersion]['inventory']}"
         cliArgs += " --global-conf ${argsMap[majorVersion]['globalConf']}"


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

**Issue:**
RHCS-deploy job failed with build unavailability. 
```
2023-02-07 03:21:49,055 (paramiko.transport.sftp) [INFO] - [chan 10] Opened sftp connection (server version 3)
2023-02-07 03:21:49,057 (cephci.test_bootstrap) [INFO] - cephci.ceph.ceph.py:954 - repo to use is http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-6.0-rhel-9/RHCEPH-6.0-RHEL-9-20230119.ci.0/compose/Tools/x86_64/os/
2023-02-07 03:21:49,100 (cephci.test_bootstrap) [INFO] - cephci.ceph.ceph.py:956 - Checking http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-6.0-rhel-9/RHCEPH-6.0-RHEL-9-20230119.ci.0/compose/Tools/x86_64/os/
```

**Solution:**
Now we should able to provide the build type as well. 
tier-0 by default, build_type `value``(i.e, tier-0, tier-1, latest) on override.

```{"command":"deploy","rhbuild":"6.0","cluster_name":"j-198vu1ce33-t1", "build":"rc"}```