### PR TITLE
Fix for ssl certificate failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "paramiko",
         "pyyaml",
         "reportportal-client",
-        "requests",
+        "requests==2.27.1",
         "softlayer",
     ],
     zip_safe=True,


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Fix for upstream pipeline failure

 File "/home/jenkins-build/workspace/rhceph-upstream-test-executor/.venv/lib64/python3.9/site-packages/urllib3/util/ssl_.py", line 493, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
  File "/usr/lib64/python3.9/ssl.py", line 501, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib64/python3.9/ssl.py", line 1041, in _create
    self.do_handshake()
  File "/usr/lib64/python3.9/ssl.py", line 1310, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)

https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-upstream-test-executor/42/execution/node/164/log/