### PR TITLE
[CDN] fix CDN issue at ceph multi client

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -214,6 +214,7 @@ class BootstrapMixin:
             rhbuild = f"{_rhcs_version}-{_platform}"
             base_url = _details[0]
 
+        self.cluster.rhcs_version = _rhcs_version or rhbuild
         if build_type == "upstream":
             self.setup_upstream_repository()
             # Todo: This is temporary workaround of installing Red Hat Ceph
@@ -225,6 +226,7 @@ class BootstrapMixin:
         elif build_type == "released" or custom_repo.lower() == "cdn":
             custom_image = False
             self.set_cdn_tool_repo()
+            self.cluster.use_cdn = True
         elif custom_repo:
             self.set_tool_repo(repo=custom_repo)
         else:

--- a/tests/cephadm/test_cephadm_upgrade.py
+++ b/tests/cephadm/test_cephadm_upgrade.py
@@ -98,6 +98,7 @@ def run(ceph_cluster, **kwargs) -> int:
                 rhbuild=config.get("rhbuild"), client=orch.installer
             ):
                 raise UpgradeFailure("Cluster is in HEALTH_ERR state")
+        ceph_cluster.rhcs_version = config.get("rhbuild")
     except BaseException as be:  # noqa
         log.error(be, exc_info=True)
         return 1


### PR DESCRIPTION
# Issue
In CDN to Dev build upgrade, the CDN repos are not being enabled. so unable to find ceph-common pkg while installation. 
```
2023-02-18 06:01:32,535 (cephci.test_client) [INFO] - cephci.ceph.ceph.py:1543 - Running command yum install -y --nogpgcheck ceph-common on 10.245.4.39 timeout 600
2023-02-18 06:01:38,686 (cephci.test_client) [ERROR] - cephci.ceph.ceph.py:1578 - Error 1 during cmd, timeout 600
2023-02-18 06:01:38,686 (cephci.test_client) [ERROR] - cephci.ceph.ceph.py:1579 - Error: Unable to find a match: ceph-common
```


**Solution:**
- Use RHCS version to find out current RHCS version and enable the repos.
- Currently RHCS 6x is Not GAed, so switching to 5x CDN if it is found.

