### PR TITLE
Switching back to rhel-8.7 ga build

### DIFF
--- a/conf/inventory/rhel-8.7-server-x86_64-large.yaml
+++ b/conf/inventory/rhel-8.7-server-x86_64-large.yaml
@@ -3,7 +3,7 @@ version_id: 8.7
 id: rhel
 instance:
   create:
-    image-name: RHEL-8.7.0-x86_64-nightly-latest
+    image-name: RHEL-8.7.0-x86_64-ga-latest
     vm-size: ci.m1.large
 
   setup: |

--- a/conf/inventory/rhel-8.7-server-x86_64.yaml
+++ b/conf/inventory/rhel-8.7-server-x86_64.yaml
@@ -3,7 +3,7 @@ version_id: 8.7
 id: rhel
 instance:
   create:
-    image-name: RHEL-8.7.0-x86_64-nightly-latest
+    image-name: RHEL-8.7.0-x86_64-ga-latest
     vm-size: ci.m1.medium
 
   setup: |


### PR DESCRIPTION
# Description
Switching back to rhel-8.7 ga build.
Fix for Problem: package ceph-base-2:16.2.10-135.el8cp.x86_64 requires ceph-selinux = 2:16.2.10-135.el8cp, but none of the providers can be installed

2023-02-15 04:46:43,373 (cephci.test_client) [INFO] - cephci.ceph.ceph.py:1543 - Running command yum install -y --nogpgcheck ceph-base on 10.0.207.136 timeout 600
2023-02-15 04:46:50,001 (cephci.test_client) [ERROR] - cephci.ceph.ceph.py:1578 - Error 1 during cmd, timeout 600
2023-02-15 04:46:50,001 (cephci.test_client) [ERROR] - cephci.ceph.ceph.py:1579 - Error: 
 Problem: package ceph-base-2:16.2.10-135.el8cp.x86_64 requires ceph-selinux = 2:16.2.10-135.el8cp, but none of the providers can be installed
  - conflicting requests
  - nothing provides selinux-policy-base >= 3.14.3-108.el8_7.1 needed by ceph-selinux-2:16.2.10-135.el8cp.x86_64

2023-02-15 04:46:50,002 (cephci.test_client) [ERROR] - cephci.ceph.parallel.py:93 - Exception in parallel execution
Traceback (most recent call last):
  File "/home/jenkins-build/workspace/rhceph-test-execution-pipeline/ceph/parallel.py", line 88, in {}exit{}
    for result in self:
  File "/home/jenkins-build/workspace/rhceph-test-execution-pipeline/ceph/parallel.py", line 106, in {}next{}
    resurrect_traceback(result)
  File "/home/jenkins-build/workspace/rhceph-test-execution-pipeline/ceph/parallel.py", line 35, in resurrect_traceback
    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
  File "/home/jenkins-build/workspace/rhceph-test-execution-pipeline/ceph/parallel.py", line 22, in capture_traceback
    return func(*args, **kwargs)
  File "/home/jenkins-build/workspace/rhceph-test-execution-pipeline/tests/cephadm/test_client.py", line 82, in setup
    cmd=f"yum install -y --nogpgcheck {pkg}", sudo=True
  File "/home/jenkins-build/workspace/rhceph-test-execution-pipeline/ceph/ceph.py", line 1581, in exec_command
    f"

{kw['cmd']} Error:  {str(stderr)} {str(self.ip_address)}"

logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GH1OWL/