### PR TITLE
tier-2_rados_basic_regression: Verification of Fragmentation scores

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -291,3 +291,11 @@ tests:
           pool_name: pool_num_chk
           delete_pool: true
 
+  - test:
+      name: OSD min-alloc size and fragmentation checks
+      module: rados_prep.py
+      polarion-id: CEPH-83573808
+      config:
+        Verify_osd_alloc_size:
+          allocation_size: 4096
+      desc: Verify the minimum allocation size for OSDs along with fragmentation scores.

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -275,3 +275,12 @@ tests:
         verify_pg_num_limit:
           pool_name: pool_num_chk
           delete_pool: true
+
+  - test:
+      name: OSD min-alloc size and fragmentation checks
+      module: rados_prep.py
+      polarion-id: CEPH-83573808
+      config:
+        Verify_osd_alloc_size:
+          allocation_size: 4096
+      desc: Verify the minimum allocation size for OSDs along with fragmentation scores.


### PR DESCRIPTION
Verification of Fragmentation Scores & Allocation size.

Steps:
1. Create a test pool, read/write/delete data, to create fragmentation on OSDs.
2. Collect Sample set of OSDs to test the allocation size and fragmentation scores.
3. Checking the config param for allocation size for ssd & hdd.
4. Checking the allocation size from the bluestore dump.
5. Checking the fragmentation scores.
6. Do this on all sample OSDs collected.

Signed-off-by: Pawan Dhiran <pdhiran@redhat.com>
