### PR TITLE
Fix logger issue in bootstrap.py

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -216,10 +216,11 @@ class BootstrapMixin:
 
         if build_type == "upstream":
             self.setup_upstream_repository()
-            logger.info(
-                "Enabling cdn tool repo to workaround ",
-                "unavailability of ceph x86_64 RPM pkgs in upstream builds",
-            )
+            # Todo: This is temporary workaround of installing Red Hat Ceph
+            #       Storage tools repo to compensate ceph-common and other pkg RPMs
+            #       used in the CI test modules.
+            #       The `set_cdn_tool_repo` should be taken out, once
+            #       we have upstream build with all necessary pkg sources.
             self.set_cdn_tool_repo()
         elif build_type == "released" or custom_repo.lower() == "cdn":
             custom_image = False


### PR DESCRIPTION
TypeError: not all arguments converted during string formatting

Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

**Issue:**

> --- Logging error ---
> Traceback (most recent call last):
>   File "/usr/lib64/python3.6/logging/__init__.py", line 994, in emit
>     msg = self.format(record)
>   File "/usr/lib64/python3.6/logging/__init__.py", line 840, in format
>     return fmt.format(record)
>   File "/usr/lib64/python3.6/logging/__init__.py", line 577, in format
>     record.message = record.getMessage()
>   File "/usr/lib64/python3.6/logging/__init__.py", line 338, in getMessage
>     msg = msg % self.args
> TypeError: not all arguments converted during string formatting
> Call stack:
>   File "run.py", line 1075, in <module>
>     rc = run(args)
>   File "run.py", line 884, in run
>     clients=clients,
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/tests/cephadm/test_bootstrap.py", line 593, in run
>     out, err = method(config)
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/ceph/ceph_admin/bootstrap.py", line 221, in bootstrap
>     "unavailability of ceph x86_64 RPM pkgs in upstream builds",
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/utility/log.py", line 142, in info
>     self._log("info", message, *args, **kwargs)
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/utility/log.py", line 128, in _log
>     **kwargs,
> Message: 'cephci.ceph.ceph_admin.bootstrap.py:221 - Enabling cdn tool repo to workaround '
> Arguments: ('unavailability of ceph x86_64 RPM pkgs in upstream builds',)
> --- Logging error ---
> Traceback (most recent call last):
>   File "/usr/lib64/python3.6/logging/__init__.py", line 994, in emit
>     msg = self.format(record)
>   File "/usr/lib64/python3.6/logging/__init__.py", line 840, in format
>     return fmt.format(record)
>   File "/usr/lib64/python3.6/logging/__init__.py", line 577, in format
>     record.message = record.getMessage()
>   File "/usr/lib64/python3.6/logging/__init__.py", line 338, in getMessage
>     msg = msg % self.args
> TypeError: not all arguments converted during string formatting
> Call stack:
>   File "run.py", line 1075, in <module>
>     rc = run(args)
>   File "run.py", line 884, in run
>     clients=clients,
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/tests/cephadm/test_bootstrap.py", line 593, in run
>     out, err = method(config)
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/ceph/ceph_admin/bootstrap.py", line 221, in bootstrap
>     "unavailability of ceph x86_64 RPM pkgs in upstream builds",
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/utility/log.py", line 142, in info
>     self._log("info", message, *args, **kwargs)
>   File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/utility/log.py", line 128, in _log
>     **kwargs,
> Message: 'cephci.ceph.ceph_admin.bootstrap.py:221 - Enabling cdn tool repo to workaround '
> Arguments: ('unavailability of ceph x86_64 RPM pkgs in upstream builds',)