### PR TITLE
Set verify_ssl to false to solve ssl certificate issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "paramiko",
         "pyyaml",
         "reportportal-client",
-        "requests==2.27.1",
+        "requests",
         "softlayer",
     ],
     zip_safe=True,

--- a/utility/rp_utils/reportportalV1.py
+++ b/utility/rp_utils/reportportalV1.py
@@ -98,6 +98,7 @@ class ReportPortalV1:
                 project=self.project,
                 token=self.api_token,
                 log_batch_size=1,
+                verify_ssl=False,
             )
             self._service.session.verify = False
 


### PR DESCRIPTION
Signed-off-by: tintumathew10 <tmathew@redhat.com>

Set verify_ssl to false to overcome ssl certificate issue with different python versions.

after the change requests version is 
reportportal-client==5.2.5
requests==2.28.2
requestsexceptions==1.4.0

2023-02-14 15:13:49,567 (__main__) [INFO] - Starting testcases
2023-02-14 15:13:49,861 (__main__) [INFO] - /home/tmathew/rp_dir/payload/attachments/check-ceph-health.err
2023-02-14 15:13:50,388 (__main__) [INFO] - Starting testcases
2023-02-14 15:13:50,798 (__main__) [INFO] - /home/tmathew/rp_dir/payload/attachments/check-ceph-health.err
2023-02-14 15:13:50,800 (__main__) [INFO] - /home/tmathew/rp_dir/payload/attachments/check-upgrade-status.err
2023-02-14 15:13:51,089 (__main__) [INFO] - 
Finished testcases
2023-02-14 15:13:51,366 (__main__) [INFO] - /home/tmathew/rp_dir/payload/attachments/check-upgrade-status.err
2023-02-14 15:13:51,644 (__main__) [INFO] - 
Finished testcases
2023-02-14 15:13:53,357 (__main__) [INFO] - RETURN OBJECT: {'launches': [6876]}
launch id: 6876
2023-02-14 15:13:53,361 (__main__) [INFO] - Log Location /tmp/cephci-run-VFK54O/report_portal.log