### PR TITLE
Automating sync-point snap delete verification testcase

### DIFF
--- a/suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-5-to-latest.yaml
@@ -209,13 +209,16 @@ tests:
       desc: Create RBD mirrored images and run IOs
 
   - test:
-      name: test_rbd_mirror
-      module: test_rbd_mirror.py
+      name: verify sync snap deletion
+      module: test_sync_point_snapshot_deletion.py
       clusters:
         ceph-rbd1:
           config:
-            imagesize: 2G
-            io-total: 200M
-            resize_to: 5G
+            ec_pool_config:
+              pool: sync_snap_del_1
+              image: image_ec
+            rep_pool_config:
+              pool: sync_snap_del_1
+              image: image_rep
       polarion-id: CEPH-83573332
-      desc: Create RBD mirrored image in pools and run IOs
+      desc: Verify sync point snapshot deletion in journal based

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -241,7 +241,7 @@ class Rbd:
         cmd = f"rbd snap create {pool_name}/{image_name}@{snap_name}"
         return self.exec_cmd(cmd=cmd)
 
-    def snap_ls(self, pool_name, image_name, snap_name=None):
+    def snap_ls(self, pool_name: str, image_name: str, snap_name=None, all=False):
         """
         Lists the snapshots present for an image and returns the given snap_name if present
         Args:
@@ -255,6 +255,8 @@ class Rbd:
             None if no specified snaps are present.
         """
         cmd = f"rbd snap ls {pool_name}/{image_name} --format json"
+        if all:
+            cmd += " --all"
         out = self.exec_cmd(cmd=cmd, output=True)
         if out == 1:
             log.error(

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -1251,7 +1251,6 @@ def prepare_for_failback(demoted: RbdMirror, imagespec: str):
     """Prepare image for failback after non-orderly failover.
 
     Args:
-        promoted: RbdMirror object of cluster with promoted image.
         demoted: RbdMirror object of cluster with previou primary.
         imagespec: Image specification of image to be failed back.
     """

--- a/tests/rbd_mirror/test_sync_point_snapshot_deletion.py
+++ b/tests/rbd_mirror/test_sync_point_snapshot_deletion.py
@@ -1,0 +1,67 @@
+"""Automating syncpoint snapshot deletion verification.
+
+Testcase information:
+CEPH-10466 - sync-point snapshot should not be listed after the re-sync completes
+Steps:
+1. configure mirroring between two clusters.
+2. Induce failure - Failover primary image.
+3. While failing back,check snapshot list and make sure that sync point snapshot is deleted.
+"""
+
+from ceph.parallel import parallel
+from tests.rbd.rbd_utils import Rbd
+from tests.rbd_mirror.rbd_mirror_utils import parallel_bench_on_n_images as write_data
+from tests.rbd_mirror.rbd_mirror_utils import prepare_for_failback, rbd_mirror_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    log.info("Starting execution for sync-point snapshot deletion verification")
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    mirror1 = mirror_obj["rep_rbdmirror"]["mirror1"]
+    mirror2 = mirror_obj["rep_rbdmirror"]["mirror2"]
+
+    imagespecs = [
+        f'{kw["config"]["rep_pool_config"]["pool"]}/{kw["config"]["rep_pool_config"]["image"]}',
+        f'{kw["config"]["ec_pool_config"]["pool"]}/{kw["config"]["ec_pool_config"]["image"]}',
+    ]
+    rbd1, rbd2 = [
+        Rbd(**kw, req_cname=cluster_name)
+        for cluster_name in kw["ceph_cluster_dict"].keys()
+    ]
+
+    def count_number_of_mirror_snaps():
+        """Returns count of snaps with 'mirror' keyword in name"""
+        snapcounts = 0
+        for imagespec in imagespecs:
+            snapcounts += str(
+                rbd1.snap_ls(
+                    imagespec.split("/")[0], imagespec.split("/")[1], None, True
+                )
+            ).count("mirror")
+        return snapcounts
+
+    initial_snapcount = count_number_of_mirror_snaps()
+
+    with parallel() as p:
+        for imagespec in imagespecs:
+            p.spawn(mirror2.promote, force=True, imagespec=imagespec)
+            write_data(mirror2, imagespecs, "100M")
+
+        for imagespec in imagespecs:
+            p.spawn(prepare_for_failback, mirror1, imagespec)
+
+    post_failback_snapcounts = count_number_of_mirror_snaps()
+
+    if initial_snapcount < post_failback_snapcounts:
+        log.error(
+            "Sync point snapshot has been found remaining after the resync operation."
+        )
+        return 1
+
+    log.info("Sync point snaps are now found stale after resync, test case passed.")
+    return 0


### PR DESCRIPTION
# Description
Testcase title -
CEPH-10466 - sync-point snapshot should not be listed after the re-sync completes

Steps:
1. configure mirroring between two clusters.
2. Induce failure - Failover primary image.
3. While failing back,check snapshot list and make sure that sync point snapshot is deleted.

Files modified:
modified:   suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-5-to-latest.yaml
Replaced redundant test for pacific suite with newel automated test.

modified:   tests/rbd/rbd_utils.py
Added new option of checking all snaps in all namespaces.
This was needed for system created snaps - example: mirror

modified:   tests/rbd_mirror/rbd_mirror_utils.py
modified incorrect doc.

new file:   tests/rbd_mirror/test_sync_point_snapshot_deletion.py
Module handling newly being automated TC.

Signed-off-by: Vasishta <vashastr@redhat.com>

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
