### PR TITLE
Enable CephCI to run tests for Crimson

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -154,7 +154,7 @@ class CephAdmin(BootstrapMixin, ShellMixin):
             node.exec_command(sudo=True, cmd=cmd)
 
     def setup_upstream_repository(self, repo_url=None):
-        """Download upstream repository to inidividual nodes.
+        """Download upstream repository to individual nodes.
 
         Args:
             repo_url: repo file URL link (default: None)

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -229,6 +229,8 @@ class BootstrapMixin:
             self.cluster.use_cdn = True
         elif custom_repo:
             self.set_tool_repo(repo=custom_repo)
+        elif build_type == "crimson":
+            self.setup_upstream_repository()
         else:
             repos = ["Tools"]
             for node in self.cluster.get_nodes():

--- a/conf/crimson/dsal_rados_conf.yaml
+++ b/conf/crimson/dsal_rados_conf.yaml
@@ -1,0 +1,104 @@
+# DSAL lab environment to be used for Ceph Crimson RADOS testing
+# The below defined cluster has 7 nodes(6 hosts and 1 client)
+# Cluster configuration for rbd tier-1 and tier-2 testcases:
+#       3 MONs, 3 MGRs, 15 OSDs, 1-Client
+globals:
+  -
+    ceph-cluster:
+      name: "ceph-crimson"
+      networks:
+        public: ["10.1.240.0/23"]
+        cluster: ["10.1.240.0/24"]
+      nodes:
+        -
+          hostname: "dell-r640-056.dsal.lab.eng.rdu2.redhat.com"
+          id: node1
+          ip: "10.1.240.31"
+          root_password: ""
+          role:
+            - _admin
+            - mon
+            - mgr
+            - installer
+            - node-exporter
+            - alertmanager
+            - grafana
+            - prometheus
+            - crash
+        -
+          hostname: "dell-r640-079.dsal.lab.eng.rdu2.redhat.com"
+          id: node2
+          ip: "10.1.240.54"
+          root_password: ""
+          role:
+            - mon
+            - mgr
+            - mds
+            - rgw
+            - node-exporter
+            - alertmanager
+            - crash
+        -
+          hostname: "dell-r640-083.dsal.lab.eng.rdu2.redhat.com"
+          id: node3
+          ip: "10.1.240.58"
+          root_password: ""
+          role:
+            - osd
+            - node-exporter
+            - crash
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+        -
+          hostname: "dell-r640-084.dsal.lab.eng.rdu2.redhat.com"
+          id: node4
+          ip: "10.1.240.59"
+          root_password: ""
+          role:
+            - osd
+            - node-exporter
+            - crash
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+        -
+          hostname: "dell-r640-085.dsal.lab.eng.rdu2.redhat.com"
+          id: node5
+          ip: "10.1.240.60"
+          root_password: ""
+          role:
+            - mon
+            - mgr
+            - mds
+            - rgw
+            - node-exporter
+            - crash
+        -
+          hostname: "dell-r640-087.dsal.lab.eng.rdu2.redhat.com"
+          id: node6
+          ip: "10.1.240.62"
+          root_password: ""
+          role:
+            - osd
+            - node-exporter
+            - crash
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+        -
+          hostname: ""            # rhos-d VM to be used as a client
+          id: node7
+          ip: ""
+          root_password: "passwd"
+          role:
+            - client

