### PR TITLE
Adds variable shard count support on brownfield cluster

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -424,7 +424,7 @@ tests:
   - test:
       name: test sharding on primary
       desc: test_Mbuckets_with_Nobjects_sharding on primary
-      polarion-id: CEPH-9245
+      polarion-id: CEPH-83573597
       module: sanity_rgw_multisite.py
       clusters:
         ceph-pri:

--- a/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_upgrade-5-to-latest.yaml
@@ -491,6 +491,17 @@ tests:
       polarion-id: CEPH-83574735
 
   - test:
+      name: test sharding on primary
+      desc: test_Mbuckets_with_Nobjects_sharding on primary
+      polarion-id: CEPH-83573600
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
+            timeout: 300
+  - test:
       clusters:
         ceph-pri:
           config:


### PR DESCRIPTION
# Description
Adds variable shard count support on brownfield cluster
Log link:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YAYO0S/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
