### PR TITLE
BZ-2174235:[SERPRO]No metadata loss post a bucket is resharded.

### DIFF
--- a/suites/pacific/rgw/tier-2_sse_s3_encryption.yaml
+++ b/suites/pacific/rgw/tier-2_sse_s3_encryption.yaml
@@ -157,4 +157,14 @@ tests:
       name: test_sse_kms_per_object
       polarion-id: CEPH-83574040
 
+  - test:
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_bucket_index_shards.yaml
+        timeout: 300
+      desc: test_metadata_integrity_with_0_num_shards
+      module: sanity_rgw.py
+      name: test_metadata_integrity_with_0_num_shards
+      polarion-id: CEPH-83575472
+      comments: BUG-2174235, customer SERPRO
 


### PR DESCRIPTION
# Description

BZ-2174235:[SERPRO]No metadata loss post a bucket is resharded.


CEPH-83575472, bug 2174235


[Test if "bucket_index_max_shards" = 0, resharding a bucket will not remove bucket metadata](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575472)


Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SUUBYD
