### PR TITLE
Automated Delayed replication - Failback scenario 

### DIFF
--- a/suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
@@ -227,3 +227,14 @@ tests:
       desc: Testing Delayed replication with failover for journal mirroring
       module: test_delayed_replication_handler.py
       polarion-id: CEPH-11490
+
+  - test:
+      name: Test delayed replication - Failback
+      clusters:
+        ceph-rbd1:
+          config:
+            direct_failback_scenario: true
+            skip_initial_config: true
+      desc: Testing Delayed replication with failback for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11493


### PR DESCRIPTION
Added automation for delay scenario with failback to existing handler which
manages rbd mirror delayed replication scenarios.

Wrokflow of Tc:
polarion-id: CEPH-11493 - Delayed Replication-Failback with delay set.

    Set delay at primary as image config
    Failback the images
    Record md5sum value of images.
    Set delay at primary as image config
    Perform some IO operations on primary
    observe image data till mentioned delay that
        there are no mirroring activity between clusters.

File changes:
modified:   suites/quincy/rbd/tier-2_rbd_upgrade_5x_to_6x.yaml
Added configs for TC automated as part of this commit

modified:   tests/rbd_mirror/rbd_mirror_utils.py
1. Added config ignore_command_failure to wait_for_status
This is required at the time of images resyncs when we expect command failures like
image unavailable during earlier wait periods.
2. Added capability to wait_for_status method to wait for specific value of description.
3. Removed a redundant code comment.
4. Added modules fail_back and prepare_for_failback to handle failback for journal based
   mirroring scenarios.

modified: tests/rbd_mirror/test_delayed_replication_handler.py
Enhanced handler to accomodate new testcase and also some minor optimization.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
