### PR TITLE
Supporting RBD persistent write bach cache feature basic functionality

### DIFF
--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -60,7 +60,9 @@ class OSD(ApplyMixin, Orch):
             devices = {"available": [], "unavailable": []}
             for device in node.get("devices"):
                 # avoid considering devices which is less than 5GB
-                if "Insufficient space (<5GB)" not in device.get(
+                if not device.get(
+                    "rejected_reasons"
+                ) or "Insufficient space (<5GB)" not in device.get(
                     "rejected_reasons", []
                 ):
                     if device["available"]:

--- a/conf/quincy/upi/octo-5-node-env.yaml
+++ b/conf/quincy/upi/octo-5-node-env.yaml
@@ -1,0 +1,88 @@
+# Physical/Bare-metal environment required for RBD persistent write back cache.
+# The below defined cluster has 5 nodes + 1 SSD cache node.
+# Cluster configuration:
+#      3 MONS, 2 MGR, 3 OSD nodes
+#      1 SSD Drive cache node
+globals:
+  -
+    ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.8.128.0/21']
+      nodes:
+        -
+          hostname: clara003
+          id: node1
+          ip: 10.8.129.3
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - mds
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara004
+          id: node2
+          ip: 10.8.129.4
+          root_password: passwd
+          role:
+            - mds
+            - mgr
+            - mon
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara006
+          id: node3
+          ip: 10.8.129.6
+          root_password: passwd
+          role:
+            - mds
+            - mon
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara007
+          id: node4
+          ip: 10.8.129.7
+          root_password: passwd
+          role:
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+
+        -
+          hostname: clara009
+          id: node5
+          ip: 10.8.129.9
+          root_password: passwd
+          role:
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc
+        -
+          hostname: clara010
+          id: node6
+          ip: 10.8.129.10
+          root_password: passwd
+          role:
+            - client
+          volumes:
+            - /dev/sdd
+            - /dev/sdb
+            - /dev/sdc

--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -1,0 +1,289 @@
+# RBD: Persistent write back cache feature
+#
+# Cluster Configuration: ( Need physical systems with SSD/NVME)
+#    Conf file - conf/quincy/upi/octo-5-node-env.yaml
+#    Ensure SSD client has at-least 8GB SSD drive.
+#
+
+tests:
+
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      name: RBD PWL cache validation.
+      desc: PWL Cache validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574707
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdb
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: PWL validation at client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - Client level configuration
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdc
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: PWL validation at pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - Pool level configuration
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdd
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: PWL validation at image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - image level configuration
+
+  - test:
+      name: RBD PWL cache size validation.
+      desc: PWL cache size validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574722
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdb
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation Client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name:  PWL cache size validation at client level
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdc
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache size validation at pool level
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdd
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache size validation at image level
+
+  - test:
+      name: RBD PWL cache path validation.
+      desc: PWL cache path validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574721
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdb
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: RBD Persistent Cache path validation Client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name:  PWL cache path validation at client level
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdc
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: RBD Persistent Cache cache path validation pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache path validation at pool level
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node6
+            drive: /dev/sdd
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: RBD Persistent Cache cache path validation image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache path validation at image level

--- a/tests/rbd/rbd_peristent_writeback_cache.py
+++ b/tests/rbd/rbd_peristent_writeback_cache.py
@@ -1,0 +1,189 @@
+"""RBD Persistent write back cache."""
+
+import datetime
+from json import loads
+
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class PWLException(Exception):
+    pass
+
+
+class PWLConfigurationError(Exception):
+    pass
+
+
+class PersistentWriteAheadLog:
+    def __init__(self, rbd, client, drive):
+        """Initialize PWL.
+
+        Args:
+             rbd: RBD object
+             client: SSD/PMEM client node(CephNode)
+             drive: Cache drive for persistent Write back cache.
+        """
+        self.rbd = rbd
+        self.client = client
+        self.drive = drive
+        self.pwl_path = None
+
+    def cleanup(self):
+        """cleanup drive."""
+        log.info("Starting to cleanup cache drive....")
+        self.client.exec_command(cmd=f"wipefs -af {self.drive}", sudo=True)
+        self.client.exec_command(
+            cmd=f"umount -v {self.drive}", sudo=True, check_ec=False
+        )
+        self.client.exec_command(cmd=f"rm -rf {self.pwl_path}", sudo=True)
+
+    def configure_cache_client(self):
+        """Configure cache device with DAX.
+
+        Configuration involves,
+        - wipe drive
+        - create mount directory.
+        - mkfs.xfs <drive> or with ext4
+        - mount drive with DAX(Direct Attached Access) option
+        """
+        log.info("Configuring SSD/PMEM cache client....")
+        self.pwl_path = f"/mnt/{self.rbd.random_string()}"
+        cmds = [
+            f"mkdir -p {self.pwl_path}",
+            f"mkfs.ext4 {self.drive}",
+            f"mount -O dax {self.drive} {self.pwl_path}",
+        ]
+
+        # Cleanup drive and get ready for mount.
+        self.cleanup()
+        for cmd in cmds:
+            self.client.exec_command(cmd=cmd, sudo=True)
+
+    def configure_pwl_cache(self, mode, level, entity, size="1073741824"):
+        """Set PWL cache mode (disabled, rwl, ssd).
+
+        Args:
+            level: cache mode applied at client or image or pool
+            mode: cache mode ( disabled or rwl or ssd )
+            entity: entity level ( client or image-name or pool-name )
+            size: cache size ( default: 1073741824 )
+        """
+        log.info(f"Configuring RBD PWL cache setting at {level}:{entity}")
+        configs = [
+            ("global", "client", "rbd_cache", "false"),
+            (level, entity, "rbd_plugins", "pwl_cache"),
+            (level, entity, "rbd_persistent_cache_mode", mode),
+            (level, entity, "rbd_persistent_cache_size", size),
+            (level, entity, "rbd_persistent_cache_path", self.pwl_path),
+        ]
+
+        for config in configs:
+            if self.rbd.set_config(*config):
+                raise PWLConfigurationError(f"{config} - failed to add configuration")
+
+    def remove_pwl_configuration(self, level, entity):
+        """Unset PWL cache mode (disabled, rwl, ssd).
+
+        Args:
+            level: cache mode applied at client or image or pool
+            entity: entity level ( client or image-name or pool-name )
+        """
+        log.info(f"Removing RBD PWL cache setting at {level}:{entity}")
+        configs = [
+            ("global", "client", "rbd_cache"),
+            (level, entity, "rbd_plugins"),
+            (level, entity, "rbd_persistent_cache_mode"),
+            (level, entity, "rbd_persistent_cache_size"),
+            (level, entity, "rbd_persistent_cache_path"),
+        ]
+
+        for config in configs:
+            if self.rbd.remove_config(*config):
+                raise PWLConfigurationError(
+                    f"{config} - failed to remove configuration"
+                )
+
+    def get_image_cache_status(self, image):
+        """Get image persistent cache status.
+
+        Args:
+            image: image name
+        Returns:
+            image_status
+        """
+        args = {"format": "json"}
+        return loads(self.rbd.image_status(image, cmd_args=args, output=True))
+
+    @staticmethod
+    def validate_cache_size(rbd_status, cache_size):
+        """Compare cache size."""
+        configured_cache_size = rbd_status["persistent_cache"]["size"]
+        if configured_cache_size != cache_size:
+            raise PWLException(
+                f"Cache size {configured_cache_size} from RBD status did not match to {cache_size}"
+            )
+        log.info(
+            f"Cache size {configured_cache_size} from RBD status matched to {cache_size}"
+        )
+
+    def validate_cache_path(self, rbd_status):
+        """Compare cache file path."""
+        configured_cache_path = rbd_status["persistent_cache"]["path"]
+        if self.pwl_path not in configured_cache_path:
+            raise PWLException(
+                f"{self.pwl_path} is not been used as cache path as configured {configured_cache_path}"
+            )
+        log.info(
+            f"{self.pwl_path} is used as cache path as configured {configured_cache_path}"
+        )
+
+    def check_cache_file_exists(self, image, timeout=120, **kw):
+        """Validate cache file existence.
+
+        Args:
+            image: name of the image.
+            timeout: timeout in seconds
+            kw: validate arguments
+        Raises:
+            PWLException
+        """
+        log.info("Validate RBD PWL cache file existence and size.")
+
+        # Validate cache file
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+        while end_time > datetime.datetime.now():
+            out = self.get_image_cache_status(image)
+            log.debug(f"RBD status of image: {out}")
+
+            cache_file_path = out.get("persistent_cache", {}).get("path")
+            if cache_file_path:
+                # validate cache from rbd status
+                if kw.get("validate_cache_size"):
+                    self.validate_cache_size(out, kw["cache_file_size"])
+                if kw.get("validate_cache_path"):
+                    self.validate_cache_path(out)
+
+                try:
+                    # validate cache file existence
+                    self.client.exec_command(
+                        cmd=f"ls -l {cache_file_path}",
+                        check_ec=True,
+                    )
+                    log.info(
+                        f"{self.client.hostname}:{cache_file_path} cache file found..."
+                    )
+                    break
+                except Exception as err:
+                    log.warning(err)
+        else:
+            raise PWLException(
+                f"{self.client.hostname}:{self.pwl_path} cache file did not found!!!"
+            )
+
+    def flush(self, image):
+        pass
+
+    def invalidate(self, image):
+        pass

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -4,6 +4,7 @@ import string
 from time import sleep
 
 from ceph.ceph import CommandFailed
+from ceph.ceph_admin.common import config_dict_to_string
 from ceph.waiter import WaitUntil
 from tests.rbd.exceptions import (
     CreateFileError,
@@ -395,6 +396,21 @@ class Rbd:
         out = self.exec_cmd(cmd=f"rbd ls {pool_name} --format json", output=True)
         images = json.loads(out)
         return images
+
+    def image_status(self, image_spec, **kw):
+        """Get Image status.
+
+        Command: rbd status <pool-name>/<image-name>
+
+        Args:
+            image_spec: image specification (ex., pool1/image1)
+            kw: other test parameters ( ex., {output: True, json: true})
+        Returns:
+            exec_cmd response
+        """
+        cmd = f"rbd status {image_spec} "
+        cmd += config_dict_to_string(kw.pop("cmd_args")) if kw.get("cmd_args") else ""
+        return self.exec_cmd(cmd=cmd, **kw)
 
     def image_info(self, pool_name, image_name):
         """

--- a/tests/rbd/test_rbd_persistent_write_back_cache.py
+++ b/tests/rbd/test_rbd_persistent_write_back_cache.py
@@ -1,0 +1,83 @@
+"""RBD Persistent write back cache.
+
+Environment and limitations:
+ - The cluster should have 5 nodes + 1 SSD cache node
+ - cluster/global-config-file: config/quincy/upi/octo-5-node-env.yaml
+ - Should be Bare-metal.
+
+Support
+- Configure cluster with PWL Cache.
+- Only replicated pool supported, No EC pools.
+- Cannot be executed in parallel, if it is same pool or image.
+"""
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id
+from tests.rbd.rbd_peristent_writeback_cache import PersistentWriteAheadLog
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """RBD persistent write back cache.
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test parameters
+
+    Pre-requisites :
+        - need client node with ceph-common package, conf and keyring files
+        - FIO should be installed on the client.
+
+    """
+    log.info("Running PWL....")
+    config = kw.get("config")
+    rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
+    cache_client = get_node_by_id(ceph_cluster, config["client"])
+    pool = config["rep_pool_config"]["pool"]
+    image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
+
+    config_level = config["level"]
+    entity = "client"
+    if config_level == "client":
+        config_level = "global"
+    elif config_level == "pool":
+        entity = pool
+    elif config_level == "image":
+        entity = image
+
+    pwl = PersistentWriteAheadLog(rbd_obj, cache_client, config.get("drive"))
+    try:
+        # Configure PWL
+        pwl.configure_cache_client()
+        pwl.configure_pwl_cache(
+            config["rbd_persistent_cache_mode"],
+            config_level,
+            entity,
+            config["cache_file_size"],
+        )
+
+        # Run FIO, validate cache file existence in self.pwl_path under cache node
+        with parallel() as p:
+            fio_args = config["fio"]
+            fio_args["client_node"] = cache_client
+            fio_args["long_running"] = True
+            p.spawn(run_fio, **fio_args)
+            pwl.check_cache_file_exists(
+                image,
+                fio_args.get("runtime", 120),
+                **config,
+            )
+
+        return 0
+    except Exception as err:
+        log.error(err)
+    finally:
+        if config.get("cleanup"):
+            pwl.remove_pwl_configuration(config_level, entity)
+            rbd_obj.clean_up(pools=[pool])
+            pwl.cleanup()
+
+    return 1


### PR DESCRIPTION
- Added basic functionality validation of RBD persistent write back(pwl) chache.
  - Required libraries.
  - Test cases which covers basic validation pwl at client, image and pool level.
  - Fix OSD validation issue, which was happening due to available and unavailable devices on refresh.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OCCN99/deploy_cluster_0.log

**Test cases:**
- [CEPH-83574721](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574721) check Configurations rbd_persistent_cache_path in SSD mode
   - Configure PWL at client level with default size 1 GB.
   - Configure cache client with DAX option.
   - run FIO and paralelly, validate cache file and its path of the cache from RBS status command.
   - Repeat the above steps for pool and image level.
- [CEPH-83574707](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574707) check the cache creation in the rbd_persistent_cache_path in SSD mode 
  - Configure PWL at client level with default size 1 GB.
  - Configure cache client with DAX option.
  - run FIO and paralelly validate file of the cache from RBD status command.
  - repeat above steps for pool and image level.
- [CEPH-83574722](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574722) check Configurations rbd_persistent_cache_size in SSD mode 
   - Configure PWL at client level with default size 1 GB.
   - Configure cache client with DAX option.
   - run FIO and paralelly validate file, size of the cache from RBD status command.
   - repeat above steps for pool and image level.

**Results:** 
(RHCS 6.x)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CSKU01 ( Passed -old)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DJD6W8  
(RHCS 5.x) 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YG72N5
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SJQUDC
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VVV44N/ ( latest )
 
