### PR TITLE
add ignore client in set_cdn_tool_repo

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -149,9 +149,7 @@ class CephAdmin(BootstrapMixin, ShellMixin):
 
         cmd = f"subscription-manager repos --enable={cdn_repo[os_major_version]}"
 
-        # Todo: Figure out a way to bail out CDN repo installation on clients
-        #       now clients go through installation, But need to avoid CDN repo enablement.
-        for node in self.cluster.get_nodes():
+        for node in self.cluster.get_nodes(ignore="client"):
             node.exec_command(sudo=True, cmd=cmd)
 
     def setup_upstream_repository(self, repo_url=None):

--- a/conf/pacific/rados/6-node-cluster-6-clients.yaml
+++ b/conf/pacific/rados/6-node-cluster-6-clients.yaml
@@ -51,24 +51,24 @@ globals:
           - rgw
       node7:
         image-name:
-          openstack: RHEL-8.6.0-x86_64-ga-latest
-          ibmc: rhel-86-server-released
+          openstack: RHEL-8.7.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
         networks:
           - provider_net_cci_8
         role:
           - client
       node8:
         image-name:
-          openstack: RHEL-8.6.0-x86_64-ga-latest
-          ibmc: rhel-86-server-released
+          openstack: RHEL-8.7.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
         networks:
           - provider_net_cci_8
         role:
           - client
       node9:
         image-name:
-          openstack: RHEL-8.6.0-x86_64-ga-latest
-          ibmc: rhel-86-server-released
+          openstack: RHEL-8.7.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
         networks:
           - provider_net_cci_9
         role:


### PR DESCRIPTION
# Description

- Ignore CDN repos installation  on the Client nodes, In order to provide full support for Multi-RHCS clients.
- Enabling Dev repos or by using repo file still continued and it would be changed unless from a client configure test case.

**Test results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MRQ4HN