### PR TITLE
Automated delayed replication scenario - per-image

### DIFF
--- a/suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
@@ -207,6 +207,17 @@ tests:
       polarion-id: CEPH-11492
 
   - test:
+      name: Test delayed replication - primary
+      clusters:
+        ceph-rbd1:
+          config:
+            skip_initial_config: true
+            delay_at_primary: true
+      desc: Testing Delayed replication with delay set in primary per image
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11494
+
+  - test:
       name: Test delayed replication - Failover
       clusters:
         ceph-rbd1:


### PR DESCRIPTION
Added automation for per-image delay scenario to existing handler which manages rbd mirror delayed replication scenarios.

Wrokflow of Tc:
polarion-id: CEPH-11494 - Delayed Replication-Delay on secondary.

    Record initial md5sum value of images.
    Set delay at primary as image config
    observe image data till mentioned delay that
    there are no mirroring activity between clusters.

File changes:
modified:   suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
Added test to call newly automated testcase.

modified:   tests/rbd_mirror/test_delayed_replication_handler.py
Added capability to handle scenario of adding perimage delay at primary.
Added doc on how to use the handler to call newly automated testcase

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
