### PR TITLE
Monitor sync performance and consistency via bucket stats

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
@@ -310,6 +310,7 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
+            monitor-consistency-bucket-stats: true
             timeout: 300
   - test:
       name: listing flat ordered buckets on secondary
@@ -321,6 +322,7 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
+            monitor-consistency-bucket-stats: true
             timeout: 300
   - test:
       name: listing flat unordered buckets on secondary
@@ -332,6 +334,7 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
+            monitor-consistency-bucket-stats: true
             timeout: 300
   - test:
       name: listing pseudo ordered dir only buckets on secondary
@@ -343,6 +346,7 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            monitor-consistency-bucket-stats: true
             timeout: 300
   - test:
       name: ordered listing of bucket with pseudo directories and objects
@@ -354,6 +358,7 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered.yaml
+            monitor-consistency-bucket-stats: true
             timeout: 300
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on secondary
@@ -365,6 +370,7 @@ tests:
           config:
             script-name: test_versioning_copy_objects.py
             config-file-name: test_versioning_copy_objects.yaml
+            monitor-consistency-bucket-stats: true
             timeout: 300
   - test:
       name: enable bucket versioning on secondary
@@ -376,6 +382,7 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_enable.yaml
+            monitor-consistency-bucket-stats: true
             verify-io-on-site: ["ceph-pri"]
             timeout: 300
   - test:

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -56,6 +56,7 @@ from utility.utils import (
     configure_kafka_security,
     install_start_kafka,
     setup_cluster_access,
+    test_sync_via_bucket_stats,
     verify_sync_status,
 )
 
@@ -210,6 +211,12 @@ def run(**kw):
                     user_details_file,
                 )
             verify_sync_status(copy_user_to_site.get_ceph_object("rgw").node)
+        monitor_consistency_via_bucket_stats = config.get(
+            "monitor-consistency-bucket-stats"
+        )
+        if monitor_consistency_via_bucket_stats:
+            log.info("Monitor sync consistency via bucket stats across sites.")
+            test_sync_via_bucket_stats(primary_rgw_node, secondary_rgw_node)
 
         verify_io_on_sites = config.get("verify-io-on-site", [])
         if verify_io_on_sites:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -146,6 +146,60 @@ def fuse_mount(fuse_clients, mounting_dir):
         log.error(e)
 
 
+def test_sync_via_bucket_stats(primary_rgw_node, secondary_rgw_node):
+    """
+    verify and monitor sync consistency via bucket stats across sites.
+    """
+    bucket_stat_pri_doc = json.loads(
+        primary_rgw_node.exec_command(cmd="sudo radosgw-admin bucket stats")[0]
+    )
+    bucket_stat_sec_doc = json.loads(
+        secondary_rgw_node.exec_command(cmd="sudo radosgw-admin bucket stats")[0]
+    )
+    total_buckets_pri = json.loads(
+        primary_rgw_node.exec_command(cmd="sudo radosgw-admin bucket list | wc -l")[0]
+    )
+    total_buckets_sec = json.loads(
+        secondary_rgw_node.exec_command(cmd="sudo radosgw-admin bucket list | wc -l")[0]
+    )
+    if total_buckets_pri == total_buckets_sec:
+        log.info("Number of buckets same on both sites, test data consistency now")
+        for bucket in range(0, total_buckets_pri - 2):
+            primary_objects = (
+                bucket_stat_pri_doc[bucket]["usage"]
+                .get("rgw.main", {})
+                .get("num_objects", 0)
+            )
+            secondary_objects = (
+                bucket_stat_sec_doc[bucket]["usage"]
+                .get("rgw.main", {})
+                .get("num_objects", 0)
+            )
+            primary_size_actual = (
+                bucket_stat_pri_doc[bucket]["usage"]
+                .get("rgw.main", {})
+                .get("size_actual", 0)
+            )
+            secondary_size_actual = (
+                bucket_stat_sec_doc[bucket]["usage"]
+                .get("rgw.main", {})
+                .get("size_actual", 0)
+            )
+            bucket_name = bucket_stat_sec_doc[bucket]["bucket"]
+            if (
+                primary_objects == secondary_objects
+                and primary_size_actual == secondary_size_actual
+            ):
+                log.info(f"bucket stats for bucket {bucket_name} is consistent")
+
+            else:
+                raise Exception(
+                    f"bucket stats for bucket {bucket_name} is inconsistent, test failure."
+                )
+    else:
+        raise Exception("Buckets not synced across sites, test failure.")
+
+
 def verify_sync_status(verify_io_on_site_node, retry=25, delay=60):
     """
     verify RGW multisite sync status


### PR DESCRIPTION
# Description

T2 automation-CEPH-83573208-Test the bucket stats behavior for sync performance and consistency.

This PR also addresses the issue filed https://github.com/red-hat-storage/ceph-qe-scripts/issues/279
[rgw/v2: Use bucket stats for doing verification on multisite]

This can be used based on the user input in the config file by providing **'monitor-consistency-bucket-stats: true'** 




Entire suite: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-B8R6Q0/
pass logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IB7NCV