### PR TITLE
[Fix] Add steps to enable licence to installing cephadm

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -9,6 +9,7 @@ scenarios for verifying and validating cephadm.
 """
 from typing import Dict
 
+from utility.install_prereq import SetupLicence
 from utility.log import Log
 
 from .bootstrap import BootstrapMixin
@@ -204,6 +205,8 @@ class CephAdmin(BootstrapMixin, ShellMixin):
             cmd += " --nogpghceck"
 
         for node in self.cluster.get_nodes(ignore="client"):
+            if self.config.get("ibm_build"):
+                SetupLicence.run(node)
             node.exec_command(
                 sudo=True,
                 cmd="yum install cephadm -y --nogpgcheck",

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -91,6 +91,9 @@ def get_custom_repo_url(base_url, cloud_type="openstack"):
         cloud_type (str): cloudtype (openstack|ibmc)
         base_url (str): base URL of repository
     """
+    if base_url.endswith(".repo"):
+        return base_url
+
     if not base_url.endswith("/"):
         base_url += "/"
 

--- a/run.py
+++ b/run.py
@@ -830,6 +830,11 @@ def run(args):
                 docker_tag,
             )
 
+            if custom_config:
+                ibm_build = [c for c in custom_config if "ibm-build=" in c]
+                if ibm_build:
+                    config["ibm_build"] = bool(ibm_build[0].split("=")[1])
+
             config["ceph_docker_registry"] = docker_registry
             report_portal_description += f"docker registry: {docker_registry}"
             config["ceph_docker_image"] = docker_image

--- a/tests/cephadm/test_cephadm_ansible_wrapper.py
+++ b/tests/cephadm/test_cephadm_ansible_wrapper.py
@@ -65,13 +65,16 @@ def setup_cluster(ceph_cluster, config):
     rhbuild = config.get("rhbuild")
     cloud_type = config.get("cloud-type")
     build_type = config.get("build_type")
+    ibm_build = config.get("ibm_build")
 
     if not Rpm(installer).query("cephadm-ansible"):
         SetUpSSHKeys.run(installer, nodes)
         ConfigureCephadmAnsibleNode.run(
-            installer, nodes, build_type, base_url, rhbuild, cloud_type
+            installer, nodes, build_type, base_url, rhbuild, cloud_type, ibm_build
         )
-        ExecutePreflightPlaybook.run(installer, base_url, cloud_type, build_type)
+        ExecutePreflightPlaybook.run(
+            installer, base_url, cloud_type, build_type, ibm_build
+        )
 
 
 def validate_cephadm_ansible_module(installer, playbook, extra_vars, extra_args):

--- a/utility/install_prereq.py
+++ b/utility/install_prereq.py
@@ -141,9 +141,9 @@ class ExecutePreflightPlaybook:
     """Execute cephadm-preflight.yaml playbook"""
 
     @staticmethod
-    def run(installer, base_url, cloud_type, build_type):
+    def run(installer, base_url, cloud_type, build_type, ibm_build=False):
         base_url = get_custom_repo_url(base_url, cloud_type)
-        extra_vars = {"ceph_origin": "rhcs"}
+        extra_vars = {"ceph_origin": "ibm" if ibm_build else "rhcs"}
         if build_type not in ["ga", "ga-async"]:
             extra_vars = {
                 "ceph_origin": "custom",
@@ -161,7 +161,7 @@ class ConfigureCephadmAnsibleNode:
     """Install cephadm-ansible and configure node"""
 
     @staticmethod
-    def run(installer, nodes, build_type, base_url, rhbuild, cloud_type):
+    def run(installer, nodes, build_type, base_url, rhbuild, cloud_type, ibm_build):
         base_url = get_custom_repo_url(base_url, cloud_type)
 
         ConfigureCephToolsRepositories().run(installer, build_type, base_url, rhbuild)
@@ -174,6 +174,8 @@ class ConfigureCephadmAnsibleNode:
                 f"Failed to enable ansible repo '{RHEL8_ANSIBLE_REPO}' on node '{installer}'"
             )
 
+        if ibm_build:
+            SetupLicence.run(installer)
         Package(installer).install("cephadm-ansible", nogpgcheck=True)
         ConfigureCephadmAnsibleInventory().run(nodes)
 


### PR DESCRIPTION
Install `ibm-cepg-storage-license, when `--custom-config ibm-build=True` is passed through `run.py`. Updated below modules to install license based on the parameter status -
1. ` ceph.ceph_admin.__init__` - To install ibm storage license 
2. `tests.cephadm.test_cephadm_ansible_wrapper` - To pass appropriate parameter to `utility.install_prereq`
3. `cli.utilities.utils` - To get appropriate `base_url`
4. `utility.install_prereq` - To  install ibm storage license & execute preflight with appropriate parameter