### PR TITLE
Changing the Owner of home directory

### DIFF
--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -95,6 +95,7 @@ class CephBaremetalNode:
         create_dir = f"install -d -m 700  -o {name} -g {name} /home/{name}/.ssh"
         copy_file = f"install -m 600 -o {name} -g {name} {key_file} /home/{name}/.ssh/"
         bash_script = f"if [ -f {key_file} ] ; then {create_dir}; {copy_file} ; fi"
+        self.rssh().exec_command(command=f"chown {name}:{name} /home/{name}")
         self.rssh().exec_command(command=bash_script)
 
     @property


### PR DESCRIPTION
# Description
Changing the Owner of home directory
Problem:
At times, even after creating cephuser the home directory of cephuser i.e., /home/cephuser is still owned by root user.
we have observed this in some runs
 [root@folio01 ~]# ls -lrt /home | grep cephuser
drwxr-xr-x. 3 root         root         4096 Apr  3 14:49 cephuser

Soultion:
So As soon as we create user we are changing the owner as precautionary step to avoid above situation

Logs : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4UT08J 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
