### PR TITLE
CEPH-83571666: Test to verify ceph df stats after creating and deleting objects from a pool

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1099,3 +1099,27 @@ class RadosOrchestrator:
             osd: "osd" service by default or "osd.<Id>"
         """
         return self.node.shell([f"ceph config set {osd} osd_mclock_profile {profile}"])
+
+    def get_cephdf_stats(self, pool_name: str = None) -> dict:
+        """
+        Retrieves and returns the output ceph df command
+        as a dictionary
+        Args:
+            pool_name: name of the pool whose stats are
+            specifically required
+        Returns:  dictionary output of ceph df
+        """
+        cephdf_stats = self.run_ceph_command(cmd="ceph df")
+
+        if pool_name:
+            try:
+                pool_stats = cephdf_stats["pools"]
+                for pool_stat in pool_stats:
+                    if pool_stat.get("name") == pool_name:
+                        return pool_stat
+                raise KeyError
+            except KeyError:
+                log.error(f"{pool_name} not found in ceph df stats")
+                return {}
+
+        return cephdf_stats

--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -96,6 +96,23 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: Verify ceph df stats
+      desc: Verify ceph df stats after creating and deleting objects from an app pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571666
+      config:
+        verify_cephdf_stats:
+          create_pool: true
+          pool_name: test-ceph-df
+          obj_nums:
+            - 5
+            - 20
+            - 50
+          delete_pool: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
       name: Verify scrub logs
       module: test_scrub_log.py
       polarion-id: CEPH-83575403

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -125,6 +125,23 @@ tests:
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
   - test:
+      name: Verify Ceph df stats
+      desc: Verify Ceph df stats after creating and deleting objects from a pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571666
+      config:
+        verify_cephdf_stats:
+          create_pool: true
+          pool_name: test-ceph-df
+          obj_nums:
+            - 5
+            - 20
+            - 50
+          delete_pool: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
       name: Mon target for PG num
       module: pool_tests.py
       polarion-id: CEPH-83573423


### PR DESCRIPTION
# Description

[CEPH-83571666](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571666) Tier-2 test case automation to verify ceph df stats updation upon creation and deletion of objects from a particular osd pool 

Steps:
1. Configure Ceph cluster
2. Create a pool with default pg number
3. Create 'n' number of objects using rados put
4. Verify ceph df stats, objects for concerned pool should be equal to 'n'
5. Remove all the objects from the given pool
6. Verify ceph df stats updated with 0 objects
7. Remove the concerned pool

RHCS 5.3 logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TBYKP0/
RHCS 6.0 logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4U75AI/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>