### PR TITLE
Remove sharding tc where operation performed from secondary and moving s3cmd suite to PSI-only

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -223,16 +223,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
-        - name: "RGW testing using S3CMD CLI commands"
-          execution_time: "45m 21s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-          platform: "rhel-8"
-          inventory:
-            openstack: "conf/inventory/rhel-8-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-          metadata:
-            - rgw
       stage-3:
         - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
           execution_time: "48m 37s"
@@ -798,6 +788,18 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rbd
+    tier-2:
+      stage-1:
+        - name: "RGW testing using S3CMD CLI commands"
+          execution_time: "45m 21s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
         - name: "Tier-2 Cephfs test Snapshot Clone"
           execution_time: "1h 18m 39s"
           suite: "suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml"
@@ -808,8 +810,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - cephfs
-    tier-2:
-      stage-1:
         - name: "S3Tests against Red Hat RGW with SSL"
           execution_time: "1h 46m 37s"
           suite: "suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -267,16 +267,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
-        - name: "RGW testing using S3CMD CLI commands"
-          execution_time: "41m 19s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - rgw
       stage-3:
         - name: "Tier-2 RGW cloud transitions"
           execution_time: "47m 35s"
@@ -746,6 +736,16 @@ pipelines:
             - rbd
     tier-2:
       stage-1:
+        - name: "RGW testing using S3CMD CLI commands"
+          execution_time: "41m 19s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
         - name: "RADOS regression testing for Mon DB trimming"
           execution_time: "1h 18m 55s"
           suite: "suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -263,16 +263,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
-        - name: "RGW testing using S3CMD CLI commands"
-          execution_time: "41m 19s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - rgw
       stage-3:
         - name: "Tier-2 RGW cloud transitions"
           execution_time: "47m 35s"
@@ -689,6 +679,16 @@ pipelines:
   sanity_openstack_only:
     tier-2:
       stage-1:
+        - name: "RGW testing using S3CMD CLI commands"
+          execution_time: "41m 19s"
+          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
         - name: "RADOS regression testing for Mon DB trimming"
           execution_time: "1h 18m 55s"
           suite: "suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml"

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -383,17 +383,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             timeout: 300
   - test:
-      name: test sharding on secondary
-      desc: test_Mbuckets_with_Nobjects_sharding on secondary
-      polarion-id: CEPH-9245
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-            timeout: 300
-  - test:
       name: test Mbuckets on secondary
       desc: test_Mbuckets on secondary
       polarion-id: CEPH-9789

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
@@ -410,18 +410,6 @@ tests:
             timeout: 300
 
   - test:
-      name: test sharding on secondary
-      desc: test_Mbuckets_with_Nobjects_sharding on secondary
-      polarion-id: CEPH-9245
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-            timeout: 300
-
-  - test:
       name: test Mbuckets on secondary
       desc: test_Mbuckets on secondary
       polarion-id: CEPH-9789


### PR DESCRIPTION

# Description
This pr contains maily 2 changes
1. Remove sharding tc where operation performed from secondary
2. moving s3cmd suite to PSI-only 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
