### PR TITLE
Integration of CEPH-83574832 in cephci

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -264,3 +264,13 @@ tests:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
         timeout: 500
+
+  - test:
+      name: Test functionality of bucket check fix
+      desc: Test functionality of bucket check fix
+      polarion-id: CEPH-83574832
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_bucket_check_fix.yaml
+        timeout: 500

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -314,3 +314,14 @@ tests:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
         timeout: 500
+
+  - test:
+      name: Test functionality of bucket check fix
+      desc: Test functionality of bucket check fix
+      polarion-id: CEPH-83574832
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_bucket_check_fix.yaml
+        timeout: 500
+


### PR DESCRIPTION
Integrate CEPH-83574832: Verify that this command removes orphaned entries : radosgw-admin bucket check --fix --bucket=bucket_name  into cephci

Adding to the below suites:
cephci/suites/pacific/rgw/tier-1-extn_rgw.yaml
cephci/suites/quincy/rgw/tier-1-extn_rgw.yaml

Logs:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-f7ars/
quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-e0k6i/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
