### PR TITLE
RBD image live in migration from s3 object

### DIFF
--- a/conf/pacific/rbd/tier-0_rbd.yaml
+++ b/conf/pacific/rbd/tier-0_rbd.yaml
@@ -28,6 +28,7 @@ globals:
         role:
           - mds
           - osd
+          - rgw
         no-of-volumes: 3
         disk-size: 20
       node6:

--- a/conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+++ b/conf/quincy/rbd/4-node-cluster-with-1-client.yaml
@@ -33,6 +33,7 @@ globals:
           - osd
           - node-exporter
           - crash
+          - rgw
         no-of-volumes: 3
         disk-size: 15
       node4:

--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -10,10 +10,9 @@
 #   - CEPH-83573308, CEPH-83573307 - clones creation with v2clone format and deletion
 #   - CEPH-83573289 - Verify force remove on trash images
 #   - CEPH-83573298 - Move images to trash, restore them and verify
-
 tests:
 
-   #Setup the cluster
+  # Setup the cluster
 
   - test:
       abort-on-fail: true
@@ -54,6 +53,14 @@ tests:
               service: osd
               args:
                 all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: RHCS cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -255,6 +262,30 @@ tests:
             data_pool: data_pool_ec2
       name: Test abort image migration from source to destination pool
       polarion-id: CEPH-83573324
+
+  - test:
+      desc: Setting up RGW user for s3 image migration test
+      module: exec.py
+      name: Setup rgw s3 user
+      config:
+        commands:
+          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
+
+  - test:
+      name: Image migration from s3 source
+      desc: Export an image to s3 source and reinstall as new image using migration
+      module: test_rbd_migration_image_s3_object.py
+      polarion-id: CEPH-83574092
+      config:
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          image: rbd_image
+          size: 100M
+        rep_pool_config:
+          pool: rbd_pool
+          image: rbd_rep_image
+          size: 100M
 
   - test:
       desc: Disable the image features on image when image is moved to trash and verify

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -54,6 +54,14 @@ tests:
               service: osd
               args:
                 all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: RHCS cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -254,6 +262,30 @@ tests:
             data_pool: data_pool_ec2
       name: Test abort image migration from source to destination pool
       polarion-id: CEPH-83573324
+
+  - test:
+      desc: Setting up RGW user for s3 image migration test
+      module: exec.py
+      name: Setup rgw s3 user
+      config:
+        commands:
+          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
+
+  - test:
+      name: Image migration from s3 source
+      desc: Export an image to s3 source and reinstall as new image using migration
+      module: test_rbd_migration_image_s3_object.py
+      polarion-id: CEPH-83574092
+      config:
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          image: rbd_image
+          size: 100M
+        rep_pool_config:
+          pool: rbd_pool
+          image: rbd_rep_image
+          size: 100M
 
   - test:
       desc: Disable the image features on image when image is moved to trash and verify

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -520,7 +520,8 @@ class Rbd:
             image_name: name of the image
 
         Returns:
-
+            True: if image exists in pool
+            False: if image doesn't exist in pool
         """
         out = self.exec_cmd(cmd=f"rbd ls {pool_name} --format json", output=True)
         images = json.loads(out)
@@ -668,10 +669,16 @@ class Rbd:
 
         Args:
             src_spec : source image spec SOURCE_POOL_NAME/SOURCE_IMAGE_NAME
+                    or json formatted string for streamed imports
             dest_spec: Target image spec TARGET_POOL_NAME/SOURCE_IMAGE_NAME
         """
