### PR TITLE
[Fix] Allow client node to add additional repo

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -143,8 +143,7 @@ def install_prereq(
             else:
                 log.info("Skipped enabling the RHEL RPM's provided by Subscription")
 
-        # todo: check if thge additional repos are needed for client setup
-        if repo and not _is_client:
+        if repo:
             setup_addition_repo(ceph, repo)
 
         ceph.exec_command(cmd="sudo yum -y upgrade", check_ec=False)


### PR DESCRIPTION
In `install_prereq.py`, skips client node to add repo passed through run.py parameter `--add-repo`. This causes issue while adding RHEL external repos.

Remove check for client node to allow additional repo.
