### PR TITLE
CEPH-83571714: Verify reduction in blocks when data in an object is removed

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1118,7 +1118,7 @@ class Ceph(object):
             )
         if cluster_name is not None:
             cmd += f" --cluster {cluster_name}"
-        if pacific:
+        if pacific and not self.get_ceph_object("client"):
             cmd = f"cephadm shell -- {cmd}"
 
         out, _ = client.exec_command(cmd=cmd, sudo=True)

--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -236,3 +236,22 @@ class OSD(ApplyMixin, Orch):
         osd_id = config["pos_args"][0]
         base_cmd.append(str(osd_id))
         return self.shell(args=base_cmd)
+
+    def flag(self, config: dict):
+        """
+        Execute the command ceph osd set/unset flag.
+        Args:
+            config (Dict): OSD flag configuration parameters
+        Returns:
+          output, error   returned by the command.
+        Example::
+            config:
+                command: set/unset
+                base_cmd_args:
+                    verbose: true
+                flag: value of flag
+        """
+        command = config.get("command")
+        flag = config.get("flag")
+        cmd = f"ceph osd {command} {flag}"
+        return self.shell(args=[cmd])

--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -129,6 +129,97 @@ class PoolFunctions:
         )
         return True
 
+    def prepare_static_data(self, node):
+        """
+        creates a 4MB obj, same obj will be put nobj times
+        because in do_rados_get we have to verify checksum
+        """
+        tmp_file = "/tmp/sdata.txt"
+        DSTR = "hello world"
+        sfd = None
+
+        try:
+            sfd = node.remote_file(file_name=tmp_file, file_mode="w+")
+            sfd.write(DSTR * 4)
+            sfd.flush()
+            cmd = f"truncate -s 4M {tmp_file}"
+            node.exec_command(cmd=cmd)
+        except Exception as e:
+            log.error(f"file creation failed with exception: {e}")
+            log.error(traceback.format_exc())
+
+        sfd.seek(0)
+        sfd.close()
+        return tmp_file
+
+    def do_rados_put(
+        self, client, pool: str, obj_name: str = None, nobj: int = 1, offset: int = 0
+    ):
+        """
+        write static data to one object or nobjs in an app pool
+        Args:
+            client: client node
+            pool: pool name to which data needs to added
+            obj_name (optional): Name of the existing object or
+            new object to be created in the pool
+            nobj: Number of times data will be put to object 'obj_name'
+            with incremental offset if 'obj_name' is specified, else
+            data will be put once to nobj number of objects -
+            obj0, obj1, obj2 and so on...
+            offset: write object with start offset, default - 0
+        Returns: 0 -> pass, 1 -> fail
+        """
+        infile = self.prepare_static_data(client)
+        log.debug(f"Input file is {infile}")
+
+        for i in range(nobj):
+            log.info(f"running command on {client.hostname}")
+            put_cmd = (
+                f"rados put -p {pool} obj{i} {infile}"
+                if obj_name is None
+                else f"rados put -p {pool} {obj_name} {infile}"
+            )
+            if offset:
+                put_cmd = f"{put_cmd} --offset {offset}"
+            try:
+                out, _ = client.exec_command(sudo=True, cmd=put_cmd)
+                if obj_name is not None and offset:
+                    offset += offset
+            except Exception:
+                log.error(traceback.format_exc)
+                return 1
+        return 0
+
+    def do_rados_append(self, client, pool: str, obj_name: str = None, nobj: int = 1):
+        """
+        Append static data to nobjs already present in a pool
+        Args:
+            client: client node
+            pool: pool name to which the object belongs
+            obj_name (optional): Name of the existing object in the pool
+            nobj (optional): Number of times data will be appended
+            to object 'obj_name' if 'obj_name' is specified, else
+            data will be appended once to nobj number of objects -
+            obj0, obj1, obj2 and so on...
+        Returns: 0 -> pass, 1 -> fail
+        """
+        infile = self.prepare_static_data(client)
+        log.debug(f"Input file is {infile}")
+
+        for i in range(nobj):
+            log.info(f"running command on {client.hostname}")
+            append_cmd = (
+                f"rados append obj{i} {infile} -p {pool}"
+                if obj_name is None
+                else f"rados append {obj_name} {infile} -p {pool}"
+            )
+            try:
+                out, _ = client.exec_command(sudo=True, cmd=append_cmd)
+            except Exception:
+                log.error(traceback.format_exc)
+                return False
+        return True
+
     def do_rados_delete(self, pool_name: str, pg_id: str = None):
         """
         deletes all the objects from the given pool / PG ID

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -204,3 +204,25 @@ def add_osd(ceph_cluster, host, device_path, osd_id):
     log.info(f"Executing daemon {config.pop('command')} service")
     daemon = Daemon(cluster=ceph_cluster, **config)
     daemon.add(config)
+
+
+def configure_osd_flag(ceph_cluster, action, flag):
+    """
+    set/unset the osd flag
+    Command example: ceph osd set noscrub
+    Args:
+        ceph_cluster: ceph cluster
+        action: set or unset
+          example: set|unset
+        flag - value of the flag
+          example:pause|noup|nodown|noout|noin|nobackfill|
+            norebalance|norecover|noscrub|nodeep-scrub|notieragent
+    Returns: True/False
+    """
+    config = {"command": action, "service": "osd", "flag": flag}
+    log.info(f"Executing OSD {action} {flag}")
+    osd = OSD(cluster=ceph_cluster, **config)
+    out, err = osd.flag(config)
+    if f"{flag} is {action}" in err:
+        return True
+    return False

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -1202,3 +1202,21 @@ def is_legacy_container_present(ceph_cluster):
             return True
 
     return False
+
+
+def systemctl(node, op, unit):
+    """Execute systemctl command operation(op) on specific service unit.
+
+    Args:
+        node: node to execute command
+        op: systemctl supported action (ex., start|stop|enable|disable..,)
+        unit: unit service-name
+
+    Returns:
+        out, err
+
+    """
+    cmd_ = f"systemctl {op} {unit}.service"
+    out, err = node.exec_command(cmd=cmd_, sudo=True)
+    log.info(out)
+    return out, err

--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -106,3 +106,28 @@ tests:
               osd_recovery_max_active: 16
         delete_pools:
           - pool_p1
+
+  - test:
+      name: ceph osd df stats
+      module: test_osd_df.py
+      desc: Mark osd out and inspect stats change in ceph osd df
+      polarion-id: CEPH-10787
+      abort-on-fail: true
+      config:
+        run_iteration: 3
+        create_pool: true
+        pool_name: test-osd-df
+        write_iteration: 4
+        delete_pool: true
+
+  - test:
+      name: ObjectStore block stats verification
+      module: test_objectstore_block.py
+      desc: Reduce data from an object and verify the decrease in blocks
+      polarion-id: CEPH-83571714
+      abort-on-fail: true
+      config:
+        create_pool: true
+        pool_name: test-objectstore
+        write_iteration: 3
+        delete_pool: true

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -204,6 +204,31 @@ class MonConfigMethods:
         log.info(f"Value for config: {kwargs['name']} was set")
         return True
 
+    def get_config(self, section: str, param: str) -> str:
+        """
+        Retrieves the config param in monitor config database,
+        Usage - config get <section> <name>
+        This is not symmetric with 'config set' because it also
+        returns compiled-in default values along with values which
+        have been explicitly set
+
+        Args:
+            **kwargs:
+                - section: which section of daemons to target
+                    allowed values: mon, mgr, osd, mds, client
+                - param: name of the config param for the selection
+        Returns: string output of ceph config get <section> <name> command
+
+        E.g.
+            - # ceph config get mon public_network
+                10.0.208.0/22
+            - # ceph config get osd bluestore_min_alloc_size_hdd
+                4096
+        """
+
+        cmd = f"ceph config get {section} {param}"
+        return self.rados_obj.node.shell([cmd])[0]
+
     def remove_config(self, **kwargs):
         """
         Removes the sent config param from monitor config database

