### PR TITLE
Adding TC_CEPH-11254

### DIFF
--- a/tests/cephfs/cephfs_system/mon_node_failure_ops.py
+++ b/tests/cephfs/cephfs_system/mon_node_failure_ops.py
@@ -1,0 +1,249 @@
+import secrets
+import string
+import traceback
+from datetime import datetime, timedelta
+from time import sleep
+
+from ceph.parallel import parallel
+from ceph.utils import check_ceph_healthly
+from tests.cephfs.cephfs_utilsV1 import FsUtils as FsUtilsV1
+from utility.log import Log
+
+log = Log(__name__)
+
+
+global stop_flag
+
+
+def start_io_time(fs_util, client1, mounting_dir, timeout=300):
+    global stop_flag
+    stop_flag = False
+    iter = 0
+    if timeout:
+        stop = datetime.now() + timedelta(seconds=timeout)
+    else:
+        stop = 0
+
+    while not stop_flag:
+        if stop and datetime.now() > stop:
+            log.info("Timed out *************************")
+            break
+        client1.exec_command(sudo=True, cmd=f"mkdir -p {mounting_dir}/run_ios_{iter}")
+        fs_util.run_ios(
+            client1, f"{mounting_dir}/run_ios_{iter}", io_tools=["smallfile"]
+        )
+        iter = iter + 1
+
+
+def run(ceph_cluster, **kw):
+    """
+    CEPH-11254 - MON failure/recovery with single and multiple services and client IOs-
+    - Mon daemon restart
+    - Mon node reboot
+    - Mon daemon kill
+    - Mon daemon stop and start
+    - MON network disconnect
+
+    Test Steps:
+    1. Mount Fuse and Kernel mounts
+    2. Run IOs and perform mon power off parallel
+    3. Do this on all the mon nodes in serial fashion
+    Args:
+        ceph_cluster:
+        **kw:
+
+    Returns:
+
+    """
+    try:
+        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        mon_nodes = ceph_cluster.get_ceph_objects("mon")
+        clients = ceph_cluster.get_ceph_objects("client")
+        config = kw.get("config")
+        osp_cred = config.get("osp_cred")
+        num_of_osds = config.get("num_of_osds")
+        build = config.get("build", config.get("rhbuild"))
+        print(osp_cred)
+        fs_name = "cephfs"
+        fs_util_v1.prepare_clients(clients, build)
+        fs_util_v1.auth_list(clients)
+        mon_node_ip = fs_util_v1.get_mon_node_ips()
+        mon_node_ip = ",".join(mon_node_ip)
+        kernel_mount_dir = "/mnt/kernel_" + "".join(
+            secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
+        )
+        fs_util_v1.kernel_mount(
+            [clients[0]],
+            kernel_mount_dir,
+            mon_node_ip,
+            new_client_hostname="admin",
+            extra_params=f",fs={fs_name}",
+        )
+        fuse_mount_dir = "/mnt/fuse_" + "".join(
+            secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
+        )
+
+        fs_util_v1.fuse_mount(
+            [clients[0]],
+            fuse_mount_dir,
+            new_client_hostname="admin",
+            extra_params=f" --client_fs {fs_name}",
+        )
+        with parallel() as p:
+            p.spawn(
+                start_io_time,
+                fs_util_v1,
+                clients[0],
+                fuse_mount_dir,
+                timeout=0,
+            )
+            p.spawn(
+                start_io_time,
+                fs_util_v1,
+                clients[0],
+                kernel_mount_dir,
+            )
+            global stop_flag
+            for mon in mon_nodes:
+                cluster_health_beforeIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                fs_util_v1.reboot_node(ceph_node=mon)
+                cluster_health_afterIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                if cluster_health_afterIO == cluster_health_beforeIO:
+                    log.info("cluster is healthy")
+                else:
+                    log.error("cluster is not healty")
+            log.info("Rebooted all the nodes and cluster is Healthy")
+            for mon in mon_nodes:
+                cluster_health_beforeIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                fs_util_v1.deamon_op(mon, "mon", "restart")
+                cluster_health_afterIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                if cluster_health_afterIO == cluster_health_beforeIO:
+                    log.info("cluster is healthy")
+                else:
+                    log.error("cluster is not healty")
+            log.info("Restarted all the mon services and cluster is Healthy")
+
+            for mon in mon_nodes:
+                cluster_health_beforeIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                fs_util_v1.pid_kill(mon, "mon")
+                cluster_health_afterIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                if cluster_health_afterIO == cluster_health_beforeIO:
+                    log.info("cluster is healthy")
+                else:
+                    log.error("cluster is not healty")
+            log.info("killed all the mon services and cluster is Healthy")
+            for mon in mon_nodes:
+                cluster_health_beforeIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                deamon_name = fs_util_v1.deamon_name(mon, "mon")
+                fs_util_v1.deamon_op(mon, "mon", "stop")
+                sleep(60)
+                fs_util_v1.deamon_op(mon, "mon", "start", service_name=deamon_name)
+                cluster_health_afterIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                if cluster_health_afterIO == cluster_health_beforeIO:
+                    log.info("cluster is healthy")
+                else:
+                    log.error("cluster is not healty")
+            log.info(
+                "mon services have been stopped and started and cluster is Healthy"
+            )
+            for mon in mon_nodes:
+                cluster_health_beforeIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                fs_util_v1.network_disconnect(mon)
+                cluster_health_afterIO = check_ceph_healthly(
+                    clients[0],
+                    num_of_osds,
+                    len(mon_nodes),
+                    build,
+                    None,
+                    300,
+                )
+                if cluster_health_afterIO == cluster_health_beforeIO:
+                    log.info("cluster is healthy")
+                else:
+                    log.error("cluster is not healty")
+            log.info(
+                "mon services have been stopped and started and cluster is Healthy"
+            )
+            log.info("Setting stop flag")
+            stop_flag = True
+        return 0
+
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        stop_flag = True
+        return 1
+    finally:
+        log.info("Cleaning up the system")
+        stop_flag = True
+        fs_util_v1.client_clean_up(
+            "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mount_dir
+        )
+        fs_util_v1.client_clean_up(
+            "umount",
+            kernel_clients=[clients[0]],
+            mounting_dir=kernel_mount_dir,
+        )

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -115,7 +115,7 @@ class FsUtils(object):
         return output_dict
 
     @staticmethod
