### PR TITLE
Adding flag for skiping reimage stage

### DIFF
--- a/pipeline/upi_test_executor.groovy
+++ b/pipeline/upi_test_executor.groovy
@@ -7,6 +7,7 @@ def phase = "${params.Build}"
 def group = "${params.Group}-"
 def suite = "${params.Suite}"
 def os_version = "${params.os_version}"
+def skip_reimage = "${params.skip_reimage}"
 def buildUserId
 def buildUserEmail
 def buildUserName
@@ -112,12 +113,15 @@ node("magna006"){
         buildUserName = buildUser["buildUserName"]
         currentBuild.description = "Triggered by : ${buildUserName}"
     }
+    println(skip_reimage)
+    if (skip_reimage){
     stage("reimageTestEnv") {
         cephVersion = sharedLib.get_ceph_version(rhcephVersion)
         nodeList = sharedLib.getNodeList("conf/${cephVersion}/${params.Group}/${params.Conf}.yaml")
         println(nodeList)
         def nodesWithSpace = nodeList.join(",")
         sharedLib.reimageNodes(os_version, nodesWithSpace)
+    }
     }
 
     stage('Execute groovy script'){


### PR DESCRIPTION
# Description
Added parameter to upi-executor to skip reimage.
Jenkins PR : https://gitlab.cee.redhat.com/ceph/rhcs-jenkins-jobs/-/merge_requests/1162

```
Problem:
Currently upi-executor job is used only for octo labs.
with this parameter we can run on any hardware which has been reimaged manually. with this we can run CI on DSAL and scalelab as well

Functionality :
if skip_reimage --> 0 then reimage stage will be executed
if skip_reimage --> 1 then reimage stage will be skiped
```
Logs : 0 -->https://jenkins.ceph.redhat.com/job/upi-executor_amk/7/console --> reimage executed
Logs : 1 -->[ https://jenkins.ceph.redhat.com/job/upi-executor_amk/8/console -](https://jenkins.ceph.redhat.com/job/upi-executor_amk/8/console)-> reimage not -executed


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
