### PR TITLE
Test Case automation for move_primary_to_trash_force_promote_secondary_resync_primary

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -15,271 +15,277 @@
 #     Node5 - OSD, RBD Mirror
 #===============================================================================================
 tests:
-  - test:
-      name: setup install pre-requisistes
-      desc: Setup phase to deploy the required pre-requisites for running the tests.
-      module: install_prereq.py
-      abort-on-fail: true
+#  - test:
+#      name: setup install pre-requisistes
+#      desc: Setup phase to deploy the required pre-requisites for running the tests.
+#      module: install_prereq.py
+#      abort-on-fail: true
+#
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            verify_cluster_health: true
+#            steps:
+#              - config:
+#                  command: bootstrap
+#                  service: cephadm
+#                  args:
+#                    mon-ip: node1
+#                    orphan-initial-daemons: true
+#                    skip-monitoring-stack: true
+#              - config:
+#                  command: add_hosts
+#                  service: host
+#                  args:
+#                    attach_ip_address: true
+#                    labels: apply-all-labels
+#              - config:
+#                  command: apply
+#                  service: mgr
+#                  args:
+#                    placement:
+#                      label: mgr
+#              - config:
+#                  command: apply
+#                  service: mon
+#                  args:
+#                    placement:
+#                      label: mon
+#              - config:
+#                  command: apply
+#                  service: osd
+#                  args:
+#                    all-available-devices: true
+#              - config:
+#                  command: apply
+#                  service: rbd-mirror
+#                  args:
+#                    placement:
+#                      nodes:
+#                        - node5
+#        ceph-rbd2:
+#          config:
+#            verify_cluster_health: true
+#            steps:
+#              - config:
+#                  command: bootstrap
+#                  service: cephadm
+#                  args:
+#                    mon-ip: node1
+#                    orphan-initial-daemons: true
+#                    skip-monitoring-stack: true
+#              - config:
+#                  command: add_hosts
+#                  service: host
+#                  args:
+#                    attach_ip_address: true
+#                    labels: apply-all-labels
+#              - config:
+#                  command: apply
+#                  service: mgr
+#                  args:
+#                    placement:
+#                      label: mgr
+#              - config:
+#                  command: apply
+#                  service: mon
+#                  args:
+#                    placement:
+#                      label: mon
+#              - config:
+#                  command: apply
+#                  service: osd
+#                  args:
+#                    all-available-devices: true
+#              - config:
+#                  command: apply
+#                  service: rbd-mirror
+#                  args:
+#                    placement:
+#                      nodes:
+#                        - node5
+#      desc: RBD Mirror cluster deployment using cephadm
+#      destroy-clster: false
+#      module: test_cephadm.py
+#      name: deploy cluster
+#  - test:
+#        abort-on-fail: true
+#        clusters:
+#          ceph-rbd1:
+#            config:
+#              command: add
+#              id: client.1
+#              node: node2
+#              install_packages:
+#                - ceph-common
+#              copy_admin_keyring: true
+#          ceph-rbd2:
+#            config:
+#                command: add
+#                id: client.1
+#                node: node2
+#                install_packages:
+#                    - ceph-common
+#                copy_admin_keyring: true
+#        desc: Configure the client system 1
+#        destroy-cluster: false
+#        module: test_client.py
+#        name: configure client
+#  - test:
+#      abort-on-fail: true
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            cephadm: true
+#            commands:
+#              - "ceph config set mon mon_allow_pool_delete true"
+#        ceph-rbd2:
+#          config:
+#            cephadm: true
+#            commands:
+#              - "ceph config set mon mon_allow_pool_delete true"
+#      desc: Enable mon_allow_pool_delete to True for deleting the pools
+#      module: exec.py
+#      name: configure mon_allow_pool_delete to True
+
+#  - test:
+#      name: test-image-delete-from-primary-site
+#      module: test-image-delete-primary-site.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-9501
+#      desc: Verify that image deleted at primary site updated at secondary
+#
+#  - test:
+#      name: test mirror on image having snap and clone after restoring from trash
+#      module: test_mirror_move_primary_trash_restore.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-11417
+#      desc: Verify that image is restore and mirroring is intact
+#
+#  - test:
+#      name: test image delete from secondary after promote and demote
+#      module: test-image-delete-from-secondary.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#            repeat_count: 1
+#      polarion-id: CEPH-83574741
+#      desc: Verify that deleting primary image also delete the secondary image
+#
+#  - test:
+#      name: image removal from secondary after journaling feature disable
+#      module: test_image_removal_from_secondary.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#            repeat_count: 10
+#      polarion-id: CEPH-10470
+#      desc: verify that image removal from secondary after disabling journaling feature
 
   - test:
