### PR TITLE
Integrate multiple changes on ceph-qe-scripts into cephCI

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw.yaml
+++ b/suites/pacific/rgw/tier-1_rgw.yaml
@@ -181,5 +181,5 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_object_lock.py
-        config-file-name: test_object_lock.yaml
+        config-file-name: test_object_lock_compliance.yaml
         timeout: 500

--- a/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
@@ -285,6 +285,18 @@ tests:
       name: create non-tenanted user
 
   - test:
+      name: Granular multisite sync policy group transition
+      desc: Test multisite sync policy group transition
+      polarion-id: CEPH-83575135
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name:  test_multisite_sync_policy.py
+            config-file-name:  test_sync_policy_state_change.yaml
+            timeout: 300
+
+  - test:
       name: Test multisite sync policy
       desc: Test multisite sync policy
       polarion-id: CEPH-83575360

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -790,3 +790,13 @@ tests:
         script-name: test_versioning_with_objects.py
         config-file-name: test_access_versioned_objects.yaml
         timeout: 300
+
+  - test:
+      name: object lock verification
+      desc: object lock test
+      polarion-id: CEPH-83574055
+      module: sanity_rgw.py
+      config:
+        script-name: test_object_lock.py
+        config-file-name: test_object_lock_governance.yaml
+        timeout: 500

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -226,7 +226,6 @@ tests:
       desc: Test Ratelimit for tenanted users
       polarion-id: CEPH-83574914
       module: sanity_rgw.py
-      comments: known issue (bz-2179360)
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml

--- a/suites/quincy/upstream/tier-1_rgw_and_lc.yaml
+++ b/suites/quincy/upstream/tier-1_rgw_and_lc.yaml
@@ -142,7 +142,7 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_object_lock.py
-        config-file-name: test_object_lock.yaml
+        config-file-name: test_object_lock_compliance.yaml
         timeout: 500
 
   - test:


### PR DESCRIPTION
1. Add object lock for governance mode with legal hold
2. Remove the known issue comment for s3cmd rate limiting tenanted users.
3. Change name of existing object lock yaml to reflect compliance mode.

Pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-A7VXO9/
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-HVCSZ0/
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-TWGG3X/
