### PR TITLE
Include version tc in quincy

### DIFF
--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -228,6 +228,46 @@ tests:
         config-file-name: test_versioning_objects_delete_from_another_user.yaml
         timeout: 300
 
+  - test:
+      name: Versioning with copy objects and delete with different user
+      desc: Versioning with copy objects and delete with different user
+      polarion-id: CEPH-9353 # Also applies for CEPH-10215
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_copy_objects.py
+        config-file-name: test_delete_version_object_using_different_user.yaml
+        timeout: 300
+
+  - test:
+      name: Test deleting the current version of the object
+      desc: Deleting the current version of the object
+      polarion-id: CEPH-10647
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_with_objects.py
+        config-file-name: test_delete_current_version_object.yaml
+        timeout: 300
+
+  - test:
+      name: Test copy versioned objects to another versioned bucket
+      desc: copy versioned objects to another versioned bucket
+      polarion-id: CEPH-10644
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_copy_objects.py
+        config-file-name: test_copy_version_object_to_version_bucket.yaml
+        timeout: 300
+
+  - test:
+      name: Test Write modify and read objects in the versioned bucket
+      desc: Test Write modify and read objects in the versioned bucket
+      polarion-id: CEPH-10641
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_with_objects.py
+        config-file-name: test_access_versioned_objects.yaml
+        timeout: 300
+
   # BucketPolicy Tests
   - test:
       name: ListBucketVersions with bucket policy for users in same tenant
@@ -551,4 +591,3 @@ tests:
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
         timeout: 500
-


### PR DESCRIPTION
Including test cases in quincy- testsuite: cephci/suites/quincy/rgw/tier-2_rgw_regression.yaml
CEPH-9353: As a different user other than bucket owner, issue a DELETE on object
CEPH-10647: Delete the current version of the object
CEPH-10644: Copy versioned objects to another versioned 
CEPH-10641: Write, modify and read objects in the versioned container

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-scdwu/
failure is not related to current PR

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
