### PR TITLE
Test for restart osd while split is in progress

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -102,3 +102,21 @@ tests:
               pool_type: replicated
         delete_pools:
           - pool1
+
+  - test:
+      name: Verify restart osd during PG split
+      module: test_pg_split.py
+      desc: Verify restart osd when PG split in progress
+      polarion-id: CEPH-11667
+      config:
+        create_pools:
+          - create_pool:
+              restart_osd: true
+              pool_name: pool1
+              pg_num: 64
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool1


### PR DESCRIPTION
# Description

CEPH-11667 - [RADOS]: Restarting the osd while splits are in progress

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QEOCJC/