-        log.info("Starting prepare Live migration of image ")
-        return self.exec_cmd(cmd=f"rbd migration prepare {src_spec} {dest_spec}")
+        log.info("Starting prepare Live migration of image")
+        command = "rbd migration prepare "
+        if "{" not in src_spec:
+            command += f"{src_spec} {dest_spec}"
+        else:
+            command += f"{dest_spec} --import-only --source-spec {src_spec}"
+        return self.exec_cmd(cmd=command)
 
     def migration_action(self, action, dest_spec):
         """Migration action

--- a/tests/rbd/test_rbd_migration_image_s3_object.py
+++ b/tests/rbd/test_rbd_migration_image_s3_object.py
@@ -1,0 +1,122 @@
+"""Module to execute Live migration as s3 image migration.
+
+Pre-requisites :
+- Cluster configured with atleast one client node with ceph-common package,
+conf and keyring files
+- Supportive rgw module to host image as s3 object in ceph-qe-scripts
+
+Test cases covered :
+CEPH-83574092 - verify snapshot downloaded creates a local RBD image
+
+Test Case Flow :
+1. Create images and take snapshots, export snapshots.
+2. Backup exported snapshots as rbd images.
+3. Mention s3 object as source for live migration preparation.
+4. Execute and commit migration and verify.
+"""
+import json
+
+from ceph.parallel import parallel
+from tests.rbd.rbd_utils import Rbd, initial_rbd_config, verify_migration_commit
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def cleanup(rbd: Rbd, pool_config):
+    for each_config in ["ec_pool_config", "rep_pool_config"]:
+        rbd.clean_up(dir_name=f"image_export_{each_config[0:2]}.raw")
+        rbd.clean_up(pools=[f"{pool_config[each_config]['pool']}"])
+
+    rbd.clean_up(dir_name="ceph-qe-scripts/")
+
+
+def run(**kw):
+    log.info(
+        "Executing CEPH-83574092 - \
+        verify snapshot downloaded creates a local RBD image"
+    )
+
+    initial_rbd_config(**kw)
+    rbd_obj = Rbd(**kw)
+
+    imagespecs = []
+
+    for each_config in ["ec_pool_config", "rep_pool_config"]:
+        pool = f"{kw['config'][each_config]['pool']}"
+        image = f"{kw['config'][each_config]['image']}"
+
+        imagespecs.append(f"{pool}/{image}")
+        rbd_obj.snap_create(pool, image, "snap")
+        rbd_obj.export_image(
+            f"{pool}/{image}@snap", f"image_export_{each_config[0:2]}.raw"
+        )
+
+    log.info("Initiating ceph-qe-script module to upload image exports")
+    rgw_ceph_object = kw["ceph_cluster"].get_ceph_object("rgw")
+    rgw_node = rgw_ceph_object.node
+    append_param = " --rgw-node " + str(rgw_node.ip_address)
+
+    repo_url = "https://github.com/red-hat-storage/ceph-qe-scripts.git"
+    rbd_obj.exec_cmd(
+        cmd="yum install python3 -y --nogpgcheck", check_ec=False, sudo=True
+    )
+    rbd_obj.exec_cmd(cmd="pip3 install --upgrade pip")
+    rbd_obj.exec_cmd(cmd="pip3 install boto3")
+
+    rbd_obj.exec_cmd(cmd=f"git clone {repo_url}")
+
+    try:
+        with parallel() as p:
+            for each_config in ["ec_pool_config", "rep_pool_config"]:
+                temp_append_param = (
+                    append_param + f" --file-name image_export_{each_config[0:2]}.raw"
+                )
+                command = f"python3 ceph-qe-scripts/rbd/functional/test_rbd_s3_upload.py {temp_append_param}"
+                p.spawn(rbd_obj.exec_cmd, cmd=command, long_running=True)
+
+    except Exception:
+        log.error("S3 upload of rbd image failed, can't proceed further")
+        cleanup(rbd_obj, kw["config"])
+        return 1
+
+    try:
+        for each_config in ["ec_pool_config", "rep_pool_config"]:
+            migration_source_spec = {
+                "type": "raw",
+                "stream": {
+                    "type": "s3",
+                    "url": f"http://{str(rgw_node.ip_address)}:80/rbd/{each_config[0:2]}",
+                    "access_key": "test_rbd",
+                    "secret_key": "test_rbd",
+                },
+            }
+
+            source_json = json.dumps(migration_source_spec)
+            destination_spec = (
+                f"{kw['config'][each_config]['pool']}/{each_config[0:2]}_import"
+            )
+
+            if rbd_obj.migration_prepare(f"'{source_json}'", destination_spec):
+                log.error("Migration prepare failed while executing the testcase")
+                return 1
+            if rbd_obj.migration_action("execute", destination_spec):
+                log.error("Migration preparation failed while executing testcase")
+                return 1
+            if rbd_obj.migration_action("commit", destination_spec):
+                log.error("Migration commit failed while executing testcase")
+                return 1
+            verify_migration_commit(
+                rbd_obj,
+                f"{kw['config'][each_config]['pool']}",
+                f"{kw['config'][each_config]['image']}",
+            )
+            log.info("Rbd live migration from s3 source successful")
+
+        return 0
+
+    except Exception:
+        log.error("Image migration Failed, testcase failed")
+        return 1
+    finally:
+        cleanup(rbd_obj, kw["config"])


### PR DESCRIPTION
# Description
RBD image live in migration from s3 object

Test cases covered :
CEPH-83574092 - verify snapshot downloaded creates a local RBD image

Test Case Flow :
1. Create images and take snapshots, export snapshots.
2. Backup exported snapshots as rbd images.
3. Mention s3 object as source for live migration preparation.
4. Execute and commit migration and verify.

File changes:
modified:   conf/pacific/rbd/tier-0_rbd.yaml
and conf/quincy/rbd/tier-0_rbd.yaml
Added rgw node required for the suite.

modified:   suites/pacific/rbd/tier-2_rbd_regression.yaml
and suites/quincy/rbd/tier-2_rbd_regression.yaml
Added tests required for testcase execution

modified:   tests/rbd/rbd_utils.py
Modified doc strings of a module with ore details
Added capability to mention source for migration prepare method.

new file:   tests/rbd/test_rbd_migration_image_s3_object.py
Module to handle the testcase by executing steps and initiate boto script to
upload exported image located in ceph-qe-scripts.

Signed-off-by: Vasishta <vashastr@redhat.com>

April 11th
Added more doc

Addressed review comments and tox errors
Log links - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ISE251
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9NGUK0/Image_migration_from_s3_source_0.log
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
