### PR TITLE
Integrate testcase CEPH-11574 to cephci

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -349,6 +349,16 @@ tests:
         config-file-name: test_bucket_policy_modify.yaml
         timeout: 300
 
+  - test:
+      name: ListBucketVersions with bucket policy for users in same tenant
+      desc: Test ListBucketVersions bucket policy for users in same tenant
+      polarion-id: CEPH-11574
+      module: sanity_rgw.py
+      config:
+        script-name: test_list_all_multipart_uploads.py
+        config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
+        timeout: 300
+
   # Bucket Lifecycle Tests
 
   - test:

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -228,6 +228,17 @@ tests:
         config-file-name: test_versioning_objects_delete_from_another_user.yaml
         timeout: 300
 
+  # BucketPolicy Tests
+  - test:
+      name: ListBucketVersions with bucket policy for users in same tenant
+      desc: Test ListBucketVersions bucket policy for users in same tenant
+      polarion-id: CEPH-11574
+      module: sanity_rgw.py
+      config:
+        script-name: test_list_all_multipart_uploads.py
+        config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
+        timeout: 300
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.


### PR DESCRIPTION
# Description
T2 automation-CEPH-11574-s3:ListBucketVersions with users in same tenant

log: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-a78zn/ListBucketVersions_with_bucket_policy_for_users_in_same_tenant_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-zcz0d/ListBucketVersions_with_bucket_policy_for_users_in_same_tenant_0.log

Steps: 

1. Set policy s3:ListBucketVersions from user1 to user2 and user3 
2. Set versioning enabled for the bucket 
3. Now, try to get the list bucket versions from user2 and user3



<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</de
tails>
