### PR TITLE
CEPH-83573341 - Set read only on namespace and migrate the images and verify if migration is blocked

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -353,3 +353,24 @@ tests:
       module: rbd_resize_image_with_image_feature.py
       name: Test to verify image resize operation while changing image feature
       polarion-id: CEPH-9861
+
+  - test:
+      desc: Image migration from namespace for read-only client
+      module: readonly_namespace_image_migration.py
+      config:
+        source:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec1
+        destination:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec2
+      name: Test image migration from namespace for read-only client
+      polarion-id: CEPH-83573341

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -353,3 +353,24 @@ tests:
       module: rbd_resize_image_with_image_feature.py
       name: Test to verify image resize operation while changing image feature
       polarion-id: CEPH-9861
+
+  - test:
+      desc: Image migration pool namespace
+      module: readonly_namespace_image_migration.py
+      config:
+        source:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec1
+        destination:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec2
+      name: Test image migration from pool namespace
+      polarion-id: CEPH-83573341

--- a/tests/rbd/readonly_namespace_image_migration.py
+++ b/tests/rbd/readonly_namespace_image_migration.py
@@ -1,0 +1,181 @@
+"""Module to execute Live migration scenario namespace from client-X
+having read-only permission to images.
+
+Pre-requisites :
+We need cluster configured with atleast one client node with ceph-common package,
+conf and keyring files
+
+Test cases covered :
+CEPH-83573341 - Set read only for client-x on namespace and migrate the images and
+verify migration is not allowed
+
+Test Case Flow :
+1. Create pool.
+2. Create a namespace within the pool
+3. Give readonly access to the namespace
+4. Create images within the namespace
+5. Migrate the created images to other pool
+6. verify that image migration is not allowed as image is read-only for client-x.
+"""
+
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd.rbd_utils import (
+    Rbd,
+    client_config_read_only,
+    initial_rbd_config,
+    verify_namespace_exist,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def image_migrate_and_verify(
+    rbd,
+    src_pool,
+    dest_pool,
+    namespace,
+    image,
+):
+    """Migrate the image from source to destination and verify migration
+
+    Args:
+        src_pool: source pool name
+        dest_pool: destination pool name
+        namespace: name of namespace
+    """
+    src_spec1 = src_pool + "/" + namespace + "/" + image
+    dest_spec1 = dest_pool + "/" + image
+    client_id = "client.1"
+    mgr_role = "profile rbd-read-only"
+    osd_role = "profile rbd-read-only"
+    if client_config_read_only(
+        rbd,
+        client_id,
+        src_pool,
+        namespace=namespace,
+        mgr_role=mgr_role,
+        osd_role=osd_role,
+    ):
+        log.error("verify for command syntax")
+        return 1
+    rbd.create_image(
+        pool_name=src_pool,
+        image_name=image,
+        size="5G",
+        namespace=namespace,
+    )
+    rbd.image_exists(
+        pool_name=src_pool,
+        image_name=image,
+        namespace=namespace,
+    )
+    out, err = rbd.migration_prepare(src_spec1, dest_spec1, client_id=client_id)
+    if "Migration: prepare: failed to open image" in err:
+        log.error(f"{err}")
+        log.info(
+            "Image migration for client-x having read-only permission to images "
+            "from namespace is successfully blocked"
+        )
+        return 0
+    else:
+        log.error(
+            "Image migration is allowed for client-x having read-only permission "
+            "to images in namespace"
+        )
+        return 1
+
+
+def run(**kw):
+    """verify for image migration when Set read only permission to client-x on namespace
+    and migrate the images.
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+    """
+
+    for key, value in kw["config"].items():
+        if key == "source":
+            kw["config"].update(value)
+            initial_rbd_config(**kw)
+            for key in kw["config"]["source"]:
+                kw["config"].pop(key)
+            kw["config"].pop("ec-pool-k-m")
+        elif key == "destination":
+            kw["config"].update(value)
+            initial_rbd_config(**kw)
+            for key in kw["config"]["destination"]:
+                kw["config"].pop(key)
+            kw["config"].pop("ec-pool-k-m")
+
+    rbd = Rbd(**kw)
+    src_pools = []
+    src_pool1 = kw["config"]["source"]["rep_pool_config"]["pool"]
+    src_pools.append(src_pool1)
+    src_pool2 = kw["config"]["source"]["ec_pool_config"]["pool"]
+    src_pools.append(src_pool2)
+    dest_pool1 = kw["config"]["destination"]["rep_pool_config"]["pool"]
+    dest_pool2 = kw["config"]["destination"]["ec_pool_config"]["pool"]
+    namespace = kw["config"].get("namespace", "testnamespace")
+    flag = 0
+    try:
+        # create namesapce for rep_pool and ec_pool
+        for pool in src_pools:
+            rbd.create_namespace(pool, namespace)
+            verify_namespace_exist(rbd, pool, namespace)
+
+        # backup the client.1 keyring file
+        cmd = (
+            "cp /etc/ceph/ceph.client.1.keyring /etc/ceph/ceph.client.1.keyring.backup"
+        )
+        rbd.exec_cmd(cmd=cmd)
+
+        log.info("running test case on Replication pool")
+        if image_migrate_and_verify(
+            rbd,
+            src_pool=src_pool1,
+            dest_pool=dest_pool1,
+            namespace=namespace,
+            image="rbd_rep_image",
+        ):
+            flag = 1
+
+        log.info("Running test case on EC pool")
+        if image_migrate_and_verify(
+            rbd,
+            src_pool=src_pool2,
+            dest_pool=dest_pool2,
+            namespace=namespace,
+            image="rbd_ec_image",
+        ):
+            flag = 1
+
+        if flag:
+            log.error("Test case failed")
+
+        return flag
+
+    except RbdBaseException as error:
+        log.error(error.message)
+
+    finally:
+        if not kw.get("config").get("do_not_cleanup_pool"):
+            rbd.clean_up(
+                pools=[
+                    src_pool1,
+                    src_pool2,
+                    dest_pool1,
+                    dest_pool2,
+                    kw["config"]["source"]["ec_pool_config"]["data_pool"],
+                    kw["config"]["destination"]["ec_pool_config"]["data_pool"],
+                ]
+            )
+        rbd.exec_cmd(cmd="rm -rf /etc/ceph/ceph.client.1.keyring")
+        rbd.exec_cmd(
+            cmd="mv /etc/ceph/ceph.client.1.keyring.backup /etc/ceph/ceph.client.1.keyring"
+        )
+        rbd.exec_cmd(cmd="ceph auth del client.1")
+        rbd.exec_cmd(cmd="ceph auth add client.1 -i /etc/ceph/ceph.client.1.keyring")


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-7786
This PR includes Automation of image migration form client-x having read-only permission to pool namespace

Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573341

File changed :
[suites/pacific/rbd/tier-2_rbd_regression.yaml] - Added test suite
[suites/quincy/rbd/tier-2_rbd_regression.yaml] - Added test suite

Module file modified :
[tests/rbd/rbd_utils.py]

New module file added  :
tests/rbd/readonly_namespace_image_migration.py

success log : 
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0v5pp/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RI6DB6

latest log : 
5.X : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6517e/Test_image_migration_from_pool_namespace_0.log
6.X : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-95g82/Test_image_migration_from_pool_namespace_0.log 
