### PR TITLE
[Pipeline failure 5.3] - RBD IOs failure for tier_2_rados_test_stretch_mode

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -160,7 +160,12 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
-          io-total: 100M
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
 
   - test:
@@ -196,7 +201,12 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
-          io-total: 100M
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
 
   - test:

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
@@ -163,6 +163,11 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
         io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
       polarion-id: CEPH-9876

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -160,7 +160,12 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
-          io-total: 100M
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
 
   - test:
@@ -196,7 +201,12 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
-          io-total: 100M
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
 
   - test:

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
@@ -162,6 +162,11 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
         io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
       polarion-id: CEPH-9876

--- a/tests/rbd/rbd_faster_exports.py
+++ b/tests/rbd/rbd_faster_exports.py
@@ -123,15 +123,13 @@ def run(**kw):
     """
     log.info("Running rbd export tests")
     rbd_obj = initial_rbd_config(**kw)
-    rc = 1
     if rbd_obj:
-        log.info("Executing test on replicated pool")
-        rc = faster_exports(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw)
-
-        if rc:
-            return rc
-
-        log.info("Executing test on ec pool")
-        rc = faster_exports(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw)
-
-    return rc
+        if "rbd_reppool" in rbd_obj:
+            log.info("Ecexuting test on Replication pool")
+            if faster_exports(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+                return 1
+        if "rbd_ecpool" in rbd_obj:
+            log.info("Executing test on EC pool")
+            if faster_exports(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+                return 1
+    return 0

--- a/tests/rbd/rbd_trash.py
+++ b/tests/rbd/rbd_trash.py
@@ -74,12 +74,13 @@ def run(**kw):
     """
     log.info("Running Trash function")
     rbd_obj = initial_rbd_config(**kw)
-    rc = 1
     if rbd_obj:
-        log.info("Executing test on Replication pool")
-        rc = rbd_trash(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw)
-        if rc:
-            return rc
-        log.info("Executing test on EC pool")
-        rc = rbd_trash(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw)
-    return rc
+        if "rbd_reppool" in rbd_obj:
+            log.info("Executing test on Replication pool")
+            if rbd_trash(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+                return 1
+        if "rbd_ecpool" in rbd_obj:
+            log.info("Executing test on EC pool")
+            if rbd_trash(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+                return 1
+    return 0

--- a/tests/rbd/rbd_trash_remove.py
+++ b/tests/rbd/rbd_trash_remove.py
@@ -63,12 +63,13 @@ def run(**kw):
     """
     log.info("Running Trash image remove test")
     rbd_obj = initial_rbd_config(**kw)
-    rc = 1
     if rbd_obj:
-        log.info("Ecexuting test on Replication pool")
-        rc = rbd_trash_remove(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw)
-        if rc:
-            return rc
-        log.info("Executing test on EC pool")
-        rc = rbd_trash_remove(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw)
-    return rc
+        if "rbd_reppool" in rbd_obj:
+            log.info("Ecexuting test on Replication pool")
+            if rbd_trash_remove(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+                return 1
+        if "rbd_ecpool" in rbd_obj:
+            log.info("Executing test on EC pool")
+            if rbd_trash_remove(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+                return 1
+    return 0


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Pipeline failure for RBD IOs for tier_2_rados_test_stretch_mode test suite.
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/5/6736/171811/171835/log

**Failure reason** : 
"Command ceph osd pool create rbd_test_data_pool_MdENumiqEh 12 12 erasure  executed failed with error ceph osd pool create rbd_test_data_pool_MdENumiqEh 12 12 erasure  Error:  Error EINVAL: prepare_pool_size: we are in stretch mode; cannot create EC pools!"

**Propose solution**:  
we are creating the EC pool along with Rep pool for RBD IO testing, but as per the limitation of stretch mode cluster, we can not use erasure coded pools with stretch mode as per below doc 
https://docs.ceph.com/en/latest/rados/operations/stretch-mode/#stretch-mode-limitations 
we will only create Rep pool for testing RBD IOs .

**success log for RBD IOs for tier_2_rados_test_stretch_mode test suite**
 5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-p67jx/
