### PR TITLE
Mandate ceph build override arguments

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1104,6 +1104,39 @@ def fetch_build_artifacts(build, ceph_version, platform, upstream_build=None):
         raise TestSetupFailure(f"Could not fetch build details of : {e}")
 
 
+def check_build_overrides(
+    rpm: any,
+    registry: any,
+    image: any,
+    tag: any,
+):
+    """Validate Ceph build Override arguments.
+
+    Ceph build parameter values can be overridden by below args. they are,
+     --rhs-ceph-repo
+     --docker-registry
+     --docker-image
+     --docker-image-tag
+
+    Conditions:
+    - Over-ridden :  all arguments has value, then return True
+    - Not-Over-ridden : all arguments has no value, then return False
+    - Exception : Not all args are provided, then raise Exception.
+
+    Returns:
+        Boolean
+    """
+    values = [i for i in [rpm, registry, image, tag] if i].__len__()
+    length = 4
+
+    if values == length:
+        return True
+    elif values == 0:
+        return False
+    elif 0 < values < length:
+        raise Exception(f"{check_build_overrides.__doc__}")
+
+
 def rp_deco(func):
     def inner_method(cls, *args, **kwargs):
         if not cls.client:


### PR DESCRIPTION
* Mandate ceph build override arguments if provided.
   * Both RPM and Container image args should be provided, if overridden.
   * Missing args leads to exception.
   * if not overridden, builds are still fetched from the recipe file or follows same workflow as before.
* Deprecated `--ignore-latest-container`.

**No Overriden args**
```
❯ python run.py --osp-cred ~/osp-cred-ci-rhosd-ceph-core.yaml --instances-name sknupstream123 --log-level DEBUG --suite suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml --global-conf conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml --platform rhel-8 --inventory conf/inventory/rhel-8-latest.yaml --rhbuild 5.3 --build latest --reuse rerun/sknupstream-L2PRKJ
/home/sunil/work-dir/cephci/venv-py39/lib64/python3.9/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.14) or chardet (5.1.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /ceph/cephci-jenkins/cephci-run-ZT4TVZ
2023-02-27 16:16:46,901 (cephci.utility.xunit) [INFO] - cephci.run.py:413 - Startup log location: /ceph/cephci-jenkins/cephci-run-ZT4TVZ/startup.log
2023-02-27 16:16:47,442 (cephci.utility.xunit) [INFO] - cephci.run.py:465 - Build Information - http://download.eng.bos.redhat.com/rhel-8/composes/auto/ceph-5.3-rhel-8/RHCEPH-5.3-RHEL-8-20230220.ci.0-registry-proxy.engineering.redhat.com-rh-osbs/rhceph-ceph-5.3-rhel-8-containers-candidate-22932-20230220150313
```

**Non-adequate override args**
```
❯ python run.py --osp-cred ~/osp-cred-ci-rhosd-ceph-core.yaml --instances-name sknupstream123 --log-level DEBUG --suite suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml --global-conf conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml --platform rhel-8 --inventory conf/inventory/rhel-8-latest.yaml --rhbuild 5.3 --build latest --reuse rerun/sknupstream-L2PRKJ --rhs-ceph-repo abc --docker-registry registry --docker-image ceph-image
/home/sunil/work-dir/cephci/venv-py39/lib64/python3.9/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.14) or chardet (5.1.0)/charset_normalizer (2.0.12) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /ceph/cephci-jenkins/cephci-run-F5G6F7
2023-02-27 16:16:59,083 (cephci.utility.xunit) [INFO] - cephci.run.py:413 - Startup log location: /ceph/cephci-jenkins/cephci-run-F5G6F7/startup.log
Traceback (most recent call last):
  File "/home/sunil/work-dir/cephci/run.py", line 1076, in <module>
    rc = run(args)
  File "/home/sunil/work-dir/cephci/run.py", line 460, in run
    if not validate_build_overrides(base_url, docker_registry, docker_image, docker_tag):
  File "/home/sunil/work-dir/cephci/utility/utils.py", line 1137, in validate_build_overrides
    raise Exception(f"{validate_build_overrides.__doc__}")
Exception: Validate override Ceph build arguments.
    Ceph build parameters can be overridden by below args. they are,
     --rhs-ceph-repo
     --docker-registry
     --docker-image
     --docker-image-tag
    Conditions:
    - Over-ridden :  all arguments has value, then return True
    - Not-Over-ridden : all arguments has no value, then return False
    - Exception : args values are provided for few, then raise Exception.
    Returns:
        Boolean
```

**All Ceph Build Override args**

```
> > ❯ python run.py --osp-cred ~/osp-cred-ci-rhosd-ceph-core.yaml --instances-name sknupstream123 --log-level DEBUG --suite suites/pacific/upgrades/tier-2_dmfg_test-elasticity-after-upgrade-from-5-cdn-to-5-latest.yaml --global-conf conf/pacific/upgrades/10-node-cluster-with-6-pools.yaml --platform rhel-8 --inventory conf/inventory/rhel-8-latest.yaml --rhbuild 5.3 --build latest --reuse rerun/sknupstream-L2PRKJ --rhs-ceph-repo abc --docker-registry registry --docker-image ceph-image --docker-tag latest
> > /home/sunil/work-dir/cephci/venv-py39/lib64/python3.9/site-packages/requests/__init__.py:102: RequestsDependencyWarning: urllib3 (1.26.14) or chardet (5.1.0)/charset_normalizer (2.0.12) doesn't match a supported version!
> >   warnings.warn("urllib3 ({}) or chardet ({})/charset_normalizer ({}) doesn't match a supported "
> > 
> > Note :
> >     1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
> >     2. If custom log directory not specified, then '/tmp' directory is considered .
> >     
> > log directory - /ceph/cephci-jenkins/cephci-run-F5SE84
> > 2023-02-27 16:17:04,502 (cephci.utility.xunit) [INFO] - cephci.run.py:413 - Startup log location: /ceph/cephci-jenkins/cephci-run-F5SE84/startup.log
> > 2023-02-27 16:17:04,502 (cephci.utility.xunit) [INFO] - cephci.run.py:465 - Build Information - abc-registry-ceph-image-latest
> 
```