### PR TITLE
Temporary fix for CDN client installation

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -148,7 +148,10 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         }
 
         cmd = f"subscription-manager repos --enable={cdn_repo[os_major_version]}"
-        for node in self.cluster.get_nodes(ignore="client"):
+
+        # Todo: Figure out a way to bail out CDN repo installation on clients
+        #       now clients go through installation, But need to avoid CDN repo enablement.
+        for node in self.cluster.get_nodes():
             node.exec_command(sudo=True, cmd=cmd)
 
     def setup_upstream_repository(self, repo_url=None):


### PR DESCRIPTION
# Issue
https://159.23.92.24/blue/rest/organizations/jenkins/pipelines/rhceph-test-execution-pipeline/runs/1133/nodes/55/steps/80/log/?start=0
```
2023-02-18 06:01:32,533 (paramiko.transport.sftp) [INFO] - [chan 17] Opened sftp connection (server version 3)
2023-02-18 06:01:32,535 (cephci.test_client) [INFO] - cephci.ceph.ceph.py:1543 - Running command yum install -y --nogpgcheck ceph-common on 10.245.4.39 timeout 600
2023-02-18 06:01:38,686 (cephci.test_client) [ERROR] - cephci.ceph.ceph.py:1578 - Error 1 during cmd, timeout 600
2023-02-18 06:01:38,686 (cephci.test_client) [ERROR] - cephci.ceph.ceph.py:1579 - Error: Unable to find a match: ceph-common
```

**Temporary Solution/Fix:**
-  allow clients in enabling the Dev repo and CDN repos.