### PR TITLE
CEPH:10417 - Test invalid inputs to arguments of 'ceph osd reweight-by' cmds

### DIFF
--- a/suites/pacific/rados/tier-4_rados_tests.yaml
+++ b/suites/pacific/rados/tier-4_rados_tests.yaml
@@ -1,0 +1,102 @@
+# Suite contains basic tier-4 rados tests
+# conf - conf/pacific/rados/11-node-cluster.yaml
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node8                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Test ceph osd command arguments
+      desc: Provide invalid values as argument to different ceph osd commands
+      module: test_osd_args.py
+      polarion-id: CEPH-10417
+      config:
+        cmd_list:
+          - "reweight-by-pg"
+          - "reweight-by-utilization"
+          - "test-reweight-by-pg"
+          - "test-reweight-by-utilization"

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -1,0 +1,102 @@
+# Suite contains basic tier-4 rados tests
+# conf - conf/quincy/rados/11-node-cluster.yaml
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node8                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Test ceph osd command arguments
+      desc: Provide invalid values as argument to different ceph osd commands
+      module: test_osd_args.py
+      polarion-id: CEPH-10417
+      config:
+        cmd_list:
+          - "reweight-by-pg"
+          - "reweight-by-utilization"
+          - "test-reweight-by-pg"
+          - "test-reweight-by-utilization"

--- a/tests/rados/test_osd_args.py
+++ b/tests/rados/test_osd_args.py
@@ -1,0 +1,90 @@
+"""
+Tier-4 test module to verify negative scenarios for 'ceph osd reweight' commands
+Currently executes the following cmds:
+    - ceph osd reweight-by-pg     [<oload:int>] [<max_change:float>] [<max_osds:int>]
+    - ceph osd reweight-by-utilization    [<oload:int>] [<max_change:float>] [<max_osds:int>]
+    - ceph osd test-reweight-by-pg    [<oload:int>] [<max_change:float>] [<max_osds:int>]
+    - ceph osd test-reweight-by-utilization    [<oload:int>] [<max_change:float>] [<max_osds:int>]
+Input Args checked:
+    oload | max_change | max_osds
+"""
+
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    #CEPH-10417
+    #BZ-1331770
+    This test is to verify negative scenarios and inputs for
+    'ceph osd' commands as listed below:
+    - ceph osd reweight-by-pg
+    - ceph osd reweight-by-utilization
+    - ceph osd test-reweight-by-pg
+    - ceph osd test-reweight-by-utilization
+    1. Create cluster with default configuration
+    2. Execute the commands with invalid inputs
+    3. Ensure that execution with invalid input fails
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    cmd_list = config["cmd_list"]
+    base_cmd = "ceph osd"
+    oload_invalid = [100, -10, 0, "abcd"]
+    max_invalid = [-10, 0, "abcd"]
+
+    def execute_cmd_verify() -> bool:
+        """
+        Executes the input command on installer node,
+        inside cephadm shell and verifies negative scenarios.
+        :param cmd: (string) command to run
+        :param value: invalid value for the cmd
+        :return: True -> pass | False -> fail
+        """
+        log.info(
+            f"Executing '{exec_cmd}' on {cephadm.installer.node.hostname} | Expected to fail"
+        )
+        out, err = cephadm.shell(args=[exec_cmd], check_status=False)
+        log.debug(f"stdout: {out}")
+        log.debug(f"stderr: {err}")
+        if type(value) == str and (
+            f"Invalid command: {value} doesn't represent a float" in err
+            or f"Invalid command: {value} doesn't represent an int"
+        ):
+            return True
+        else:
+            if "oload" in exec_cmd and (
+                "Error EINVAL: You must give a percentage higher than 100." in err
+                or "FAILED reweight-by-" in err
+            ):
+                return True
+            if f"{value} must be positive" in err:
+                return True
+        return False
+
+    try:
+        for _cmd in cmd_list:
+            for value in oload_invalid:
+                exec_cmd = f"{base_cmd} {_cmd} --oload {value}"
+                assert execute_cmd_verify()
+                log.info("Failed as expected")
+            for value in max_invalid:
+                exec_cmd = f"{base_cmd} {_cmd} --max_change {value}"
+                assert execute_cmd_verify()
+                log.info("Failed as expected")
+            for value in max_invalid:
+                exec_cmd = f"{base_cmd} {_cmd} --max_osds {value}"
+                assert execute_cmd_verify()
+                log.info("Failed as expected")
+            log.info(f"Verification for {base_cmd} {_cmd} completed")
+    except AssertionError as AE:
+        log.error(f"CMD: {exec_cmd} did not fail as expected")
+        log.error(f"Execution failed with exception: {AE.__doc__}")
+        log.exception(AE)
+        return 1
+    log.info("All verifications completed")
+    return 0


### PR DESCRIPTION
[CEPH-1041](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10417): Tier-4 test to verify negative scenarios around ceph osd reweight commands.
#[BZ-1331770](https://bugzilla.redhat.com/show_bug.cgi?id=1331770)
Commands covered - 

```
ceph osd reweight-by-pg       [<oload:int>] [<max_change:float>] [<max_osds:int>]
ceph osd reweight-by-utilization     [<oload:int>] [<max_change:float>] [<max_osds:int>]
ceph osd test-reweight-by-pg         [<oload:int>] [<max_change:float>] [<max_osds:int>]
ceph osd test-reweight-by-utilization        [<oload:int>] [<max_change:float>] [<max_osds:int>]
```

**Tests added -**
- tests/rados/test_osd_args.py

**Test suites modified -**
- suites/pacific/rados/tier-4_rados_tests.yaml
- suites/quincy/rados/tier-4_rados_tests.yaml

**Steps -**
1. Setup cluster with default config
2. Execute each command with invalid input for each argument
3. Ensure execution should fail with appropriate error msg

**Logs -**
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0BMV5N
RHCS 6.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AFWEQ1/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>