### PR TITLE
[Ceph-Volume] Validate LVM persistent naming

### DIFF
--- a/cli/ceph/orch/orch.py
+++ b/cli/ceph/orch/orch.py
@@ -48,7 +48,7 @@ class Orch(Cli):
             return out[0].strip()
         return out
 
-    def apply(self, service_name, check_ec=False, **kw):
+    def apply(self, service_name=None, check_ec=False, **kw):
         """
         Applies the configuration to hosts.
 
@@ -62,7 +62,9 @@ class Orch(Cli):
               placement (dict): placement on hosts.
               count (int): number of hosts to be applied
         """
-        cmd = f"{self.base_cmd} apply {service_name}"
+        cmd = f"{self.base_cmd} apply"
+        if service_name:
+            cmd += " {service_name}"
         for arg in kw.pop("pos_args"):
             cmd += f" {arg}"
         cmd += build_cmd_from_args(**kw)

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -452,3 +452,26 @@ def get_lvm_on_osd_container(container_id, node, format="json"):
     cmd = f"ceph-volume lvm list --format {format}"
     out, _ = exec_command_on_container(node=node, ctr=container_id, cmd=cmd, sudo=True)
     return loads(out)
+
+
+def get_disk_devlinks(node, disk):
+    """
+    Parses the devlink data to identify the by-id and by-path values
+    Args:
+        node (ceph): Node to execute cmd
+        disk (str): disk nam. e.g: /dev/vdb
+
+    Returns (list, list): by-id and by-path values
+    """
+
+    cmd = f"udevadm info --query=property {disk} | grep DEVLINKS"
+    out, _ = node.exec_command(cmd=cmd)
+    by_id = []
+    by_path = []
+    for entry in out.split(" "):
+        path = entry.split("=")[-1]
+        if "by-id" in path:
+            by_id.append(path)
+        elif "by-path" in path:
+            by_path.append(path)
+    return by_id, by_path

--- a/suites/pacific/ceph_volume/tier-2-ceph-volume.yaml
+++ b/suites/pacific/ceph_volume/tier-2-ceph-volume.yaml
@@ -75,6 +75,27 @@ tests:
       name: Deploy cluster using cephadm
 
   - test:
+      name: Configure client
+      desc: Configure client on node5
+      module: test_client.py
+      polarion-id: CEPH-83573758
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node5                       # client node
+        install_packages:
+          - ceph-common                   # install ceph common packages
+        copy_admin_keyring: true          # Copy admin keyring to node
+        store-keyring: true               # /etc/ceph/ceph.client.1.keyring
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
       name: Validate lvm tags post osd rm command
       desc: Verify the lvm tags are removed after osd rm
       polarion-id: CEPH-83575103
@@ -87,3 +108,22 @@ tests:
       module: test_ceph_volume_lvm_tags_after_osd_rm.py
       config:
         operation: lvm-zap
+
+  - test:
+      name: Validate lvm batch persistent
+      desc: Validate lvm batch /dev/disk/by-path/ & /dev/disk/by-id/ for persistent naming
+      polarion-id: CEPH-83575117
+      module: test_ceph_volume_validate_persistent_naming.py
+      config:
+        specs:
+          service_type: osd
+          service_id: osd.3
+          placement:
+            hosts:
+              - node3
+          data_devices:
+            paths:
+              - PATH
+          db_devices:
+            paths:
+              - PATH

--- a/tests/ceph_volume/test_ceph_volume_validate_persistent_naming.py
+++ b/tests/ceph_volume/test_ceph_volume_validate_persistent_naming.py
@@ -1,0 +1,106 @@
+import json
+import tempfile
+from json import loads
+
+import yaml
+
+from cli.ceph.ceph import Ceph
+from cli.cephadm.cephadm import CephAdm
+from cli.utilities.utils import (
+    get_disk_devlinks,
+    get_lvm_on_osd_container,
+    get_running_containers,
+)
+
+SPEC_FILE_PATH = "/tmp/osd.yaml"
+
+
+class SpecFileCreationError(Exception):
+    pass
+
+
+class SpecFileApplyError(Exception):
+    pass
+
+
+def _identify_disks(node):
+    """
+    Identifies the disks associated with the node
+    Args:
+        node (ceph): Node in which the cmd is executed
+
+    Returns (list): List of available disks
+    """
+
+    disks = []
+    conf = {"format": "json"}
+    available_disks = json.loads(CephAdm(node).ceph.orch.device.ls(**conf))
+    for key in available_disks:
+        if key.get("devices"):
+            for dev in key.get("devices"):
+                disks.append(dev.get("path"))
+    return list(set(disks))
+
+
+def _create_spec_file(node, specs):
+    """
+    Creates the spec file as per the requirement
+    Args:
+        node (ceph): Node to execute cmd
+        specs(str): given spec file data
+    """
+    temp_file = tempfile.NamedTemporaryFile(suffix=".yaml")
+    spec = yaml.dump(specs, sort_keys=False, indent=2).encode("utf-8")
+    temp_file.write(spec)
+    temp_file.flush()
+    node.upload_file(src=temp_file.name, dst=SPEC_FILE_PATH, sudo=True)
+    return temp_file.name
+
+
+def run(ceph_cluster, **kw):
+    """Check LVM persistent naming
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+
+    mon_node = ceph_cluster.get_nodes(role="mon")[0]
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+    disks = _identify_disks(mon_node)
+
+    nodes = config.get("specs", {}).get("placement", {}).get("hosts")
+    host = [ceph_cluster.get_nodes()[int(node[-1])].hostname for node in nodes]
+    running_containers, _ = get_running_containers(
+        mon_node, format="json", expr="name=osd", sudo=True
+    )
+    container_ids = [item.get("Names")[0] for item in loads(running_containers)]
+
+    # Get the initial lvm list
+    initial_lvm_list = get_lvm_on_osd_container(container_ids[0], mon_node)
+
+    by_id, by_path = get_disk_devlinks(mon_node, disks[0])
+
+    # Create spec file specific to by-path and by-id
+    for data_device in [by_path[0], by_id[0]]:
+        specs = config.get("specs")
+        specs["data_devices"]["paths"] = data_device
+        specs["db_devices"]["paths"] = data_device
+        specs["placement"]["hosts"] = host
+        spec_file = _create_spec_file(client_node, specs)
+        if not spec_file:
+            raise SpecFileCreationError(
+                f"Failed to create Spec file with {data_device}"
+            )
+
+        # Execute orch apply with spec file
+        conf = {"pos_args": ["-i", spec_file]}
+        if Ceph(client_node).orch.apply(**conf):
+            raise SpecFileApplyError("Failed to apply spec file")
+
+    final_lvm_list = get_lvm_on_osd_container(container_ids[0], mon_node)
+
+    # Checking whether the lvm has been updated or not
+    if initial_lvm_list != final_lvm_list:
+        raise SpecFileApplyError("LVM's not updated after applying spec")
+
+    return 0


### PR DESCRIPTION
# Description

Polarion Test case included:

CEPH-83575117    BZ-2064429 -[CEE/SD][ceph-volume] ceph-volume lvm batch not accepting the /dev/disk/by-path/ & /dev/disk/by-id/ for persistent naming

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
