### PR TITLE
Fixing ci Issue RHCEPHQE-8158

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -317,7 +317,7 @@ pipelines:
         - name: "Tier-2 Cephfs test mds pinning"
           execution_time: "1h 7m 50s"
           suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
-          global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
           platform: "rhel-8"
           inventory:
             openstack: "conf/inventory/rhel-8-latest.yaml"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -402,7 +402,7 @@ pipelines:
         - name: "Tier-2 Cephfs test mds pinning"
           execution_time: ""
           suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
-          global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
           platform: "rhel-9"
           inventory:
             openstack: "conf/inventory/rhel-9-latest.yaml"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -398,7 +398,7 @@ pipelines:
         - name: "Tier-2 Cephfs test mds pinning"
           execution_time: ""
           suite: "suites/pacific/cephfs/tier-2_cephfs_test_mds_pinning.yaml"
-          global-conf: "conf/pacific/cephfs/tier-2_cephfs_mds_pinning.yaml"
+          global-conf: "conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml"
           platform: "rhel-9"
           inventory:
             openstack: "conf/inventory/rhel-9-latest.yaml"

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_life_cycle.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_life_cycle.py
@@ -6,6 +6,7 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
+from utility.retry import retry
 
 log = Log(__name__)
 """
@@ -87,7 +88,8 @@ def run(ceph_cluster, **kw):
         create_cmd = f"ceph fs new {fs_name} {pool_meta}_1 {pool_data}_1"
 
         client1.exec_command(sudo=True, cmd=create_cmd)
-        fs_util.kernel_mount([client1], kernel_mounting_dir_1, ",".join(mon_node_ips))
+        retry_mount = retry(CommandFailed, tries=3, delay=30)(fs_util.kernel_mount)
+        retry_mount([client1], kernel_mounting_dir_1, ",".join(mon_node_ips))
 
         out7, ec7 = client1.exec_command(sudo=True, cmd=f"ceph fs get {fs_name}")
         log.info(print(out7))


### PR DESCRIPTION
# Description
Fixing ci Issue RHCEPHQE-8158
[CephCI] - FS life cycle failed with mds laggy

Problem: 
FS is taking time to make MDS active and accept mounts

Solution:
Added retry for 3 times in interval of 30 sec

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-32L866

This conains fix for [RHCEPHQE-8159](https://issues.redhat.com/browse/RHCEPHQE-8159)

Problem: This had wrong conf file.

Solution : 
Updated the conf file to conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N5G837

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
