### PR TITLE
Test to verify write operation should fail from secondary site in rbd mirroring

### DIFF
--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -60,7 +60,9 @@ class OSD(ApplyMixin, Orch):
             devices = {"available": [], "unavailable": []}
             for device in node.get("devices"):
                 # avoid considering devices which is less than 5GB
-                if "Insufficient space (<5GB)" not in device.get(
+                if not device.get(
+                    "rejected_reasons"
+                ) or "Insufficient space (<5GB)" not in device.get(
                     "rejected_reasons", []
                 ):
                     if device["available"]:

--- a/conf/quincy/upi/octo-5-node-env.yaml
+++ b/conf/quincy/upi/octo-5-node-env.yaml
@@ -1,0 +1,88 @@
+# Physical/Bare-metal environment required for RBD persistent write back cache.
+# The below defined cluster has 5 nodes + 1 SSD cache node.
+# Cluster configuration:
+#      3 MONS, 2 MGR, 3 OSD nodes
+#      1 SSD Drive cache node
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.8.128.0/21']
+      nodes:
+        -
+          hostname: clara003
+          id: node1
+          ip: 10.8.129.3
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - mds
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara004
+          id: node2
+          ip: 10.8.129.4
+          root_password: passwd
+          role:
+            - mds
+            - mgr
+            - mon
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara006
+          id: node3
+          ip: 10.8.129.6
+          root_password: passwd
+          role:
+            - mds
+            - mon
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara007
+          id: node4
+          ip: 10.8.129.7
+          root_password: passwd
+          role:
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+
+        -
+          hostname: clara009
+          id: node5
+          ip: 10.8.129.9
+          root_password: passwd
+          role:
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara010
+          id: node6
+          ip: 10.8.129.10
+          root_password: passwd
+          role:
+            - client
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc

--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -1,0 +1,289 @@
+# RBD: Persistent write back cache feature
+#
+# Cluster Configuration: ( Need physical systems with SSD/NVME)
+#    Conf file - conf/quincy/upi/octo-5-node-env.yaml
+#    Ensure SSD client has at-least 8GB SSD drive.
+#
+
+tests:
+
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      name: RBD PWL cache validation.
+      desc: PWL Cache validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574707
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdb
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: PWL validation at client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - Client level configuration
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdc
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: PWL validation at pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - Pool level configuration
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdd
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: PWL validation at image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - image level configuration
+
+  - test:
+      name: RBD PWL cache size validation.
+      desc: PWL cache size validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574722
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdb
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation Client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name:  PWL cache size validation at client level
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdc
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache size validation at pool level
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdd
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache size validation at image level
+
+  - test:
+      name: RBD PWL cache path validation.
+      desc: PWL cache path validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574721
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdb
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: RBD Persistent Cache path validation Client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name:  PWL cache path validation at client level
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdc
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: RBD Persistent Cache cache path validation pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache path validation at pool level
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdd
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: RBD Persistent Cache cache path validation image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache path validation at image level

--- a/tests/rbd/rbd_peristent_writeback_cache.py
+++ b/tests/rbd/rbd_peristent_writeback_cache.py
@@ -1,0 +1,189 @@
+"""RBD Persistent write back cache."""
+
+import datetime
+from json import loads
+
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class PWLException(Exception):
+    pass
+
+
+class PWLConfigurationError(Exception):
+    pass
+
+
+class PersistentWriteAheadLog:
+    def __init__(self, rbd, client, drive):
+        """Initialize PWL.
+
+        Args:
+             rbd: RBD object
+             client: SSD/PMEM client node(CephNode)
+             drive: Cache drive for persistent Write back cache.
+        """
+        self.rbd = rbd
+        self.client = client
+        self.drive = drive
+        self.pwl_path = None
+
+    def cleanup(self):
+        """cleanup drive."""
+        log.info("Starting to cleanup cache drive....")
+        self.client.exec_command(cmd=f"wipefs -af {self.drive}", sudo=True)
+        self.client.exec_command(
+            cmd=f"umount -v {self.drive}", sudo=True, check_ec=False
+        )
+        self.client.exec_command(cmd=f"rm -rf {self.pwl_path}", sudo=True)
+
+    def configure_cache_client(self):
+        """Configure cache device with DAX.
+
+        Configuration involves,
+        - wipe drive
+        - create mount directory.
+        - mkfs.xfs <drive> or with ext4
+        - mount drive with DAX(Direct Attached Access) option
+        """
+        log.info("Configuring SSD/PMEM cache client....")
+        self.pwl_path = f"/mnt/{self.rbd.random_string()}"
+        cmds = [
+            f"mkdir -p {self.pwl_path}",
+            f"mkfs.ext4 {self.drive}",
+            f"mount -O dax {self.drive} {self.pwl_path}",
+        ]
+
+        # Cleanup drive and get ready for mount.
+        self.cleanup()
+        for cmd in cmds:
+            self.client.exec_command(cmd=cmd, sudo=True)
+
+    def configure_pwl_cache(self, mode, level, entity, size="1073741824"):
+        """Set PWL cache mode (disabled, rwl, ssd).
+
+        Args:
+            level: cache mode applied at client or image or pool
+            mode: cache mode ( disabled or rwl or ssd )
+            entity: entity level ( client or image-name or pool-name )
+            size: cache size ( default: 1073741824 )
+        """
+        log.info(f"Configuring RBD PWL cache setting at {level}:{entity}")
+        configs = [
+            ("global", "client", "rbd_cache", "false"),
+            (level, entity, "rbd_plugins", "pwl_cache"),
+            (level, entity, "rbd_persistent_cache_mode", mode),
+            (level, entity, "rbd_persistent_cache_size", size),
+            (level, entity, "rbd_persistent_cache_path", self.pwl_path),
+        ]
+
+        for config in configs:
+            if self.rbd.set_config(*config):
+                raise PWLConfigurationError(f"{config} - failed to add configuration")
+
+    def remove_pwl_configuration(self, level, entity):
+        """Unset PWL cache mode (disabled, rwl, ssd).
+
+        Args:
+            level: cache mode applied at client or image or pool
+            entity: entity level ( client or image-name or pool-name )
+        """
+        log.info(f"Removing RBD PWL cache setting at {level}:{entity}")
+        configs = [
+            ("global", "client", "rbd_cache"),
+            (level, entity, "rbd_plugins"),
+            (level, entity, "rbd_persistent_cache_mode"),
+            (level, entity, "rbd_persistent_cache_size"),
+            (level, entity, "rbd_persistent_cache_path"),
+        ]
+
+        for config in configs:
+            if self.rbd.remove_config(*config):
+                raise PWLConfigurationError(
+                    f"{config} - failed to remove configuration"
+                )
+
+    def get_image_cache_status(self, image):
+        """Get image persistent cache status.
+
+        Args:
+            image: image name
+        Returns:
+            image_status
+        """
+        args = {"format": "json"}
+        return loads(self.rbd.image_status(image, cmd_args=args, output=True))
+
+    @staticmethod
+    def validate_cache_size(rbd_status, cache_size):
+        """Compare cache size."""
+        configured_cache_size = rbd_status["persistent_cache"]["size"]
+        if configured_cache_size != cache_size:
+            raise PWLException(
+                f"Cache size {configured_cache_size} from RBD status did not match to {cache_size}"
+            )
+        log.info(
+            f"Cache size {configured_cache_size} from RBD status matched to {cache_size}"
+        )
+
+    def validate_cache_path(self, rbd_status):
+        """Compare cache file path."""
+        configured_cache_path = rbd_status["persistent_cache"]["path"]
+        if self.pwl_path not in configured_cache_path:
+            raise PWLException(
+                f"{self.pwl_path} is not been used as cache path as configured {configured_cache_path}"
+            )
+        log.info(
+            f"{self.pwl_path} is used as cache path as configured {configured_cache_path}"
+        )
+
+    def check_cache_file_exists(self, image, timeout=120, **kw):
+        """Validate cache file existence.
+
+        Args:
+            image: name of the image.
+            timeout: timeout in seconds
+            kw: validate arguments
+        Raises:
+            PWLException
+        """
+        log.info("Validate RBD PWL cache file existence and size.")
+
+        # Validate cache file
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+        while end_time > datetime.datetime.now():
+            out = self.get_image_cache_status(image)
+            log.debug(f"RBD status of image: {out}")
+
+            cache_file_path = out.get("persistent_cache", {}).get("path")
+            if cache_file_path:
+                # validate cache from rbd status
+                if kw.get("validate_cache_size"):
+                    self.validate_cache_size(out, kw["cache_file_size"])
+                if kw.get("validate_cache_path"):
+                    self.validate_cache_path(out)
+
+                try:
+                    # validate cache file existence
+                    self.client.exec_command(
+                        cmd=f"ls -l {cache_file_path}",
+                        check_ec=True,
+                    )
+                    log.info(
+                        f"{self.client.hostname}:{cache_file_path} cache file found..."
+                    )
+                    break
+                except Exception as err:
+                    log.warning(err)
+        else:
+            raise PWLException(
+                f"{self.client.hostname}:{self.pwl_path} cache file did not found!!!"
+            )
+
+    def flush(self, image):
+        pass
+
+    def invalidate(self, image):
+        pass

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -4,6 +4,7 @@ import string
 from time import sleep
 
 from ceph.ceph import CommandFailed
+from ceph.ceph_admin.common import config_dict_to_string
 from ceph.waiter import WaitUntil
 from tests.rbd.exceptions import (
     CreateFileError,
@@ -395,6 +396,21 @@ class Rbd:
         out = self.exec_cmd(cmd=f"rbd ls {pool_name} --format json", output=True)
         images = json.loads(out)
         return images
+
+    def image_status(self, image_spec, **kw):
+        """Get Image status.
+
+        Command: rbd status <pool-name>/<image-name>
+
+        Args:
+            image_spec: image specification (ex., pool1/image1)
+            kw: other test parameters ( ex., {output: True, json: true})
+        Returns:
+            exec_cmd response
+        """
+        cmd = f"rbd status {image_spec} "
+        cmd += config_dict_to_string(kw.pop("cmd_args")) if kw.get("cmd_args") else ""
+        return self.exec_cmd(cmd=cmd, **kw)
 
     def image_info(self, pool_name, image_name):
         """

--- a/tests/rbd/test_rbd_persistent_write_back_cache.py
+++ b/tests/rbd/test_rbd_persistent_write_back_cache.py
@@ -1,0 +1,83 @@
+"""RBD Persistent write back cache.
+
+Environment and limitations:
+ - The cluster should have 5 nodes + 1 SSD cache node
+ - cluster/global-config-file: config/quincy/upi/octo-5-node-env.yaml
+ - Should be Bare-metal.
+
+Support
+- Configure cluster with PWL Cache.
+- Only replicated pool supported, No EC pools.
+- Cannot be executed in parallel, if it is same pool or image.
+"""
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id
+from tests.rbd.rbd_peristent_writeback_cache import PersistentWriteAheadLog
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """RBD persistent write back cache.
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test parameters
+
+    Pre-requisites :
+        - need client node with ceph-common package, conf and keyring files
+        - FIO should be installed on the client.
+
+    """
+    log.info("Running PWL....")
+    config = kw.get("config")
+    rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
+    cache_client = get_node_by_id(ceph_cluster, config["client"])
+    pool = config["rep_pool_config"]["pool"]
+    image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
+
+    config_level = config["level"]
+    entity = "client"
+    if config_level == "client":
+        config_level = "global"
+    elif config_level == "pool":
+        entity = pool
+    elif config_level == "image":
+        entity = image
+
+    pwl = PersistentWriteAheadLog(rbd_obj, cache_client, config.get("drive"))
+    try:
+        # Configure PWL
+        pwl.configure_cache_client()
+        pwl.configure_pwl_cache(
+            config["rbd_persistent_cache_mode"],
+            config_level,
+            entity,
+            config["cache_file_size"],
+        )
+
+        # Run FIO, validate cache file existence in self.pwl_path under cache node
+        with parallel() as p:
+            fio_args = config["fio"]
+            fio_args["client_node"] = cache_client
+            fio_args["long_running"] = True
+            p.spawn(run_fio, **fio_args)
+            pwl.check_cache_file_exists(
+                image,
+                fio_args.get("runtime", 120),
+                **config,
+            )
+
+        return 0
+    except Exception as err:
+        log.error(err)
+    finally:
+        if config.get("cleanup"):
+            pwl.remove_pwl_configuration(config_level, entity)
+            rbd_obj.clean_up(pools=[pool])
+            pwl.cleanup()
+
+    return 1

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -60,7 +60,7 @@ class RbdMirror:
             if kw.get("ceph_args", True):
                 cmd = cmd + self.ceph_args
 
-            if kw.get("long_running"):
+            if kw.get("long_running", True):
                 out = node.exec_command(
                     sudo=True,
                     cmd=cmd,
@@ -688,7 +688,7 @@ class RbdMirror:
                 cmd="rbd bench-write --io-total {} {}".format(
                     kw.get("io", "500M"), kw.get("imagespec")
                 ),
-                long_running=True,
+                **kw,
             )
         else:
             return self.exec_cmd(
@@ -696,7 +696,7 @@ class RbdMirror:
                     "rbd bench --io-type write --io-threads 16 "
                     f"--io-total {kw.get('io', '500M')} {kw.get('imagespec')}"
                 ),
-                long_running=True,
+                **kw,
             )
 
     def create_pool(self, **kw):

--- a/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
+++ b/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
@@ -1,18 +1,49 @@
 from ceph.parallel import parallel
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
+def test_write_from_secondary(self, mirrormode, imagespec):
+    """Method to verify write operation should not be performed from secondary site,
+    as mirrored image got locked from primary site.
+
+    Args:
+        self: mirror2 object
+        mirrormode: type of mirroring journal or snapshot
+        imagespec: poolname + "/" + imagename
+    Returns:
+        0 - if test case pass
+        1 - if test case fails
+    """
+    out, err = self.benchwrite(
+        imagespec=imagespec, long_running=False, all=True, check_ec=False
+    )
+    log.debug(err)
+
+    if "Read-only file system" in err:
+        log.info(
+            "As Expected writing data from secondary got failed, "
+            f"mirrored image got locked from primary in {mirrormode} based mirroring"
+        )
+        return 0
+
+    log.error(
+        f"Able to write data into secondary image for {mirrormode} based mirroring,"
+        " This is invalid since image should be locked at primary."
+    )
+    return 1
+
+
+def test_journal_to_snapshot(rbd_mirror, pool_type, **kw):
     """verification Snap mirroring on journaling based image after disable journaling on image.
 
     Args:
         **kw:
     Returns:
         0 - if test case pass
-        1 - it test case fails
+        1 - if test case fails
 
     Test case flow:
     1. Create image on cluster-1.
@@ -26,10 +57,8 @@ def run(**kw):
     try:
         log.info("Starting RBD mirroring test case")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         poolname = mirror1.random_string() + "_tier_2_rbd_mirror_pool"
         imagename = mirror1.random_string() + "_tier_2_rbd_mirror_image"
         imagespec = poolname + "/" + imagename
@@ -46,6 +75,10 @@ def run(**kw):
             **kw,
         )
 
+        mirrormode = mirror1.get_mirror_mode(imagespec)
+        # Verification of Negative test as image should not allow write operation from secondary
+        test_write_from_secondary(mirror2, mirrormode, imagespec)
+
         # Disabling journal mirror on image
         mirror1.disable_mirroring("image", imagespec)
 
@@ -55,7 +88,9 @@ def run(**kw):
 
         # Verification of mirrored image on cluster
         mirror2.image_exists(imagespec)
-        if mirror1.get_mirror_mode(imagespec) == "snapshot":
+
+        mirrormode = mirror1.get_mirror_mode(imagespec)
+        if mirrormode == "snapshot":
             log.info("snapshot mirroring is enabled")
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
         with parallel() as p:
@@ -67,16 +102,56 @@ def run(**kw):
                 imagespec=imagespec,
                 state_pattern="up+replaying",
             )
