### PR TITLE
[Pipeline failure] - test_rbd_mirror and test_rbd_mirror_daemon_status failure

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -296,6 +296,8 @@ class RbdMirror:
             p.spawn(mirror2.create_pool, poolname=poolname)
 
         self.create_image(imagespec=imagespec, size=imagesize)
+        if kw.get("mirrormode") != "snapshot":
+            self.image_feature_enable(imagespec=imagespec, image_feature="journaling")
         if kw.get("image_feature"):
             image_feature = kw.get("image_feature")
             self.image_feature_enable(imagespec=imagespec, image_feature=image_feature)
@@ -1013,6 +1015,7 @@ def rbd_mirror_config(**kw):
             kw["config"]["ec_pool_config"]["mode"] = kw["config"][
                 "rep_pool_config"
             ].get("mode", "pool")
+
         # Create rep pool config with all necessary config when no rep pool config is specified
         else:
             kw["config"]["rep_pool_config"] = {
@@ -1030,6 +1033,8 @@ def rbd_mirror_config(**kw):
             imagesize=kw["config"]["rep_pool_config"]["size"],
             io_total=kw["config"]["rep_pool_config"]["io_total"],
             mode=kw["config"]["rep_pool_config"]["mode"],
+            mirrormode=kw["config"]["rep_pool_config"].get("mirrormode", ""),
+            image_feature=kw["config"]["ec_pool_config"].get("image_feature"),
             **kw,
         )
 
@@ -1065,6 +1070,7 @@ def rbd_mirror_config(**kw):
             kw["config"]["ec_pool_config"]["mode"] = kw["config"]["ec_pool_config"].get(
                 "mode", "pool"
             )
+
         # Create ec pool config with all necessary config when no ec pool config is specified
         else:
             kw["config"]["ec_pool_config"] = {
@@ -1074,6 +1080,7 @@ def rbd_mirror_config(**kw):
                 "io_total": "1G",
                 "mode": "pool",
             }
+
         ec_mirror1.initial_mirror_config(
             ec_mirror2,
             poolname=kw["config"]["ec_pool_config"]["pool"],
@@ -1081,6 +1088,8 @@ def rbd_mirror_config(**kw):
             imagesize=kw["config"]["ec_pool_config"]["size"],
             io_total=kw["config"]["ec_pool_config"]["io_total"],
             mode=kw["config"]["ec_pool_config"]["mode"],
+            mirrormode=kw["config"]["ec_pool_config"].get("mirrormode", ""),
+            image_feature=kw["config"]["ec_pool_config"].get("image_feature"),
             **kw,
         )
 

--- a/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
+++ b/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
@@ -51,14 +51,12 @@ def run(**kw):
         poolname = mirror1.random_string()
         imagename = mirror1.random_string()
         imagespec = poolname + "/" + imagename
-        image_feature = "journaling"
         mirror1.initial_mirror_config(
             mirror2,
             poolname=poolname,
             imagename=imagename,
             imagesize=config.get("imagesize", "1G"),
             mode="pool",
-            image_feature=image_feature,
             **kw,
         )
 


### PR DESCRIPTION
Signed-off-by: Rajendra Khambadkar <rkhambad@rkhambad.remote.csb>

Failure Reason : observing failure with test_rbd_mirror and test_rbd_mirror_deamon_status while creating pool mirror on pool, as image is not created with journaling feature, Image is not mirroring in secondary cluster.

Solution : we will create image and enable the journaling feature on the image, if the type of "mode" is "pool"

success log : 
1) **tier_1_rbd_mirror** : 
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/5/6788/173617 
2) **tier2_rbd_mirror_regression** : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ao42h/
