### PR TITLE
Install ibm-vpc==0.10.0 for Python-3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "ibm-cos-sdk",
         "ibm-cos-sdk-core",
         "ibm-cos-sdk-s3transfer",
-        "ibm-vpc>=0.8.0",
+        "ibm-vpc==0.10.0",
         "ibm-cloud-networking-services",
         "jinja_markdown",
         "jinja2",


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Install ibm-vpc=0.10.0 for newer RHEL-9 agents along with python3.9. 

**Results**:
https://159.23.92.24/job/custom-test-sunil/6/console
