### PR TITLE
set config parameters during multisite deployment

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -55,6 +55,7 @@ from utility.log import Log
 from utility.utils import (
     configure_kafka_security,
     install_start_kafka,
+    set_config_param,
     setup_cluster_access,
     test_sync_via_bucket_stats,
     verify_sync_status,
@@ -142,6 +143,10 @@ def run(**kw):
             if archive_cluster_exists:
                 setup_cluster_access(archive_cluster, archive_rgw_node)
                 setup_cluster_access(archive_cluster, archive_client_node)
+                set_config_param(archive_client_node)
+            ms_clusters = [primary_client_node, secondary_client_node]
+            for cluster_node in ms_clusters:
+                set_config_param(cluster_node)
     # run the test
     script_name = config.get("script-name")
     config_file_name = config.get("config-file-name")


### PR DESCRIPTION
# Description
This PR is to set ceph configuration parameters mentioned below, across all sites of a multisite cluster ( ceph-pri, ceph-sec, ceph-arc) on cluster deployment.
ceph configuration parameter:

- rgw_max_objs_per_shard = 5
- rgw_lc_debug_interval = 30
- osd_deep_scrub_large_omap_object_key_threshold = 200 

Pass logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FJE326/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
