### PR TITLE
Fix for long_running argument

### DIFF
--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -60,7 +60,7 @@ class RbdMirror:
             if kw.get("ceph_args", True):
                 cmd = cmd + self.ceph_args
 
-            if kw.get("long_running", True):
+            if kw.get("long_running", False):
                 out = node.exec_command(
                     sudo=True,
                     cmd=cmd,


### PR DESCRIPTION
# Description
when `long_running` is set to true by default it's not returning output, hence it should be set to `false` by default.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
