### PR TITLE
Move to rhel-9 agents with py3.9

### DIFF
--- a/pipeline/cvp.groovy
+++ b/pipeline/cvp.groovy
@@ -105,7 +105,7 @@ def postUMB(Map arg, String status) {
 
 // Pipeline script entry point
 
-node("rhel-8-medium") {
+node("rhel-9-medium") {
 
     stage('prepareNode') {
         if (env.WORKSPACE) {

--- a/pipeline/ibm-scheduled-pipeline-executor.groovy
+++ b/pipeline/ibm-scheduled-pipeline-executor.groovy
@@ -6,7 +6,7 @@
 def SSHServer = "ssh 10.245.4.89"
 
 // Set default values
-def nodeName = "agent-01"
+def nodeName = "agent-rhel9"
 
 // Recipe file path details
 def recipeFile = "RHCEPH-*.yaml"

--- a/pipeline/osp-results-notifier.groovy
+++ b/pipeline/osp-results-notifier.groovy
@@ -37,7 +37,7 @@ def sendEMail(def bodyMap) {
     )
 }
 
-node('rhel-8-medium || ceph-qe-ci') {
+node('rhel-9-medium || ceph-qe-ci') {
 
     stage('prepareJenkinsNode') {
 

--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -22,7 +22,7 @@ def majorVersion
 def minorVersion
 def failureReason
 
-node("rhel-8-medium") {
+node("rhel-9-medium") {
 
     try {
         stage('prepareJenkinsAgent') {

--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -6,7 +6,7 @@ def ciMap
 def sharedLib
 
 
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-9-medium || ceph-qe-ci") {
 
     stage('prepareNode') {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }

--- a/pipeline/psi-post-umb.groovy
+++ b/pipeline/psi-post-umb.groovy
@@ -7,7 +7,7 @@
 */
 def featureCompleteReleases = ['RHCEPH-4.3.yaml', 'RHCEPH-5.3.yaml', 'RHCEPH-6.0.yaml']
 
-node('rhel-8-medium || ceph-qe-ci') {
+node('rhel-9-medium || ceph-qe-ci') {
     stage('prepareNode') {
         checkout(
             scm: [

--- a/pipeline/psi-scheduled-pipeline-executor.groovy
+++ b/pipeline/psi-scheduled-pipeline-executor.groovy
@@ -12,7 +12,7 @@ def tags = "${params.tags}" ? "schedule_openstack_only,tier-1,stage-1" : "${para
 
 
 // Pipeline script entry point
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-9-medium || ceph-qe-ci") {
     stage('prepareNode') {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
         checkout(

--- a/pipeline/psi-tier-3-pipeline-executor.groovy
+++ b/pipeline/psi-tier-3-pipeline-executor.groovy
@@ -10,7 +10,7 @@ def overrides = (params.overrides)?.trim() ?: "{}"
 def tags = (params.tags)?.trim() ?: "schedule,openstack-only,tier-3,stage-1"
 
 // Pipeline script entry point
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-9-medium || ceph-qe-ci") {
     stage('prepareNode') {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
         checkout(

--- a/pipeline/released.groovy
+++ b/pipeline/released.groovy
@@ -19,7 +19,7 @@ def launch_id = ""
 
 
 // Pipeline script entry point
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-9-medium || ceph-qe-ci") {
 
     stage('Preparing') {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }

--- a/pipeline/rhcs_delete.groovy
+++ b/pipeline/rhcs_delete.groovy
@@ -3,7 +3,7 @@
 */
 def sharedLib
 
-node("rhel-8-medium || ceph-qe-ci") {
+node("rhel-9-medium || ceph-qe-ci") {
 
     stage("prepareNode") {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }

--- a/pipeline/rhcs_deploy.groovy
+++ b/pipeline/rhcs_deploy.groovy
@@ -33,7 +33,7 @@ def ciMap = [:]
 def sharedLib
 def vmPrefix
 
-node ("rhel-8-medium || ceph-qe-ci") {
+node ("rhel-9-medium || ceph-qe-ci") {
 
     stage("prepareJenkinsAgent") {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }

--- a/pipeline/test_executor.groovy
+++ b/pipeline/test_executor.groovy
@@ -85,7 +85,7 @@ def buildArtifactDetails(def sharedLib){
     return artifactDetails
 }
 
-node("rhel-8-medium"){
+node("rhel-9-medium"){
     stage('Install pre req') {
         if (env.WORKSPACE) { sh script: "sudo rm -rf * .venv" }
         checkout([

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -15,7 +15,7 @@ def buildArtifacts
 def buildType
 def final_stage = false
 def run_type
-def nodeName = "rhel-8-medium || ceph-qe-ci"
+def nodeName = "rhel-9-medium"
 def tags = ""
 def majorVersion
 def minorVersion
@@ -37,7 +37,7 @@ if (params.containsKey('tags')){
     tags=params.tags
     tags_list = tags.split(',') as List
     if (tags_list.contains('ibmc')){
-        nodeName = "agent-01 || ceph-qe-ci"
+        nodeName = "agent-rhel9"
     }
 }
 


### PR DESCRIPTION
As part CephCI migration to python 3.9,
- Moving to rhel-9 agents in PSI and IBM executors & others pipeline.  