--- a/conf/crimson/dsal_rbd_conf.yaml
+++ b/conf/crimson/dsal_rbd_conf.yaml
@@ -1,0 +1,69 @@
+# DSAL lab environment to be used for Ceph Crimson RBD testing
+# The below defined cluster has 4 nodes(3 hosts and 1 client)
+# Cluster configuration for rbd tier-1 and tier-2 testcases:
+#       3 MONs, 2 MGRs, 9 OSDs, 1-Client
+globals:
+  -
+    ceph-cluster:
+      name: "ceph-crimson"
+      networks:
+        public: ["10.1.240.0/23"]
+        cluster: ["10.1.240.0/24"]
+      nodes:
+        -
+          hostname: "dell-r640-079.dsal.lab.eng.rdu2.redhat.com"
+          id: node1
+          ip: "10.1.240.54"
+          root_password: ""
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - crash
+            - alertmanager
+            - prometheus
+            - osd
+            - grafana
+            - node-exporter
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+        -
+          hostname: "dell-r640-083.dsal.lab.eng.rdu2.redhat.com"
+          id: node2
+          ip: "10.1.240.58"
+          root_password: ""
+          role:
+            - mon
+            - crash
+            - osd
+            - node-exporter
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+        -
+          hostname: "dell-r640-084.dsal.lab.eng.rdu2.redhat.com"
+          id: node3
+          ip: "10.1.240.59"
+          root_password: ""
+          role:
+            - mon
+            - mgr
+            - crash
+            - osd
+            - node-exporter
+            - alertmanager
+          volumes:
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+        -
+          hostname: "dell-r640-085.dsal.lab.eng.rdu2.redhat.com"
+          id: node4
+          ip: "10.1.240.60"
+          root_password: ""
+          role:
+            - client

--- a/run.py
+++ b/run.py
@@ -112,7 +112,7 @@ Options:
   --rhbuild <1.3.0>                 ceph downstream version
                                     eg: 1.3.0, 2.0, 2.1 etc
   --build <latest>                  Type of build to be use for testing
-                                    eg: latest|tier-0|tier-1|tier-2|released|upstream
+                                    eg: latest|tier-0|tier-1|tier-2|released|upstream|crimson
                                     [default: released]
   --upstream-build <upstream-build> eg: quincy|pacific
   --platform <rhel-8>               select platform version eg., rhel-8, rhel-7
@@ -529,7 +529,7 @@ def run(args):
             distro.append(image_name.replace(".iso", ""))
 
         # get COMPOSE ID and ceph version
-        if build not in ["released", "cvp", "upstream", None]:
+        if build not in ["released", "cvp", "upstream", "crimson", None]:
             compose_id = get_html_page(url=f"{base_url}/COMPOSE_ID")
 
             ver_url = f"{base_url}/compose/Tools/x86_64/os/Packages/"

