### PR TITLE
[unittests] fix isort issue

### DIFF
--- a/tests/mgr/test_cephapi_auth.py
+++ b/tests/mgr/test_cephapi_auth.py
@@ -1,6 +1,5 @@
 from api import BadRequestError
 from api.cephapi.auth.auth import Auth
-
 from utility.log import Log
 
 # LOG constant


### PR DESCRIPTION
# Issue
```
py: commands[2]> isort -c .
ERROR: /home/runner/work/cephci/cephci/tests/mgr/test_cephapi_auth.py Imports are incorrectly sorted and/or formatted.
Skipped 3 files
py: exit 1 (1.86 seconds) /home/runner/work/cephci/cephci> isort -c . pid=1865
.pkg: _exit> python /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py: FAIL code 1 (57.80=setup[43.76]+cmd[2.[46](https://github.com/red-hat-storage/cephci/actions/runs/4593442720/jobs/8111373255?pr=2420#step:5:47),9.73,1.86] seconds)
  evaluation failed :( (58.12 seconds)
Error: Process completed with exit code 1.
```
https://github.com/red-hat-storage/cephci/actions/runs/4593442720/jobs/8111373255?pr=2420

