### PR TITLE
Integrating polarion TC-CEPH-11623 to cephci

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -165,15 +165,6 @@ tests:
         config-file-name: test_sts_invalid_principal.yaml
         timeout: 500
   - test:
-      name: Test rename of large object using sts user through AWS
-      desc: Test rename of large object using sts user through AWS
-      polarion-id: CEPH-83575419
-      module: sanity_rgw.py
-      config:
-        script-name: ../aws/test_sts_rename_large_object.py
-        config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
-  - test:
       name: reshard cancel command
       desc: reshard cancel command
       polarion-id: CEPH-11474

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -355,8 +355,18 @@ tests:
       polarion-id: CEPH-11574
       module: sanity_rgw.py
       config:
-        script-name: test_list_all_multipart_uploads.py
+        script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
+        timeout: 300
+
+  - test:
+      name: GetBucketLocation with bucket policy for users in same tenant
+      desc: Test GetBucketLocation bucket policy for users in same tenant
+      polarion-id: CEPH-11623
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_with_tenant_user.py
+        config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
         timeout: 300
 
   # Bucket Lifecycle Tests

--- a/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
@@ -121,3 +121,13 @@ tests:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_bi_purge.yaml
               timeout: 300
+ # STS tests
+  - test:
+      name: Test rename of large object using sts user through AWS
+      desc: Test rename of large object using sts user through AWS
+      polarion-id: CEPH-83575419
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_sts_rename_large_object.py
+        config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
+        timeout: 500

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -171,15 +171,6 @@ tests:
         config-file-name: test_sts_invalid_principal.yaml
         timeout: 500
   - test:
-      name: Test rename of large object using sts user through AWS
-      desc: Test rename of large object using sts user through AWS
-      polarion-id: CEPH-83575419
-      module: sanity_rgw.py
-      config:
-        script-name: ../aws/test_sts_rename_large_object.py
-        config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
-  - test:
       name: reshard cancel command
       desc: reshard cancel command
       polarion-id: CEPH-11474

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -275,8 +275,18 @@ tests:
       polarion-id: CEPH-11574
       module: sanity_rgw.py
       config:
-        script-name: test_list_all_multipart_uploads.py
+        script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
+        timeout: 300
+
+  - test:
+      name: GetBucketLocation with bucket policy for users in same tenant
+      desc: Test GetBucketLocation bucket policy for users in same tenant
+      polarion-id: CEPH-11623
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_with_tenant_user.py
+        config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
         timeout: 300
 
   # Bucket Lifecycle Tests


### PR DESCRIPTION
# Description
T2 automation-CEPH-11623-s3:GetBucketLocation with users in same tenant
log: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-wktej/GetBucketLocation_with_bucket_policy_for_users_in_same_tenant_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-lflaf/GetBucketLocation_with_bucket_policy_for_users_in_same_tenant_0.log

aws testcase is moved to non-ssl suite: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-vzhvd/Test_rename_of_large_object_using_sts_user_through_AWS_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
