### PR TITLE
Fix for mount failure in magna

### DIFF
--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -20,7 +20,7 @@ sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.
 sudo yum install -y p7zip
 
 # Mount reesi for storing logs
-if [ ! -d "/ceph" ]; then
+if [ ! -d "/cephh/cephci-jenkins" ]; then
     echo "Mounting ressi004"
     sudo mkdir -p /ceph
     sudo mount -t nfs -o sec=sys,nfsvers=4.1 reesi004.ceph.redhat.com:/ /ceph


### PR DESCRIPTION
# Description

Fix for mount failure in magna

+ ls -l /ceph/cephci-jenkins/.rp_preproc_conf.yaml
ls: cannot access '/ceph/cephci-jenkins/.rp_preproc_conf.yaml': No such file or directory
[Pipeline] echo
File /ceph/cephci-jenkins/.rp_preproc_conf.yaml does not exist.
