### PR TITLE
CEPH-83572740: Check Cluster Health warning when Objects have large number of OMAP entries

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -468,15 +468,19 @@ class RadosOrchestrator:
          Args:
             kwargs:
             1. osd : if an OSD id is passed , scrub to be triggered on that osd
-                    eg: obj.run_scrub(osd=3)
+                    eg- obj.run_scrub(osd=3)
             2. pgid: if a PGID is passed, scrubs are run on that PG
-                    eg: obj.run_scrub(pgid=1.0)
+                    eg- obj.run_scrub(pgid=1.0)
+            3. pool: if pool name is passed, scrubs are run on that pool
+                    eg- obj.run_scrub(pool="test-pool")
          Returns: None
         """
         if kwargs.get("osd"):
             cmd = f"ceph osd scrub {kwargs.get('osd')}"
         elif kwargs.get("pgid"):
             cmd = f"ceph pg scrub {kwargs.get('pgid')}"
+        elif kwargs.get("pool"):
+            cmd = f"ceph osd pool scrub {kwargs.get('pool')}"
         else:
             # scrubbing all the OSD's
             cmd = "ceph osd scrub all"
@@ -486,17 +490,21 @@ class RadosOrchestrator:
         """
         Run scrub on the given OSD or on all OSD's
             Args:
-            kwargs:
-            1. osd : if a OSD id is passed , deep-scrub to be triggered on that osd
-                    eg: obj.run_deep_scrub(osd=3)
-            2. pgid: if a PGID is passed, deep-scrubs are run on that PG
-                    eg: obj.run_deep_scrub(pgid=1.0)
+                kwargs:
+                1. osd : if an OSD id is passed , deep-scrub to be triggered on that osd
+                        eg- obj.run_deep_scrub(osd=3)
+                2. pgid: if a PGID is passed, deep-scrubs are run on that PG
+                        eg- obj.run_deep_scrub(pgid=1.0)
+                3. pool: if pool name is passed, deep-scrubs are run on that pool
+                        eg- obj.run_deep_scrub(pool="test-pool")
             Returns: None
         """
         if kwargs.get("osd"):
             cmd = f"ceph osd deep-scrub {kwargs.get('osd')}"
         elif kwargs.get("pgid"):
             cmd = f"ceph pg deep-scrub {kwargs.get('pgid')}"
+        elif kwargs.get("pool"):
+            cmd = f"ceph osd pool deep-scrub {kwargs.get('pool')}"
         else:
             # scrubbing all the OSD's
             cmd = "ceph osd deep-scrub all"
@@ -936,10 +944,10 @@ class RadosOrchestrator:
         """
         Changes the state of the OSD daemons wrt the action provided
         Args:
-            action: operation to be performed on the service, i.e
+            action: operation to be performed on the service, i.e.
             start, stop, restart, disable, enable
             target: ID osd the target OSD
