### PR TITLE
updates for scheduled run pipeline

### DIFF
--- a/pipeline/psi-only-executor.groovy
+++ b/pipeline/psi-only-executor.groovy
@@ -70,7 +70,7 @@ node("rhel-9-medium || ceph-qe-ci") {
                     string(name: 'tags', value: tags),
                     string(name: 'buildType', value: buildType),
                     string(name: 'overrides', value: overridesStr),
-                    string(name: 'buildArtifacts', value: buildArtifacts.toString())]
+                    string(name: 'buildArtifacts', value: buildArtifacts['recipe'].toString())]
             ])
         }
         else


### PR DESCRIPTION
# Description

Updates for psi scheduled pipline to include non psi scheduled suites as well.

logs:
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/7453
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all
PSI-Only Schedule Run RHCEPH-5.3 16.2.10-160
PSI-Only Sanity Run RHCEPH-5.3 16.2.10-160