### PR TITLE
[Pipeline Failure]:tier-2_rbd_mirror_regression suite failure

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -1091,7 +1091,7 @@ def rbd_mirror_config(**kw):
             io_total=kw["config"]["rep_pool_config"]["io_total"],
             mode=kw["config"]["rep_pool_config"]["mode"],
             mirrormode=kw["config"]["rep_pool_config"].get("mirrormode", ""),
-            image_feature=kw["config"]["ec_pool_config"].get("image_feature"),
+            image_feature=kw["config"]["rep_pool_config"].get("image_feature"),
             **kw,
         )
 


### PR DESCRIPTION
Automation failure with tier_2_rbd_mirror_regression suite.

**cause** : trying to assign ec_pool_config for image_feature instead of rep_pool_config in rep_pool configuration.

**Solution** : Assign rep_pool_config for rep pool configuration for image feature.