### PR TITLE
Integration of CEPH-83575439 on cephci

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -274,3 +274,14 @@ tests:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
         timeout: 500
+
+  - test:
+      name: Test functionality of user stat reset
+      desc: Test functionality of user stat reset
+      comments: Known issue BZ-2167475
+      polarion-id: CEPH-83575439
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_user_stats_reset.yaml
+        timeout: 500

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -325,3 +325,13 @@ tests:
         config-file-name: test_bucket_check_fix.yaml
         timeout: 500
 
+  - test:
+      name: Test functionality of user stat reset
+      desc: Test functionality of user stat reset
+      comments: Known issue BZ-2167475
+      polarion-id: CEPH-83575439
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_user_stats_reset.yaml
+        timeout: 500


### PR DESCRIPTION
[Close-loop-automation]: Integration of CEPH-83575439 on cephci
CEPH-83575439: Test User Stats Reset
Known issue bz: https://bugzilla.redhat.com/show_bug.cgi?id=2167475 
logs:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-daudx/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-c70lo/

added comment in testcase as "comments: Known issue BZ-2167475"
since failure is observed in both pacific and quicy build


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
