### PR TITLE
[CEPH-83574719] Validate pwl without exclusive-lock

### DIFF
--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -287,3 +287,28 @@ tests:
           desc: RBD Persistent Cache cache path validation image level
           module: test_rbd_persistent_write_back_cache.py
           name: PWL cache path validation at image level
+
+  - test:
+      abort-on-fail: true
+      config:
+        level: client                        # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node6
+        drive: /dev/sdb
+        cleanup: true
+        validate_exclusive_lock: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          runtime: 120
+      desc: Validate PWL cache non-working without exclusive lock feature
+      destroy-cluster: false
+      module: test_rbd_persistent_write_back_cache.py
+      name: PWL cache creation with exclusive lock
+      polarion-id: CEPH-83574719

--- a/tests/rbd/rbd_peristent_writeback_cache.py
+++ b/tests/rbd/rbd_peristent_writeback_cache.py
@@ -187,3 +187,28 @@ class PersistentWriteAheadLog:
 
     def invalidate(self, image):
         pass
+
+
+# utils
+def get_entity_level(config):
+    """Method to get config level and entity."""
+    config_level = config["level"]
+    entity = "client"
+    pool = config["rep_pool_config"]["pool"]
+    image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
+    if config_level == "client":
+        config_level = "global"
+    elif config_level == "pool":
+        entity = pool
+    elif config_level == "image":
+        entity = image
+
+    return config_level, entity
+
+
+def fio_ready(config, client):
+    """Method to prepare FIO config args."""
+    fio_args = config["fio"]
+    fio_args["client_node"] = client
+    fio_args["long_running"] = True
+    return fio_args

--- a/tests/rbd/test_rbd_persistent_write_back_cache.py
+++ b/tests/rbd/test_rbd_persistent_write_back_cache.py
@@ -12,12 +12,54 @@ Support
 """
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
-from tests.rbd.rbd_peristent_writeback_cache import PersistentWriteAheadLog
+from tests.rbd.rbd_peristent_writeback_cache import (
+    PersistentWriteAheadLog,
+    PWLException,
+    fio_ready,
+    get_entity_level,
+)
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.utils import run_fio
 
 log = Log(__name__)
+
+
+def validate_pwl_without_exclusive_lock(cache, cfg, client):
+    """Validate PWL cache without exclusive lock feature.
+
+    Method would validate that cache file will not be created
+     when exclusive lock feature of image is disabled.
+
+    If Image exclusive-lock = No, then  PWL Cache = No
+
+    Args:
+        cache: PersistentWriteAheadLog object
+        cfg: test config
+        client: cache client node
+    """
+    config_level, entity = get_entity_level(cfg)
+    pool, image = cfg["image_spec"].split("/")
+    cache.rbd.disable_rbd_feature(pool, image, "object-map,exclusive-lock")
+    cache.configure_pwl_cache(
+        cfg["rbd_persistent_cache_mode"],
+        config_level,
+        entity,
+        cfg["cache_file_size"],
+    )
+
+    # Run FIO, validate cache file non-existence during entire FIO.
+    with parallel() as p:
+        p.spawn(run_fio, **fio_ready(cfg, client))
+        try:
+            cache.check_cache_file_exists(
+                cfg["image_spec"],
+                cfg["fio"].get("runtime", 120),
+                **cfg,
+            )
+            raise Exception("PWL Cache file created with exclusive lock disabled..")
+        except PWLException as error:
+            log.info(f"{error} as expected in entire FIO execution...")
 
 
 def run(ceph_cluster, **kw):
@@ -39,19 +81,18 @@ def run(ceph_cluster, **kw):
     pool = config["rep_pool_config"]["pool"]
     image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
 
-    config_level = config["level"]
-    entity = "client"
-    if config_level == "client":
-        config_level = "global"
-    elif config_level == "pool":
-        entity = pool
-    elif config_level == "image":
-        entity = image
-
     pwl = PersistentWriteAheadLog(rbd_obj, cache_client, config.get("drive"))
+    config_level, entity = get_entity_level(config)
+
     try:
         # Configure PWL
         pwl.configure_cache_client()
+
+        if config.get("validate_exclusive_lock"):
+            config["image_spec"] = image
+            validate_pwl_without_exclusive_lock(pwl, config, cache_client)
+            return 0
+
         pwl.configure_pwl_cache(
             config["rbd_persistent_cache_mode"],
             config_level,
@@ -61,13 +102,10 @@ def run(ceph_cluster, **kw):
 
         # Run FIO, validate cache file existence in self.pwl_path under cache node
         with parallel() as p:
-            fio_args = config["fio"]
-            fio_args["client_node"] = cache_client
-            fio_args["long_running"] = True
-            p.spawn(run_fio, **fio_args)
+            p.spawn(run_fio, **fio_ready(config, cache_client))
             pwl.check_cache_file_exists(
                 image,
-                fio_args.get("runtime", 120),
+                config["fio"].get("runtime", 120),
                 **config,
             )
 


### PR DESCRIPTION
**CEPH-83574719** - exclusive lock disabled, check cache image status in SSD mode
- Create pool and image.
- Disable `exclusive-lock feature` on the image.
- Configure PWL on cache client.
- Run FIO and validate the cache file not created & PWL won't work there.

**Test results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WBMHVZ/PWL_cache_creation_with_exclusive_lock_0.log

