### PR TITLE
[Lib] Include rbd config methods

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -621,6 +621,66 @@ class Rbd:
         log.info(f"Starting the {action} migration process")
         return self.exec_cmd(cmd=f"rbd migration {action} {dest_spec}")
 
+    def list_config(self, level, entity, **kw):
+        """List all RBD config settings.
+
+        rbd config <global|pool|image> list <entity>
+
+        Args:
+            level: global|pool|image level configuration
+            entity: config entity (global or image-name or pool-name)
+            kw: other rbd arguments like config options
+        Returns:
+            exec_cmd response
+        """
+        return self.exec_cmd(cmd=f"rbd config {level} list {entity}", **kw)
+
+    def get_config(self, level, entity, key, **kw):
+        """Get RBD config settings.
+
+        rbd config <global|pool|image> get <entity> <key>
+
+        Args:
+            level: global|pool|image level configuration
+            entity: config entity (global or image-name or pool-name)
+            key: config option key (ex., rbd_move_to_trash_on_remove)
+            kw: other rbd arguments like config options
+        Returns:
+            exec_cmd response
+        """
+        return self.exec_cmd(cmd=f"rbd config {level} get {entity} {key}", **kw)
+
+    def remove_config(self, level, entity, key, **kw):
+        """Remove RBD config settings.
+
+        rbd config <global|pool|image> remove <entity> <key>
+
+        Args:
+            level: global|pool|image level configuration
+            entity: config entity (global or image-name or pool-name)
+            key: config option key (ex., rbd_move_to_trash_on_remove)
+            kw: other rbd arguments like config options
+        Returns:
+            exec_cmd response
+        """
+        return self.exec_cmd(cmd=f"rbd config {level} remove {entity} {key}", **kw)
+
+    def set_config(self, level, entity, key, value, **kw):
+        """Override RBD config settings.
+
+        rbd config <global|pool|image> set <entity> <key> <value>
+
+        Args:
+            level: global|pool|image level configuration
+            entity: config entity (global, image-name, pool-name)
+            key: config option key (ex., rbd_move_to_trash_on_remove)
+            value: config option value to be set
+            kw: other rbd arguments like config options
+        Returns:
+            exec_cmd response
+        """
+        return self.exec_cmd(cmd=f"rbd config {level} set {entity} {key} {value}", **kw)
+
 
 def initial_rbd_config(**kw):
     """


### PR DESCRIPTION
- Methods for RBD config options at global, pool and image level.

> config global get config-entity key
> Get a global-level configuration override.
> 
> config global list [–format plain | json | xml] [–pretty-format] config-entity
> List global-level configuration overrides.
> 
> config global set config-entity key value
> Set a global-level configuration override.
> 
> config global remove config-entity key
> Remove a global-level configuration override.
> 
> config image get image-spec key
> Get an image-level configuration override.
> 
> config image list [–format plain | json | xml] [–pretty-format] image-spec
> List image-level configuration overrides.
> 
> config image set image-spec key value
> Set an image-level configuration override.
> 
> config image remove image-spec key
> Remove an image-level configuration override.
> 
> config pool get pool-name key
> Get a pool-level configuration override.
> 
> config pool list [–format plain | json | xml] [–pretty-format] pool-name
> List pool-level configuration overrides.
> 
> config pool set pool-name key value
> Set a pool-level configuration override.
> 
> config pool remove pool-name key
> Remove a pool-level configuration override.
> 