--- a/tests/rados/test_objectstore_block.py
+++ b/tests/rados/test_objectstore_block.py
@@ -1,0 +1,229 @@
+import json
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    #CEPH-83571714
+    Capture the block stats of an object using ceph-objectstore-tool utility
+    Verify the decrease in number of blocks when the amount of data in an object
+    is reduced by overwrite
+    1. Create pool and write data to an object
+    2. Fetch the acting pg set for the object and corresponding osd nodes
+    3. Stop any one of the OSDs from the acting pg set using systemctl
+    4. Capture the object dump using ceph-objectstore-tool
+    5. Start the OSD which was previously stopped
+    6. Overwrite the data in the object with a smaller chunk
+    7. Stop the same OSD and fetch object dump using ceph-objectstore-tool
+    8. Verify the difference in block stats and decrease in the number of blocks
+    should be proportional to the decrease in data in the object
+
+    # Test currently does not pass on RHCS 6.0 because the acting PG set
+     changes for the object as soon as one of the OSD is brought down even if
+     no-recovery flags are set. Needs further investigation
+     Execution with RHCS 5.3 is fine, passes 10/10 times
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+    iterations = config.get("write_iteration")
+
+    pool_name = config["pool_name"]
+    object_name = config.get("object_name", "obj-objectstore")
+
+    log.info(
+        "Running test case to verify changes in number "
+        "of blocks when data is written to an object and removed from an object"
+    )
+
+    try:
+        # create pool with given config
+        if config["create_pool"]:
+            rados_obj.create_pool(pool_name=pool_name)
+
+        bluestore_min_alloc_size = int(
+            mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+        )
+        log.info(f"bluestore_min_alloc_size: {bluestore_min_alloc_size}")
+
+        # create single object and perform IOPs
+        pool_obj.do_rados_put(client=client_node, pool=pool_name, obj_name=object_name)
+
+        pool_obj.do_rados_append(
+            client=client_node,
+            pool=pool_name,
+            obj_name=object_name,
+            nobj=(iterations - 1),
+        )
+
+        osd_map = rados_obj.get_osd_map(pool=pool_name, obj=object_name)
+        acting_pg_set = osd_map["acting"]
+        log.info(f"Acting pg set for {object_name} in {pool_name}: {acting_pg_set}")
+        if not acting_pg_set:
+            log.error("Failed to retrieve acting pg set")
+            raise Exception("Failed to retrieve acting pg set")
+
+        acting_osd_id = acting_pg_set[0]
+        acting_osd_node = rados_obj.fetch_host_node(
+            daemon_type="osd", daemon_id=acting_osd_id
+        )
+        osd_data_path = ceph_cluster.get_osd_metadata(acting_osd_id).get("osd_data")
+        log.info(f"osd_data_path: {osd_data_path}")
+
+        assert rados_obj.change_osd_state(action="stop", target=acting_osd_id)
+        assert rados_obj.change_osd_state(action="disable", target=acting_osd_id)
+
+        cmd_base = f"cephadm shell --name osd.{acting_osd_id} -- "
+        cmd_fetch_obj_dump = f"{cmd_base} ceph-objectstore-tool --data-path {osd_data_path} {object_name} dump"
+
+        try:
+            obj_dump_, _ = acting_osd_node.exec_command(
+                sudo=True, cmd=cmd_fetch_obj_dump
+            )
+            obj_dump = json.loads(obj_dump_)
+            obj_dump_stats = obj_dump["stat"]
+            obj_dump_extents = obj_dump["onode"]["extents"]
+        except (KeyError, ValueError) as e:
+            log.error(
+                f"Object dump json for {object_name} could not be fetched correctly"
+            )
+            log.error(f"{e.__doc__}")
+            log.exception(e)
+
+        log.debug(f"Object dump for {object_name} after initial write operation")
+        log.debug(obj_dump)
+        log.info(
+            "Verify the block size, total size and number of blocks after write operation"
+        )
+        try:
+            log.info(f"{obj_dump_stats['blksize']} == {bluestore_min_alloc_size}")
+            assert obj_dump_stats["blksize"] == bluestore_min_alloc_size
+            log.info(f"{obj_dump_stats['size']} == {iterations * 4 * 1048576}")
+            assert obj_dump_stats["size"] == (iterations * 4 * 1048576)
+            log.info(
+                f"{obj_dump_stats['blocks']} == {(iterations * 4 * 1048576) / bluestore_min_alloc_size}"
+            )
+            assert obj_dump_stats["blocks"] == int(
+                (iterations * 4 * 1048576) / bluestore_min_alloc_size
+            )
+            l_offset = obj_dump_extents[-1]["logical_offset"]
+            length = obj_dump_extents[-1]["length"]
+            log.info(f"{l_offset} + {length} == {(iterations * 4 * 1048576)}")
+            assert l_offset + length == (iterations * 4 * 1048576)
+            blocks_l_extent = int(
+                length / obj_dump_stats["blksize"]
+            )  # number of blocks in a logical extent
+            log.info(
+                f"{len(obj_dump_extents)} == {int(obj_dump_stats['blocks']/blocks_l_extent)}"
+            )
+            assert len(obj_dump_extents) == int(
+                obj_dump_stats["blocks"] / blocks_l_extent
+            )
+            log.info("PASS")
+        except (AssertionError, KeyError) as e:
+            log.info("^FAIL")
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            raise
+
+        assert rados_obj.change_osd_state(action="start", target=acting_osd_id)
+        assert rados_obj.change_osd_state(action="enable", target=acting_osd_id)
+
+        for i in range(2):
+            time.sleep(3)
+            new_acting_pg_set = rados_obj.get_osd_map(pool=pool_name, obj=object_name)[
+                "acting"
+            ]
+            log.info(new_acting_pg_set)
+            if new_acting_pg_set == acting_pg_set:
+                break
+            elif i == 1:
+                log.error(
+                    f"{acting_osd_id} could not return to PG {new_acting_pg_set} within timeout. "
+                    f"New acting pg set({new_acting_pg_set} and old acting pg set({acting_pg_set}) are not same"
+                )
+                raise Exception("acting pg set has changed")
+
+        # Perform single write operation on the same object again to overwrite all previous data
+        pool_obj.do_rados_put(client=client_node, pool=pool_name, obj_name=object_name)
+
+        assert rados_obj.change_osd_state(action="stop", target=acting_osd_id)
+        assert rados_obj.change_osd_state(action="disable", target=acting_osd_id)
+
+        obj_dump_single_, _ = acting_osd_node.exec_command(
+            sudo=True, cmd=cmd_fetch_obj_dump
+        )
+        obj_dump_single = json.loads(obj_dump_single_)
+        obj_dump_single_stats = obj_dump_single["stat"]
+        obj_dump_single_extents = obj_dump_single["onode"]["extents"]
+
+        log.debug(f"Object dump for {object_name} after overwrite operation")
+        log.debug(obj_dump_single)
+        log.info(
+            "Verify change in block size, total size and number of blocks after data removal"
+        )
+        try:
+            log.info(
+                f"{obj_dump_single_stats['blksize']} == {bluestore_min_alloc_size}"
+            )
+            assert obj_dump_single_stats["blksize"] == bluestore_min_alloc_size
+            log.info(
+                f"{obj_dump_single_stats['size']} "
+                f"== {obj_dump_stats['size']} - {(iterations - 1) * 4 * 1048576}"
+            )
+            assert (
+                obj_dump_single_stats["size"]
+                == obj_dump_stats["size"] - (iterations - 1) * 4 * 1048576
+            )
+            log.info(
+                f"{obj_dump_single_stats['blocks']} "
+                f"== {obj_dump_stats['blocks']} "
+                f"- {((iterations - 1) * 4 * 1048576) / bluestore_min_alloc_size}"
+            )
+            assert obj_dump_single_stats["blocks"] == obj_dump_stats["blocks"] - int(
+                ((iterations - 1) * 4 * 1048576) / bluestore_min_alloc_size
+            )
+            l_offset = obj_dump_single_extents[-1]["logical_offset"]
+            length = obj_dump_single_extents[-1]["length"]
+            log.info(f"{l_offset} + {length} == {4 * 1048576}")
+            assert l_offset + length == (4 * 1048576)
+            blocks_l_extent = int(
+                length / obj_dump_single_stats["blksize"]
+            )  # number of blocks in a logical extent
+            log.info(
+                f"{len(obj_dump_single_extents)} == {int(obj_dump_single_stats['blocks']/blocks_l_extent)}"
+            )
+            assert len(obj_dump_single_extents) == int(
+                obj_dump_single_stats["blocks"] / blocks_l_extent
+            )
+            log.info("PASS")
+        except (AssertionError, KeyError) as e:
+            log.info("^FAIL")
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            raise
+    except Exception as e:
+        log.error(f"Execution failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        rados_obj.change_osd_state(action="start", target=acting_osd_id)
+        rados_obj.change_osd_state(action="enable", target=acting_osd_id)
+
+        # Delete the created osd pool
+        if config.get("delete_pool"):
+            rados_obj.detete_pool(pool=pool_name)
+
+    return 0


### PR DESCRIPTION
[CEPH-83571714](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571714): Tier 2 test case to verify block allocation and reduction when data is written to an object and removed from the object respectively

_ceph-objectstore-utility_ is used to fetch the object dump from the osd node

Test suites modified:
- suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml

Test case and modules added:
- tests/rados/test_objectstore_block.py
 _systemctl_ in ceph/utils.py
- _get_config_ in tests/rados/monitor_configurations.py
- _configure_osd_flag_ in ceph/rados/utils.py

References:
- https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/5/html/troubleshooting_guide/troubleshooting-ceph-objects#listing-objects_diag
- https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/5/html/administration_guide/osd-bluestore#tuning-ceph-bluestore-using-bluestore-min-alloc-size-parameter_admin
- https://docs.ceph.com/en/quincy/rados/configuration/bluestore-config-ref/#minimum-allocation-size

**Steps:**

1. Configure Ceph cluster, create pool and write data to an object
2. Fetch the acting pg set for the object and corresponding osd nodes
3. Stop any one of the OSDs from the acting pg set using systemctl
4. Capture the object dump using ceph-objectstore-tool
5. Start the OSD which was previously stopped
6. Overwrite the data in the object with a smaller chunk
7. Stop the same OSD and fetch object dump using ceph-objectstore-tool
8. Verify the difference in block stats and decrease in the number of blocks

**Logs:**
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6FJFWL/
Test passes 10/10 on RHCS 5.3 but only 5/10 on RHCS 6.0

Signed-off-by: Harsh Kumar <hakumar@redhat.com>