-      abort-on-fail: true
-      clusters:
-        ceph-rbd1:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: bootstrap
-                  service: cephadm
-                  args:
-                    mon-ip: node1
-                    orphan-initial-daemons: true
-                    skip-monitoring-stack: true
-              - config:
-                  command: add_hosts
-                  service: host
-                  args:
-                    attach_ip_address: true
-                    labels: apply-all-labels
-              - config:
-                  command: apply
-                  service: mgr
-                  args:
-                    placement:
-                      label: mgr
-              - config:
-                  command: apply
-                  service: mon
-                  args:
-                    placement:
-                      label: mon
-              - config:
-                  command: apply
-                  service: osd
-                  args:
-                    all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
-        ceph-rbd2:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: bootstrap
-                  service: cephadm
-                  args:
-                    mon-ip: node1
-                    orphan-initial-daemons: true
-                    skip-monitoring-stack: true
-              - config:
-                  command: add_hosts
-                  service: host
-                  args:
-                    attach_ip_address: true
-                    labels: apply-all-labels
-              - config:
-                  command: apply
-                  service: mgr
-                  args:
-                    placement:
-                      label: mgr
-              - config:
-                  command: apply
-                  service: mon
-                  args:
-                    placement:
-                      label: mon
-              - config:
-                  command: apply
-                  service: osd
-                  args:
-                    all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
-      desc: RBD Mirror cluster deployment using cephadm
-      destroy-clster: false
-      module: test_cephadm.py
-      name: deploy cluster
-  - test:
-        abort-on-fail: true
-        clusters:
-          ceph-rbd1:
-            config:
-              command: add
-              id: client.1
-              node: node2
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true
-          ceph-rbd2:
-            config:
-                command: add
-                id: client.1
-                node: node2
-                install_packages:
-                    - ceph-common
-                copy_admin_keyring: true
-        desc: Configure the client system 1
-        destroy-cluster: false
-        module: test_client.py
-        name: configure client
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-rbd1:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set mon mon_allow_pool_delete true"
-        ceph-rbd2:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set mon mon_allow_pool_delete true"
-      desc: Enable mon_allow_pool_delete to True for deleting the pools
-      module: exec.py
-      name: configure mon_allow_pool_delete to True
+      name: move_primary_to_trash_force_promote_secondary_resync_primary
+      module: test_trash_primary_image.py
+      polarion-id: CEPH-11418
+      desc: move primary to trash, force promote secondary, restore and resync primary
 
