### PR TITLE
Fixing RHCEPHQE-7439

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1519,6 +1519,29 @@ class FsUtils(object):
 
         return cmd_out, cmd_rc
 
+    def get_snapshot_info(self, client, vol_name, subvol_name, snap_name, **kwargs):
+        """
+
+        Args:
+            client:
+            vol_name:
+            snap_name:
+            **kwargs:
+
+        Returns:
+
+        """
+        snap_info_cmd = (
+            f"ceph fs subvolume snapshot info {vol_name} {subvol_name} {snap_name}"
+        )
+        if kwargs.get("group_name"):
+            snap_info_cmd += f" --group_name {kwargs.get('group_name')}"
+        snap_info_cmd += " --format json"
+        cmd_out, cmd_rc = client.exec_command(
+            sudo=True, cmd=snap_info_cmd, check_ec=kwargs.get("check_ec", True)
+        )
+        return cmd_out, cmd_rc
+
     def clone_cancel(self, client, vol_name, clone_name, **kwargs):
         """
         Cancels the clone operation

--- a/tests/cephfs/snapshot_clone/clone_subvolume_full_vol.py
+++ b/tests/cephfs/snapshot_clone/clone_subvolume_full_vol.py
@@ -92,6 +92,11 @@ def run(ceph_cluster, **kw):
             f"{kernel_mounting_dir_1}",
             long_running=True,
         )
+        client1.exec_command(
+            sudo=True,
+            cmd=f"dd if=/dev/zero of={kernel_mounting_dir_1}/file_5gb bs=1M count=5000",
+            long_running=True,
+        )
         c_out2, c_err2 = client1.exec_command(
             sudo=True,
             cmd="ceph fs subvolume info cephfs subvol_full_vol --group_name subvolgroup_full_vol_1 -f json",


### PR DESCRIPTION
# Description
Fixing RHCEPHQE-7439

Problem: small file is not filling the complete volume and so the test case is getting skipped for that

Solution:
Added DD command as well to fill remaining data

Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-piixx/subvolume_full_vol_0.log


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
