### PR TITLE
update ocs global conf.

### DIFF
--- a/conf/pacific/integrations/7_node_ceph.yaml
+++ b/conf/pacific/integrations/7_node_ceph.yaml
@@ -10,7 +10,6 @@ globals:
           - installer
           - mgr
           - mon
-          - client
 
       node2:
         disk-size: 20
@@ -55,3 +54,6 @@ globals:
         role:
           - osd
           - rgw
+
+      node8:
+        role: client

--- a/suites/pacific/integrations/ocs.yaml
+++ b/suites/pacific/integrations/ocs.yaml
@@ -94,9 +94,10 @@ tests:
       config:
         command: add
         id: client.1
-        node: node1
+        node: node8
         install_packages:
           - ceph-common
+          - cephadm
         copy_admin_keyring: true
       desc: Configure the ceph client
       destroy-cluster: false


### PR DESCRIPTION
New RHCS multi-client code changes will not install cephadm on the client node, it should be done explicitly by configure client test case. 
Global configuration files should not have client role on the installer node.  

In 7_node config had installer node which has client role as well, which is avoided by above code commits.
- Fix issue with ocs interop conf file by moving client role from installer node to new node. 

> ceph.ceph.CommandFailed: cephadm -v shell -- ceph status Error:  bash: cephadm: command not found
>  10.0.208.199