### PR TITLE
PSI listeners will fail when there is an error during ibm cos upload

### DIFF
--- a/pipeline/scripts/ci/get_email_body.py
+++ b/pipeline/scripts/ci/get_email_body.py
@@ -11,8 +11,8 @@ This script updates the confluence page titled "RHCS Test Execution Summary"
 with the results of execution given as input.
 
 Usage:
-get_email_body.py --template <template_name> --testResults <test_results> --testArtifacts <test_artifacts>
-get_email_body.py --template <template> --testResultsFile <file> --testArtifacts <test_artifacts> --runType <run_type>
+get_email_body.py --template <template_name> --testResults <test_results> [--testArtifacts <test_artifacts>]
+get_email_body.py --template <template> --testResultsFile <file> --runType <run_type> [--testArtifacts <test_artifacts>]
 
 get_email_body.py (-h | --help)
 
@@ -172,7 +172,7 @@ class GenerateEmailBody:
             test_results=test_results, test_artifacts=artifactDetails
         )
 
-    def get_stage_email(self, **kwargs):
+    def get_basic_email(self, **kwargs):
         """
         This method creates stage level email html body based on the template specified
         Args:
@@ -193,6 +193,8 @@ class GenerateEmailBody:
 if __name__ == "__main__":
     cli_args = docopt(doc)
     template = cli_args.get("--template")
+    testResults = dict()
+    testArtifacts = dict()
     if cli_args.get("--testResults"):
         testResults = json.loads(cli_args.get("--testResults"))
     if cli_args.get("--testArtifacts"):
@@ -200,8 +202,8 @@ if __name__ == "__main__":
     try:
         cls = GenerateEmailBody()
 
-        if template == "stage_email.jinja":
-            html = cls.get_stage_email(
+        if template != "consolidated_email.jinja":
+            html = cls.get_basic_email(
                 template=template, testResults=testResults, testArtifacts=testArtifacts
             )
         else:

--- a/pipeline/scripts/ci/jinja_templates/listener_email.jinja
+++ b/pipeline/scripts/ci/jinja_templates/listener_email.jinja
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <style>
+    table.full-table{
+        font-family: arial, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
+    }
+
+    td, th {
+        border: 1px solid #dddddd;
+        text-align: left;
+        padding: 8px;
+    }
+    table.half-table{
+        font-family: arial, sans-serif;
+        border-collapse: collapse;
+        width: 75%;
+    }
+
+    td, th {
+        border: 1px solid #dddddd;
+        text-align: left;
+        padding: 8px;
+    }
+
+    p { margin:0 }
+    </style>
+</head>
+<body>
+    <h3><u>Job {{ test_results["result"] }}</u></h3>
+    <table>
+        <tr><td>RHCS Version</td><td>{{ test_results["rhcephVersion"] }}</td></tr>
+        <tr><td>Ceph Version</td><td>{{ test_results["cephVersion"] }}</td></tr>
+        {% if test_results.get("composeLabel") %}
+        <tr><td>Compose Label</td><td>{{ test_results["composeLabel"] }}</td></tr>
+        {% endif %}
+        {% if test_results.get("composeId") %}
+        <tr><td>Compose ID</td><td>{{ test_results["composeId"] }}</td></tr>
+        {% endif %}
+        {% if test_results.get("composeUrl") %}
+        <tr><td>Compose URL</td><td>{{ test_results["composeUrl"] }}</td></tr>
+        {% endif %}
+        {% if test_results.get("containerImage") %}
+        <tr><td>Container Image</td><td>{{ test_results["containerImage"] }}</td></tr>
+        {% endif %}
+        {% if test_results["result"] != "SUCCESS" %}
+        <tr><td>{{ test_results["result"] }} Reason</td><td>{{ test_results["failureReason"] }}</td></tr>
+        <tr><td>UMB Message</td><td>{{ test_results["ciMsg"] }}</td></tr>
+        {% endif %}
+        <tr><td>Jenkins Build</td><td>{{ test_results["jobUrl"] }}</td></tr>
+    </table>
+</body>

--- a/pipeline/signed-compose-listener.groovy
+++ b/pipeline/signed-compose-listener.groovy
@@ -7,6 +7,7 @@ def composeUrl
 def platform
 def failureReason = ""
 def cimsg = ""
+def emailLib
 
 // Pipeline script entry point
 node("rhel-8-medium || ceph-qe-ci") {
@@ -38,6 +39,7 @@ node("rhel-8-medium || ceph-qe-ci") {
                 poll: false
             )
             sharedLib = load("${env.WORKSPACE}/pipeline/vars/v3.groovy")
+            emailLib = load("${env.WORKSPACE}/pipeline/vars/email.groovy")
             sharedLib.prepareNode()
         }
 
@@ -126,25 +128,13 @@ node("rhel-8-medium || ceph-qe-ci") {
             println "Failure Reason: ${failureReason}"
         }
     } finally {
-        def body = "<body><h3><u>Job ${currentBuild.result}</u></h3>"
-        body += "<dl><dt>RHCS Version:</dt><dd>RHCEPH-${versions.major_version}.${versions.minor_version}</dd>"
-        body += "<dt>Ceph Version:</dt><dd>${cephVersion}</dd>"
-        body += "<dt>Compose Label:</dt><dd>${cimsg['compose-label']}</dd>"
-        body += "<dt>Compose URL:</dt><dd>${composeUrl}</dd>"
-        if (currentBuild.result != "SUCCESS") {
-            body += "<dt>${currentBuild.result} Reason:</dt><dd>${failureReason}</dd>"
-            body += "<dt>UMB Message:</dt><dd>${cimsg}</dd>"
-        }
-        body += "<dt>Jenkins Build:</dt><dd>${env.BUILD_URL}</dd></dl></body>"
-        def subject = "RHCEPH-${versions.major_version}.${versions.minor_version} (RC) Release Candidate build - ${currentBuild.result}"
-
-        emailext (
-            mimeType: 'text/html',
-            subject: "${subject}",
-            body: "${body}",
-            from: "cephci@redhat.com",
-            to: "cephci@redhat.com"
-        )
+        rhcephVersion = "RHCEPH-${versions.major_version}.${versions.minor_version}"
+        composeInfo = [
+            "composeLabel": "${cimsg['compose-label']}",
+            "composeUrl": composeUrl
+        ]
+        def subject = "${env.JOB_NAME} ${currentBuild.result} for ${rhcephVersion} - ${cephVersion} (RC) Release Candidate build"
+        emailLib.sendEmailForListener(rhcephVersion, cephVersion, composeInfo, cimsg, failureReason, subject)
         subject += "\n Jenkins URL: ${env.BUILD_URL}"
         googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
     }

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -333,8 +333,8 @@ def uploadCompose(def rhBuild, def cephVersion, def baseUrl) {
 
         sh script: "${cpFile} && ${cmd} ${scriptFile} ${args}"
     } catch(Exception exc) {
-        println "Encountered a failure during compose upload."
         println exc
+        error("Encountered a failure during compose upload. ${exc}")
     }
 }
 


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

Compose listeners in openstack jenkins were catching any exception during ibm cos upload. Hence even though there was an error during compose upload to IBM, a UMB message used to get sent and the pipeline in IBM environment used to fail because they didn't have necessary data there.

With the change in this PR, this will be avoided, since psi listeners will fail whenever there is any exception during ibm cos upload and they will not send a UMB message, inturn avoiding failure in IBM pipeline.

Results - Emails with below subjects sent only to reviewers in order to avoid spamming others mailboxes.

unsigned compose listener - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-listener-manasa/28/console
Email notification with subject - rhceph-listener-manasa FAILURE for RHCEPH-6.0 - 17.2.5-66 build

signed compose listener - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-listener-manasa/31/console
Email notification with subject - rhceph-listener-manasa FAILURE for RHCEPH-6.0 - 17.2.5-63 (RC) Release Candidate build

signed container image listener - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-listener-manasa/34/console
Email notification with subject - rhceph-listener-manasa SUCCESS for RHCEPH-5.3 - 16.2.10-94 (RC) Release Candidate build
