### PR TITLE
Removing special characters from suite name in metadata file

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -203,7 +203,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - cephfs
-        - name: "test-5.3-specific-fixes"
+        - name: "test-53-specific-fixes"
           execution_time: "41m 40s"
           suite: "suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
@@ -326,7 +326,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - cephfs
-        - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
+        - name: "test-rgw-ms-omap-datalog-on-primary"
           execution_time: "1h 54m 39s"
           suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
           global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
@@ -347,7 +347,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rados
-        - name: "Tier-2 RGW multisite test async data notifications on 5.3"
+        - name: "Tier-2 RGW multisite test async data notifications on 53"
           execution_time: "2h 14m 43s"
           suite: "suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml"
           global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
@@ -398,7 +398,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
-        - name: "Tier-2 RGW single site upgrade from 5.x GA to latest developmet build"
+        - name: "Tier-2 RGW single site upgrade from 5x GA to latest development build"
           execution_time: "2h 58m 22s"
           suite: "suites/pacific/rgw/tier-1_rgw_ssl_test-upgrade-5-to-latest.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -153,7 +153,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+        - name: "Bootstrap cluster with skip-dashboard output configuration directories or files"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -163,7 +163,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+        - name: "Bootstrap cluster with custom ssl-dashboard-port ssh-user ssh-public-key ssh-private-key and apply-spec options"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -422,7 +422,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
-        - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
+        - name: "test-rgw-ms-omap-datalog-on-primary"
           execution_time: "1h 26m 11s"
           suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
           global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
@@ -699,7 +699,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
-        - name: "Tier-2 cephfs upgrade 5.3 to 6.0"
+        - name: "Tier-2 cephfs upgrade 5-3 to 6-0"
           execution_time: ""
           suite: "suites/quincy/cephfs/tier-0_cephfs_upgrade_53_to_6x.yaml"
           global-conf: "conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml"
@@ -731,7 +731,7 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - cephfs
-        - name: "cephadm cluster bootstrap with mutiple public network."
+        - name: "cephadm cluster bootstrap with mutiple public network"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
           global-conf: "conf/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
@@ -919,7 +919,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+        - name: "Bootstrap cluster with skip-dashboard output configuration directories or files."
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -929,7 +929,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+        - name: "Bootstrap cluster with custom ssl-dashboard-port ssh-user ssh-public-key ssh-private-key and apply-spec options"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -1086,7 +1086,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+        - name: "Bootstrap cluster with skip-dashboard output configuration directories or files."
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -1096,7 +1096,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+        - name: "Bootstrap cluster with custom ssl-dashboard-port ssh-user ssh-public-key ssh-private-key and apply-spec options"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -139,7 +139,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+        - name: "Bootstrap cluster with skip-dashboard output configuration directories or files."
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -149,7 +149,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+        - name: "Bootstrap cluster with custom ssl-dashboard-port ssh-user ssh-public-key ssh-private-key and apply-spec options"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -408,7 +408,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
-        - name: "test-rgw-ms-omap-datalog-on-primary.yaml"
+        - name: "test-rgw-ms-omap-datalog-on-primary"
           execution_time: "1h 26m 11s"
           suite: "suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml"
           global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
@@ -706,7 +706,7 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - cephfs
-        - name: "cephadm cluster bootstrap with mutiple public network."
+        - name: "cephadm cluster bootstrap with mutiple public network"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
           global-conf: "conf/quincy/cephadm/tier-2_multiple_subnet_openstack_only.yaml"
@@ -894,7 +894,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+        - name: "Bootstrap cluster with skip-dashboard output configuration directories or files"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -904,7 +904,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+        - name: "Bootstrap cluster with custom ssl-dashboard-port ssh-user ssh-public-key ssh-private-key and apply-spec options"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -1061,7 +1061,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with skip-dashboard, output configuration directories/files."
+        - name: "Bootstrap cluster with skip-dashboard output configuration directories or files"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_skip_dashboard.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
@@ -1071,7 +1071,7 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - dmfg
-        - name: "Bootstrap cluster with custom ssl-dashboard-port, ssh-user, ssh-public-key, ssh-private-key and apply-spec options."
+        - name: "Bootstrap cluster with custom ssl-dashboard-port ssh-user ssh-public-key ssh-private-key and apply-spec options"
           execution_time: ""
           suite: "suites/quincy/cephadm/tier-1_ssl_dashboard_port.yaml"
           global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

Removed special characters from suite name in metadata file to avoid the following error.

Feb 11, 2023, 11:49 PM
RHCEPH-6.0 - tier-1 - stage-3
ceph-version : 17.2.5-67

/data/jenkins/workspace/rhceph-test-execution-pipeline@2/logs/4jwwa-1077/Install_ceph_pre-requisites_0.log /data/jenkins/workspace/rhceph-test-execution-pipeline@2/logs/4jwwa-1077/startup.log
tar: Removing leading `/' from member names
tar (child): /data/jenkins/workspace/rhceph-test-execution-pipeline@2/logs/4jwwa-1077/Bootstrap-cluster-with-skip-dashboard,-output-configuration-directories/files..tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
/data/jenkins/workspace/rhceph-test-execution-pipeline@2/logs/4jwwa-1077/Add_all_hosts_to_ceph_cluster_0.log
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
ERROR: script returned exit code 141
Finished: FAILURE
