### PR TITLE
Add support to check for omap in cluster health

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -269,6 +269,21 @@ def verify_sync_status(verify_io_on_site_node, retry=25, delay=60):
     else:
         raise Exception("sync is either in progress or stuck")
 
+    # check for large omap in cluster status
+    check_ceph_status(verify_io_on_site_node)
+
+
+def check_ceph_status(site):
+    """
+    get the ceph cluster status and health
+    """
+    log.info("get ceph status")
+    ceph_status = site.exec_command(cmd="sudo ceph status")
+    if "HEALTH_ERR" in ceph_status or "large omap objects" in ceph_status:
+        raise Exception(
+            "ceph status is either in HEALTH_ERR or we have large omap objects."
+        )
+
 
 def kernel_mount(mounting_dir, mon_node_ip, kernel_clients):
     try:


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>
This PR is to check for cluster health for any large omaps. 
This is an extension of PR - https://github.com/red-hat-storage/ceph-qe-scripts/pull/421 

Pass logs: 
Pass logs with health_ok - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/large_omap/bucket_listing_health_ok_console.log

with large omap - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/large_omap/test_bucket_listing_large_omap.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