-  - test:
-      name: test-image-delete-from-primary-site
-      module: test-image-delete-primary-site.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9501
-      desc: Verify that image deleted at primary site updated at secondary
-
-  - test:
-      name: test mirror on image having snap and clone after restoring from trash
-      module: test_mirror_move_primary_trash_restore.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-11417
-      desc: Verify that image is restore and mirroring is intact
-
-  - test:
-      name: test image delete from secondary after promote and demote
-      module: test-image-delete-from-secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            repeat_count: 1
-      polarion-id: CEPH-83574741
-      desc: Verify that deleting primary image also delete the secondary image
-
-  - test:
-      name: image removal from secondary after journaling feature disable
-      module: test_image_removal_from_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            repeat_count: 10
-      polarion-id: CEPH-10470
-      desc: verify that image removal from secondary after disabling journaling feature
-
-  - test:
-      name: Attempt shrinking secondary image
-      module: test_9500_shrink_img_at_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9500
-      desc: Verify that deleting secondary image fails
-
-  - test:
-      name: test image meta operations sync to secondary
-      module: test_rbd_image_meta_mirroring.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            key: ping
-            value: pong
-      polarion-id: CEPH-9524
-      desc: Verify removal of image meta gets mirrored
-
-  - test:
-      name: Recovery of abrupt failure of primary cluster
-      module: test_9470.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9470
-      desc: Test unplanned failover and failback scenario
-
-  - test:
-      name: Recovery of shutdown primary cluster
-      module: test_9471.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9471
-      desc: Test planned failover and failback scenario
-
-  - test:
-      name: Recovery of abrupt failure of secondary cluster
-      module: test_9474.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9474
-      desc: Recovery of abrupt failure of secondary cluster
-
-  - test:
-      name: Recovery of shutdown secondary cluster
-      module: test_9475.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9475
-      desc: Testing secondary cluster unplanned failover test
-
-  - test:
-      name: Mirroring of cloned image
-      module: test_rbd_clone_mirror.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-9521
-      desc: Testing mirroring of cloned image
-
-  - test:
-      name: Mirroring from journal to snapshot
-      module: test_rbd_mirror_journal_to_snap.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-83573618
-      desc: Testing journal mirroring to snapshot mirroring
+#  - test:
+#      name: Attempt shrinking secondary image
+#      module: test_9500_shrink_img_at_secondary.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-9500
+#      desc: Verify that deleting secondary image fails
+#
+#  - test:
+#      name: test image meta operations sync to secondary
+#      module: test_rbd_image_meta_mirroring.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#            key: ping
+#            value: pong
+#      polarion-id: CEPH-9524
+#      desc: Verify removal of image meta gets mirrored
+#
+#  - test:
+#      name: Recovery of abrupt failure of primary cluster
+#      module: test_9470.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-9470
+#      desc: Test unplanned failover and failback scenario
+#
+#  - test:
+#      name: Recovery of shutdown primary cluster
+#      module: test_9471.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-9471
+#      desc: Test planned failover and failback scenario
+#
+#  - test:
+#      name: Recovery of abrupt failure of secondary cluster
+#      module: test_9474.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-9474
+#      desc: Recovery of abrupt failure of secondary cluster
+#
+#  - test:
+#      name: Recovery of shutdown secondary cluster
+#      module: test_9475.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#            io-total: 200M
+#      polarion-id: CEPH-9475
+#      desc: Testing secondary cluster unplanned failover test
+#
+#  - test:
+#      name: Mirroring of cloned image
+#      module: test_rbd_clone_mirror.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#      polarion-id: CEPH-9521
+#      desc: Testing mirroring of cloned image
+#
+#  - test:
+#      name: Mirroring from journal to snapshot
+#      module: test_rbd_mirror_journal_to_snap.py
+#      clusters:
+#        ceph-rbd1:
+#          config:
+#            imagesize: 2G
+#      polarion-id: CEPH-83573618
+#      desc: Testing journal mirroring to snapshot mirroring

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -190,6 +190,12 @@ tests:
       desc: verify that image removal from secondary after disabling journaling feature
 
   - test:
+      name: move_primary_to_trash_force_promote_secondary_resync_primary
+      module: test_trash_primary_image.py
+      polarion-id: CEPH-11418
+      desc: move primary to trash, force promote secondary, restore and resync primary
+
+  - test:
       name: Attempt shrinking secondary image
       module: test_9500_shrink_img_at_secondary.py
       clusters:

--- a/tests/rbd_mirror/test_trash_primary_image.py
+++ b/tests/rbd_mirror/test_trash_primary_image.py
@@ -1,0 +1,151 @@
+import pdb
+import time
+
+from ceph.parallel import parallel
+from ceph.utils import hard_reboot
+from tests.rbd.rbd_utils import execute_dynamic
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_trash_primary_image(rbd_mirror, pool_type, **kw):
+    try:
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
+        rbd1 = rbd_mirror.get("rbd1")
+        rbd2 = rbd_mirror.get("rbd2")
+        config = kw.get("config")
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
+
+        image_id = rbd1.get_image_id(pool, image)
+        if rbd1.move_image_trash(pool, image):
+            log.error(f"Moving {image} to trash failed")
+            return 1
+        if not rbd1.trash_exist(pool, image):
+            log.error(f"Trashed Image {image} not found in the Trash")
+            return 1
+
+        mirror2.promote(imagespec=imagespec, force=True)
+        mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
+
+        results = {}
+
+        log.info(
+            "Create multiple snapshots when IO on image is in progress. (use rbd bench)"
+        )
+        with parallel() as p:
+            p.spawn(
+                execute_dynamic,
+                rbd2,
+                "rbd_bench",
+                results,
+                imagespec=imagespec,
+            )
+            p.spawn(
+                execute_dynamic,
+                rbd2,
+                "create_multiple_snapshots",
+                results,
+                pool_name=pool,
+                image_name=image,
+                snap_names=f"{pool_type}_snap",
+                snap_count=12,
+                wait=10,
+            )
+        if results["create_multiple_snapshots"] or results["rbd_bench"]:
+            log.error(f"Creating snapshots while writing IOs failed for {pool}/{image}")
+            return 1
+
+        log.info("Restore trashed image")
+        if rbd1.trash_restore(pool, image_id):
+            log.error(f"Trash restore failed for {pool}/{image}")
+            return 1
+        if rbd1.trash_exist(pool, image):
+            log.error("Restored image found in the Trash")
+            return 1
+
+        log.info("Demote primary, resync and check if data integrity is maintained")
+        mirror1.demote(imagespec=imagespec)
+        mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+error")
+        mirror1.resync(imagespec=imagespec)
+        time.sleep(100)
+        mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
+        mirror1.wait_for_replay_complete(imagespec=imagespec)
+        mirror2.check_data(peercluster=mirror1, imagespec=imagespec)
+
+        log.info("Get cluster mirroring back to its initial state")
+        mirror2.demote(imagespec=imagespec)
+        mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+unknown")
+        mirror1.promote(imagespec=imagespec)
+        mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
+        mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
+
+        mirror2.clean_up(peercluster=mirror1, pools=[pool])
+        return 0
+
+    except Exception as e:
+        log.exception(e)
+        return 1
+
+
+def run(**kw):
+    """
+    Image mirroring - Try marking the primary image for deletion. Promote secondary create snaps on secondary,
+    restore primary and verify the relationship and IO is not affected.
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Test case covered -
+    CEPH-9470 - Image mirroring - Try marking the primary image for deletion. Promote secondary
+    create snaps on secondary, restore primary and verify the relationship and IO is not affected.
+    Pre-requisites -
+    Two ceph clusters with rbd mirror configured along with:
+        1. 3 monitors
+        2. Atleast 9 osds
+        3. Atleast 1 Client
+
+    Test Case Flow:
+    1. configure image mirroring
+    2. Move primary to trash. Promote --force secondary.
+    3. Run IOs and Create snapshot on secondary snapshots at various points.
+    4. Restore primary, demote and resync.
+    """
+    pdb.set_trace()
+    log.info("Starting CEPH-11418")
+    config = {
+        "create_rbd_object": True,
+        "rep_pool_config": {
+            "mode": "image",
+        },
+        "ec_pool_config": {
+            "mode": "image",
+        },
+    }
+    if kw.get("config"):
+        kw["config"].update(config)
+    else:
+        kw["config"] = config
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_trash_primary_image(
+            mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+        ):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_trash_primary_image(
+            mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+        ):
+            return 1
+
+    return 0


### PR DESCRIPTION
This PR is for automation of the following test scenario for test case with polarion id - CEPH-11418

Image mirroring - Try marking the primary image for deletion. Promote secondary create snaps on secondary,
    restore primary and verify the relationship and IO is not affected.
Pre-requisites -
    Two ceph clusters with rbd mirror configured along with:
        1. 3 monitors
        2. Atleast 9 osds
        3. Atleast 1 Client

   ```
 Test Case Flow:
    1. configure image mirroring
    2. Move primary to trash. Promote --force secondary.
    3. Run IOs and Create snapshot on secondary snapshots at various points.
    4. Restore primary, demote and resync.
```