### PR TITLE
updates for split merge

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -96,10 +96,9 @@ tests:
           - create_pool:
               pool_name: pool1
               pg_num: 64
-              rados_write_duration: 50
+              rados_put: true
+              num_objs: 200
               byte_size: 1024
               pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
         delete_pools:
           - pool1

--- a/tests/rados/rados_test_util.py
+++ b/tests/rados/rados_test_util.py
@@ -46,8 +46,9 @@ def write_to_pools(config, rados_obj, client_node):
     pools = config.get("create_pools")
     for each_pool in pools:
         cr_pool = each_pool["create_pool"]
+        nobj = cr_pool.get("num_objs", 100)
         if cr_pool.get("rados_put", False):
-            do_rados_put(mon=client_node, pool=cr_pool["pool_name"], nobj=100)
+            do_rados_put(mon=client_node, pool=cr_pool["pool_name"], nobj=nobj)
         else:
             method_should_succeed(rados_obj.bench_write, **cr_pool)
 


### PR DESCRIPTION
# Description

Few changes to split merge test scenario for getting consistent execution logs.
removed cahnge recovery  threads operations and introduced rados_put instead of benchwrite.

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-H76V7L/