### PR TITLE
fix odf RHCS deploy interop suite

### DIFF
--- a/suites/quincy/integrations/ocs.yaml
+++ b/suites/quincy/integrations/ocs.yaml
@@ -94,7 +94,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node1
+        node: node8           # new client node
         install_packages:
           - ceph-common
         copy_admin_keyring: true


### PR DESCRIPTION
**Issue:**
client configured on node1, But node8 is actual client node which test_cluster_health.py
```
- test:
    abort-on-fail: true
    config:
      command: add
      id: client.1
      node: node1
      install_packages:
        - ceph-common
      copy_admin_keyring: true
    desc: Configure the ceph client
    destroy-cluster: false
    module: test_client.py
    name: configure client
```
```
node8:
  role: client
```

