### PR TITLE
CEPH-9489: Test Case automation for scale osd with mirroring

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -1033,3 +1033,67 @@ def validate_spec_services(installer, specs, rhcs_version) -> None:
             rhcs_version=rhcs_version,
         ):
             raise Exception(f"{svc_name or svc_type} service deployment failed!!!")
+
+
+def add_remove_osd(command, osd_nodes, ceph_nodes, orch_obj, osd_obj, ceph_admin):
+    """
+    Performs the operation specified in command on all the OSDs in the osd_nodes specified
+    Args:
+        command: add, rm
+        osd_nodes: [node4,node5]
+        config:
+            ceph_cluster_config
+    """
+    if command == "add":
+        try:
+            add_config = {
+                "service": "orch",
+                "validate-spec-services": "true",
+                "specs": [
+                    {
+                        "service_type": "osd",
+                        "service_id": "osd_add_nodes",
+                        "placement": {"nodes": osd_nodes},
+                        "spec": {"data_devices": {"all": "true"}},
+                    }
+                ],
+            }
+            orch_obj.apply_spec(add_config)
+            add_config.update({"validate-spec-services": "false"})
+            add_config["specs"][0].update({"unmanaged": "true"})
+            orch_obj.apply_spec(add_config)
+        except BaseException as e:
+            LOG.error(f"Adding OSDs failed on nodes {osd_nodes} with error {e}")
+            return 1
+        return 0
+
+    if command == "rm":
+        nodes = get_nodes_by_ids(ceph_nodes, osd_nodes)
+        for node in nodes:
+            osds = json.loads(
+                orch_obj.ps(
+                    {
+                        "base_cmd_args": {"format": "json"},
+                        "args": {"hostname": node.hostname},
+                    }
+                )[0]
+            )
+            for osd in osds[:-1]:
+                try:
+                    rm_config = {
+                        "command": command,
+                        "base_cmd_args": {"zap": "true"},
+                        "pos_args": [osd["daemon_id"]],
+                    }
+                    osd_obj.rm(rm_config)
+                except BaseException as e:
+                    LOG.error(
+                        f"OSD removal failed for osd {osd['daemon_id']} with error {e}"
+                    )
+                    return 1
+
+            LOG.info(
+                f"Fetching cluster state after removal of OSD from node {node.hostname}"
+            )
+            get_cluster_state(cls=ceph_admin)
+        return 0

--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -167,17 +167,16 @@ class OSD(ApplyMixin, Orch):
             config:
                 command: rm
                 base_cmd_args:
-                    verbose: true
+                    zap: true
                 pos_args:
                     - 1
         """
-
         base_cmd = ["ceph", "orch", "osd"]
-        if config.get("base_cmd_args"):
-            base_cmd.append(config_dict_to_string(config["base_cmd_args"]))
         base_cmd.append("rm")
         osd_id = config["pos_args"][0]
         base_cmd.append(str(osd_id))
+        if config.get("base_cmd_args"):
+            base_cmd.append(config_dict_to_string(config["base_cmd_args"]))
         self.shell(args=base_cmd)
 
         check_osd_id_dict = {
@@ -194,12 +193,12 @@ class OSD(ApplyMixin, Orch):
             try:
                 status = json.loads(out)
                 for osd_id_ in status:
-                    if osd_id_["osd_id"] == osd_id:
+                    if int(osd_id_["osd_id"]) == int(osd_id):
                         LOG.info(f"OSDs removal in progress: {osd_id_}")
+                        sleep(2)
+                        continue
+                    else:
                         break
-                else:
-                    break
-                sleep(2)
 
             except json.decoder.JSONDecodeError:
                 break
@@ -213,7 +212,7 @@ class OSD(ApplyMixin, Orch):
             if id_["id"] == osd_id:
                 LOG.error("OSD Removed ID found")
                 raise AssertionError("fail, OSD is present still after removing")
-        LOG.info(f" OSD {osd_id} Removal is successfully")
+        LOG.info(f" OSD {osd_id} Removal is successful")
 
     def out(self, config: Dict):
         """

