### PR TITLE
Adding test CEPH-11414 trash restore parent image when IO running on clone

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -145,6 +145,12 @@ tests:
       polarion-id: CEPH-11413
 
   - test:
+      desc: Verify parent-clone relationship and clone IOs are not affected when parent moved to trash
+      module: rbd_trash_restore_image_having_clone.py
+      name: Test parent trash restore with clone IOs
+      polarion-id: CEPH-11414
+
+  - test:
       desc: Rename image snapshots on an image on replicated and ecpools and its clones
       module: rbd_snapshot_rename.py
       name: Test Snapshot Rename functionality

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -144,6 +144,12 @@ tests:
       polarion-id: CEPH-11413
 
   - test:
+      desc: Verify parent-clone relationship and clone IOs are not affected when parent moved to trash
+      module: rbd_trash_restore_image_having_clone.py
+      name: Test parent trash restore with clone IOs
+      polarion-id: CEPH-11414
+
+  - test:
       desc: Rename image snapshots on an image on replicated and ecpools and its clones
       module: rbd_snapshot_rename.py
       name: Test Snapshot Rename functionality

--- a/tests/rbd/rbd_trash_restore_image_having_clone.py
+++ b/tests/rbd/rbd_trash_restore_image_having_clone.py
@@ -1,0 +1,174 @@
+from time import sleep
+
+from ceph.parallel import parallel
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def move_to_trash_and_restore(rbd, pool, image, sleep_time):
+    """
+    Move given image to trash, sleep for given time and restore image back from trash
+
+    Args:
+        rbd: RBD object
+        pool: pool in which image is present
+        image: image to be trashed
+        sleep_time: seconds to sleep before restoring
+    """
+    if rbd.move_image_trash(pool, image):
+        log.error(f"Moving image {image} to trash failed")
+        raise Exception(f"Moving image {image} to trash failed")
+
+    image_id = rbd.get_image_id(pool, image)
+
+    if not rbd.trash_exist(pool, image):
+        log.error("Image is not found in the Trash")
+        raise Exception("Image is not found in the Trash")
+    else:
+        log.info(f"Image {image} moved to trash")
+
+    sleep(sleep_time)
+
+    if rbd.trash_restore(pool, image_id):
+        log.error(f"Trash restore failed for image {image}")
+        raise Exception(f"Trash restore failed for image {image}")
+    return 0
+
+
+def rbd_trash_restore_image_having_clone(rbd, pool_type, **kw):
+    """
+    Verify parent image moved to trash and restored back when IO running on clone
+    and parent clone relationship still active.
+    Args:
+        rbd: rbd object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    pool = kw["config"][pool_type]["pool"]
+    image = kw["config"][pool_type]["image"]
+    snap = kw["config"][pool_type].get("snap", f"{image}_snap")
+    clone = kw["config"][pool_type].get("clone", f"{image}_clone")
+    try:
+        # Create snap and clone
+        rbd.snap_create(pool, image, snap)
+        snap_name_1 = f"{pool}/{image}@{snap}"
+        rbd.protect_snapshot(snap_name_1)
+        rbd.create_clone(snap_name_1, pool, clone)
+
+        log.info(
+            f"Checking parent-clone relationship for parent: {image}, clone: {clone}"
+        )
+        rbd_info = rbd.image_info(pool, clone)
+        if (
+            rbd_info.get("parent").get("image") == image
+            and rbd_info.get("parent").get("snapshot") == snap
+            and not rbd_info.get("parent").get("trash")
+        ):
+            log.info(
+                f"Parent-clone {image}-{clone} relationship is intact and parent is not in trash"
+            )
+        else:
+            log.error(f"Parent-clone {image}-{clone} relationship broken")
+            return 1
+
+        rbd_du = rbd.get_disk_usage_for_pool(pool, image=clone)
+        size_before_io = rbd_du["images"][0]["used_size"]
+        log.info(f"Clone size before IO : {size_before_io}")
+
+        client = kw["ceph_cluster"].get_nodes(role="client")[0]
+        log.info("Move parent image to trash when IO on Clone is in progress.")
+        with parallel() as p:
+            p.spawn(
+                run_fio,
+                image_name=clone,
+                pool_name=pool,
+                client_node=client,
+                size="1G",
+            )
+            p.spawn(
+                move_to_trash_and_restore,
+                rbd=rbd,
+                pool=pool,
+                image=image,
+                sleep_time=60,
+            )
+
+        rbd_du = rbd.get_disk_usage_for_pool(pool, image=clone)
+        size_after_io = rbd_du["images"][0]["used_size"]
+        log.info(f"Clone size after IO : {size_after_io}")
+
+        written = int(
+            (size_after_io - size_before_io) / 1073741824
+        )  # 1GB = 1073741824 bytes
+        if written != 1:
+            log.error(
+                f"1GB of IOs were intended to be written on clone but only {written}GB"
+                "were written, so there might have been some interruption in IO"
+            )
+            return 1
+
+        rbd_info = rbd.image_info(pool, clone)
+        if (
+            rbd_info.get("parent").get("image") == image
+            and rbd_info.get("parent").get("snapshot") == snap
+            and not rbd_info.get("parent").get("trash")
+        ):
+            log.info(
+                f"Parent-clone {image}-{clone} relationship is intact and parent is restored from trash"
+            )
+        else:
+            log.error(f"Parent-clone {image}-{clone} relationship broken")
+            return 1
+
+        return 0
+    except Exception as error:
+        log.error(str(error))
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
+
+
+def run(**kw):
+    """Verify parent image moved to trash and restored back when IO running on clone
+    and parent clone relationship still active.
+
+    Args:
+        kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+
+    Pre-requisites :
+    We need atleast one client node with ceph-common package,
+    conf and keyring files
+
+    Test cases covered -
+    1) CEPH-11414 - In a parent clone relationship, move parent image to trash.
+    Dont sever the child image from parent, but try to restore the parent, and
+    verify the clone relationship is intact. (Keep IO in progress on clone image)
+    Test Case Flow
+    1. Create pool, image and clone the image. Start IOs on clone.
+    2. Move the parent image to trash.
+    3. Restore the parent  image back
+    4. Check parent-clone relationship.(Do rbd info on clone)
+    """
+    log.info(
+        "Executing test CEPH-11414 - Trash restore parent image while IOs on clone are in progress..."
+    )
+    rbd_obj = initial_rbd_config(**kw)
+    if rbd_obj:
+        log.info("Executing test on Replication pool")
+        if rbd_trash_restore_image_having_clone(
+            rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw
+        ):
+            return 1
+        log.info("Executing test on EC pool")
+        if rbd_trash_restore_image_having_clone(
+            rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw
+        ):
+            return 1
+    return 0

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -1,6 +1,7 @@
 import json
 import random
 import string
+from importlib import import_module
 from time import sleep
 
 from ceph.ceph import CommandFailed
@@ -722,6 +723,23 @@ class Rbd:
         """
         return self.exec_cmd(cmd=f"rbd config {level} set {entity} {key} {value}", **kw)
 
