### PR TITLE
Adding FS TC-83573992

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml
@@ -18,7 +18,7 @@
 # CEPH-83573995 - Create cephfs nfs export on existing path
 # CEPH-11310 -  Run IOs by mounting same subvolume with all the three mounts
 # CEPH-11314 - Backup and restore data using existing NFS backup tools
-
+# CEPH-83573992 - Verifying ceph nfs ls export with --detailed option and info with cluster_id
 #=======================================================================================================================
 tests:
   -
@@ -261,3 +261,11 @@ tests:
       module: nfs.data_backup_restore_bw_nfs_and_local_mounts.py
       name: "backup and restore data bw nfs exports and local dir"
       polarion-id: "CEPH-11314"
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+

--- a/tests/cephfs/nfs/nfs_info_cluster_id_and_ls_export_detailed.py
+++ b/tests/cephfs/nfs/nfs_info_cluster_id_and_ls_export_detailed.py
@@ -1,0 +1,135 @@
+import json
+import random
+import string
+import traceback
+
+from ceph.ceph_admin import CephAdmin
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+"""
+pre-requisites:
+1. nfs cluster ready
+2. export the nfs cluster
+Test operation:
+1. check if input and --detailed value match
+2. check if nfs clsuter info using its cluster_id
+"""
+
+
+def run(ceph_cluster, **kw):
+    try:
+        tc = "CEPH-83573992"
+        log.info(f"Running CephFS tests for BZ-{tc}")
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        build = config.get("build", config.get("rhbuild"))
+        clients = ceph_cluster.get_ceph_objects("client")
+        client1 = clients[0]
+        fs_details = fs_util.get_fs_info(client1)
+        if not fs_details:
+            fs_util.create_fs(client1, "cephfs")
+        fs_util.auth_list([client1])
+        fs_util.prepare_clients(clients, build)
+
+        instance = CephAdmin(cluster=ceph_cluster, **config)
+        host_cmd = "cephadm shell ceph orch ps --format json-pretty"
+        res, ec = instance.installer.exec_command(sudo=True, cmd=host_cmd)
+        results = json.loads(res)
+        nfs_hosts_name = []
+        log.info(print(results))
+        nfs_target_node = ""
+        for ps in results:
+            log.info(print(ps))
+            if "nfs" in ps["service_name"]:
+                nfs_hosts_name.append(ps["hostname"])
+            if "mds" in ps["service_name"]:
+                nfs_target_node = ps["hostname"]
+        log.info(print("NFS service is being hosted by ", nfs_hosts_name))
+
+        rand = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(5))
+        )
+        cluster_id = f"test-nfs_{rand}"
+        path = "/"
+        export_id = "1"
+        fs_name = "cephfs"
+        bind = "/ceph"
+        user_id = f"nfs.{cluster_id}.{export_id}"
+
+        passed = []
+        client1.exec_command(
+            sudo=True, cmd=f'ceph nfs cluster create {cluster_id} "{nfs_target_node}"'
+        )
+        cmd_nfs_export = (
+            f"ceph nfs export create cephfs {cluster_id} {bind} {fs_name} --path={path}"
+        )
+
+        client1.exec_command(sudo=True, cmd=cmd_nfs_export)
+
+        res, ec = client1.exec_command(
+            sudo=True, cmd=f"ceph nfs export ls {cluster_id} --detailed --format json"
+        )
+        results = json.loads(res)
+        log.info(print(results))
+        res2, ec2 = client1.exec_command(
+            sudo=True, cmd=f"ceph nfs cluster info {cluster_id}"
+        )
+
+        if res2:
+            results2 = json.loads(res2)
+            log.info(print(results2))
+            passed.append(True)
+        else:
+            log.error("Getting cluster info using the cluster ID has failed")
+            passed.append(False)
+
+        do_not_match = []
+        result = results[0]
+
+        if result["fsal"]["name"] != "CEPH":
+            do_not_match.append("[fsal][name]")
+
+        elif result["fsal"]["user_id"] != user_id:
+            do_not_match.append("[fsid][user_id]")
+
+        elif result["fsal"]["fs_name"] != fs_name:
+            do_not_match.append("[fsal][fs_name")
+
+        elif result["path"] != path:
+            do_not_match.append("[path]")
+
+        elif result["cluster_id"] != cluster_id:
+            do_not_match.append("[cluster_id]")
+
+        elif result["pseudo"] != bind:
+            do_not_match.append("[pseudo]")
+
+        if len(do_not_match) != 0:
+            passed.append(False)
+            log.error("There is some mismatch")
+            log.error(print(do_not_match))
+        else:
+            passed.append(True)
+
+        if passed[0] is False and passed[1] is True:
+            log.error("Failed to load info using cluster ID")
+            return 1
+        elif passed[0] is True and passed[1] is False:
+            log.error("Failed to get right details from --detailed option")
+            return 1
+        elif passed[0] is False and passed[1] is False:
+            log.error("Failed to load info using cluster ID")
+            log.error("Failed to get right details from --detailed option")
+            return 1
+        else:
+            return 0
+
+        return 0
+
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1


### PR DESCRIPTION
Automation - T2 - CEPH-83573992 - List the nfs export details within nfs cluster in detail with --detailed option and note all the details are proper

https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83573992

pre-requisites:
1. nfs cluster ready
2. export the nfs cluster
Test operation:
1. check if input and --detailed value match
2. check if nfs clsuter info using its cluster_id

Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1MOSS5/




# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
