### PR TITLE
Fix for osd reblance suites are failing with invalid syntax error

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -81,7 +81,6 @@ tests:
         node: node8                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps: # authorize client capabilities
           mon: "allow *"

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -170,15 +170,15 @@ def wait_for_device(host, osd_id, action: str) -> bool:
         time.sleep(120)
         container, device_path = validate(host, osd_id)
 
-        match action:
-            case "add":
-                if device_path and container:
-                    log.info(f"[osd.{osd_id}] {container}-{device_path} added..")
-                    return True
-            case "remove":
-                if not (device_path and container):
-                    log.info(f"[osd.{osd_id}] {container}-{device_path} removed..")
-                    return True
+        if action == "add":
+            if device_path and container:
+                log.info(f"[osd.{osd_id}] {container}-{device_path} added..")
+                return True
+        elif action == "remove":
+            if not (device_path and container):
+                log.info(f"[osd.{osd_id}] {container}-{device_path} removed..")
+                return True
+
         log.info(
             f"waiting for the {action} to complete...\n"
             f"container: {container}, device_path: {device_path}"


### PR DESCRIPTION
# Description

Fix for osd reblance suites are failing with invalid syntax error.
https://issues.redhat.com/browse/RHCEPHQE-7179

File "run.py", line 1077, in <module>
    rc = run(args)
  File "run.py", line 786, in run
    test_mod = importlib.import_module(mod_file_name)
  File "/usr/lib64/python3.6/importlib/{}init{}.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 674, in exec_module
  File "<frozen importlib._bootstrap_external>", line 781, in get_code
  File "<frozen importlib._bootstrap_external>", line 741, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/data/jenkins/workspace/rhcs-tintu/tests/rados/test_osd_rebalance.py", line 173
    match action:
               ^
SyntaxError: invalid syntax

logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ELMGZY/