--- a/conf/pacific/rbd/rbd_mirror_large.yaml
+++ b/conf/pacific/rbd/rbd_mirror_large.yaml
@@ -1,0 +1,81 @@
+globals:
+  - ceph-cluster:
+      name: ceph-rbd1
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+      node4:
+        role:
+          - osd
+          - rbd-mirror
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - client
+  - ceph-cluster:
+      name: ceph-rbd2
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+      node4:
+        role:
+          - osd
+          - rbd-mirror
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - client

--- a/conf/quincy/rbd/rbd_mirror_large.yaml
+++ b/conf/quincy/rbd/rbd_mirror_large.yaml
@@ -1,0 +1,81 @@
+globals:
+  - ceph-cluster:
+      name: ceph-rbd1
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+      node4:
+        role:
+          - osd
+          - rbd-mirror
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - client
+  - ceph-cluster:
+      name: ceph-rbd2
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+      node4:
+        role:
+          - osd
+          - rbd-mirror
+        no-of-volumes: 4
+        disk-size: 15
+      node5:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node6:
+        role: osd
+        no-of-volumes: 4
+        disk-size: 15
+      node7:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node8:
+        role: pool
+        no-of-volumes: 4
+        disk-size: 15
+      node9:
+        role:
+          - client

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -790,6 +790,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rbd
+        - name: "RBD mirroring with OSD add and remove"
+          execution_time: "4h 16m 0s"
+          suite: "suites/pacific/rbd/tier-2_rbd_mirror_scale_osd.yaml"
+          global-conf: "conf/pacific/rbd/rbd_mirror_large.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
         - name: "RGW Regression testing"
           execution_time: "4h 49m 28s"
           suite: "suites/pacific/rgw/tier-2_rgw_regression.yaml"
@@ -812,6 +822,7 @@ pipelines:
             - upgrades
             - dmfg
             - again
+      stage-5:
         - name: "test-cephfs-upgrade-4-to-latest"
           execution_time: ""
           suite: "suites/pacific/cephfs/tier-2_cephfs_upgrade_4x_5x.yaml"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -741,6 +741,16 @@ pipelines:
             - rbd
             - upgrades
       stage-4:
+        - name: "RBD mirroring with OSD add and remove"
+          execution_time: "4h 16m 0s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml"
+          global-conf: "conf/quincy/rbd/rbd_mirror_large.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
         - name: "RADOS regression for testing various pool functionalities"
           execution_time: ""
           suite: "suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml"

--- a/suites/pacific/rbd/tier-2_rbd_mirror_scale_osd.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_scale_osd.yaml
@@ -1,0 +1,224 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_scale_osd.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/rbd_mirror_large.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    9-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGRS, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon
+#     Node4 - OSD, RBD Mirror
+#     Node5 - OSD
+#     Node6 - OSD
+#     Node7 - Pool (Node to scale up OSD)
+#     Node8 - Pool (Node to scale up OSD)
+#     Node9 - Client
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: false
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      unmanaged: true
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      unmanaged: true
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node9
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node9
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      name: test-add-remove-osd-with-mirroring
+      module: test-add-remove-osd-with-mirroring.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            osds_to_add:
+              - node7
+              - node8
+            osds_to_remove:
+              - node5
+              - node6
+        ceph-rbd2:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            osds_to_add:
+              - node7
+              - node8
+            osds_to_remove:
+              - node5
+              - node6
+      polarion-id: CEPH-9501
+      desc: Verify that image deleted at primary site updated at secondary

--- a/suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml
@@ -1,0 +1,224 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_scale_osd.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/rbd_mirror_large.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    9-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGRS, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - Mon, Mgr
+#     Node3 - Mon
+#     Node4 - OSD, RBD Mirror
+#     Node5 - OSD
+#     Node6 - OSD
+#     Node7 - Pool (Node to scale up OSD)
+#     Node8 - Pool (Node to scale up OSD)
+#     Node9 - Client
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: false
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      unmanaged: true
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: osd
+                      service_id: osd_nodes
+                      unmanaged: true
+                      placement:
+                        nodes:
+                          - node4
+                          - node5
+                          - node6
+                      spec:
+                        data_devices:
+                          all: "true"
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node9
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node9
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      name: test-add-remove-osd-with-mirroring
+      module: test-add-remove-osd-with-mirroring.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            osds_to_add:
+              - node7
+              - node8
+            osds_to_remove:
+              - node5
+              - node6
+        ceph-rbd2:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            osds_to_add:
+              - node7
+              - node8
+            osds_to_remove:
+              - node5
+              - node6
+      polarion-id: CEPH-9501
+      desc: Verify that image deleted at primary site updated at secondary

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -4,6 +4,7 @@ import json
 import random
 import string
 import time
