### PR TITLE
Fixes for post results and tier executor

### DIFF
--- a/pipeline/post-results.groovy
+++ b/pipeline/post-results.groovy
@@ -238,7 +238,7 @@ node("rhel-9-medium") {
                     )
 
                     emailLib.sendGChatNotification(
-                        run_type, metaData["results"], tierLevel, stageLevel, build_url
+                        sharedLib, run_type, metaData["results"], tierLevel, stageLevel, build_url
                     )
                 }
             }
@@ -246,7 +246,7 @@ node("rhel-9-medium") {
             stage('updateRecipeFile'){
                 println("Stage updateRecipeFile")
                 if ( composeInfo != null ) {
-                    if ( run_type == "Sanity Run") {
+                    if (run_type.contains("Sanity Run")) {
                         if ( tierLevel == null ) {
                             tierLevel = msgMap["pipeline"]["name"]
                         }

--- a/pipeline/tier_executor.groovy
+++ b/pipeline/tier_executor.groovy
@@ -155,7 +155,7 @@ node(nodeName) {
             }
         }
 
-        if("ibmc" in tags_list) {
+        if("ibmc" in tags_list || "sanity" in tags_list || "schedule" in tags_list) {
             def workspace = "${env.WORKSPACE}"
             def build_number = "${currentBuild.number}"
             overrides.put("workspace", workspace.toString())
@@ -164,8 +164,8 @@ node(nodeName) {
         print(overrides)
         // Till the pipeline matures, using the build that has passed tier-0 suite.
 
-        if (tags_list.containsAll(["ibmc","sanity"]) && (tierLevel != "tier-0")){
-            def recipeFileContent = sharedLib.readFromRecipeFile(rhcephVersion)
+         if (tags_list.containsAll(["sanity"]) && (tierLevel != "tier-0")){
+            def recipeFileContent = sharedLib.readFromReleaseFile(majorVersion, minorVersion, lockFlag=false)
             def content = recipeFileContent['latest']
             println "recipeFile ceph-version : ${content['ceph-version']}"
             println "buildArtifacts ceph-version : ${buildArtifacts['ceph-version']}"
@@ -344,7 +344,7 @@ node(nodeName) {
                     "result": testStatus,
                     "object-prefix": dirName,
                 ],
-                "recipe": buildArtifacts['recipe'],
+                "recipe": buildArtifacts,
                 "generated_at": env.BUILD_ID,
                 "version": "3.0.0",
             ]

--- a/pipeline/vars/email.groovy
+++ b/pipeline/vars/email.groovy
@@ -229,6 +229,7 @@ def sendConsolidatedEmail(
 }
 
 def sendGChatNotification(
+    def sharedLib,
     def run_type,
     def testResults,
     def tierLevel,
@@ -248,9 +249,9 @@ def sendGChatNotification(
                          Notification message to be sent.
                          Notification message to be sent.
     */
-    def ciMsg = getCIMessageMap()
+    def ciMsg = sharedLib.getCIMessageMap()
     def status = "STABLE"
-    if ('FAIL' in fetchStageStatus(testResults)) {
+    if ('FAIL' in sharedLib.fetchStageStatus(testResults)) {
         status = "UNSTABLE"
     }
     if (! build_url){


### PR DESCRIPTION
# Description

Fixes for post results and tier executor to move the regression runs back to openstack environment.

[consoleTex_psit.txt](https://github.com/red-hat-storage/cephci/files/11112024/consoleTex_psit.txt)
