### PR TITLE
Testing of nodeep-scrub flag

### DIFF
--- a/ceph/rados/rados_scrub.py
+++ b/ceph/rados/rados_scrub.py
@@ -88,23 +88,26 @@ class RadosScrubber(RadosOrchestrator):
         else:
             return pgDump
 
-    def verify_scrub(self, before_scrub_data, after_scrub_data):
+    def verify_scrub_deepscrub(self, before_scrub_data, after_scrub_data, flag):
         """
-        Used to validate the scrubbing done or not
+        Used to validate the scrubbing and deep scrubbing done or not
 
         Args:
             1.before_scrub_data - It is dictionary which conatin the
               pgId and last scrub time data before scrubbing.
             2.after_scrub_data - It is a dictionary that conatins the
               PDId and lst surb time data after scrubbing.
+            3.flag - scrub or deep-scrub
         Return: 0 for Pass or 1 for Failure
         """
+        if flag == "scrub":
+            stamp = "last_scrub_stamp"
+        else:
+            stamp = "last_deep_scrub_stamp"
         before_scrub_log = dict(
-            zip(before_scrub_data["pgid"], before_scrub_data["last_scrub_stamp"])
+            zip(before_scrub_data["pgid"], before_scrub_data[stamp])
         )
-        after_scrub_log = dict(
-            zip(after_scrub_data["pgid"], after_scrub_data["last_scrub_stamp"])
-        )
+        after_scrub_log = dict(zip(after_scrub_data["pgid"], after_scrub_data[stamp]))
 
         number_of_pgs = len(before_scrub_log.keys())
         count_pg = 0


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>
 The test cases CEPH-9374 and CEPH-83574485 are similar verification steps. The only step that does not exist in the CEPH-9374 is setting nodeep-scrub flag.CEPH-9374 is already automated. I added the step in CEPH-9374 and make CEPH-83574485 inactive.


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [x] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
