### PR TITLE
Fixing fetch recipe content for psi scheduled pipeline trigger

### DIFF
--- a/pipeline/psi-scheduled-pipeline-executor.groovy
+++ b/pipeline/psi-scheduled-pipeline-executor.groovy
@@ -53,9 +53,12 @@ node("rhel-8-medium || ceph-qe-ci") {
             error("There no new RHCS build since last Friday")
         }
 
+        println("Valid recipe files : ${validRecipeFiles}")
+
         for (validRecipeFile in validRecipeFiles) {
             def rhcephVersion = validRecipeFile.split("/").last().replace(".yaml", "")
             def recipeContent = readYaml file: "${validRecipeFile}"
+            recipeContent = recipeContent.get("tier-0")
             recipeContent = writeJSON returnText: true, json:  recipeContent
 
             println "Starting test execution with parameters:"
@@ -69,7 +72,7 @@ node("rhel-8-medium || ceph-qe-ci") {
                     string(name: 'tags', value: tags),
                     string(name: 'buildType', value: buildType.toString()),
                     string(name: 'overrides', value: overrides.toString()),
-                    string(name: 'buildArtifacts', value: recipeContent.get("tier-0").toString())]
+                    string(name: 'buildArtifacts', value: recipeContent.toString())]
             ])
         }
     }


### PR DESCRIPTION
Error : 
hudson.remoting.ProxyException: groovy.lang.MissingMethodException: No signature of method: java.lang.String.get() is applicable for argument types: (java.lang.String) values: [composes]
Possible solutions: getAt(java.lang.String), grep(), next(), getAt(groovy.lang.IntRange), getAt(java.util.Collection), getAt(groovy.lang.Range)

The error was in line https://github.com/red-hat-storage/cephci/blob/master/pipeline/psi-scheduled-pipeline-executor.groovy#L72 while fetching tier-0 content. The recipeContent variable was already a string.

I have made changes to make sure that the tier-0 is fetched before converting recipeContent to json string.

Success logs : https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-scheduled-pipeline-trigger/26/console
