### PR TITLE
 Fixing snapshot reboot

### DIFF
--- a/tests/cephfs/snapshot_clone/snapshot_reboot.py
+++ b/tests/cephfs/snapshot_clone/snapshot_reboot.py
@@ -2,8 +2,10 @@ import random
 import string
 import traceback
 
+from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
+from utility.retry import retry
 
 log = Log(__name__)
 
@@ -107,7 +109,8 @@ def run(ceph_cluster, **kw):
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
         )
-        client1.exec_command(
+        retry_revert = retry(CommandFailed, tries=3, delay=60)(client1.exec_command)
+        retry_revert(
             sudo=True,
             cmd=f"cd {kernel_mounting_dir_2};yes | cp -rf .snap/_snap_1_*/* .",
         )


### PR DESCRIPTION
# Description
 Fixing snapshot reboot

Issue:
After reboot and mounting the FS. it is not loading the snap directory.

Solution:
Added retry for snapshot revert 

Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K5LI4E/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
