### PR TITLE
[Automation-Tier2] Verify Deletion of Protected snapshot on RBD image

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -173,3 +173,15 @@ tests:
       module: rbd_image_Live_migration_rep2Rep.py
       name: Test image migration on replication pool
       polarion-id: CEPH-83573293
+
+  - test:
+      desc: Trying to delete a protected snapshot should fail - negative
+      config:
+        do_not_create_image: True
+        operations:
+          map: true
+          io: true
+          nounmap: true
+      module: rbd_delete_protected_snapshot_krbd.py
+      name: krbd client - Test to Perform Deletion of protected snapshot
+      polarion-id: CEPH-9224

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -172,3 +172,15 @@ tests:
       module: rbd_image_Live_migration_rep2Rep.py
       name: Test image migration on replication pool
       polarion-id: CEPH-83573293
+
+  - test:
+      desc: Trying to delete a protected snapshot should fail - negative
+      config:
+        do_not_create_image: True
+        operations:
+          map: true
+          io: true
+          nounmap: true
+      module: rbd_delete_protected_snapshot_krbd.py
+      name: krbd client - Test to Perform Deletion of protected snapshot
+      polarion-id: CEPH-9224

--- a/tests/rbd/rbd_delete_protected_snapshot_krbd.py
+++ b/tests/rbd/rbd_delete_protected_snapshot_krbd.py
@@ -1,0 +1,93 @@
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd.krbd_io_handler import krbd_io_handler
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def rbd_delete_protect_snap(rbd, pool_type, **kw):
+    """
+        Deletion of protected snapshot on  RBD image should fail
+    Args:
+        rbd: RBD object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: test data
+    """
+    try:
+        pool = kw["config"][pool_type]["pool"]
+        image = kw["config"][pool_type]["image"]
+        snap = kw["config"][pool_type].get("snap", f"{pool}_{image}_snap")
+        clone_prefix = kw["config"][pool_type].get("clone", f"{pool}_{image}_clone")
+        size = kw["config"][pool_type]["size"]
+        snap_name = f"{pool}/{image}@{snap}"
+        image_spec = f"{pool}/{image}"
+
+        # Run fio and krbd map operations on image
+        kw.get("config")["image_spec"] = [image_spec]
+        kw.get("config")["size"] = size
+        kw["rbd_obj"] = rbd
+        krbd_io_handler(**kw)
+
+        if rbd.snap_create(pool, image, snap):
+            log.error(f"Creation of snapshot {snap} failed")
+            return 1
+
+        if rbd.protect_snapshot(snap_name):
+            log.error(f"Snapshot protect failed for {snap_name}")
+            return 1
+
+        log.info("Create multiple clones from the snap image")
+        for i in range(1, 11):
+            clone_name = f"{clone_prefix}_{i}"
+            if rbd.create_clone(snap_name, pool, clone_name):
+                log.error(f"Creation of clone {clone_name} failed")
+                return 1
+            else:
+                log.debug(f"Clone {clone_name} created successfully")
+
+        if rbd.snap_remove(pool, image, snap):
+            return 0
+
+    except RbdBaseException as error:
+        log.error(error.message)
+        return 1
+
+    finally:
+        if not kw.get("config").get("do_not_cleanup_pool"):
+            rbd.clean_up(pools=[pool])
+
+
+def run(**kw):
+    """Delete the protected snapshot and it should fail.
+    This test verifies removal of protected snapshot.
+    Args:
+        kw: test data
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+    Test case covered -
+    CEPH-9224 - Trying to delete a protected snapshot will fail.
+    Pre-requisites :
+    1. Cluster must be up and running with capacity to create pool
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+    Test Case Flow:
+    1. Create a pool
+    2. Create an image
+    3. Run Ios on an Image using krbd client
+    4. Take a snapshot
+    5. Protect a snapshot
+    6. clone a snapshot
+    7. try to delete the snap and it should fail
+    8. Repeat steps 1 to 7 for ecpool
+    """
+    log.info("Running Test for deletion of protected snapshot")
+    rbd_obj = initial_rbd_config(**kw)
+    if rbd_obj:
+        log.info("Executing test on Replication pool")
+        if rbd_delete_protect_snap(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+            return 1
+        log.info("Executing test on EC pool")
+        if rbd_delete_protect_snap(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+            return 1
+    return 0


### PR DESCRIPTION
Jira ticket -https://issues.redhat.com/browse/RHCEPHQE-7783
Test case - On krbd client - Performs deletion of protected snapshot on a RBD image
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9224

Test flow:
1) Create a pool and an Image 
2) using KRBD client, map the image and run IOs using FIO 
3) Perform snapshot create on a RBD image
3) Perform snapshot protect for the image
4) Perform clone of af an image, Have mulitple clones 
5) Perform Delete of a snapshot which is protected 
6) Cover the above steps on EC pool as well
Expected result-
at step 6 - Delete of a snap should fail since it is protected

Test Results:
5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7OGN7G
6.0- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NST9O7



