### PR TITLE
Fixing Post results failures

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -18,7 +18,7 @@ def launch_id = ""
 def testStatus
 def date
 
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-8-medium") {
 
     try {
         stage('prepareJenkinsAgent') {


### PR DESCRIPTION
**Problem :** 
Post results job was failing when ran on `magna005`.
Because it did not had /ceph mount on it. It was not able to pull the `/ceph/cephci-jenkins/.rp_preproc_conf.yaml`

**Solution:**
We are restricting it to run on only `rhel-8-medium`

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
