### PR TITLE
fix release set issue in RHEL-7.9

### DIFF
--- a/conf/inventory/rhel-7.9-server-x86_64.yaml
+++ b/conf/inventory/rhel-7.9-server-x86_64.yaml
@@ -3,7 +3,7 @@ version_id: 7.9
 id: rhel
 instance:
     create:
-      image-name: rhel-7.9-server-x86_64-released
+      image-name: RHEL-7.9-x86_64-ga-latest
       vm-size: m1.medium
 
     setup: |

--- a/conf/pacific/rados/6-node-cluster-6-clients.yaml
+++ b/conf/pacific/rados/6-node-cluster-6-clients.yaml
@@ -75,7 +75,7 @@ globals:
           - client
       node10:
         image-name:
-          openstack: rhel-7.9-server-x86_64-released
+          openstack: RHEL-7.9-x86_64-ga-latest
           ibmc: rhel-server-79-x86-64-kvm
         networks:
           - provider_net_cci_9


### PR DESCRIPTION
**Issue:**
subscription manager could not set release version(7.9).
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5C13L6/
> 2022-12-26 05:05:13,521 - INFO - cephci.ceph.ceph.py:1514 - Running command subscription-manager release --set 7.9 on 10.0.211.80 timeout 600
> 2022-12-26 05:05:14,315 - ERROR - cephci.ceph.ceph.py:1549 - Error 65 during cmd, timeout 600
> 2022-12-26 05:05:14,315 - ERROR - cephci.ceph.ceph.py:1550 - No releases match '7.9'.  Consult 'release --list' for a full listing.
> 
> 2022-12-26 05:05:14,316 - ERROR - cephci.ceph.parallel.py:93 - Exception in parallel execution
> Traceback (most recent call last):
>   File "/home/jenkins-build/workspace/rhceph-test-executor/ceph/parallel.py", line 88, in __exit__
>     for result in self:
>   File "/home/jenkins-build/workspace/rhceph-test-executor/ceph/parallel.py", line 106, in __next__
>     resurrect_traceback(result)
>   File "/home/jenkins-build/workspace/rhceph-test-executor/ceph/parallel.py", line 35, in resurrect_traceback
>     raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
>   File "/home/jenkins-build/workspace/rhceph-test-executor/ceph/parallel.py", line 22, in capture_traceback
>     return func(*args, **kwargs)
>   File "/home/jenkins-build/workspace/rhceph-test-executor/tests/misc_env/install_prereq.py", line 141, in install_prereq
>     enable_rhel_rpms(ceph, distro_ver)
>   File "/home/jenkins-build/workspace/rhceph-test-executor/tests/misc_env/install_prereq.py", line 315, in enable_rhel_rpms
>     ceph.exec_command(sudo=True, cmd=f"subscription-manager release --set {distro_ver}")
>   File "/home/jenkins-build/workspace/rhceph-test-executor/ceph/ceph.py", line 1552, in exec_command
>     f"{kw['cmd']} Error:  {str(stderr)} {str(self.ip_address)}"
> ceph.ceph.CommandFailed: subscription-manager release --set 7.9 Error:  No releases match '7.9'.  Consult 'release --list' for a full listing.
>  10.0.210.57

**Test Result:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-97F16F/