### PR TITLE
[Cephadm][Tier-2] Validate cephadm bootstrap with selinux permissive

### DIFF
--- a/cli/ceph/ceph.py
+++ b/cli/ceph/ceph.py
@@ -45,3 +45,11 @@ class Ceph(Cli):
         if isinstance(out, tuple):
             return out[0].strip()
         return out
+
+    def health(self):
+        """Returns the Ceph cluster health"""
+        cmd = f"{self.base_cmd} health"
+        out = self.execute(sudo=True, check_ec=False, long_running=False, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out

--- a/suites/pacific/cephadm/tier-2_cephadm_scenarios_with_permissive_mode.yaml
+++ b/suites/pacific/cephadm/tier-2_cephadm_scenarios_with_permissive_mode.yaml
@@ -1,0 +1,123 @@
+---
+# ==================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephadm_scenarios_with_permissive_mode.yaml
+# Cluster Configuration:
+#    conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml
+# Test Scenarios:
+#   Bootstap a cluster with selinux set to Permissive mode
+#   Add OSD nodes
+#   Check cluster status when nodes are performed with reboot/powercycle
+#   Check cluster status when daemon services are started/restart/stop with systemctl
+# ==================================================================================
+tests:
+  - test:
+      name: Install ceph pre-requisites
+      desc: installation of ceph pre-requisites
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap cluster with selinux set to Permissive
+      desc: Execute 'playbooks/bootstrap-cluster.yaml' playbook
+      polarion-id: CEPH-83573579
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "cephadm_bootstrap"
+          playbook: playbooks/bootstrap-cluster.yml
+          module_args:
+            mon_node: node1
+            selinux: permissive  # permissive or enforcing
+  - test:
+      name: Add host with labels to cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/add-host-to-cluster.yaml' playbook
+      polarion-id: CEPH-83575203
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_host"
+          playbook: playbooks/add-host-to-cluster.yaml
+          module_args:
+            host: node2
+            label: osd.1
+
+  - test:
+      name: Deploy OSD service to cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/deploy-osd-service.yml' playbook
+      polarion-id: CEPH-83575213
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_apply"
+          playbook: playbooks/deploy-osd-service.yml
+          module_args:
+            node: node2
+            label: osd.1
+  - test:
+      name: Add host with labels to cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/add-host-to-cluster.yaml' playbook
+      polarion-id: CEPH-83575203
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_host"
+          playbook: playbooks/add-host-to-cluster.yaml
+          module_args:
+            host: node3
+            label: osd.2
+
+  - test:
+      name: Deploy OSD service to cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/deploy-osd-service.yml' playbook
+      polarion-id: CEPH-83575213
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_apply"
+          playbook: playbooks/deploy-osd-service.yml
+          module_args:
+            node: node3
+            label: osd.2
+
+  - test:
+      name: Add host with labels to cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/add-host-to-cluster.yaml' playbook
+      polarion-id: CEPH-83575203
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_host"
+          playbook: playbooks/add-host-to-cluster.yaml
+          module_args:
+            host: node4
+            label: osd.3
+
+  - test:
+      name: Deploy OSD service to cluster using cephadm-ansible wrapper modules
+      desc: Execute 'playbooks/deploy-osd-service.yml' playbook
+      polarion-id: CEPH-83575213
+      module: test_cephadm_ansible_wrapper.py
+      config:
+        ansible_wrapper:
+          module: "ceph_orch_apply"
+          playbook: playbooks/deploy-osd-service.yml
+          module_args:
+            node: node4
+            label: osd.3
+
+  - test:
+      name: Check cluster status when nodes are performed with reboot
+      desc: Perform reboot and check ceph status
+      polarion-id: CEPH-83573754
+      module: test_verify_cluster_health_after_reboot.py
+      config:
+        action: node-reboot
+
+  - test:
+      name: Check cluster status when daemon services are started restart stop with systemctl
+      desc: Verify systemctl ops of services
+      polarion-id: CEPH-83573755
+      module: test_verify_cluster_health_after_reboot.py
+      config:
+        action: service-state

--- a/tests/cephadm/test_verify_cluster_health_after_reboot.py
+++ b/tests/cephadm/test_verify_cluster_health_after_reboot.py
@@ -1,0 +1,67 @@
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from cli.utilities.utils import get_service_id, reboot_node, set_service_state
+
+
+class RebootFailed(Exception):
+    pass
+
+
+class ClusterNotHealthy(Exception):
+    pass
+
+
+class SystemctlFailed(Exception):
+    pass
+
+
+def _is_cluster_healthy(node):
+    # Verify if the cluster is in healthy state
+    timeout, interval = 100, 10
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        if CephAdm(node).ceph.health() == "HEALTH_OK":
+            return True
+    if w.expired:
+        return False
+
+
+def run(ceph_cluster, **kw):
+    """Verify rebooting a node doesn't affect the ceph health
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    action = config.get("action")
+    mon_node = ceph_cluster.get_nodes("mon")[0]
+
+    if action == "node-reboot":
+        for node in ceph_cluster.get_nodes():
+            # Perform node reboot
+            status = reboot_node(node)
+            if not status:
+                raise RebootFailed(f"Node {node.hostname} failed to reboot.")
+
+            # Verify the reboot doesn't affect the cluster health
+            if not _is_cluster_healthy(mon_node):
+                raise ClusterNotHealthy(
+                    f"Ceph cluster not healthy after rebooting {node.hostname}"
+                )
+
+    elif action == "service-state":
+        # Get the SERVICE_ID of the mon service
+        mon_service = get_service_id(mon_node, "mon")
+
+        for state in ["start", "stop", "restart"]:
+            # Set the service to each state
+            status = set_service_state(mon_node, mon_service, state)
+            if not status:
+                raise SystemctlFailed(
+                    f"Failed to {state} mon service on {mon_node.hostname}"
+                )
+
+            # Verify the change of state doesn't affect the cluster health
+            if not _is_cluster_healthy(mon_node):
+                raise ClusterNotHealthy(
+                    f"Ceph cluster not healthy after setting mon service to {state}"
+                )
+    return 0


### PR DESCRIPTION
# Description
Tests included:

CEPH-83573579 Cephadm: Verify Cephadm deployment in Permissive mode - Tier2
CEPH-83573754 Cephadm: Check cluster status when nodes are performed with reboot/powercycle - Tier2
CEPH-83573755 Check cluster status when daemon services are started/restart/stop with systemct... - Tier2

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
