### PR TITLE
Temporarily default m,k = 2,1 fo rbd tests

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -40,6 +40,8 @@ class Rbd:
                 if self.config.get("ec_pool_config", {}).get("data_pool")
                 else "rbd_test_data_pool_" + self.random_string()
             )
+            self.k_m = "2,1"
+            # Temporary change untill we get more info on default value of k and m
             if "," in self.k_m:
                 self.ec_profile = self.config.get("ec_pool_config", {}).get(
                     "ec_profile", "rbd_ec_profile_" + self.random_string()


### PR DESCRIPTION
Most if the rbd test config have 3 osd nodes
default ceph erasure values of m,n are 2+2 now
we find it in our storage downstream strategies guide that it is 2,1

Defaulting them to 2,1 untill we get clarity to keep pipelines clean.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
