### PR TITLE
Integrating bucket lifecycle transition feature automation (8 tests)

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw.yaml
+++ b/suites/pacific/rgw/tier-1_rgw.yaml
@@ -130,6 +130,15 @@ tests:
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
         timeout: 300
   - test:
+      name: Bucket Lifecycle Object_transition_tests for Prefix filter and versioned buckets
+      desc: Test object transition for Prefixand versioned buckets
+      polarion-id: CEPH-83574050 # also applies to CEPH-83574049
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_transition_with_prefix_rule.yaml
+        timeout: 300
+  - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
       polarion-id: CEPH-83571740 # also applies to ceph-11479, ceph-11477

--- a/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
@@ -115,6 +115,16 @@ tests:
         timeout: 300
 
   - test:
+      name: Bucket Lifecycle Object_transition_tests for 100 buckets
+      desc: Test Bucket Lifecycle Object_transition_tests for 100 buckets
+      polarion-id: CEPH-83574043
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_transition_multiple_bucket.yaml
+        timeout: 300
+
+  - test:
       name: Enable lifecycle and disable it on a bucket before objects expires
       desc: Enable lifecycle and disable it on a bucket before the objects get expired
       polarion-id: CEPH-11196

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -134,3 +134,41 @@ tests:
       module: sanity_rgw.py
       name: test lc with prefix containing underscore
       polarion-id: CEPH-11192
+
+# bucket lifecycle transition tests
+  - test:
+      name: Bucket Lifecycle Object_transition_tests for Prefix and tag based filter
+      desc: Test object transition for Prefix and tag based filter and for more than one days
+      polarion-id: CEPH-83574045
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_transition_prefix_and_TAG_rule.yaml
+        timeout: 300
+  - test:
+      name: Bucket Lifecycle Object_transition_tests multiple rules and different storage class
+      desc: Test Object_transition_tests multiple rules and different storage class
+      polarion-id: CEPH-83573372 # also CEPH-83574052
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_transition_multiple_rules.yaml
+        timeout: 300
+  - test:
+      name: Bucket Lifecycle Object_transition_tests multiple pool transition
+      desc: Bucket Lifecycle Object_transition_tests multiple pool transition
+      polarion-id: CEPH-83574051
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_transition_2_pools.yaml
+  - test:
+      name: Bucket Lifecycle Object_transition_tests to ec pool
+      desc: Test Bucket Lifecycle Object_transition_tests to ec pool
+      polarion-id: CEPH-83574470
+      comment: Known issue Bug-2172838
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration.py
+        config-file-name: test_lc_transition_ecpool_with_prefix_rule.yaml
+        timeout: 300


### PR DESCRIPTION
Adding bucket lifecycle transition feature automation (8 tests)

Automates below tests:

1. CEPH-83574043: Test transition 3: Test LC policy set for more than 100 buckets
2. CEPH-83574049: Test transition 4: Test LC transition of objects from a storage pool p1 to pool p2 with
no Filters in the policy.
3. CEPH-83574050: Test transition 5: Test LC transition of objects from a storage pool p1 to pool p2 with PREFIX filters in the policy
4. CEPH-83574045: Test transition 6: Test LC transition of objects from a storage pool p1 to pool p2 with TAG filters in the policy.
5. CEPH-83574051: Test transition 8: Test multiple transitions from pool1 to pool2 to pool3 and verify the object version status.
6. CEPH-83574052: Test transition 10: Test the state of objects (currents and non-currents) post-transition.
7. CEPH-83574470: Test transition 13: Test transition from replicated pool to ec pool (this would fail, product bug.) https://bugzilla.redhat.com/show_bug.cgi?id=2172838
8. CEPH-83573372: Tiering: transition from hot to cold pools


Planned for the future:

Renaming the test_bucket_lifecycle_object_expiration.py to also include 'transition' in the name
Testing with resharded bucket
Test object downloads of transitioned objects.


Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-87W122
the logs have the test runs for the new feature (transition) as well as the existing one (expiration.)
known failure : Ec pool transition