### PR TITLE
CEPH-11416 Pool Mirror-Try marking the secondary on the relationship for deletion, and observe the behaviour

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
@@ -208,6 +208,17 @@ tests:
       desc: Verify that deleting secondary image fails
 
   - test:
+      name: Attempt moving secondary image to trash
+      module: test_mirror_move_secondary_trash.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11416
+      desc: Verify that moving secondary to trash fails
+
+  - test:
       name: test image meta operations sync to secondary
       module: test_rbd_image_meta_mirroring.py
       clusters:

--- a/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml
@@ -201,6 +201,17 @@ tests:
       desc: Verify that deleting secondary image fails
 
   - test:
+      name: Attempt moving secondary image to trash
+      module: test_mirror_move_secondary_trash.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11416
+      desc: Verify that moving secondary to trash fails
+
+  - test:
       name: test image meta operations sync to secondary
       module: test_rbd_image_meta_mirroring.py
       clusters:

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -451,9 +451,16 @@ class Rbd:
             pool_name : name of the pool
             image_name : mane of the image
         Returns:
-
+            0: on success
+            1: on failure
         """
-        return self.exec_cmd(cmd=f"rbd trash mv {pool_name}/{image_name}")
+        cmd = f"rbd trash mv {pool_name}/{image_name}"
+        rc = self.exec_cmd(sudo=True, cmd=cmd)
+        if rc:
+            log.error("Error while moving image to trash")
+            return rc
+        log.info("Moving image to trash is successful")
+        return rc
 
     def remove_image_trash(self, pool_name, image_id):
         """

--- a/tests/rbd_mirror/test_mirror_move_secondary_trash.py
+++ b/tests/rbd_mirror/test_mirror_move_secondary_trash.py
@@ -1,0 +1,81 @@
+from tests.rbd.rbd_utils import Rbd
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_image_move_secondary_trash(rbd_mirror, pool_type, **kw):
+    """
+    Test to check secondary image move to trash is failed as image will be locked and busy.
+    Args:
+        rbd_mirror: rbd mirror object
+        pool_type: ec pool or rep pool
+        **kw:
+    Returns:
+        0 if test pass, else 1
+    """
+    try:
+        mirror1 = rbd_mirror.get("mirror1")
+        config = kw.get("config")
+        pool = config[pool_type]["pool"]
+        image = config[pool_type]["image"]
+        imagespec = pool + "/" + image
+
+        rbd1, rbd2 = [
+            Rbd(**kw, req_cname=cluster_name)
+            for cluster_name in kw.get("ceph_cluster_dict").keys()
+        ]
+
+        mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
+
+        # Move secondary image to trash
+        if rbd2.move_image_trash(pool, image):
+            log.info("Image not moved to trash since it is in secondary cluster")
+            return 0
+        else:
+            log.error("Image moved to trash inspite of it being in secondary cluster")
+            return 1
+
+    except Exception as e:
+        log.exception(e)
+        return 1
+
+
+def run(**kw):
+    log.info("Starting RBD mirroring test case - CEPH-11416")
+    """verify that moving of secondary image on the relationship to trash is failed.
+    Args:
+        **kw:
+    Returns:
+        0 - if test case pass
+        1 - it test case fails
+    Test case covered -
+    CEPH-11416 - Pool Mirror - Try marking the secondary on the relationship for deletion, and observe the behaviour
+    Pre-requisites :
+    1. At least two clusters must be up and running with enough number of OSDs to create pools
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+    Test Case Flow:
+    1. Create an image in primary and perform IOs.
+    2. enable pool mirroring on the image.
+    3. verify for the pool mirror mode enabled on secondary.
+    4. Move the secondary image to the trash.
+    6. verify that unable to mark the secondary image for deletion, as image is locked.
+    """
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        if "rep_rbdmirror" in mirror_obj:
+            log.info("Executing test on replicated pool")
+            if test_image_move_secondary_trash(
+                mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+            ):
+                return 1
+        if "ec_rbdmirror" in mirror_obj:
+            log.info("Executing test on ec pool")
+            if test_image_move_secondary_trash(
+                mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+            ):
+                return 1
+    return 0


### PR DESCRIPTION
**Polarion Link** : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11416

**Test Case Flow**:
    1. Create an image in primary and perform IOs.
    2. enable pool mirroring on the image.
    3. verify for the pool mirror mode enabled on secondary.
    4. Move the secondary image to the trash.
    6. verify that unable to mark the secondary image for deletion, as image is locked.

**success log** :
 5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-inb8p/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-onrif/