### PR TITLE
[Pipeline Failure]-RBD 6.0 failure with tier_1 rbd mirror suite

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -296,7 +296,7 @@ class RbdMirror:
         log.debug(
             f"Config Recieved for initial mirror config: poolname:{poolname}, imagename:{imagename}\nkw:{kw}"
         )
-        if kw["mirrormode"] == "snapshot" and kw["mode"] == "pool":
+        if kw.get("mirrormode") == "snapshot" and kw.get("mode") == "pool":
             log.error("Invalid scenario for configuring mirror")
             return 1
 
@@ -309,7 +309,7 @@ class RbdMirror:
 
         self.create_image(imagespec=imagespec, size=imagesize)
         if kw.get("mirrormode") != "snapshot" and "journaling" not in kw.get(
-            "image_feature"
+            "image_feature", ""
         ):
             self.image_feature_enable(imagespec=imagespec, image_feature="journaling")
         if kw.get("image_feature"):
@@ -1115,7 +1115,7 @@ def rbd_mirror_config(**kw):
             io_total=kw["config"]["rep_pool_config"]["io_total"],
             mode=kw["config"]["rep_pool_config"]["mode"],
             mirrormode=kw["config"]["rep_pool_config"].get("mirrormode", ""),
-            image_feature=kw["config"]["rep_pool_config"].get("image_feature"),
+            image_feature=kw["config"]["rep_pool_config"].get("image_feature", ""),
             **kw,
         )
 
@@ -1170,7 +1170,7 @@ def rbd_mirror_config(**kw):
             io_total=kw["config"]["ec_pool_config"]["io_total"],
             mode=kw["config"]["ec_pool_config"]["mode"],
             mirrormode=kw["config"]["ec_pool_config"].get("mirrormode", ""),
-            image_feature=kw["config"]["ec_pool_config"].get("image_feature"),
+            image_feature=kw["config"]["ec_pool_config"].get("image_feature", ""),
             **kw,
         )
 


### PR DESCRIPTION
This PR is with reference to Pipeline failure issues 
https://issues.redhat.com/browse/RHCEPHQE-7774 

**Observations:**
We are observing failure with tier_1_rbd_mirror and tier_2_rbd_mirror_regression suite
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/5/7085/182486/182502/log 
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/5/7112/184018 

**Reason for failure :** 
we are trying to iterate over NoneType object for image_feature in rbd_mirror_util.py 

**Fix :**
made image feature as empty string by default.

success log : 

tier_1_rbd_mirror : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-dym19/ 

tier_2_rbd_mirror_regression (in-progress) : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-b3zm0/


