### PR TITLE
[Tier2] [Cephadm] Validate ceph health log when node is offline

### DIFF
--- a/cli/ceph/ceph.py
+++ b/cli/ceph/ceph.py
@@ -46,9 +46,11 @@ class Ceph(Cli):
             return out[0].strip()
         return out
 
-    def health(self):
+    def health(self, detail=False):
         """Returns the Ceph cluster health"""
         cmd = f"{self.base_cmd} health"
+        if detail:
+            cmd += " detail"
         out = self.execute(sudo=True, check_ec=False, long_running=False, cmd=cmd)
         if isinstance(out, tuple):
             return out[0].strip()

--- a/suites/pacific/cephadm/tier-2_cephadm_scenarios_with_permissive_mode.yaml
+++ b/suites/pacific/cephadm/tier-2_cephadm_scenarios_with_permissive_mode.yaml
@@ -121,3 +121,9 @@ tests:
       module: test_verify_cluster_health_after_reboot.py
       config:
         action: service-state
+
+  - test:
+      name: Verify 'ceph health detail' output
+      desc: Verify ceph health detail info when mon node is offline
+      polarion-id: CEPH-83575328
+      module: test_ceph_health_detail_when_mon_offline.py

--- a/tests/cephadm/test_ceph_health_detail_when_mon_offline.py
+++ b/tests/cephadm/test_ceph_health_detail_when_mon_offline.py
@@ -1,0 +1,64 @@
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from cli.utilities.utils import bring_node_offline, is_node_online
+
+
+class ClusterHealthError(Exception):
+    pass
+
+
+class UnexpectedNodeStatusError(Exception):
+    pass
+
+
+def run(ceph_cluster, **kw):
+    """Verify cluster health detail result when a node is down
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
+    mon_node = ceph_cluster.get_nodes(role="mon")[1]
+
+    # Get Ceph Health Detail
+    ceph_health = CephAdm(installer_node).ceph.health()
+    if not ceph_health == "HEALTH_OK":
+        raise ClusterHealthError("Ceph cluster not healthy")
+
+    # Bring the mon_node down
+    out = bring_node_offline(mon_node, timeout=120)
+    if not out:
+        raise UnexpectedNodeStatusError(f"Failed to bring {mon_node.hostname} offline")
+
+    # Once the mon node is offline, check for the cluster health detail
+    # Validate whether the ceph health detail returns unnecessary info
+    # as mentioned in https://tracker.ceph.com/issues/54132
+    unexpected_entries = [
+        "Received MSG_CHANNEL_OPEN_CONFIRMATION",
+        "Initial send window",
+        "Sent MSG_IGNORE",
+        "Sent MSG_CHANNEL_CLOSE",
+        "Received channel close",
+        "Received MSG_CHANNEL_REQUEST",
+        "Received MSG_CHANNEL_EOF",
+    ]
+
+    # Check whether the health detail doesn't dump unexpected data
+    # Repeat the checks multiple times and validate data
+    timeout, interval = 120, 10
+    for _ in WaitUntil(timeout=timeout, interval=interval):
+        ceph_health_detail = CephAdm(installer_node).ceph.health(detail=True)
+        for entry in unexpected_entries:
+            if entry in ceph_health_detail:
+                raise ClusterHealthError(
+                    f"{entry} present in result: {ceph_health_detail}"
+                )
+    # Wait for the thread to complete and bring the n/w interface up
+    out.join()
+
+    # Check whether the node is up
+    if not is_node_online(mon_node):
+        raise UnexpectedNodeStatusError(
+            f"{mon_node.hostame} is not up after the n/w interface is up"
+        )
+
+    return 0


### PR DESCRIPTION
# Description

Polarion Tc's included:

CEPH-83575328 Cephadm - verify 'ceph health detail' does not report some massive info dump about packets when one of the MON host is offline and out of the quorum from the cluster - Tier2


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