--- a/suites/crimson/tier-1_rbd.yaml
+++ b/suites/crimson/tier-1_rbd.yaml
@@ -1,0 +1,199 @@
+# Tier1: RBD build evaluation
+#
+# This test suite evaluates the build to determine the execution of identified
+# regression test suites.
+# This suite requires node2 to be a client node with mons, mgrs and osds
+# Example config - conf/crimson/dsal_rbd_conf.yaml
+# Tests which are commented out are currently failing for Crimson
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: "install ceph pre-requisites"
+
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                allow-fqdn-hostname: true
+                mon-ip: node1
+                orphan-initial-daemons: true
+                custom_image: true
+                initial-dashboard-password: Ceph_Crims
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                - "ceph config set global 'enable_experimental_unrecoverable_data_corrupting_features' crimson"
+              command: shell
+          - config:
+              args:
+                - "ceph osd set-allow-crimson --yes-i-really-mean-it"
+              command: shell
+          - config:
+              args:
+                - "ceph config set mon osd_pool_default_crimson true"
+              command: shell
+          - config:
+              args:
+                - "ceph config set global osd_pool_default_pg_autoscale_mode off"
+              command: shell
+          - config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: false
+
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - rbd-nbd
+          - jq
+          - fio
+        node: node4
+      desc: "Configure the client system"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+      polarion-id: CEPH-83573758
+
+  -
+    test:
+      config:
+        script: rbd_groups.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD CLI Groups scenarios"
+      module: test_rbd.py
+      name: 1_rbd_cli_groups
+      polarion-id: CEPH-83574239
+  -
+    test:
+      config:
+        script: import_export.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD CLI Import Export scenarios"
+      module: test_rbd.py
+      name: 2_rbd_cli_import_export
+      polarion-id: CEPH-83574240
+  -
+    test:
+      config:
+        script: luks-encryption.sh
+        script_path: qa/workunits/rbd
+      desc: "Executing upstream RBD LUKS Encryption scenarios"
+      module: test_rbd.py
+      name: 3_rbd_luks_encryption
+      polarion-id: CEPH-83574242
+#  -
+#    test:
+#      config:
+#        script: cli_migration.sh
+#        script_path: qa/workunits/rbd
+#      desc: "Executing upstream RBD CLI Migration scenarios"
+#      module: test_rbd.py
+#      name: 4_rbd_cli_migration
+#      polarion-id: CEPH-83574243
+
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: test_librbd_python.sh
+      desc: Executig upstream LibRBD scenarios
+      module: test_rbd.py
+      name: 5_librbd_python
+      polarion-id: CEPH-83574524
+
+#  - test:
+#      config:
+#        script_path: qa/workunits/rbd
+#        script: permissions.sh
+#      desc: Executig upstream RBD permissions scenarios
+#      module: test_rbd.py
+#      name: 6_rbd_permissions
+#      polarion-id: CEPH-83574525
+
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: read-flags.sh
+      desc: Executig upstream RBD Read Flag scenarios
+      module: test_rbd.py
+      name: 7_rbd_read_flags
+      polarion-id: CEPH-83574526
+
+  - test:
+      config:
+        script_path: qa/workunits/rbd
+        script: journal.sh
+      desc: Executig upstream RBD Journal scenarios
+      module: test_rbd.py
+      name: 9_journal
+      polarion-id: CEPH-83574527
+
+#  - test:
+#      config:
+#        script_path: qa/workunits/rbd
+#        script: kernel.sh
+#      desc: Executig upstream RBD Kernal scenarios
+#      module: test_rbd.py
+#      name: 10_rbd_kernel
+#      polarion-id: CEPH-83574528
+#  - test:
+#      config:
+#        script_path: qa/workunits/rbd
+#        script: krbd_exclusive_option.sh
+#      desc: Executig upstream RBD kernel exclusive scenarios
+#      module: test_rbd.py
+#      name: 11_rbd_krbd_exclusive
+#      polarion-id: CEPH-83574531
+#
+#  - test:
+#      module: delete_clones_with_io.py
+#      name: test delete clones with io
+#      polarion-id: CEPH-9225
+#      Desc: Create clone of an image and delete while krbd IO is running