+    def get_disk_usage_for_pool(self, pool, **kw):
+        """
+        Fetch disk usage using rbd du command
+
+        Args:
+            pool: pool for which usage to be fetched
+            **kw: Any other optional arguments
+
+        Returns:
+            disk usage in json format
+        """
+        cmd = f"rbd du -p {pool} --format json"
+        for key, val in kw.items():
+            cmd += f" --{key} {val}"
+
+        return json.loads(self.exec_cmd(cmd=cmd, output=True))
+
 
 def initial_rbd_config(**kw):
     """
@@ -841,11 +859,11 @@ def initial_rbd_config(**kw):
     return rbd_obj
 
 
-def execute_dynamic(rbd, test, results: dict, **kwargs):
+def execute_dynamic(obj, test, results: dict, **kwargs):
     """
     Executes the test specified in test parameter with inputs args and returns results
     Args:
-        rbd: rbd object
+        obj: rbd object or module to be imported
         test: test to be executed
         results: test result
         **kwargs: input args required for the test
@@ -853,7 +871,9 @@ def execute_dynamic(rbd, test, results: dict, **kwargs):
     Returns:
         results updated to results dict
     """
-    method = getattr(rbd, test)
+    if isinstance(obj, str):
+        obj = import_module(obj)
+    method = getattr(obj, test)
     rc = method(**kwargs)
     log.info(f"Return value for execution of method: {test} is {rc}")
     if rc:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1812,11 +1812,21 @@ def run_fio(**fio_args):
     if fio_args.get("size"):
         opt_args += f" --size={fio_args.get('size', '100M')}"
 
+    run_time = fio_args.get("run_time")
+
+    # Take default runtime only when size is not specified
+    # if size is mentioned then IOs should run till required size is filled
+    if not run_time and not fio_args.get("size"):
+        run_time = 120
+
+    if run_time:
+        opt_args += f" --runtime={run_time} --time_based"
+
     long_running = fio_args.get("long_running", False)
     cmd = (
         "fio --name=test-1  --numjobs=1 --rw=write"
-        " --iodepth=8 --fsync=32  --time_based"
-        f" --group_reporting --runtime={fio_args.get('runtime', 120)} {opt_args}"
+        " --iodepth=8 --fsync=32 "
+        f" --group_reporting {opt_args}"
     )
 
     return fio_args["client_node"].exec_command(


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-8226
This PR includes Automation of trash restore parent image when IO running on clone

Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11414

File changed/Renamed/modified :
suites/pacific/rbd/tier-2_rbd_regression.yaml
suites/quincy/rbd/tier-2_rbd_regression.yaml

New file/Module added :
tests/rbd/rbd_clone_trash_restore_parent_image.py

success log :
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3A15AO/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PH83IV/
