### PR TITLE
Fix for report portal launch failure

### DIFF
--- a/pipeline/scripts/ci/update_results.py
+++ b/pipeline/scripts/ci/update_results.py
@@ -102,8 +102,9 @@ if __name__ == "__main__":
     cephVersion = cli_args.get("--cephVersion")
     testResults = cli_args.get("--testResults")
     rpLink = cli_args.get("--rpLink")
-    attributes = json.loads(rpLink)
-    if attributes:
-        update_rp_link(cephVersion, attributes["build_type"], attributes["rp_link"])
-        sys.exit(0)
+    if rpLink:
+        attributes = json.loads(rpLink)
+        if attributes:
+            update_rp_link(cephVersion, attributes["build_type"], attributes["rp_link"])
+            sys.exit(0)
     update_results(cephVersion, testResults)


### PR DESCRIPTION
# Description

Fix for report portal launch failure.

failed log - https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-post-results/3719/console

[consoleText_failed.txt](https://github.com/red-hat-storage/cephci/files/11111860/consoleText_failed.txt)

passed log - https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-post-results/3707/console
[consoleText.txt](https://github.com/red-hat-storage/cephci/files/11111864/consoleText.txt)