--- a/suites/crimson/tier-2_rados.yaml
+++ b/suites/crimson/tier-2_rados.yaml
@@ -1,0 +1,480 @@
+# Suite contains basic tier-2 rados tests
+# Cluster config: conf/crimson/dsal_rados_conf.yaml
+# Tests commented out are currently failing for Crimson
+# Tests which are double commented are yet to be executed
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                allow-fqdn-hostname: true
+                mon-ip: node1
+                orphan-initial-daemons: true
+                custom_image: true
+                initial-dashboard-password: Ceph_Crims
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              args:
+                - "ceph config set global 'enable_experimental_unrecoverable_data_corrupting_features' crimson"
+              command: shell
+          - config:
+              args:
+                - "ceph osd set-allow-crimson --yes-i-really-mean-it"
+              command: shell
+          - config:
+              args:
+                - "ceph config set mon osd_pool_default_crimson true"
+              command: shell
+          - config:
+              args:
+                - "ceph config set global osd_pool_default_pg_autoscale_mode off"
+              command: shell
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure email alerts
+      module: rados_prep.py
+      polarion-id: CEPH-83574472
+      config:
+        email_alerts:
+          smtp_host: smtp.corp.redhat.com
+          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
+          smtp_port: 25
+          interval: 10
+          smtp_destination:
+            - pdhiran@redhat.com
+          smtp_from_name: Rados Sanity Cluster Alerts
+      desc: Configure email alerts on ceph cluster
+
+##  - test:
+##      name: Test configuration Assimilation
+##      module: test_config_assimilation.py
+##      polarion-id: CEPH-83573480
+##      config:
+##        cluster_conf_path: "conf/quincy/rados/test-confs/cluster-configs"
+##        Verify_config_parameters:
+##          configurations:
+##            - config-1:
+##                section: "mon"
+##                name: "mon_cluster_log_to_syslog"
+##                value: "true"
+##            - config-2:
+##                section: "osd"
+##                name: "debug_osd"
+##                value: "5/5"
+##            - config-3:
+##                section: "mgr"
+##                name: "mgr_stats_period"
+##                value: "10"
+##            - config-4:
+##                section: "mgr"
+##                name: "debug_mgr"
+##                value: "5/5"
+##            - config-5:
+##                section: "mds"
+##                name: "mds_op_history_size"
+##                value: "40"
+##      desc: Verify config assimilation into ceph mon configuration database
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+##  - test:
+##      name: Verify osd heartbeat no reply
+##      desc: heartbeat_check log entries should contain hostname:port
+##      polarion-id: CEPH-10839
+##      module: test_osd_heartbeat.py
+##      destroy-cluster: false
+##      abort-on-fail: true
+
+  - test:
+      name: Monitor configuration - section and masks changes
+      module: rados_prep.py
+      polarion-id: CEPH-83573477
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "osd"
+                name: "osd_max_backfills"
+                value: "8"
+                location_type: "class"
+                location_value: "hdd"
+            - config-2:
+                section: "osd"
+                name: "osd_recovery_max_active"
+                value: "8"
+                location_type: "host"
+                location_value: "host"
+            - config-3:
+                section: "global"
+                name: "debug_mgr"
+                value: "10/10"
+            - config-4:
+                section: "osd"
+                name: "osd_max_scrubs"
+                value: "5"
+            - config-5:
+                section: "osd.1"
+                name: "osd_max_scrubs"
+                value: "3"
+            - config-6:
+                section: "mds"
+                name: "mds_op_history_size"
+                value: "40"
+            - config-7:
+                section: "client.rgw"
+                name: "rgw_lc_debug_interval"
+                value: "1"
+            - config-8:
+                section: "global"
+                name: "debug_mgr"
+                value: "10/10"
+            - config-9:
+                section: "osd.2"
+                name: "debug_ms"
+                value: "10/10"
+      desc: Verify config changes for section & masks like device class, host etc
+
+  - test:
+      name: Monitor configuration - msgrv2 compression modes
+      module: rados_prep.py
+      polarion-id: CEPH-83574961
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "force"
+            - config-2:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "512"
+            - config-3:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "none"
+            - config-4:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "1024"
+      desc: Verify the health status of the cluster by randomly changing the compression configuration values
+
+#  - test:
+#      name: Replicated pool LC
+#      module: rados_prep.py
+#      polarion-id: CEPH-83571632
+#      config:
+#        replicated_pool:
+#          create: true
+#          pool_name: test_re_pool
+#          pg_num: 16
+#          size: 2
+#          disable_pg_autoscale: true
+#          rados_write_duration: 50
+#          rados_read_duration: 30
+#        set_pool_configs:
+#          pool_name: test_re_pool
+#          configurations:
+#            pg_num: 32
+#            pgp_num: 32
+#            pg_autoscale_mode: 'on'
+#            compression_mode: aggressive
+#            compression_algorithm: zlib
+#      desc: Create replicated pools and run IO
+
+  - test:
+      name: Compression algorithms
+      module: rados_prep.py
+      polarion-id: CEPH-83571669
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression algorithms.
+
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571669
+      config:
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.
+
+  - test:
+      name: Ceph balancer plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83573247
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: crush-compat
+          target_max_misplaced_ratio: 0.04
+          sleep_interval: 30
+      desc: Ceph balancer plugins CLI validation in crush-compat mode
+
+  - test:
+      name: Ceph balancer test
+      module: rados_prep.py
+      polarion-id: CEPH-83573251
+      config:
+        configure_balancer:
+          configure: true
+          balancer_mode: upmap
+          target_max_misplaced_ratio: 0.05
+          sleep_interval: 60
+      desc: Ceph balancer plugins CLI validation in upmap mode
+
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts
+
+#  - test:
+#      name: Ceph PG Autoscaler
+#      module: rados_prep.py
+#      polarion-id: CEPH-83573412
+#      config:
+#        replicated_pool:
+#          create: true
+#          pool_name: rep_test_pool
+#          rados_write_duration: 50
+#          rados_read_duration: 50
+#          pg_num: 32
+#        configure_pg_autoscaler:
+#          default_mode: warn
+#          mon_target_pg_per_osd: 128
+#          pool_config:
+#            pool_name: rep_test_pool
+#            pg_autoscale_mode: "on"
+#            pg_num_min: 16
+#            target_size_ratio: 0.4
+#      desc: Ceph PG autoscaler CLI validation
+
+  - test:
+      name: Config checks
+      module: rados_prep.py
+      polarion-id: CEPH-83574529
+      config:
+        cluster_configuration_checks:
+          configure: true
+          disable_check_list:
+            - osd_mtu_size
+            - osd_linkspeed
+            - kernel_security
+          enable_check_list:
+            - kernel_security
+            - osd_linkspeed
+      desc: Enable Cluster Configuration checks
+
+  - test:
+      name: config source changes log
+      module: test_mon_config_history.py
+      polarion-id: CEPH-83573479
+      desc: Config sources - Verify config source changes in the log
+
+  - test:
+      name: config source changes reset
+      module: test_mon_config_reset.py
+      polarion-id: CEPH-83573478
+      desc: Config sources - Verify config source changes and reset config
+
+#  - test:
+#      name: Compression test - replicated pool
+#      module: pool_tests.py
+#      polarion-id: CEPH-83571673
+#      config:
+#        Compression_tests:
+#          verify_compression_ratio_set: true          # TC : CEPH-83571672
+#          pool_type: replicated
+#          pool_config:
+#            pool-1: test_compression_repool-1
+#            pool-2: test_compression_repool-2
+#            rados_write_duration: 200
+#            byte_size: 400KB
+#            pg_num: 32
+#          compression_config:
+#            compression_mode: aggressive
+#            compression_algorithm: snappy
+#            compression_required_ratio: 0.3
+#            compression_min_blob_size: 1B
+#            byte_size: 10KB
+#      desc: Verification of the effect of compression on replicated pools
+
+  - test:
+      name: autoscaler flags
+      module: test_pg_autoscale_flag.py
+      polarion-id: CEPH-83574794
+      desc: verify autoscaler flags functionality

