### PR TITLE
CEPH-11393 - Delayed Deletion - Verify there is no name collision with a trashed image

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -233,3 +233,9 @@ tests:
       module: rbd_flatten_image_feature_disable.py
       name: Test to disable image feature when flatten operation is performed
       polarion-id: CEPH-9862
+
+  - test:
+      desc: Verify image trash restore when same name image is already present
+      module: trash_restore_same_name_image.py
+      name: Test to verify image restore with same name
+      polarion-id: CEPH-11393

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -232,3 +232,9 @@ tests:
       module: rbd_flatten_image_feature_disable.py
       name: Test to disable image feature when flatten operation is performed
       polarion-id: CEPH-9862
+
+  - test:
+      desc: Verify image trash restore when same name image is already present
+      module: trash_restore_same_name_image.py
+      name: Test to verify image restore with same name
+      polarion-id: CEPH-11393

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -550,9 +550,10 @@ class Rbd:
         image_info = json.loads(out)
         for value in image_info:
             if value["name"] == image_name:
+                log.debug(f"Image id for {image_name} is {value['id']}")
                 return value["id"]
 
-    def trash_restore(self, pool_name, image_id):
+    def trash_restore(self, pool_name, image_id, **kw):
         """
          Move images to trash, restore them
         Args:
@@ -560,7 +561,7 @@ class Rbd:
              image_id: image id of the image
          Returns:
         """
-        return self.exec_cmd(cmd=f"rbd trash restore {pool_name}/{image_id}")
+        return self.exec_cmd(cmd=f"rbd trash restore {pool_name}/{image_id}", **kw)
 
     def image_meta(self, **kw):
         """Manage image-meta.

--- a/tests/rbd/trash_restore_same_name_image.py
+++ b/tests/rbd/trash_restore_same_name_image.py
@@ -1,0 +1,94 @@
+"""Verify there is no name collision with a trashed image.
+This module verifies trash operations
+
+Pre-requisites :
+
+We need atleast one client node with ceph-common package,
+conf and keyring files
+
+Test cases covered -
+
+CEPH-11393 - Delayed Deletion - Verify there is no name collision with a trashed image
+
+Test case flow -
+1. Create a Rep pool and an Image
+2. generate IO in images
+3. Move images to trash
+4. Create a same(trashed image) name image again.
+4. Restore the moved image in trash
+5. verify restore failes with message as
+'an image with the same name already exists,
+try again with with a different name'
+6. Repeat the above steps for EC-pool.
+"""
+
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def trash_restore_same_name_image(rbd, pool_type, **kw):
+    """
+    Run move image to trash and restore back the image from trash with same name
+        Args:
+        rbd: rbd object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: Test data
+    """
+    pool = kw["config"][pool_type]["pool"]
+    image = kw["config"][pool_type]["image"]
+
+    try:
+        # run ios on image and move image to trash
+        client = kw["ceph_cluster"].get_nodes(role="client")[0]
+        run_fio(image_name=image, pool_name=pool, client_node=client)
+        rbd.move_image_trash(pool, image)
+
+        # Create a image with same name as moved to trash
+        rbd.create_image(pool, image, "10G")
+
+        # Restore the image from trash
+        image_id = rbd.get_image_id(pool, image)
+        out, err = rbd.trash_restore(pool, image_id, all=True, check_ec=False)
+        if "an image with the same name already exists" in err:
+            log.info("As expected Restoration of image with same name is restricted")
+            return 0
+        log.error(err)
+        return 1
+
+    except RbdBaseException as error:
+        log.error(error.message)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
+
+
+def run(**kw):
+    """verifies the image restoration is block from trash,
+    when image with same name already present.
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    """
+    log.info("CEPH-11393 - Running Trash image restore with same name")
+    rbd_obj = initial_rbd_config(**kw)
+    if rbd_obj:
+        log.info("Executing test on Replication pool")
+        if trash_restore_same_name_image(
+            rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw
+        ):
+            return 1
+        log.info("Executing test on EC pool")
+        if trash_restore_same_name_image(
+            rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw
+        ):
+            return 1
+    return 0


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-8237
This PR includes Automation for image trash restore when same name image is already present
Verify there is no name collision with a trashed image 
Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11393

File changed/Renamed/modified :
tests/rbd/rbd_utils.py
suites/pacific/rbd/tier-2_rbd_regression.yaml
suites/quincy/rbd/tier-2_rbd_regression.yaml

New file/Module added : 
tests/rbd/trash_restore_same_name_image.py

success log :
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-62UZVK/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-omyph/