### PR TITLE
fix libarrow with epel repo for rhel/centos-9 pkgs

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -157,17 +157,26 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         Args:
             repo_url: repo file URL link (default: None)
         """
+        EPEL_REPOS = {
+            "7": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm",
+            "8": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+            "9": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+        }
+
         if not repo_url:
             repo_url = self.config["base_url"]
 
         for node in self.cluster.get_nodes():
+            # Ceph Repo
             node.exec_command(
                 sudo=True, cmd=f"curl -o /etc/yum.repos.d/upstream_ceph.repo {repo_url}"
             )
             node.exec_command(sudo=True, cmd="yum update metadata", check_ec=False)
+
+            # Epel Repo
             node.exec_command(
                 sudo=True,
-                cmd="dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y",
+                cmd=f"dnf install {EPEL_REPOS[node.distro_info['VERSION_ID'][0]]} -y",
                 check_ec=False,
             )
 

--- a/suites/quincy/upstream/tier-1-cephadm-basic-regression.yaml
+++ b/suites/quincy/upstream/tier-1-cephadm-basic-regression.yaml
@@ -217,6 +217,7 @@ tests:
                     nodes:
                       - node4
                       - node3
+                      - node2
                   spec:
                     rgw_frontend_port: 8080
                     rgw_realm: east
@@ -227,6 +228,26 @@ tests:
                 - sleep
                 - "120"
   # Testing stage
+  - test:
+      name: Configure client
+      desc: Configure client on node5
+      module: test_client.py
+      polarion-id: CEPH-83573758
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node5                       # client node
+        install_packages:
+          - ceph-common                   # install ceph common packages
+        copy_admin_keyring: true          # Copy admin keyring to node
+        store-keyring: true               # /etc/ceph/ceph.client.1.keyring
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      destroy-cluster: false
+      abort-on-fail: true
   - test:
       name: Executes RGW, RBD and FS operations
       desc: Run object, block and filesystem basic operations parallelly.
@@ -247,26 +268,6 @@ tests:
             module: cephfs_basic_tests.py
             name: cephfs-basics
             polarion-id: "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295"
-  - test:
-      name: Configure client
-      desc: Configure client on node5
-      module: test_client.py
-      polarion-id: CEPH-83573758
-      config:
-        command: add
-        id: client.1                      # client Id (<type>.<Id>)
-        node: node5                       # client node
-        install_packages:
-          - ceph-common                   # install ceph common packages
-        copy_admin_keyring: true          # Copy admin keyring to node
-        store-keyring: true               # /etc/ceph/ceph.client.1.keyring
-        caps:                             # authorize client capabilities
-          mon: "allow *"
-          osd: "allow *"
-          mds: "allow *"
-          mgr: "allow *"
-      destroy-cluster: false
-      abort-on-fail: true
   - test:
       name: test_label_no_schedule
       desc: Adding  "__no_schedule" label to a node and verify its functionality in a cluster.


### PR DESCRIPTION
**Issue:**
```
ceph.ceph.CommandFailed: yum install -y --nogpgcheck ceph-common Error:  Error: 
 Problem: conflicting requests
  - nothing provides libarrow.so.900()(64bit) needed by ceph-common-2:18.0.0-2333.gd8dcffa4.el9.x86_64
  - nothing provides libparquet.so.900()(64bit) needed by ceph-common-2:18.0.0-2333.gd8dcffa4.el9.x86_64
```
https://jenkins.ceph.redhat.com/blue/organizations/jenkins/rhceph-upstream-test-executor/detail/rhceph-upstream-test-executor/43/pipeline/45/


**Solution:**
Enable right epel repo for centos9 nodes. https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm

**Results:**
 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QMNUDV/
