### PR TITLE
Moving upgrade suite from IBM to PSI-only

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -689,17 +689,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
-        - name: "Tier-2 cephfs upgrade 5-3 to 6-0"
-          execution_time: ""
-          suite: "suites/quincy/cephfs/tier-0_cephfs_upgrade_53_to_6x.yaml"
-          global-conf: "conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - cephfs
-            - upgrades
   sanity_openstack_only:
     tier-2:
       stage-1:
@@ -772,6 +761,16 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "Tier-2 cephfs upgrade 5-3 to 6-0"
+          execution_time: "54m 21s"
+          suite: "suites/quincy/cephfs/tier-0_cephfs_upgrade_53_to_6x.yaml"
+          global-conf: "conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+          metadata:
+            - cephfs
+            - upgrades
   rc:
     tier-0:
       stage-1:


### PR DESCRIPTION
Moving upgrade suite from IBM to PSI-only
https://issues.redhat.com/browse/RHCEPHQE-7445

As we are not maintaining GA builds in IBM. I am moving this to PSI-only

Signed-off-by: Amarnath K <amk@amk.remote.csb>

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
