### PR TITLE
Test to verify write operation should fail from secondary site in rbd mirroring

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -60,7 +60,7 @@ class RbdMirror:
             if kw.get("ceph_args", True):
                 cmd = cmd + self.ceph_args
 
-            if kw.get("long_running"):
+            if kw.get("long_running", True):
                 out = node.exec_command(
                     sudo=True,
                     cmd=cmd,
@@ -688,7 +688,7 @@ class RbdMirror:
                 cmd="rbd bench-write --io-total {} {}".format(
                     kw.get("io", "500M"), kw.get("imagespec")
                 ),
-                long_running=True,
+                **kw,
             )
         else:
             return self.exec_cmd(
@@ -696,7 +696,7 @@ class RbdMirror:
                     "rbd bench --io-type write --io-threads 16 "
                     f"--io-total {kw.get('io', '500M')} {kw.get('imagespec')}"
                 ),
-                long_running=True,
+                **kw,
             )
 
     def create_pool(self, **kw):

--- a/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
+++ b/tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py
@@ -1,18 +1,49 @@
 from ceph.parallel import parallel
-from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from tests.rbd_mirror.rbd_mirror_utils import rbd_mirror_config
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(**kw):
+def test_write_from_secondary(self, mirrormode, imagespec):
+    """Method to verify write operation should not be performed from secondary site,
+    as mirrored image got locked from primary site.
+
+    Args:
+        self: mirror2 object
+        mirrormode: type of mirroring journal or snapshot
+        imagespec: poolname + "/" + imagename
+    Returns:
+        0 - if test case pass
+        1 - if test case fails
+    """
+    out, err = self.benchwrite(
+        imagespec=imagespec, long_running=False, all=True, check_ec=False
+    )
+    log.debug(err)
+
+    if "Read-only file system" in err:
+        log.info(
+            "As Expected writing data from secondary got failed, "
+            f"mirrored image got locked from primary in {mirrormode} based mirroring"
+        )
+        return 0
+
+    log.error(
+        f"Able to write data into secondary image for {mirrormode} based mirroring,"
+        " This is invalid since image should be locked at primary."
+    )
+    return 1
+
+
+def test_journal_to_snapshot(rbd_mirror, pool_type, **kw):
     """verification Snap mirroring on journaling based image after disable journaling on image.
 
     Args:
         **kw:
     Returns:
         0 - if test case pass
-        1 - it test case fails
+        1 - if test case fails
 
     Test case flow:
     1. Create image on cluster-1.
@@ -26,10 +57,8 @@ def run(**kw):
     try:
         log.info("Starting RBD mirroring test case")
         config = kw.get("config")
-        mirror1, mirror2 = [
-            rbdmirror.RbdMirror(cluster, config)
-            for cluster in kw.get("ceph_cluster_dict").values()
-        ]
+        mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         poolname = mirror1.random_string() + "_tier_2_rbd_mirror_pool"
         imagename = mirror1.random_string() + "_tier_2_rbd_mirror_image"
         imagespec = poolname + "/" + imagename
@@ -46,6 +75,11 @@ def run(**kw):
             **kw,
         )
 
+        mirrormode = mirror1.get_mirror_mode(imagespec)
+        # Verification of Negative test as image should not allow write operation from secondary
+        if test_write_from_secondary(mirror2, mirrormode, imagespec):
+            return 1
+
         # Disabling journal mirror on image
         mirror1.disable_mirroring("image", imagespec)
 
@@ -54,8 +88,11 @@ def run(**kw):
         mirror2.wait_for_status(poolname=poolname, images_pattern=1)
 
         # Verification of mirrored image on cluster
-        mirror2.image_exists(imagespec)
-        if mirror1.get_mirror_mode(imagespec) == "snapshot":
+        if mirror2.image_exists(imagespec):
+            return 1
+
+        mirrormode = mirror1.get_mirror_mode(imagespec)
+        if mirrormode == "snapshot":
             log.info("snapshot mirroring is enabled")
         mirror1.benchwrite(imagespec=imagespec, io=config.get("io-total", "1G"))
         with parallel() as p:
@@ -67,16 +104,57 @@ def run(**kw):
                 imagespec=imagespec,
                 state_pattern="up+replaying",
             )
-
-        # Cleans up the configuration
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+        # Verification of Negative test as image should not allow write operation from secondary
+        if test_write_from_secondary(mirror2, mirrormode, imagespec):
+            return 1
         return 0
-
-    except ValueError:
-        log.error(
-            f"{kw.get('ceph_cluster_dict').values} has less or more clusters Than Expected(2 clusters expected)"
-        )
 
     except Exception as e:
         log.error(e)
         return 1
+
+    # Cleans up the configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
+
+
+def run(**kw):
+    """
+    Journal based mirroring to snapshot based mirroring conversion.
+
+    Args:
+        **kw: test data
+            Example::
+            config:
+                ec_pool_config:
+                  mirrormode: snapshot
+                  mode: image
+                rep_pool_config:
+                  mirrormode: snapshot
+                  mode: image
+                snapshot_schedule_level: "cluster"
+                imagesize: 2G
+
+    Returns:
+        int: The return value - 0 for success, 1 for failure
+    """
+    log.info(
+        "Starting CEPH-83573618, "
+        "Test to verify snapshot based mirroring on journaling based mirrored images."
+    )
+
+    mirror_obj = rbd_mirror_config(**kw)
+
+    if mirror_obj:
+        log.info("Executing test on replicated pool")
+        if test_journal_to_snapshot(
+            mirror_obj.get("rep_rbdmirror"), "rep_pool_config", **kw
+        ):
+            return 1
+
+        log.info("Executing test on ec pool")
+        if test_journal_to_snapshot(
+            mirror_obj.get("ec_rbdmirror"), "ec_pool_config", **kw
+        ):
+            return 1
+    return 0


### PR DESCRIPTION
# Description
Automated below test case
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9503

As discussed with team since it's just one negative test to validate, hence accommodate that test in existing 
`tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py` as it covers both validation from `journal` and `snapshot` based mirroring.

**Test flow:**
- On the remote/secondary cluster, try using the mirrored image for writing.
- command should error out saying `Read only file system`

**Files modified:**
tests/rbd_mirror/rbd_mirror_utils.py
tests/rbd_mirror/test_rbd_mirror_journal_to_snap.py

**Test Result:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DMXXLM


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
