### PR TITLE
extending support for bucket notifications suites (using kafka security) to run on ibm cloud

### DIFF
--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -152,7 +152,7 @@ def run(ceph_cluster, **kw):
     if install_start_kafka_broker:
         install_start_kafka(rgw_node, cloud_type)
     if configure_kafka_broker_security:
-        configure_kafka_security(rgw_node)
+        configure_kafka_security(rgw_node, cloud_type)
 
     out, err = exec_from.exec_command(cmd="ls -l venv", check_ec=False)
     if not out:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1329,15 +1329,21 @@ def install_start_kafka(rgw_node, cloud_type):
     time.sleep(30)
 
 
-def configure_kafka_security(rgw_node):
+def configure_kafka_security(rgw_node, cloud_type):
     """Configure kafka security and restart zookeeper and kafka services."""
     KAFKA_HOME = "/usr/local/kafka"
 
     # append security types configuration into server.properties
+    if cloud_type == "ibmc":
+        curl_server_properties = "curl -o /tmp/kafka_server.properties https://10.245.4.89/kafka_server.properties"
+    else:
+        curl_server_properties = (
+            "curl -o /tmp/kafka_server.properties http://magna002.ceph.redhat.com/cephci-jenkins"
+            + "/kafka_server.properties"
+        )
     rgw_node.exec_command(
         sudo=True,
-        cmd="curl -o /tmp/kafka_server.properties http://magna002.ceph.redhat.com/cephci-jenkins"
-        + "/kafka_server.properties",
+        cmd=curl_server_properties,
     )
     rgw_node.exec_command(
         sudo=True,
@@ -1345,9 +1351,18 @@ def configure_kafka_security(rgw_node):
     )
 
     # download kafka_security.sh script, create certs and and store them in keystore and truststore
+    if cloud_type == "ibmc":
+        curl_security_sh = (
+            "curl -o /tmp/kafka-security.sh https://10.245.4.89/kafka-security.sh"
+        )
+    else:
+        curl_security_sh = (
+            "curl -o /tmp/kafka-security.sh http://magna002.ceph.redhat.com/cephci-jenkins"
+            + "/kafka-security.sh"
+        )
     rgw_node.exec_command(
         sudo=True,
-        cmd="curl -o /tmp/kafka-security.sh http://magna002.ceph.redhat.com/cephci-jenkins/kafka-security.sh",
+        cmd=curl_security_sh,
     )
     status = rgw_node.exec_command(
         sudo=True,


### PR DESCRIPTION
adding alternative links to download kafka security config files for ibmc as magna server is not reachable from ibm cloud machines
pass logs:
ibmc: https://159.23.92.24/job/Custom%20Test%20Run/38/console
openstack: 

1. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-32hl8/
2. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-qgycr/

(failures are known issues on quincy for multipart upload events, refer https://bugzilla.redhat.com/show_bug.cgi?id=1979564)


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