-
-        # Cleans up the configuration
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        # Verification of Negative test as image should not allow write operation from secondary
+        test_write_from_secondary(mirror2, mirrormode, imagespec)
         return 0
-
-    except ValueError:
-        log.error(
-            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
-        )
 
     except Exception as e:
         log.error(e)
         return 1
+
+    # Cleans up the configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+
+
+def run(**kw):
+    """
+    Journal based mirroring to snapshot based mirroring conversion.
+
+    Args:
+        **kw: test data
+            Example::
+            config:
+                ec_pool_config:
+                  mirrormode: snapshot
+                  mode: image
+                rep_pool_config:
+                  mirrormode: snapshot
+                  mode: image
+                snapshot_schedule_level: "cluster"
+                imagesize: 2G
+
+    Returns:
+        int: The return value - 0 for success, 1 for failure
+    """
+    log.info(
+        "Starting CEPH-83573618, "
+        "Test to verify snapshot based mirroring on journaling based mirrored images."
+    )
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_journal_to_snapshot(
+            mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+        ):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_journal_to_snapshot(
+            mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+        ):
+            return 1
+    return 0


### PR DESCRIPTION
# Description
Automated below test case
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9503

As discussed with team since it's just one negative test to validate, hence accommodate that test in existing 
`tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py` as it covers both validation from `journal` and `snapshot` based mirroring.

Test flow:

- On the remote/secondary cluster, try using the mirrored image for writing.
- command should error out saying `Read only file system`

Test Result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BBJH8C



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