--- a/utility/upstream_recipe.py
+++ b/utility/upstream_recipe.py
@@ -1,0 +1,244 @@
+"""
+#### This is a copy of pipeline/scripts/ci/upstream_cli.py with minor
+enhancements to enable fetching of crimson composes. It was copied here
+as using upstream_cli.py from pipeline/scripts/ci causes a tox failure.
+Once the pipeline listener is setup to update recipe for crimson in
+magna002, this file will be removed.
+####
+This script provides the upstream latest rpm repo path and container image.
+Please note that this script should be run under root privilages
+inorder to pull the image and podman should be installed on that host.
+"""
+import logging
+import os
+import re
+import sys
+import time
+
+import requests
+import yaml
+from docopt import docopt
+from yaml.loader import SafeLoader
+
+LOG = logging.getLogger(__name__)
+
+
+def set_lock(file_name):
+    """Method to lock the file to avoid race condition"""
+    lock_file = file_name + ".lock"
+    exit_status = os.system(f"ls -l {lock_file}")
+    if exit_status:
+        print("File lock does not exist, Creating it")
+        os.system(f"touch {lock_file}")
+        return
+    # If any process locks the file it will wait till it unlock
+    timeout = 600
+    timeout_start = time.time()
+    while time.time() < timeout_start + timeout:
+        # wait for 2 minutes before retrying
+        time.sleep(120)
+        exit_status = os.system(f"ls -l {lock_file}")
+        if exit_status:
+            print("File lock does not exist, Creating it")
+            os.system(f"touch {lock_file}")
+            return
+
+    raise Exception(f"Lock file: {lock_file} already exist, can not create lock file")
+
+
+def unset_lock(file_name):
+    """Method to unlock the above set lock"""
+    lock_file = file_name + ".lock"
+    exit_status = os.system(f"rm -f {lock_file}")
+    if exit_status == 0:
+        print("File un-locked successfully")
+        return
+    raise Exception("Unable to unlock the file")
+
+
+def update_upstream(file_name, content, repo, image, upstream_version):
+    """Method to update for the provided file
+    along with file set lock to avoid race condition.
+    Args:
+        file_name: Name of the file to update
+        content: things to update in file
+    """
+    with open(file_name, "w") as yaml_file:
+        try:
+            # To lock the file to avoid race condition
+            set_lock(file_name)
+            # update the file with write operation
+            yaml_file.write(yaml.dump(content, default_flow_style=False))
+        finally:
+            # unlock it so other processed can use it
+            unset_lock(file_name)
+            LOG.info(
+                f"Updated build info: \n repo:{repo} \n image:{image} \n ceph version:{upstream_version} in {file_name}"
+            )
+
+
+def compare(ex, new):
+    """Returns true if new version > than existing.
+
+    Args:
+        ex: Existing ceph version
+        new: Newer Ceph version
+
+    Returns:
+        Boolean
+    """
+    ev = "".join(re.split("[-.]", ex))
+    nv = "".join(re.split("[-.]", new))
+
+    length = ev.__len__() if ev.__len__() > nv.__len__() else nv.__len__()
+
+    def zero_padding(x):
+        return x if len(x) == length else x.ljust(length, "0")
+
+    return zero_padding(nv) > zero_padding(ev)
+
+
+def store_in_upstream(branch_name, repo, image, upstream_version, flavor="default"):
+    """Method to update it in upstream.yaml.
+    Args:
+        branch_name: Name of upstream branch
+        repo: upstream branch compose URL
+        image: upstream branch image
+        upstream_version: upstream branch ceph version.
+        flavor: upstream branch build flavor
+    """
+    file_name = "/ceph/cephci-jenkins/latest-rhceph-container-info/upstream.yaml"
+    if flavor == "crimson":
+        file_name = "/tmp/crimson.yaml"
+        branch_name = flavor
+    repo_details = {}
+    if os.path.exists(file_name):
+        stream = open(file_name, "r")
+        repo_details = yaml.load(stream, Loader=SafeLoader) or {}
+    if repo_details and repo_details.get(branch_name):
+        existing_version = repo_details[branch_name]["ceph-version"]
+        # update only if current version is greater than existing version.
+        if not compare(existing_version, upstream_version):
+            print(
+                f"Current version:{upstream_version} not greater than existing version:{existing_version}"
+            )
+            return
+        repo_details[branch_name]["composes"] = repo
+        repo_details[branch_name]["image"] = image
+        repo_details[branch_name]["ceph-version"] = upstream_version
+    else:
+        # updating new branch details in upstream.yaml
+        repo_details[branch_name] = {
+            "ceph-version": upstream_version,
+            "composes": repo,
+            "image": image,
+        }
+    update_upstream(file_name, repo_details, repo, image, upstream_version)
+
+
+usage = """
+This script helps to provide needed info for upstream specific.
+
+Usage:
+  upstream_recipe.py build <branch_name> [flavor <flavor_name>]
+
+Example:
+    python upstream_recipe.py build quincy
+
+Options:
+    -h --help                       Show this screen
+    build                           Branch name
+    flavor                          Build flavor (default: default)
+"""
+
+
+def fetch_upstream_build(
+    branch: str,
+    centos_version: str = "9",
+    arch: str = "x86_64",
+    flavor: str = "default",
+):
+    """
+    Method to get rpm repo path,container image and ceph version of given branch.
+
+    Args:
+        branch: str         Upstream branch name
+        centos_version: str Centos Version (default: 9)
+        arch: str           CPU Architecture (default: x86_64)
+        flavor: str         Build flavor (default: default)
+    """
+    url = "https://shaman.ceph.com/api/repos/ceph/"
+    url += f"{branch.lower()}/latest/centos/{centos_version}"
+    url = f"{url}/flavors/crimson" if flavor == "crimson" else url
+
+    def check_status(resp):
+        if resp.ok:
+            resp.raise_for_status()
+
+    # if any connection issue to URL it will wait for 30 seconds to establish connection.
+    response = requests.get(url, timeout=30)
+    check_status(response)
+    _repo, _id, _version = None, None, None
+    for srcs in response.json():
+        if arch in srcs["archs"]:
+            _version = srcs["extra"]["version"]
+            _url = srcs["chacra_url"]
+            _repo = f"{_url}repo" if _url.endswith("/") else f"{_url}/repo"
+            _id = srcs["sha1"]
+            break
+    else:
+        raise Exception(
+            f"Could not find build source for {branch}-centos-{centos_version}-{arch}"
+        )
+
+    LOG.info(f"Upstream repo for the given branch is {_repo}")
+
+    # To get image for that rpm repo
+    image = "quay.ceph.io/ceph-ci/ceph:" + _id
+    image = f"{image}-crimson" if flavor == "crimson" else image
+    LOG.info(f"Upstream image for the given branch is {image}")
+
+    cmd = "podman -v"
+    exit_status = os.system(cmd)
+    if exit_status:
+        raise Exception("Please install podman on host")
+
+    cmd = f"podman pull {image}"
+    exit_status = os.system(cmd)
+    if exit_status:
+        raise Exception(f"{image} is unable to pull")
+
+    LOG.info(f"Upstream version for the given branch is {_version}")
+    store_in_upstream(branch, _repo, image, _version, flavor)
+
+
+OPS = {
+    "build": fetch_upstream_build,
+}
+
+if __name__ == "__main__":
+    _args = docopt(usage, help=True, version=None, options_first=False)
+    logging.basicConfig(
+        handlers=[logging.StreamHandler(sys.stdout)],
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s",
+    )
+
+    try:
+        method = None
+        for key, value in OPS.items():
+            if _args[key]:
+                method = value
+                break
+        else:
+            raise Exception("please provide right action")
+
+        branch_name = _args["<branch_name>"]
+        flavor_name = _args.get("<flavor_name>", "default")
+        args = [branch_name]
+
+        method(*args) if flavor_name != "crimson" else method(
+            *args, "8", flavor=flavor_name
+        )
+    except BaseException as be:
+        raise Exception(be)


