### PR TITLE
tier-2_rados_basic_regression: assimilate configurations from ceph.conf

### DIFF
--- a/conf/pacific/rados/test-confs/cluster-configs
+++ b/conf/pacific/rados/test-confs/cluster-configs
@@ -1,0 +1,13 @@
+
+[mon]
+mon_cluster_log_to_syslog = true
+
+[osd]
+debug_osd = 5/5
+
+[mgr]
+mgr_stats_period = 10
+debug_mgr = 5/5
+
+[mds]
+mds_op_history_size = 40

--- a/conf/quincy/rados/test-confs/cluster-configs
+++ b/conf/quincy/rados/test-confs/cluster-configs
@@ -1,0 +1,13 @@
+
+[mon]
+mon_cluster_log_to_syslog = true
+
+[osd]
+debug_osd = 5/5
+
+[mgr]
+mgr_stats_period = 10
+debug_mgr = 5/5
+
+[mds]
+mds_op_history_size = 40

--- a/suites/pacific/rados/tier-2_rados_basic_regression.yaml
+++ b/suites/pacific/rados/tier-2_rados_basic_regression.yaml
@@ -121,6 +121,36 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      config:
+        cluster_conf_path: "conf/pacific/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  - test:
       name: Monitor configuration - section and masks changes
       module: rados_prep.py
       polarion-id: CEPH-83573477

--- a/suites/quincy/rados/tier-2_rados_basic_regression.yaml
+++ b/suites/quincy/rados/tier-2_rados_basic_regression.yaml
@@ -114,6 +114,36 @@ tests:
       desc: Configure email alerts on ceph cluster
 
   - test:
+      name: Test configuration Assimilation
+      module: test_config_assimilation.py
+      polarion-id: CEPH-83573480
+      config:
+        cluster_conf_path: "conf/quincy/rados/test-confs/cluster-configs"
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "mon_cluster_log_to_syslog"
+                value: "true"
+            - config-2:
+                section: "osd"
+                name: "debug_osd"
+                value: "5/5"
+            - config-3:
+                section: "mgr"
+                name: "mgr_stats_period"
+                value: "10"
+            - config-4:
+                section: "mgr"
+                name: "debug_mgr"
+                value: "5/5"
+            - config-5:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+      desc: Verify config assimilation into ceph mon configuration database
+
+  - test:
       name: Enable logging to file
       module: rados_prep.py
       config:

--- a/tests/rados/test_config_assimilation.py
+++ b/tests/rados/test_config_assimilation.py
@@ -1,0 +1,83 @@
+"""
+Module to Verify if the config changes made in the ceph.conf file can be moved to central monitor database.
+
+This is achieved by ceph config assimilate-conf -i <input file> -o <output file>.
+This will ingest a configuration file from input file and move any valid options into the monitors’
+configuration database.
+
+Any settings that are unrecognized, invalid, or cannot be controlled by the monitor will be returned in an
+abbreviated config file stored in output file.
+
+This command is useful for transitioning from legacy configuration files to centralized monitor-based configuration.
+"""
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw) -> int:
+    """
+    Module to Verify if the config changes made in the ceph.conf file can be moved to central monitor database.
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    cluster_conf_path = config["cluster_conf_path"]
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+
+    log.info("Testing configuration assimilation from ceph.conf files")
+    with open(cluster_conf_path, "r") as fd:
+        cluster_conf_file = fd.read()
+
+    log.debug(
+        f"Content to be added in /etc/ceph/ceph.conf file : \n {cluster_conf_file}"
+    )
+
+    # Adding the configurations into the conf file.
+    cmd = f"""cat <<EOF >> /etc/ceph/ceph.conf
+{cluster_conf_file}
+EOF"""
+    client_node.exec_command(cmd=cmd, sudo=True)
+    log.debug("Completed adding the configurations into the ceph.conf file ")
+
+    log.debug(
+        f"printing file contents of ceph.conf post modification "
+        f"\n{client_node.exec_command(cmd='cat /etc/ceph/ceph.conf', sudo=True)}"
+    )
+
+    log.info("Assimilating the contents of ceph.conf into mon config")
+    cmd = "ceph config assimilate-conf -i /etc/ceph/ceph.conf -o /etc/ceph/assimilate-op.txt"
+    client_node.exec_command(cmd=cmd, sudo=True)
+
+    # Verifying the configs set via the CLI in the mon config database.
+    test_config = config.get("Verify_config_parameters")
+    for conf in test_config["configurations"]:
+        for entry in conf.values():
+            if not mon_obj.verify_set_config(**entry):
+                log.error(f"Error setting config {entry}")
+                return 1
+
+    log.info(
+        "Verified the configurations set."
+        " The configs are successfully moved from ceph.conf to mon database "
+    )
+
+    # removing the additional configurations set in the mon database
+    for conf in test_config["configurations"]:
+        for entry in conf.values():
+            if not mon_obj.remove_config(**entry):
+                log.error(
+                    f"Failed to remove config : {conf} from the mon config database"
+                )
+                return 1
+
+    log.info("Configurations added from file and then removed. Workflow complete")
+    return 0


### PR DESCRIPTION
Test workflow to move the daemon configurations set in ceph.conf file into ceph monitor configuration database. Document : https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/5/html/configuration_guide/the-basics-of-ceph-configuration#the-ceph-configuration-database_conf

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [x] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarion Test with Automation script details and update automation fields
- [x] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
