### PR TITLE
[Automation-Tier2- Adding Error validation steps for Deletion of protected snapshot 

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -10,7 +10,6 @@ from tests.rbd.exceptions import (
     ImageIsDeletedError,
     ImageNotFoundError,
     ImportFileError,
-    ProtectSnapError,
     RbdBaseException,
 )
 from utility.log import Log
@@ -309,14 +308,7 @@ class Rbd:
             cmd = f"rbd snap rm --image-id {kw['image_id']} --pool {pool_name} --snap {snap_name}"
         else:
             cmd = f"rbd snap rm {pool_name}/{image_name}@{snap_name}"
-        out, err = self.exec_cmd(cmd=cmd, all=True, check_ec=False)
-        if "Removing snap: 0% complete...failed" not in err:
-            log.error(f"{out}")
-            raise ProtectSnapError(f" Removal of protected Snap failed: {out}")
-        log.debug(
-            f"Snapshot '{snap_name}' for image '{image_name}' in pool '{pool_name}' removed successfully: {out}"
-        )
-        log.info(f"{err}")
+        return self.exec_cmd(cmd=cmd, **kw)
 
     def protect_snapshot(self, snap_name):
         """


### PR DESCRIPTION
Jira ticket -https://issues.redhat.com/browse/RHCEPHQE-7783
Description-  Adding Error validation steps for Deletion of protected snapshot 
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9224

Test flow:

Create a pool and an Image
using KRBD client, map the image and run IOs using FIO
Perform snapshot create on a RBD image
Perform snapshot protect for the image
Perform clone of af an image, Have mulitple clones
Perform Delete of a snapshot which is protected
Cover the above steps on EC pool as well
Expected result-
at step 6 - Delete of a snap should fail since it is protected
Test Results:
latest logs attached - 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RUGCJX
