### PR TITLE
fix upstream failure on build args

### DIFF
--- a/pipeline/metadata/quincy.yaml
+++ b/pipeline/metadata/quincy.yaml
@@ -24,7 +24,7 @@ suites:
 - name: "Basic Regression Upstream Testing For DMFG"
   suite: "suites/quincy/upstream/tier-1-cephadm-basic-regression.yaml"
   global-conf: "conf/quincy/upstream/4-node-cluster-with-1-client.yaml"
-  platform: "rhel-9"
+  platform: "rhel-8"
   rhbuild: "6.0"
   inventory:
     openstack: "conf/inventory/rhel-8-latest.yaml"


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Fixing minor issue at runtime cli args.

**Issue:**
`--platform rhel-9 --rhbuild 6.0 --inventory conf/inventory/rhel-8-latest.yaml 
`