### PR DESCRIPTION
Purpose of this PR is to enhance CephCI framework to run tests with Crimson builds.
Limitations:
- Baremetal lab would need to be setup manually
- Cluster conf file would need to be updated with the physical lab details

Arguments added for Crimson:
Existing argument `--build` now takes `crimson` as input
New argument `--crimson-image` takes the crimson build image sha1 id as input

> Note: The PR is to merge these changes on a private branch "crimson" to avoid conflicts and noise in master branch

Modules added to facilitate crimson builds -
- `set_crimson_repo` in `ceph/ceph_admin/__init__.py` : Adds the Crimson repo compose to each node in the cluster
- `apply` of `class OSD` in `ceph/ceph_admin/osd.py`: crimson specific ceph config applied if appropriate argument is passed
- `retrieve_shaman_chacra_url` in `utility/utils.py` : Retrieves the chacra url of a build using the build image sha1 id

Cluster configs added:
- `conf/crimson/dsal_rados_conf.yaml` : 7 node (6 hosts + 1 client) config for RADOS tests
- `conf/crimson/dsal_rbd_conf.yaml` : 4 node (3 hosts + 1 client) config for RBD tests

Test suites added:
- suites/crimson/tier-1_rbd.yaml
- suites/crimson/tier-2_rados.yaml

Sample command line -
 `python3.9 run.py --rhbuild 6.0 --cloud baremetal --global-conf conf/crimson/dsal_rbd_conf.yaml --osp-cred osp/osp-cred-ci-2.yaml --inventory conf/inventory/rhel-8-latest.yaml --suite suites/quincy/crimson/tier-1_rbd.yaml --log-level info --platform rhel-8 --skip-sos-report --build crimson --crimson-image b682861f8690608d831f58603303388dd7915aa7`

Logs:
RBD tests:
http://magna002.ceph.redhat.com/ceph-qe-logs/harsh/crimson-cephci-rbd-bootstrap/
http://magna002.ceph.redhat.com/ceph-qe-logs/harsh/crimson-cephci-rbd/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
