### PR TITLE
Adapt test-image-delete-from-primary to test for both ecpools and replicated pools

### DIFF
--- a/tests/rbd_mirror/test-image-delete-primary-site.py
+++ b/tests/rbd_mirror/test-image-delete-primary-site.py
@@ -1,7 +1,28 @@
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
+
+
+def test_image_delete_from_primary(rbd_mirror, pool_type, **kw):
+    try:
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
+        config = kw.get("config")
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
+
+        mirror1.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
+
+        mirror1.delete_image(imagespec)
+        if mirror2.image_exists(imagespec):
+            return 0
+
+    except Exception as e:
+        log.exception(e)
+
+    return 1
 
 
 def run(**kw):
@@ -29,33 +50,20 @@ def run(**kw):
     2. Delete the image when contents are getting mirrored.
     3. Make sure that image is deleted in secondary site.
     """
-    try:
-        log.info("Starting RBD mirroring test case - 9501")
-        config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
-        poolname = mirror1.random_string() + "_ceph_9501"
-        imagename = mirror1.random_string() + "_ceph_9501"
-        imagespec = poolname + "/" + imagename
+    log.info("Starting RBD mirroring test case - 9501")
+    mirror_obj = rbd_mirror_config(**kw)
 
-        mirror1.initial_mirror_config(
-            mirror2,
-            poolname=poolname,
-            imagename=imagename,
-            imagesize=config.get("imagesize", "1G"),
-            mode="pool",
-            **kw,
-        )
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_image_delete_from_primary(
+            mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+        ):
+            return 1
 
-        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
+        log.info("Executing test on ec pool")
+        if test_image_delete_from_primary(
+            mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+        ):
+            return 1
 
-        mirror1.delete_image(imagespec)
-        if mirror2.image_exists(imagespec):
-            return 0
-
-    except Exception as e:
-        log.exception(e)
-
-    return 1
+    return 0


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Goal is to adapt test-image-delete-from-primary to test for both ecpools and replicated pools.
Modified module : https://github.com/red-hat-storage/cephci/blob/master/tests/rbd_mirror/test-image-delete-primary-site.py

Success log : 
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-o2d77/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-xe8mw/ 