### PR TITLE
 [Automation-Tier2] Verify Exclusive lock feature on RBD image

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -84,6 +84,22 @@ tests:
       polarion-id: CEPH-9230
 
   - test:
+      desc: Verify Delayed deletion with exclusive feature on RBD image
+      module: rbd_exclusive_lock_rm_image.py
+      config:
+        io-total: 5G
+      name: Verify exclusive lock feature
+      polarion-id: CEPH-11408
+
+  - test:
+      desc: verify for parent image deletion after flattening the clone and removing snap
+      config:
+        io-total: 5G
+      module: rbd_clone_delete_parent_image.py
+      name: Test for parent image deletion after flattening the clone and removing snap
+      polarion-id: CEPH-11409
+
+  - test:
       desc: Verify that clones creation and deletion of parent image with V2 enabled
       destroy-cluster: false
       module: rbd_clonev2.py
@@ -127,14 +143,6 @@ tests:
       module: trash_restore_create_clone_snap.py
       name: Test snap and clone creation on restored image from trash
       polarion-id: CEPH-11413
-
-  - test:
-      desc: verify for parent image deletion after flattening the clone and removing snap
-      config:
-        io-total: 5G
-      module: rbd_clone_delete_parent_image.py
-      name: Test for parent image deletion after flattening the clone and removing snap
-      polarion-id: CEPH-11409
 
   - test:
       desc: Rename image snapshots on an image on replicated and ecpools and its clones

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -83,6 +83,22 @@ tests:
       polarion-id: CEPH-9230
 
   - test:
+      desc: Verify Delayed deletion with exclusive feature on RBD image
+      module: rbd_exclusive_lock_rm_image.py
+      config:
+        io-total: 5G
+      name: Verify exclusive lock feature
+      polarion-id: CEPH-11408
+
+  - test:
+      desc: verify for parent image deletion after flattening the clone and removing snap
+      config:
+        io-total: 5G
+      module: rbd_clone_delete_parent_image.py
+      name: Test for parent image deletion after flattening the clone and removing snap
+      polarion-id: CEPH-11409
+
+  - test:
       desc: Verify that clones creation and deletion of parent image with V2 enabled
       destroy-cluster: false
       module: rbd_clonev2.py
@@ -126,14 +142,6 @@ tests:
       module: trash_restore_create_clone_snap.py
       name: Test snap and clone creation on restored image from trash
       polarion-id: CEPH-11413
-
-  - test:
-      desc: verify for parent image deletion after flattening the clone and removing snap
-      config:
-        io-total : 5G
-      module: rbd_clone_delete_parent_image.py
-      name: Test for parent image deletion after flattening the clone and removing snap
-      polarion-id: CEPH-11409
 
   - test:
       desc: Rename image snapshots on an image on replicated and ecpools and its clones

--- a/tests/rbd/exceptions.py
+++ b/tests/rbd/exceptions.py
@@ -56,3 +56,9 @@ class ImageFoundError(RbdBaseException):
     """Raised when image is found in Trash"""
 
     pass
+
+
+class ImageIsDeletedError(RbdBaseException):
+    """Raised when image is deleted when exclusive image is enabled IO in progress"""
+
+    pass

--- a/tests/rbd/rbd_clone_delete_parent_image.py
+++ b/tests/rbd/rbd_clone_delete_parent_image.py
@@ -1,6 +1,6 @@
 from ceph.parallel import parallel
 from tests.rbd.exceptions import RbdBaseException
-from tests.rbd.rbd_utils import initial_rbd_config
+from tests.rbd.rbd_utils import initial_rbd_config, rbd_remove_image_negative_validate
 from utility.log import Log
 
 log = Log(__name__)
@@ -60,7 +60,7 @@ def rbd_clone_delete_parent_image(rbd, pool_type, **kw):
                 rbd.exec_cmd,
                 cmd=f"rbd bench --io-type write --io-total {config.get('io-total')} {pool}/{image}",
             )
-            p.spawn(rbd.remove_image, pool, image)
+            p.spawn(rbd_remove_image_negative_validate, rbd, pool, image)
 
         # move image to trash and delete permanantly and verify trash
         rbd.move_image_trash(pool, image)

--- a/tests/rbd/rbd_exclusive_lock_rm_image.py
+++ b/tests/rbd/rbd_exclusive_lock_rm_image.py
@@ -1,0 +1,66 @@
+from ceph.parallel import parallel
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd.rbd_utils import initial_rbd_config, rbd_remove_image_negative_validate
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def rbd_exclusive_verify(rbd, pool_type, **kw):
+    """
+    Run exclusive-lock test and verify
+    Args:
+        rbd: rbd object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: Test data
+    """
+    pool = kw["config"][pool_type]["pool"]
+    image = kw["config"][pool_type]["image"]
+    config = kw.get("config")
+
+    try:
+        with parallel() as p:
+            p.spawn(
+                rbd.exec_cmd,
+                cmd=f"rbd bench --io-type write --io-total {config.get('io-total')} {pool}/{image}",
+            )
+            p.spawn(rbd_remove_image_negative_validate, rbd, pool, image)
+        return 0
+
+    except RbdBaseException as error:
+        log.error(error.message)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
+
+
+def run(**kw):
+    """If the image has an exclusive-lock on it, verify the behaviour on delayed deletion.
+    This module verifies rbd remove when image is enabled with exclusive-lock feature
+    Args:
+        kw: test data
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+    Pre-requisites :
+    We need atleast one client node with ceph-common package,
+    conf and keyring files
+    Test cases covered -
+    1) CEPH-11408- Create a pool and an image, ensure that image has exclusive lock feature enabled
+    2) an RBD image has a exclusive lock on it, When IO is progress, remove an image and check the behaviour
+    3) Verify the behaviour in this scenario. remove image should fail due to the exclusive lock enabled
+    """
+    log.info("Running rbd remove operation during IO in progress")
+    rbd_obj = initial_rbd_config(**kw)
+    if rbd_obj:
+        if "rbd_reppool" in rbd_obj:
+            log.info("Executing test on Replication pool")
+            if rbd_exclusive_verify(
+                rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw
+            ):
+                return 1
+        if "rbd_ecpool" in rbd_obj:
+            log.info("Executing test on EC pool")
+            if rbd_exclusive_verify(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+                return 1
+    return 0


### PR DESCRIPTION
Jira ticket - https://issues.redhat.com/browse/RHCEPHQE-7586
Test case to cover exclusive feature enabled on image
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11408

Test flow:
Create a pool and an image, ensure that image has exclusive lock feature enabled
an RBD image has a exclusive lock on it, When IO is progress, remove an image and check the behaviour

Test Results:
5.3 -http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GCH3RE
6.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6A982S

Updated the module "rbd_clone_delete_parent_image.py" with the remove image validate method for verification and below logs for the same
logs-  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BJN2T2