-    def deamon_op(node, service, op):
+    def deamon_op(node, service, op, **kwargs):
         """
         It performs given operation on service given
         Args:
@@ -126,12 +126,21 @@ class FsUtils(object):
         Returns:
 
         """
+        if kwargs.get("service_name"):
+            node.exec_command(
+                sudo=True, cmd=f"systemctl {op} {kwargs.get('service_name')}"
+            )
+        service_deamon = FsUtils.deamon_name(node, service)
+        node.exec_command(sudo=True, cmd=f"systemctl {op} {service_deamon}")
+
+    @staticmethod
+    def deamon_name(node, service):
         out, rc = node.exec_command(
             sudo=True,
             cmd=f"systemctl list-units --type=service | grep {service}.ceph | awk {{'print $1'}}",
         )
         service_deamon = out.strip()
-        node.exec_command(sudo=True, cmd=f"systemctl {op} {service_deamon}")
+        return service_deamon
 
     @staticmethod
     @retry(CommandFailed, tries=5, delay=60)
@@ -1632,6 +1641,34 @@ class FsUtils(object):
                 node=ceph_node.node.ip_address
             )
         )
+
+    def pid_kill(self, node, daemon):
+        out, rc = node.exec_command(cmd="pgrep %s " % daemon, container_exec=False)
+        out = out.split("\n")
+        out.pop()
+        for pid in out:
+            node.exec_command(sudo=True, cmd="kill -9 %s" % pid, container_exec=False)
+            sleep(10)
+        return 0
+
+    def network_disconnect(self, ceph_object, sleep_time=20):
+        script = f"""import time,os
+os.system('sudo systemctl stop network')
+time.sleep({sleep_time})
+os.system('sudo systemctl start  network')
+    """
+        node = ceph_object.node
+        nw_disconnect = node.remote_file(
+            sudo=True, file_name="/home/cephuser/nw_disconnect.py", file_mode="w"
+        )
+        nw_disconnect.write(script)
+        nw_disconnect.flush()
+
+        log.info("Stopping the network..")
+        node.exec_command(sudo=True, cmd="yum install -y python3")
+        node.exec_command(sudo=True, cmd="python3 /home/cephuser/nw_disconnect.py")
+        log.info("Starting the network..")
+        return 0
 
     def node_power_failure(
         self,


### PR DESCRIPTION
# Description
Adding TC_CEPH-11254
CEPH-11254 - MON failure/recovery with single and multiple services and client IOs- Mon daemon restart- Mon node reboot- Mon daemon kill- Mon daemon stop and start- MON network disconnect

logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BG2O2B/
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of 

customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
