### PR TITLE
PSI-only jenkin job Abort execution if new build available

### DIFF
--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -51,6 +51,14 @@ node("rhel-8-medium || ceph-qe-ci") {
 
         // Trigger psi_only pipeline based on ciMessage content
         if (ciMap.pipeline.final_stage && ciMap.pipeline.tags.contains("tier-0") && ciMap.test.result == "SUCCESS") {
+            def recipeFileContent = sharedLib.yamlToMap("${rhcephVersion}.yaml")
+            def content = recipeFileContent['latest']
+            println "recipeFile ceph-version : ${content['ceph-version']}"
+            println "buildArtifacts ceph-version : ${ciMap.recipe.'ceph-version'}"
+            if ( ciMap.recipe."ceph-version" != content['ceph-version']) {
+                currentBuild.result = "ABORTED"
+                error "Aborting the execution as new builds are available.."
+            }
             println "Starting test execution with parameters:"
             println "\trhcephVersion: ${rhcephVersion}\n\tbuildType: ${buildType}\n\tbuildArtifacts: ${buildArtifacts}\n\toverrides: ${overrides}\n\ttags: ${tags}"
 

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -144,6 +144,15 @@ node(nodeName) {
             def build_number = "${currentBuild.number}"
             overrides.put("workspace", workspace.toString())
             overrides.put("build_number", build_number.toInteger())
+            def recipeFileContent = sharedLib.yamlToMap("${rhcephVersion}.yaml")
+            def content = recipeFileContent['latest']
+            println "recipeFile ceph-version : ${content['ceph-version']}"
+            def currentCephVersion = buildArtifacts['ceph-version'] ?: buildArtifacts['recipe']['ceph-version']
+            println "buildArtifacts ceph-version : ${currentCephVersion}"
+            if ( currentCephVersion != content['ceph-version']) {
+                currentBuild.result = "ABORTED"
+                error "Aborting the execution as new builds are available.."
+            }
         }
 
         if("ibmc" in tags_list) {


### PR DESCRIPTION
# Description
Abort execution in PSI-only executor if there is new build available:

new build available:
https://jenkins.ceph.redhat.com/job/rhceph-execute-psi-only-suites/2703/console
https://jenkins.ceph.redhat.com/job/rhceph-test-execution-pipeline/1838/console
+ ls -l /ceph/cephci-jenkins/latest-rhceph-container-info/RHCEPH-5.3.yaml
-rw-rw-r--. 1 jenkins-build jenkins-build 2948 Feb 16 11:57 /ceph/cephci-jenkins/latest-rhceph-container-info/RHCEPH-5.3.yaml
[Pipeline] readYaml
[Pipeline] echo
recipeFile ceph-version : 16.2.10-137
[Pipeline] echo
buildArtifacts ceph-version : 16.2.10-136
.....................................
ERROR: Aborting the execution as new builds are available..
Finished: ABORTED

If there is no new build 
https://jenkins.ceph.redhat.com/job/rhceph-execute-psi-only-suites/2704/console
https://jenkins.ceph.redhat.com/job/rhceph-test-execution-pipeline/1839/console
+ ls -l /ceph/cephci-jenkins/latest-rhceph-container-info/RHCEPH-5.3.yaml
-rw-rw-r--. 1 ubuntu ci 2948 Feb 16 16:57 /ceph/cephci-jenkins/latest-rhceph-container-info/RHCEPH-5.3.yaml
[Pipeline] readYaml
[Pipeline] echo
recipeFile ceph-version : 16.2.10-137
[Pipeline] echo
buildArtifacts ceph-version : 16.2.10-137
[Pipeline] echo
Starting test execution with parameters:
[Pipeline] echo
	rhcephVersion: RHCEPH-5.3
..........................


- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
