### PR TITLE
Restricting rp_client to 5.2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "junitparser",
         "paramiko",
         "pyyaml",
-        "reportportal-client",
+        "reportportal-client==5.2.5",
         "requests",
         "softlayer",
     ],


### PR DESCRIPTION
# Description
Restricting reportportal_client to5.2.5.
latest reportportal_client 5.3.0 is causing  issues. 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