+from importlib import import_module
 from typing import List
 
 from ceph.ceph import CommandFailed
@@ -336,8 +337,8 @@ class RbdMirror:
             self.config_mirror(mirror2, poolname=poolname, **kw)
 
         # Enable image level mirroring only when mode is image type
-        if kw.get("mirrormode") and kw.get("mode") == "image":
-            mirrormode = kw.get("mirrormode")
+        if kw.get("mode") == "image":
+            mirrormode = kw.get("mirrormode", "")
             self.enable_mirror_image(poolname, imagename, mirrormode)
             self.wait_for_status(poolname=poolname, health_pattern="OK")
             mirror2.wait_for_status(poolname=poolname, health_pattern="OK")
@@ -663,14 +664,14 @@ class RbdMirror:
             imagespec: image specification
         """
         if self.ceph_version < 3:
-            self.exec_cmd(
+            return self.exec_cmd(
                 cmd="rbd bench-write --io-total {} {}".format(
                     kw.get("io", "500M"), kw.get("imagespec")
                 ),
                 long_running=True,
             )
         else:
-            self.exec_cmd(
+            return self.exec_cmd(
                 cmd=(
                     "rbd bench --io-type write --io-threads 16 "
                     f"--io-total {kw.get('io', '500M')} {kw.get('imagespec')}"
@@ -912,10 +913,20 @@ class RbdMirror:
         if kw.get("dir_name"):
             self.exec_cmd(cmd="rm -rf {}".format(kw.get("dir_name")))
             peercluster.exec_cmd(cmd="rm -rf {}".format(kw.get("dir_name")))
+
         if kw.get("pools"):
             pool_list = kw.get("pools")
             if self.datapool:
                 pool_list.append(self.datapool)
+
+            # mon_allow_pool_delete must be True for removing pool
+            if self.ceph_version >= 5:
+                self.exec_cmd(cmd="ceph config set mon mon_allow_pool_delete true")
+                peercluster.exec_cmd(
+                    cmd="ceph config set mon mon_allow_pool_delete true"
+                )
+                time.sleep(20)
+
             for pool in pool_list:
                 self.delete_pool(poolname=pool)
                 peercluster.delete_pool(poolname=pool)
@@ -1079,6 +1090,33 @@ class RbdMirror:
                     self.ceph_nodes, each_daemon["hostname"].split("-")[-1]
                 )
                 break
+
+
+def execute_dynamic(obj, test, results: dict, **kwargs):
+    """
+    Executes the test specified in test parameter with inputs args and returns results
+    Args:
+        obj: rbd mirror object, or a string to a module in which the test method exists
+        test: test to be executed
+        results: test results
+        **kwargs: input args required for the test
+
+    Returns:
+        test results updated to results dict
+    """
+    if isinstance(obj, str):
+        obj = import_module(obj)
+    method = getattr(obj, test)  # if obj else globals()[test]
+    try:
+        rc = method(**kwargs)
+        log.info(f"Return value for execution of method: {test} is {rc}")
+        if rc:
+            results.update({test: 1})
+        else:
+            results.update({test: 0})
+    except BaseException as e:
+        log.error(f"Error while running method {method}: {e}")
+        results.update({test: 1})
 
 
 def rbd_mirror_config(**kw):

--- a/tests/rbd_mirror/test-add-remove-osd-with-mirroring.py
+++ b/tests/rbd_mirror/test-add-remove-osd-with-mirroring.py
@@ -1,0 +1,250 @@
+from ceph.ceph_admin import CephAdmin
+from ceph.ceph_admin.orch import Orch
+from ceph.ceph_admin.osd import OSD
+from ceph.parallel import parallel
+from tests.rbd_mirror.rbd_mirror_utils import execute_dynamic, rbd_mirror_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_add_remove_osd_with_mirroring(rbd_mirror, pool_type, **kw):
+    """
+    Test to add and remove osd nodes with mirroring
+    Args:
+        rbd_mirror: rbd mirror object
+        pool_type: ec pool or rep pool
+        **kw:
+
+    Returns:
+        0 if test passes, else 1
+    """
+    try:
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
+        config = kw.get("config")
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
+
+        results = {}
+
+        orch_obj = Orch(cluster=mirror1.ceph_nodes, **config)
+        osd_obj = OSD(cluster=mirror1.ceph_nodes, **config)
+        ceph_admin = CephAdmin(cluster=mirror1.ceph_nodes, **config)
+
+        log.info("Add OSDs to primary cluster with bench IOs running on mirrored image")
+        with parallel() as p:
+            p.spawn(
+                execute_dynamic,
+                mirror1,
+                "benchwrite",
+                results,
+                imagespec=imagespec,
+                io="100M",
+            )
+            p.spawn(
+                execute_dynamic,
+                "ceph.ceph_admin.helper",
+                "add_remove_osd",
+                results,
+                command="add",
+                osd_nodes=config["osds_to_add"],
+                ceph_nodes=mirror1.ceph_nodes,
+                orch_obj=orch_obj,
+                osd_obj=osd_obj,
+                ceph_admin=ceph_admin,
+            )
+
+        if results["benchwrite"] or results["add_remove_osd"]:
+            log.error(f"Results of benchwrite : {results['benchwrite']}")
+            log.error(f"Results of add_remove_osd : {results['add_remove_osd']}")
+            log.error("Adding OSDs failed for primary cluster")
+            return 1
+
+        log.info("Check if mirror data is consistent")
+        try:
+            mirror1.check_data(mirror2, imagespec)
+        except BaseException:
+            log.error(
+                "Data consistency check failed after adding OSDs to primary cluster"
+            )
+            return 1
+
+        log.info(
+            "Remove OSDs from primary cluster with bench IOs running on mirrored image"
+        )
+        with parallel() as p:
+            p.spawn(
+                execute_dynamic,
+                mirror1,
+                "benchwrite",
+                results,
+                imagespec=imagespec,
+                io="100M",
+            )
+            p.spawn(
+                execute_dynamic,
+                "ceph.ceph_admin.helper",
+                "add_remove_osd",
+                results,
+                command="rm",
+                osd_nodes=config["osds_to_remove"],
+                ceph_nodes=mirror1.ceph_nodes,
+                orch_obj=orch_obj,
+                osd_obj=osd_obj,
+                ceph_admin=ceph_admin,
+            )
+
+        if results["benchwrite"] or results["add_remove_osd"]:
+            log.error(f"Results of benchwrite : {results['benchwrite']}")
+            log.error(f"Results of add_remove_osd : {results['add_remove_osd']}")
+            log.error("Removing OSDs failed for primary cluster")
+            return 1
+
+        log.info("Check if mirror data is consistent")
+        try:
+            mirror1.check_data(mirror2, imagespec)
+        except BaseException:
+            log.error(
+                "Data consistency check failed after removing OSDs from primary cluster"
+            )
+            return 1
+
+        orch_obj = Orch(cluster=mirror2.ceph_nodes, **config)
+        osd_obj = OSD(cluster=mirror2.ceph_nodes, **config)
+        ceph_admin = CephAdmin(cluster=mirror2.ceph_nodes, **config)
+
+        log.info(
+            "Add OSDs to secondary cluster with bench IOs running on mirrored image"
+        )
+        with parallel() as p:
+            p.spawn(
+                execute_dynamic,
+                mirror1,
+                "benchwrite",
+                results,
+                imagespec=imagespec,
+                io="100M",
+            )
+            p.spawn(
+                execute_dynamic,
+                "ceph.ceph_admin.helper",
+                "add_remove_osd",
+                results,
+                command="add",
+                osd_nodes=config["osds_to_add"],
+                ceph_nodes=mirror2.ceph_nodes,
+                orch_obj=orch_obj,
+                osd_obj=osd_obj,
+                ceph_admin=ceph_admin,
+            )
+
+        if results["benchwrite"] or results["add_remove_osd"]:
+            log.error(f"Results of benchwrite : {results['benchwrite']}")
+            log.error(f"Results of add_remove_osd : {results['add_remove_osd']}")
+            log.error("Adding OSDs failed for secondary cluster")
+            return 1
+
+        log.info("Check if mirror data is consistent")
+        try:
+            mirror1.check_data(mirror2, imagespec)
+        except BaseException:
+            log.error(
+                "Data consistency check failed after adding OSDs to secondary cluster"
+            )
+            return 1
+
+        log.info(
+            "Remove OSDs from secondary cluster with bench IOs running on mirrored image"
+        )
+        with parallel() as p:
+            p.spawn(
+                execute_dynamic,
+                mirror1,
+                "benchwrite",
+                results,
+                imagespec=imagespec,
+                io="100M",
+            )
+            p.spawn(
+                execute_dynamic,
+                "ceph.ceph_admin.helper",
+                "add_remove_osd",
+                results,
+                command="rm",
+                osd_nodes=config["osds_to_remove"],
+                ceph_nodes=mirror2.ceph_nodes,
+                orch_obj=orch_obj,
+                osd_obj=osd_obj,
+                ceph_admin=ceph_admin,
+            )
+
+        if results["benchwrite"] or results["add_remove_osd"]:
+            log.error(f"Results of benchwrite : {results['benchwrite']}")
+            log.error(f"Results of add_remove_osd : {results['add_remove_osd']}")
+            log.error("Removing OSDs failed for secondary cluster")
+            return 1
+
+        log.info("Check if mirror data is consistent")
+        try:
+            mirror1.check_data(mirror2, imagespec)
+        except BaseException:
+            log.error(
+                "Data consistency check failed after removing OSDs from secondary cluster"
+            )
+            return 1
+        return 0
+
+    except Exception as e:
+        log.exception(e)
+        return 1
+
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
+
+def run(**kw):
+    """
+    Add remove osd with mirroring - local/primary cluster and remote/secondary cluster
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9489 - Add remove osd with mirroring - local/primary cluster and remote/secondary cluster
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. 3 monitors
+        2. Atleast 9 osds
+        3. Atleast 1 Client
+        4. 2 nodes dedicated to be added as OSDs.
+
+    Test Case Flow:
+    1. Follow the latest official Block device Doc to configure RBD Mirroring - For Image Based Mirroring.
+        VMs should be running on the images that get mirrored.
+    2. Add 2 new osd nodes to the primary cluster, while running IOs on RBD mirrored images
+    3. Remove 2 existing osd nodes from the primary cluster, while running IOs on RBD mirrored images
+    4. Add 2 new osd nodes to the secondary cluster, while running IOs on RBD mirrored images
+    5. Remove 2 existing osd nodes from the secondary cluster, while running IOs on RBD mirrored images
+    """
+    log.info("Starting CEPH-9489")
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_add_remove_osd_with_mirroring(
+            mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+        ):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_add_remove_osd_with_mirroring(
+            mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+        ):
+            return 1
+
+    return 0


### PR DESCRIPTION
Signed-off-by: mgowri <mgowri@redhat.com>

This PR is for automation of the following test scenario for test case with polarion id - CEPH-9489

Add remove osd with mirroring - local/primary cluster and remote/secondary cluster
    Pre-requisites -
    Two ceph clusters with rbd mirror configured along with:
        1. 3 monitors
        2. Atleast 9 osds
        3. Atleast 1 Client
        4. 2 nodes dedicated to be added as OSDs.

    Test Case Flow:
    1. Follow the latest official Block device Doc to configure RBD Mirroring - For Image Based Mirroring.
        VMs should be running on the images that get mirrored.
    2. Add 2 new osd nodes to the primary cluster, while running IOs on RBD mirrored images
    3. Remove 2 existing osd nodes from the primary cluster, while running IOs on RBD mirrored images
    4. Add 2 new osd nodes to the secondary cluster, while running IOs on RBD mirrored images
    5. Remove 2 existing osd nodes from the secondary cluster, while running IOs on RBD mirrored images

Success logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2qjnq/ 
Few issues : In the above success logs I have removed only 3 out of 4 OSDs present in 2 OSD nodes. 
But when we try to remove all the OSDs present in the two nodes, we are hitting an issue. The removal is getting stuck at the removal of the 8th OSD node infinitely. 
We are discussing with dev on this issue. Until that is fixed, we can go ahead with merging this code where I am removing one less OSD from each node. Hope that is okay!! 