### PR TITLE
Adding test coverage for datalog and mdlog trim

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -528,3 +528,42 @@ tests:
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-sec"]
             timeout: 300
+# Log trimming tests
+  - test:
+      name: Mdlog trimming test on primary
+      desc: test mdlog trimming on primary
+      polarion-id: CEPH-10544
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bilog_trimming.py
+            config-file-name: test_mdlog_trimming.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-sec"]
+
+  - test:
+      name: Datalog trimming test on secondary
+      desc: test datalog trimming on secondary
+      polarion-id: CEPH-10540
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bilog_trimming.py
+            config-file-name: test_datalog_trimming.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-pri"]
+
+
+  - test:
+      name: Bilog trimming test on primary
+      desc: test bilog trimming on primary
+      polarion-id: CEPH-83572658
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bilog_trimming.py
+            config-file-name: test_bilog_trimming.yaml
+            timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
@@ -425,4 +425,3 @@ tests:
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_versioning
       polarion-id: CEPH-83575153
-


### PR DESCRIPTION
# Description

Automating mdlog and datalog trimming.

This PR would test log trimming (mdlog, datalog, and bilog) happens after the default interval of 20 minutes

The test covered: CEPH-10540, and CEPH-10544.

logs http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-A5MZHX

