### PR TITLE
Fix to include only current execution result in email sent

### DIFF
--- a/pipeline/upstream_test_executor.groovy
+++ b/pipeline/upstream_test_executor.groovy
@@ -20,6 +20,7 @@ def status = "STABLE"
 def upstreamArtifact =  [:]
 def failureReason
 def reportPotalLink
+def executionResult
 
 // Pipeline script entry point
 node('ceph-qe-ci || rhel-9-medium') {
@@ -122,6 +123,7 @@ node('ceph-qe-ci || rhel-9-medium') {
             metaData["rp_link"] = "${rp_base_link}/ui/#cephci/launches/all/${launch_id}"
             println("metadata: ${metaData}")
             reportPotalLink = metaData["rp_link"]
+            executionResult = metaData["results"]
         }
 
         stage('publish result') {
@@ -163,7 +165,7 @@ node('ceph-qe-ci || rhel-9-medium') {
         body += "<h3><u>Test Summary</u></h3>"
         body += "<table>"
         body += "<tr><th>Test Suite</th><th>Result</th></tr>"
-        testResults.each{k,v->
+        executionResult.each{k,v->
             def test_name = k.replace("-", " ")
             body += "<tr><td>${test_name.capitalize()}</td><td>${v['status']}</td></tr>"
         }


### PR DESCRIPTION
# Description
Fix to include only current execution result in email sent
currently upstream execution mail is sending current execution result along with next stage suite names with status as null
it should only send current exection result, should not send next stage suite names

stage-2 :
https://jenkins.ceph.redhat.com/job/rhceph-upstream-test-executor/48/console

![Screenshot from 2023-02-21 13-17-52](https://user-images.githubusercontent.com/83442624/220280921-1ada0df1-b8c0-4dcb-ac85-5af6e720ddfd.png)


stage-3:
https://jenkins.ceph.redhat.com/job/rhceph-upstream-test-executor/49/console

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