-            timeout: timeout in seconds, (default = 10s)
+            timeout: timeout in seconds, (default = 15s)
         Returns: Pass -> True, Fail -> False
         """
         cluster_fsid = self.run_ceph_command(cmd="ceph fsid")["fsid"]
@@ -979,7 +987,7 @@ class RadosOrchestrator:
                 )
                 return False
         else:
-            time.sleep(5)
+            time.sleep(7)
         return True
 
     def fetch_host_node(self, daemon_type: str, daemon_id: str = None):
@@ -1264,3 +1272,45 @@ class RadosOrchestrator:
         osd_stats = self.run_ceph_command(cmd=cmd)
         log.debug(f" The OSD Statistics are : {osd_stats}")
         return osd_stats
+
+    def get_pgid(
+        self,
+        pool_name: str = None,
+        pool_id: int = None,
+        osd: int = None,
+        osd_primary: int = None,
+    ) -> list:
+        """
+        Retrieves all the PG IDs for a pool or PG IDs where a
+        certain osd is primary in the acting set or PG IDs which are
+        utilizing the concerned osd
+        Ideally, only one argument should be provided
+        Args:
+            pool_name: name of the pool
+            pool_id: pool id
+            osd: osd id whose pgs are to be retrieved
+            osd_primary: primary osd id whose pgs are to be retrieved
+        Returns:
+            list having pgids in string format
+        """
+
+        pgid_list = []
+        cmd = "ceph pg "
+        if pool_name:
+            cmd += f"ls-by-pool {pool_name}"
+        elif pool_id:
+            cmd += f"ls {pool_id}"
+        elif osd:
+            cmd += f"ls-by-osd {osd}"
+        elif osd_primary:
+            cmd += f"ls-by-primary {osd_primary}"
+        else:
+            log.info("No argument was provided.")
+            return pgid_list
+
+        pgid_dict = self.run_ceph_command(cmd=cmd)
+
+        for pg_stats in pgid_dict["pg_stats"]:
+            pgid_list.append(pg_stats["pgid"])
+
+        return pgid_list

--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -201,25 +201,36 @@ tests:
       polarion-id: CEPH-83571702
       config:
         verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: ec_pool_3
-              pool_type: erasure
-              pg_num: 1
-              k: 8
-              m: 4
-              plugin: jerasure
-              crush-failure-domain: osd
-              disable_pg_autoscale: true
+          pool_config:
+            # EC pool config is commented out because
+            # omap entries is not working on an EC pool
+#            pool-1:
+#              pool_name: ec_pool_3
+#              pool_type: erasure
+#              pg_num: 1
+#              k: 8
+#              m: 4
+#              plugin: jerasure
+#              crush-failure-domain: osd
+#              disable_pg_autoscale: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_3
               pg_num: 1
               disable_pg_autoscale: true
           omap_config:
-            obj_start: 0
-            obj_end: 4000
-            num_keys_obj: 20000
+            small_omap:
+              large_warn: false
+              obj_start: 0
+              obj_end: 5
+              normal_objs: 400
+              num_keys_obj: 200000
+            large_omap:
+              large_warn: true
+              obj_start: 0
+              obj_end: 5
+              normal_objs: 400
+              num_keys_obj: 200001
       desc: Large number of omap creations on objects backed by bluestore
 
   - test:

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -187,25 +187,36 @@ tests:
       polarion-id: CEPH-83571702
       config:
         verify_osd_omap_entries:
-          configurations:
-            pool-1:
-              pool_name: ec_pool_3
-              pool_type: erasure
-              pg_num: 1
-              k: 8
-              m: 4
-              plugin: jerasure
-              crush-failure-domain: osd
-              disable_pg_autoscale: true
+          pool_config:
+            # EC pool config is commented out because
+            # omap entries is not working on an EC pool
+#            pool-1:
+#              pool_name: ec_pool_3
+#              pool_type: erasure
+#              pg_num: 1
+#              k: 8
+#              m: 4
+#              plugin: jerasure
+#              crush-failure-domain: osd
+#              disable_pg_autoscale: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_3
               pg_num: 1
               disable_pg_autoscale: true
           omap_config:
-            obj_start: 0
-            obj_end: 4000
-            num_keys_obj: 20000
+            small_omap:
+              large_warn: false
+              obj_start: 0
+              obj_end: 5
+              normal_objs: 400
+              num_keys_obj: 200000
+            large_omap:
+              large_warn: true
+              obj_start: 0
+              obj_end: 5
+              normal_objs: 400
+              num_keys_obj: 200001
       desc: Large number of omap creations on objects backed by bluestore
 
   - test:

--- a/tests/rados/test_omap_entries.py
+++ b/tests/rados/test_omap_entries.py
@@ -25,60 +25,92 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     pool_obj = PoolFunctions(node=cephadm)
+    client_node = rados_obj.ceph_cluster.get_nodes(role="client")[0]
 
-    pool_target_configs = config["verify_osd_omap_entries"]["configurations"]
+    pool_target_configs = config["verify_osd_omap_entries"]["pool_config"]
     omap_target_configs = config["verify_osd_omap_entries"]["omap_config"]
 
     # Creating pools and starting the test
     for entry in pool_target_configs.values():
-        log.debug(
-            f"Creating {entry['pool_type']} pool on the cluster with name {entry['pool_name']}"
-        )
-        if entry.get("pool_type", "replicated") == "erasure":
-            method_should_succeed(
-                rados_obj.create_erasure_pool, name=entry["pool_name"], **entry
-            )
-        else:
-            method_should_succeed(
-                rados_obj.create_pool,
-                **entry,
-            )
-
-        log.debug(
-            "Created the pool. beginning to create large number of omap entries on the pool"
-        )
-        if not pool_obj.fill_omap_entries(
-            pool_name=entry["pool_name"], **omap_target_configs
-        ):
-            log.error(f"Omap entries not generated on pool {entry['pool_name']}")
-            return 1
-
-        # Fetching the current acting set for the pool
-        acting_set = rados_obj.get_pg_acting_set(pool_name=entry["pool_name"])
-        rados_obj.change_recover_threads(config={}, action="set")
-        log.debug(f"Proceeding to restart OSd's from the acting set {acting_set}")
-        for osd_id in acting_set:
-            rados_obj.change_osd_state(action="stop", target=osd_id)
-            # sleeping for 5 seconds for re-balancing to begin
-            time.sleep(5)
-
-            # Waiting for cluster to get clean state after OSD stopped
-            if not wait_for_clean_pg_sets(rados_obj):
-                log.error("PG's in cluster are not active + Clean state.. ")
-                return 1
-            rados_obj.change_osd_state(action="restart", target=osd_id)
+        try:
             log.debug(
-                f"Cluster reached clean state after osd {osd_id} stop and restart"
+                f"Creating {entry['pool_type']} pool on the cluster with name {entry['pool_name']}"
             )
+            if entry.get("pool_type", "replicated") == "erasure":
+                log.info(
+                    "\n***[27-Mar-2023]***\nIt has been found that omap entries/object creation "
+                    "on an EC pool with concerned python script(generate_omap_entries.py) "
+                    "is not working.\nA BZ will be raised for this and this test will be "
+                    "updated post resolution, until then EC pool section of this test "
+                    "shall remain inactive."
+                )
+                method_should_succeed(
+                    rados_obj.create_erasure_pool, name=entry["pool_name"], **entry
+                )
+            else:
+                method_should_succeed(rados_obj.create_pool, **entry)
 
-        rados_obj.change_recover_threads(config={}, action="rm")
-        # deleting the pool created after the test
-        rados_obj.detete_pool(pool=entry["pool_name"])
+            for omap_config in omap_target_configs.keys():
+                normal_objs = omap_target_configs[omap_config]["normal_objs"]
+                # create n number of objects without any omap entry
+                pool_obj.do_rados_put(
+                    client=client_node, pool=entry["pool_name"], nobj=normal_objs
+                )
 
-        log.info(
-            f"All the OSD's from the acting set {acting_set} were restarted "
-            f"and object movement completed for pool {entry['pool_name']}"
-        )
+                # calculate objects to be written with omaps and begin omap creation process
+                omap_obj_num = (
+                    omap_target_configs[omap_config]["obj_end"]
+                    - omap_target_configs[omap_config]["obj_start"]
+                )
+                log.debug(
+                    "Created the pool. beginning to create large number of omap entries on the pool"
+                )
+                if not pool_obj.fill_omap_entries(
+                    pool_name=entry["pool_name"], **omap_target_configs[omap_config]
+                ):
+                    log.error(
+                        f"Omap entries not generated on pool {entry['pool_name']}"
+                    )
+                    raise Exception(
+                        f"Omap entries not generated on pool {entry['pool_name']}"
+                    )
+
+                assert pool_obj.check_large_omap_warning(
+                    pool=entry["pool_name"],
+                    obj_num=omap_obj_num,
+                    check=omap_target_configs[omap_config]["large_warn"],
+                )
+
+            # Fetching the current acting set for the pool
+            acting_set = rados_obj.get_pg_acting_set(pool_name=entry["pool_name"])
+            rados_obj.change_recover_threads(config={}, action="set")
+            log.debug(f"Proceeding to restart OSDs from the acting set {acting_set}")
+            for osd_id in acting_set:
+                rados_obj.change_osd_state(action="stop", target=osd_id)
+                # sleeping for 5 seconds for re-balancing to begin
+                time.sleep(5)
+
+                # Waiting for cluster to get clean state after OSD stopped
+                if not wait_for_clean_pg_sets(rados_obj):
+                    log.error("PG's in cluster are not active + Clean state.. ")
+                    raise Exception("PG's in cluster are not active + Clean state.. ")
+                rados_obj.change_osd_state(action="restart", target=osd_id)
+                log.debug(
+                    f"Cluster reached clean state after osd {osd_id} stop and restart"
+                )
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            return 1
+        finally:
+            rados_obj.change_recover_threads(config={}, action="rm")
+            # deleting the pool created after the test
+            rados_obj.detete_pool(pool=entry["pool_name"])
+
+            log.info(
+                f"All the OSD's from the acting set {acting_set} were restarted "
+                f"and object movement completed for pool {entry['pool_name']}"
+            )
 
     log.info("Completed testing effects of large number of omap entries on pools ")
     return 0


### PR DESCRIPTION
[CEPH-83572740](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83572740): Tier-2 test to ensure Ceph Cluster health warning gets triggered with appropriate message when a pool contains objects having omap entries beyond the threshold.

Current threshold at time of automation is 200000

**_[CEPH-83572740](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83572740) is being merged with existing Polarion test - [CEPH-83571702](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571702) and will be marked inactive_**

References:
- https://access.redhat.com/solutions/6450561
- https://www.42on.com/how-to-handle-large-omap-objects/
- https://ceph-users.ceph.narkive.com/IORITRg4/large-omap-objects-how-to-fix

**Test modules modified:**
_run_scrub_ in _ceph/rados/core_workflows.py_
_run_deep_scrub_ in _ceph/rados/core_workflows.py_
_fill_omap_entries_ in _ceph/rados/pool_workflows.py_
_tests/rados/test_omap_entries.py_

**Test modules added:**
_get_pgid_ in _ceph/rados/core_workflows.py_
_check_large_omap_warning_ in _ceph/rados/pool_workflows.py_

**Steps:**
1. Create a cluster with default config
2. Create a replicated pool with single pg
3. Perform IOPS with regular objects(rados put)
4. Create objects with omap entries just below the threshold. 
5. Perform deep-scrub on the pool. Ensure no health warning
6. Create objects with omap entries above the threshold. 
7. Perform deep-scrub on the pool. Ensure correct health warning shows up

**Logs:**
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WKW5AV/
RHCS 6.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1Q1T5A/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
