### PR TITLE
Automating multiple rbd-mirroring daemons per cluster - configuration and verification of daemon failure

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -667,7 +667,18 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
-            - rgw
+            - rbd
+        - name: "tier-2_rbd_mirror_multiple_daemon_failure"
+          execution_time: "66 m, 25 s"
+          suite: "suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+            - upgrades
       stage-4:
         - name: "RADOS regression for testing various pool functionalities"
           execution_time: ""

--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -81,7 +81,6 @@ tests:
         node: node8                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps: # authorize client capabilities
           mon: "allow *"

--- a/suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
@@ -1,0 +1,160 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_upgrade_5x_to_6x.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "tier-0"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+                        - node4
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "tier-0"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+                        - node4
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+      desc: Configure the client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      desc: Multicluster upgrade with rbd mirror daemon
+      module: test_cephadm_upgrade.py
+      name: multi-cluster ceph upgrade
+      clusters:
+        ceph-rbd1:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-rbd2:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+
+  - test:
+      name: Test daemon failure in dual rbd-mirror daemon clusters
+      clusters:
+        ceph-rbd1:
+          dummy: true
+      desc: Verification of mirorring with failures of mirror daemons
+      module: test_rbd_mirror_multi_daemon.py
+      polarion-id: CEPH-83574962

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -170,15 +170,15 @@ def wait_for_device(host, osd_id, action: str) -> bool:
         time.sleep(120)
         container, device_path = validate(host, osd_id)
 
