### PR TITLE
Add data omap offload with fifo log type on upgrade pacific

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_test-upgrade-4-to-latest.yaml
@@ -211,6 +211,18 @@ tests:
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
       polarion-id: CEPH-83574735
+#  datalog offload tests
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_data_omap_offload.py
+            config-file-name: test_data_omap_offload_change_datatype_fifo.yaml
+            timeout: 300
+      desc: change datalog type to fifo before upgrade
+      module: sanity_rgw_multisite.py
+      name: change datalog type to fifo before upgrade
+      polarion-id: CEPH-83573697
 
   # Performing cluster upgrade
 
@@ -454,3 +466,16 @@ tests:
             config-file-name:  test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
             timeout: 300
             verify-io-on-site: ["ceph-sec"]
+
+#  datalog offload tests
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_data_omap_offload.py
+            config-file-name: test_data_omap_offload.yaml
+            timeout: 300
+      desc: verify datalog type is fifo after upgrade
+      module: sanity_rgw_multisite.py
+      name: verify datalog type is fifo after upgrade
+      polarion-id: CEPH-83573697


### PR DESCRIPTION
# Description
Add data omap offload with fifo log type on upgrade
Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RQL9S5

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
