### PR TITLE
Temporary execution switch onto centos-8 builds.

### DIFF
--- a/pipeline/metadata/main.yaml
+++ b/pipeline/metadata/main.yaml
@@ -7,6 +7,12 @@
 # parameter required to create a similar custom file is suite name, suite yaml file, global configuration file,
 # platform, rhbuild, inventory and metadata information like frequency of execution, tier, cloud type, functional group and stage.
 #=====================================================================================
+overrides:
+  platform: "rhel-8"
+  openstack:
+    inventory: "conf/inventory/rhel-8-latest.yaml"
+  rhbuild: "6.0"
+
 suites:
 - name: "Core Feature Upstream Testing For DMFG"
   suite: "suites/quincy/cephadm/sanity-test.yaml"

--- a/pipeline/metadata/quincy.yaml
+++ b/pipeline/metadata/quincy.yaml
@@ -7,6 +7,12 @@
 # parameter required to create a similar custom file is suite name, suite yaml file, global configuration file,
 # platform, rhbuild, inventory and metadata information like frequency of execution, tier, cloud type, functional group and stage.
 #=====================================================================================
+overrides:
+  platform: "rhel-8"
+  openstack:
+    inventory: "conf/inventory/rhel-8-latest.yaml"
+  rhbuild: "6.0"
+
 suites:
 - name: "Core Feature Upstream Testing For DMFG"
   suite: "suites/quincy/cephadm/sanity-test.yaml"

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -925,7 +925,7 @@ def SendUMBMessage(def msgMap, def overrideTopic, def msgType) {
 
 }
 
-def updateUpstreamFile(def version) {
+def updateUpstreamFile(def version, def osType, def osVersion) {
     /*
         Updates upstream yaml file for the version passed as argument
 
@@ -939,7 +939,7 @@ def updateUpstreamFile(def version) {
         sh ".venv/bin/python3 -m pip install packaging"
         sh "sudo yum install podman -y"
         def scriptFile = "pipeline/scripts/ci/upstream_cli.py"
-        def args = "build ${version}"
+        def args = "build ${version} --os-type ${osType} --os-version ${osVersion}"
         sh script: "${cmd} ${scriptFile} ${args}"
     } catch(Exception exc) {
         error "${exc}"


### PR DESCRIPTION
Since Ceph builds on centos-9 are not generated, moving back the execution to run on centos-8 builds.
In future we should revert back to latest builds with latest os version.

