### PR TITLE
Enhancement: Fetch upstream build info for x86_64 arch

### DIFF
--- a/pipeline/metadata/main.yaml
+++ b/pipeline/metadata/main.yaml
@@ -1,0 +1,149 @@
+#=====================================================================================
+# Metadata file for quincy upstream testing.
+# Single file to specify test suites to be executed for all regression (sanity) and schedule tests
+# as per defined in each stages.
+# Each stage will execute in sequential pattern.
+# Contains all Default parameter used for Execution when no override is specified.
+# parameter required to create a similar custom file is suite name, suite yaml file, global configuration file,
+# platform, rhbuild, inventory and metadata information like frequency of execution, tier, cloud type, functional group and stage.
+#=====================================================================================
+suites:
+- name: "Core Feature Upstream Testing For DMFG"
+  suite: "suites/quincy/cephadm/sanity-test.yaml"
+  global-conf: "conf/3-node-cluster-with-1-client.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - dmfg
+    - stage-1
+
+- name: "Basic Regression Upstream Testing For DMFG"
+  suite: "suites/quincy/upstream/tier-1-cephadm-basic-regression.yaml"
+  global-conf: "conf/quincy/upstream/4-node-cluster-with-1-client.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - dmfg
+    - stage-1
+
+- name: "Core Feature Upstream Testing For CephFS"
+  suite: "suites/quincy/cephfs/test-core-functionality.yaml"
+  global-conf: "conf/6-node-cluster-with-1-client.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - cephfs
+    - stage-1
+
+- name: "Core Feature Upstream Testing For RBD"
+  suite: "suites/quincy/rbd/basic-operations-unit-testing.yaml"
+  global-conf: "conf/5-node-cluster-with-1-client.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rbd
+    - stage-1
+
+- name: "Core Feature Upstream Testing For RGW"
+  suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
+  global-conf: "conf/5-node-cluster-1-client-with-1-rgw.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rgw
+    - stage-1
+
+- name: "Upstream Testing For RGW Multisite"
+  suite: "suites/quincy/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
+  global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rgw
+    - stage-2
+
+- name: "Core Feature Upstream Testing For RGW and RGW LC tests"
+  suite: "suites/quincy/upstream/tier-1_rgw_and_lc.yaml"
+  global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rgw
+    - stage-2
+
+- name: "Upstream Testing For rbd and rbd-mirror"
+  suite: "suites/quincy/upstream/tier-1_rbd_mirror_and_rbd.yaml"
+  global-conf: "conf/quincy/upstream/5-node-2-clusters.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rbd
+    - stage-2
+- name: "Upstream Testing For Rados Regression"
+  suite: "suites/quincy/upstream/tier-2_rados_basic_regression.yaml"
+  global-conf: "conf/quincy/rados/7-node-cluster.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rados
+    - stage-2
+- name: "Upstream Testing For Rados Stretch cluster"
+  suite: "suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml"
+  global-conf: "conf/quincy/rados/11-node-cluster.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - rados
+    - stage-3
+- name: "Upstream Testing For CephFS Regression"
+  suite: "suites/quincy/cephfs/tier-1_cephfs_upstream-core-functionality.yaml"
+  global-conf: "conf/pacific/cephfs/tier-1_fs.yaml"
+  platform: "rhel-9"
+  rhbuild: "6.0"
+  inventory:
+    openstack: "conf/inventory/rhel-9-latest.yaml"
+  metadata:
+    - upstream
+    - openstack
+    - cephfs
+    - stage-2

--- a/pipeline/metadata/quincy.yaml
+++ b/pipeline/metadata/quincy.yaml
@@ -11,10 +11,10 @@ suites:
 - name: "Core Feature Upstream Testing For DMFG"
   suite: "suites/quincy/cephadm/sanity-test.yaml"
   global-conf: "conf/3-node-cluster-with-1-client.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack
@@ -24,10 +24,10 @@ suites:
 - name: "Basic Regression Upstream Testing For DMFG"
   suite: "suites/quincy/upstream/tier-1-cephadm-basic-regression.yaml"
   global-conf: "conf/quincy/upstream/4-node-cluster-with-1-client.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack
@@ -37,10 +37,10 @@ suites:
 - name: "Core Feature Upstream Testing For CephFS"
   suite: "suites/quincy/cephfs/test-core-functionality.yaml"
   global-conf: "conf/6-node-cluster-with-1-client.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack
@@ -50,10 +50,10 @@ suites:
 - name: "Core Feature Upstream Testing For RBD"
   suite: "suites/quincy/rbd/basic-operations-unit-testing.yaml"
   global-conf: "conf/5-node-cluster-with-1-client.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack
@@ -63,10 +63,10 @@ suites:
 - name: "Core Feature Upstream Testing For RGW"
   suite: "suites/quincy/rgw/test-basic-object-operations.yaml"
   global-conf: "conf/5-node-cluster-1-client-with-1-rgw.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack
@@ -76,10 +76,10 @@ suites:
 - name: "Upstream Testing For RGW Multisite"
   suite: "suites/quincy/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml"
   global-conf: "conf/quincy/rgw/rgw_multisite.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack
@@ -89,10 +89,10 @@ suites:
 - name: "Core Feature Upstream Testing For RGW and RGW LC tests"
   suite: "suites/quincy/upstream/tier-1_rgw_and_lc.yaml"
   global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-  platform: "rhel-8"
+  platform: "rhel-9"
   rhbuild: "6.0"
   inventory:
-    openstack: "conf/inventory/rhel-8-latest.yaml"
+    openstack: "conf/inventory/rhel-9-latest.yaml"
   metadata:
     - upstream
     - openstack


### PR DESCRIPTION
Signed-off-by: Sunil Kumar Nagaraju <sunnagar@redhat.com>

- Fetch upstream x86_64 arch and CentOS 9 builds.
```

❯ python pipeline/scripts/ci/upstream_cli.py build main
/home/sunil/work-dir/cephci/venv-py39/lib64/python3.9/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.14) or chardet (5.1.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
> /home/sunil/work-dir/cephci/pipeline/scripts/ci/upstream_cli.py(138)fetch_upstream_build()
-> url = "https://shaman.ceph.com/api/repos/ceph/"
(Pdb) c
2023-02-14 16:37:42,853 - INFO - upstream_cli.py:138 - Upstream repo for the given branch is https://2.chacra.ceph.com/repos/ceph/main/ea33358e18f233ccba9f80a7b3d0a90b2fbb7549/centos/9/flavors/default//repo
2023-02-14 16:37:42,854 - INFO - upstream_cli.py:138 - Upstream image for the given branch is quay.ceph.io/ceph-ci/ceph:ea33358e18f233ccba9f80a7b3d0a90b2fbb7549
podman version 4.3.1
Trying to pull quay.ceph.io/ceph-ci/ceph:ea33358e18f233ccba9f80a7b3d0a90b2fbb7549...
Getting image source signatures
Copying blob cd8a180700c0 skipped: already exists  
Copying blob c9a93b47ad08 skipped: already exists  
Copying blob 4ef69b820011 skipped: already exists  
Copying blob ea0a20a2c448 skipped: already exists  
Copying config a9ea9b108f done  
Writing manifest to image destination
Storing signatures
a9ea9b108f92cea4f7e0c28b7730fee9252b1c040dd01d20a49f6c309ded2ea8
2023-02-14 16:37:48,070 - INFO - upstream_cli.py:138 - Upstream version for the given branch is 18.0.0-2221-gea33358e
ls: cannot access '/ceph/cephci-jenkins/latest-rhceph-container-info/upstream.yaml.lock': No such file or directory
File lock does not exist, Creating it
File un-locked successfully
2023-02-14 16:37:53,230 - INFO - upstream_cli.py:70 - Updated build info: 
 repo:https://2.chacra.ceph.com/repos/ceph/main/ea33358e18f233ccba9f80a7b3d0a90b2fbb7549/centos/9/flavors/default//repo 
 image:quay.ceph.io/ceph-ci/ceph:ea33358e18f233ccba9f80a7b3d0a90b2fbb7549 
 ceph version:18.0.0-2221-gea33358e in /ceph/cephci-jenkins/latest-rhceph-container-info/upstream.yaml

```

**Results:**
http://magna002.ceph.redhat.com/cephci-jenkins/latest-rhceph-container-info/upstream.yaml