-        match action:
-            case "add":
-                if device_path and container:
-                    log.info(f"[osd.{osd_id}] {container}-{device_path} added..")
-                    return True
-            case "remove":
-                if not (device_path and container):
-                    log.info(f"[osd.{osd_id}] {container}-{device_path} removed..")
-                    return True
+        if action == "add":
+            if device_path and container:
+                log.info(f"[osd.{osd_id}] {container}-{device_path} added..")
+                return True
+        elif action == "remove":
+            if not (device_path and container):
+                log.info(f"[osd.{osd_id}] {container}-{device_path} removed..")
+                return True
+
         log.info(
             f"waiting for the {action} to complete...\n"
             f"container: {container}, device_path: {device_path}"

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -7,6 +7,7 @@ import time
 
 from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
+from ceph.utils import get_node_by_id
 from tests.rbd.exceptions import IOonSecondaryError
 from utility.log import Log
 
@@ -197,6 +198,7 @@ class RbdMirror:
         peer_mode = kw.get("peer_mode")
         rbd_client = kw.get("rbd_client")
         build = kw.get("build")
+        wait_for_status = kw.get("wait_for_status", True)
 
         self.enable_mirroring(mirror_level="pool", specs=poolname, mode=mode)
         peer_cluster.enable_mirroring(mirror_level="pool", specs=poolname, mode=mode)
@@ -269,8 +271,11 @@ class RbdMirror:
         else:
             log.error("Peers were not added")
 
-        self.wait_for_status(poolname=poolname, health_pattern="OK")
-        peer_cluster.wait_for_status(poolname=poolname, health_pattern="OK")
+        # Waiting for OK pool mirror status to be okay based on user input as in image based
+        # mirorring status wouldn't reach OK without enabling mirroing on individual images
+        if wait_for_status:
+            self.wait_for_status(poolname=poolname, health_pattern="OK")
+            peer_cluster.wait_for_status(poolname=poolname, health_pattern="OK")
 
     # configure initial mirroring steps
     def initial_mirror_config(self, mirror2, poolname, imagename, **kw):
@@ -288,6 +293,9 @@ class RbdMirror:
             mode - mirror mode to be configured pool or image
             mirrormode - type of mirror configured journal or snapshot
         """
+        log.debug(
+            f"Config Recieved for initial mirror config: poolname:{poolname}, imagename:{imagename}\nkw:{kw}"
+        )
         imagespec = poolname + "/" + imagename
         imagesize = kw.get("imagesize")
         io = kw.get("io_total")
@@ -299,16 +307,26 @@ class RbdMirror:
         if kw.get("image_feature"):
             image_feature = kw.get("image_feature")
             self.image_feature_enable(imagespec=imagespec, image_feature=image_feature)
+
         if kw.get("mode"):
             kw["peer_mode"] = kw.get("peer_mode", "bootstrap")
             kw["rbd_client"] = kw.get("rbd_client", "client.admin")
+            if kw.get("mode") == "image":
+                kw["wait_for_status"] = False
             self.config_mirror(mirror2, poolname=poolname, **kw)
+
         # Enable image level mirroring only when mode is image type
         if kw.get("mirrormode") and kw.get("mode") == "image":
             mirrormode = kw.get("mirrormode")
             self.enable_mirror_image(poolname, imagename, mirrormode)
+            self.wait_for_status(poolname=poolname, health_pattern="OK")
+            mirror2.wait_for_status(poolname=poolname, health_pattern="OK")
 
-        mirror2.wait_for_status(poolname=poolname, images_pattern=1)
+        # TBD: We need to override wait_for_status to match images in cluster1==cluster2
+        # ITs failing here when the pool contains more than 1 image
+        # Using same image pool for replicated and ec pool
+        # mirror2.wait_for_status(poolname=poolname, images_pattern=1)
+
         if kw.get("io_total"):
             self.benchwrite(imagespec=imagespec, io=io)
             time.sleep(60)
@@ -353,11 +371,12 @@ class RbdMirror:
                     else:
                         num_image = out[state_pattern]
                     log.info(
-                        "Images in {} pool in {} cluster {}: {}".format(
+                        "Images in {} pool in {} cluster {}: {}, expected is :{}".format(
                             kw.get("poolname"),
                             self.cluster_name,
                             state_pattern,
                             num_image,
+                            kw.get("images_pattern"),
                         )
                     )
                     if kw.get("images_pattern") == num_image:
@@ -563,7 +582,7 @@ class RbdMirror:
         peercluster.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         if self.get_mirror_mode(imagespec) != "snapshot":
             peercluster.wait_for_replay_complete(imagespec)
-        export_path = "/home/cephuser/image.export"
+        export_path = "/home/cephuser/image.export_" + self.random_string()
         self.export_image(imagespec=imagespec, path=export_path)
         peercluster.export_image(imagespec=imagespec, path=export_path)
         local_md5 = self.exec_cmd(
@@ -933,6 +952,42 @@ class RbdMirror:
             return 1
         return 0
 
+    def get_mirror_pool_daemon_status(self, poolname):
+        """Refresh object argument ceph_rbdmirror based on mirror daemon status present in given pool's status.
+        Args:
+            poolname: name of the pool based on which status of daemon needs to be updated.
+        returns:
+            dict: dictionary of daemon details
+            1: if no daemons are up
+        """
+        out = self.exec_cmd(
+            cmd=f"rbd mirror pool status {poolname} --verbose --format json",
+            output=True,
+        )
+        json_dict = json.loads(out)
+
+        return json_dict.get("daemons", 1)
+
+    def update_ceph_rbdmirror(self, poolname, leader=True):
+        """Update ceph_rbdmirror value based on the provided values.
+        Args:
+            poolname: poolname to fetch mirror status.
+            leader: which daemon to be updated.
+            # currently it assumes that only 2 per cluster.
+        returns:
+            1: upon failure
+        """
+        mirror_daemon_dict = self.get_mirror_pool_daemon_status(poolname)
+        if mirror_daemon_dict == 1:
+            return 1
+        log.debug(f"mirror_daemon_dict: {mirror_daemon_dict}")
+        for each_daemon in mirror_daemon_dict:
+            if each_daemon["leader"] == leader:
+                self.ceph_rbdmirror = get_node_by_id(
+                    self.ceph_nodes, each_daemon["hostname"].split("-")[-1]
+                )
+                break
+
 
 def rbd_mirror_config(**kw):
     """
@@ -941,10 +996,10 @@ def rbd_mirror_config(**kw):
         **kw:
 
     Examples: In default configuration, pool and image names will be taken as random values.
-        Default configuration for ecpools only :
+        Configuration for ecpools only :
             config:
                 ec-pool-only: True
-        Default configuration for replicated pools only :
+        Configuration for replicated pools only :
             config:
                 rep-pool-only: True
         Advanced configuration:
@@ -975,7 +1030,9 @@ def rbd_mirror_config(**kw):
         RBD mirror objects for ecpool and replicated pool
     """
     rbd_obj = dict()
-
+    log.debug(
+        f'config recieved for rbd_mirror_config: {kw.get("config", "Config not recieved, assuming default values")}'
+    )
     # Create all the necessary configuration for replicated pool if not specified by user
     if not kw.get("config") or not kw.get("config").get("ec-pool-only"):
         ec_pool_k_m = kw.get("config", {}).pop("ec-pool-k-m", None)
@@ -1030,6 +1087,7 @@ def rbd_mirror_config(**kw):
             imagesize=kw["config"]["rep_pool_config"]["size"],
             io_total=kw["config"]["rep_pool_config"]["io_total"],
             mode=kw["config"]["rep_pool_config"]["mode"],
+            mirrormode=kw["config"]["rep_pool_config"].get("mirrormode", ""),
             **kw,
         )
 
@@ -1081,6 +1139,7 @@ def rbd_mirror_config(**kw):
             imagesize=kw["config"]["ec_pool_config"]["size"],
             io_total=kw["config"]["ec_pool_config"]["io_total"],
             mode=kw["config"]["ec_pool_config"]["mode"],
+            mirrormode=kw["config"]["ec_pool_config"].get("mirrormode", ""),
             **kw,
         )
 

--- a/tests/rbd_mirror/test_rbd_mirror_multi_daemon.py
+++ b/tests/rbd_mirror/test_rbd_mirror_multi_daemon.py
@@ -1,0 +1,145 @@
+import time
+
+from ceph.parallel import parallel
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """
+    Multiple rbd-mirroring daemons per cluster - configuration and verification of daemon failure
+    Args:
+        **kw: test data
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+    Test case covered -
+    CEPH-83574962 - Multiple rbd-mirroring daemons per cluster - configuration and verification of daemon failure
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. At least 2 rbd mirror daemons per cluster
+        2. 1 client
+
+    Test Case Flow:
+    1. Configure rbd mirroring between two clusters with both ec and replicated images.
+    2. Bring down one of the rbd mirroring daemon on cluster 2
+    3. Do relocation operation from cluster 1 to 2
+    4. Bring up the brought down daemon
+    5. Bring down leader daemon on both clusters.
+    6. Perform failover from cluster 2 to cluster 1
+    7. Check for data integrity.
+    """
+    log.info("Starting CEPH-83574962")
+
+    config = {
+        "rep_pool_config": {
+            "mode": "image",
+            "mirrormode": "snapshot",
+            "image": "rbd_image_rep",
+            "io_total": "1G",
+            "pool": "rbd_pool",
+            "size": "10G",
+        },
+        "ec_pool_config": {
+            "pool": "rbd_pool",
+            "image": "rbd_image_ec",
+            "mode": "image",
+            "data_pool": "data_pool",
+            "io_total": "1G",
+            "mirrormode": "snapshot",
+            "size": "10G",
+        },
+    }
+    kw["config"].update(config)
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        mirror1 = mirror_obj["rep_rbdmirror"]["mirror1"]
+        mirror2 = mirror_obj["rep_rbdmirror"]["mirror2"]
+
+        rep_image_spec = (
+            f'{config["rep_pool_config"]["pool"]}/{config["rep_pool_config"]["image"]}'
+        )
+        ec_image_spec = (
+            f'{config["ec_pool_config"]["pool"]}/{config["ec_pool_config"]["image"]}'
+        )
+        image_spec_list = [rep_image_spec, ec_image_spec]
+
+        log.info(
+            "Stopping an rbd daemon in cluster 2 and performing relocate operation"
+        )
+
+        # Gather service name in cluster2 and stop non-leader daemon
+        mirror2.update_ceph_rbdmirror(config["rep_pool_config"]["pool"], leader=False)
+        service_name_mirror2 = mirror2.get_rbd_service_name("rbd-mirror")
+        mirror2.change_service_state(service_name_mirror2, "stop")
+
+        # Relocate: Demote image at cluster1
+        for imagespec in image_spec_list:
+            mirror1.demote(imagespec=imagespec)
+        with parallel() as p:
+            p.spawn(
+                mirror2.wait_for_status,
+                imagespec=rep_image_spec,
+                state_pattern="up+unknown",
+            )
+            p.spawn(
+                mirror2.wait_for_status,
+                imagespec=ec_image_spec,
+                state_pattern="up+unknown",
+            )
+        # Relocate: promote image at cluster2
+        for imagespec in image_spec_list:
+            mirror2.promote(imagespec=imagespec)
+
+        with parallel() as p:
+            p.spawn(mirror2.benchwrite, imagespec=rep_image_spec, io="1G")
+            p.spawn(mirror2.benchwrite, imagespec=ec_image_spec, io="1G")
+        time.sleep(30)
+        mirror2.change_service_state(service_name_mirror2, "start")
+
+        log.info(
+            "Marking leader rbd daemon in booth clusters and performing failover operation"
+        )
+        # Stop leader daemon on both the clusters
+        service_names = []
+
+        for cluster in [mirror1, mirror2]:
+            cluster.update_ceph_rbdmirror(config["rep_pool_config"]["pool"], True)
+            service_names.append(cluster.get_rbd_service_name("rbd-mirror"))
+            cluster.change_service_state(service_names[-1], "stop")
+
+        # Failover: force promote both images on cluster1
+        for imagespec in image_spec_list:
+            mirror1.promote(imagespec=imagespec, force=True)
+
+        with parallel() as p:
+            p.spawn(
+                mirror1.wait_for_status,
+                imagespec=rep_image_spec,
+                state_pattern="up+stopped",
+            )
+            p.spawn(
+                mirror1.wait_for_status,
+                imagespec=ec_image_spec,
+                state_pattern="up+stopped",
+            )
+        with parallel() as p:
+            p.spawn(mirror1.benchwrite, imagespec=rep_image_spec, io="1G")
+            p.spawn(mirror1.benchwrite, imagespec=ec_image_spec, io="1G")
+
+        # Failover: demote images at cluster2 and initiate resync
+        for imagespec in image_spec_list:
+            mirror2.demote(imagespec=imagespec)
+            time.sleep(10)
+            mirror2.resync(imagespec)
+
+        with parallel() as p:
+            p.spawn(mirror1.change_service_state, service_names[0], "start")
+            p.spawn(mirror2.change_service_state, service_names[1], "start")
+            time.sleep(30)
+            for imagespec in image_spec_list:
+                p.spawn(mirror1.check_data, peercluster=mirror2, imagespec=imagespec)
+
+    return 0


### PR DESCRIPTION
# Description
Automating multiple rbd-mirroring daemons per cluster
    
    Including configuration and verification of daemon failure
    Apart from that minor changes to initial mirror config method to accomodate mirroring at image level.
    
    new file:   suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
    New file with suite defining path -
    1) Install 5.x with 2 rbd mirror daemons
    2) Upgrade clusters to 6.x
    3) Execute CEPH-83574962
    
    modified:   tests/rbd_mirror/rbd_mirror_utils.py
    Modified some existing methods to address failure on snapshot based mirroring
    Added new methods required for CEPH-83574962 and other future modules.
    Please refer method docs for more information.
    
    new file:   tests/rbd_mirror/test_rbd_mirror_mult_daemon.py
    Module handling TC of image relocate/failover with failure of rbd mirror daemons.
    
    Signed-off-by: Vasishta <vashastr@redhat.com>

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
