### PR TITLE
CEPH-9864-Disable some existing Image Feature which have Image metadata set on it, with IO in progress

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -273,3 +273,11 @@ tests:
       module: trash_restore_same_name_image.py
       name: Test to verify image restore with same name
       polarion-id: CEPH-11393
+
+  - test:
+      desc: Verify image feature disable on image having image meta set on it
+      config:
+        image_feature : deep-flatten
+      module: image_with_metadata_feature_disable.py
+      name: Test to verify image feature disable with image meta on it
+      polarion-id: CEPH-9864

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -272,3 +272,11 @@ tests:
       module: trash_restore_same_name_image.py
       name: Test to verify image restore with same name
       polarion-id: CEPH-11393
+
+  - test:
+      desc: Verify image feature disable on image having image meta set on it
+      config:
+        image_feature: deep-flatten
+      module: image_with_metadata_feature_disable.py
+      name: Test to verify image feature disable with image meta on it
+      polarion-id: CEPH-9864

--- a/tests/cephadm/test_verify_cluster_health_after_reboot.py
+++ b/tests/cephadm/test_verify_cluster_health_after_reboot.py
@@ -17,7 +17,7 @@ class SystemctlFailed(Exception):
 
 def _is_cluster_healthy(node):
     # Verify if the cluster is in healthy state
-    timeout, interval = 100, 10
+    timeout, interval = 300, 10
     for w in WaitUntil(timeout=timeout, interval=interval):
         if CephAdm(node).ceph.health() == "HEALTH_OK":
             return True

--- a/tests/rbd/image_with_metadata_feature_disable.py
+++ b/tests/rbd/image_with_metadata_feature_disable.py
@@ -1,0 +1,113 @@
+"""Module to verify disable image feature with meta-data set on image.
+
+Pre-requisites :
+We need cluster configured with atleast one client node with ceph-common package,
+conf and keyring files
+
+Test case covered -
+CEPH-9864 - Disable some existing Image Feature on Image having metadata set on it,
+with IO in progress from Client Side
+
+Test Case Flow:
+1. Create a Replicated pool
+2. Create an image
+3. Run Ios on an Image
+4. Set image meta on the image
+5. verify that image meta is set properly.
+6. Initiate IOs from client
+7. While running the IOs disable the existing image feature.
+8. Image features should be disable properly
+8. Repeat steps 1 to 7 for ecpool
+"""
+
+from ceph.parallel import parallel
+from tests.rbd.exceptions import RbdBaseException
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def image_metadata_feature_disable(rbd, pool_type, **kw):
+    """Disable some existing Image Feature on Image having metadata set on it with IO in-progress.
+
+    Args:
+        rbd: RBD object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: test data
+    """
+    pool = kw["config"][pool_type]["pool"]
+    image = kw["config"][pool_type]["image"]
+    feature_name = kw["config"]["image_feature"]
+    image_spec = pool + "/" + image
+    value = 120
+
+    try:
+        run_fio(image_name=image, pool_name=pool, client_node=rbd.ceph_client)
+
+        # set meta value on image
+        rbd.image_meta(
+            action="set",
+            image_spec=image_spec,
+            key="rbd_op_thread_timeout",
+            value=value,
+        )
+
+        # verify meta value is set on an image
+        if value != int(
+            rbd.image_meta(
+                action="get", image_spec=image_spec, key="rbd_op_thread_timeout"
+            )[:-1]
+        ):
+            log.error(f"Expected Meta value did not set on {image_spec}")
+            return 1
+
+        with parallel() as p:
+            p.spawn(
+                run_fio, image_name=image, pool_name=pool, client_node=rbd.ceph_client
+            )
+            p.spawn(rbd.disable_rbd_feature, pool, image, feature_name)
+
+        # Verify the feature is disabled
+        image_load = rbd.image_info(pool, image)
+        if feature_name in image_load.get("features", {}):
+            log.error(
+                f"Feature {feature_name} is present in the rbd info of {image_spec}."
+            )
+            return 1
+        log.info(f"Image feature {feature_name} on {image} is disabled successfully")
+        return 0
+
+    except RbdBaseException as error:
+        log.error(error.message)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
+
+
+def run(**kw):
+    """Perform feature disable while running IOs.
+    verify feature disables on an image having meta set on it while IO operation in progress
+    Args:
+        kw: test data
+    Returns:
+        int: The return value. 0 for success, 1 otherwise
+    """
+    log.info(
+        "CEPH-9864 - Running test to verify disable image feature with meta set on it"
+    )
+    rbd_obj = initial_rbd_config(**kw)
+    if rbd_obj:
+        log.info("Executing test on Replication pool")
+        if image_metadata_feature_disable(
+            rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw
+        ):
+            return 1
+        log.info("Executing test on EC pool")
+        if image_metadata_feature_disable(
+            rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw
+        ):
+            return 1
+    return 0


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-8238
This PR includes Automation of image feature disabling with meta set on image and IO is in progress

Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9864

File changed :
[suites/pacific/rbd/tier-2_rbd_regression.yaml] - Added test suite
[suites/quincy/rbd/tier-2_rbd_regression.yaml] - Added test suite

New module file added :
tests/rbd/image_with_metadata_feature_disable.py

success log :
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-wil1y/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-csexk/
