### PR TITLE
Fix upstream listener job

### DIFF
--- a/pipeline/upstream_listener.groovy
+++ b/pipeline/upstream_listener.groovy
@@ -4,6 +4,9 @@
 // Global variables section
 def sharedLib
 def upstreamVersion = "${params.releaseName}" ?: "" // Gets the upstream version to be executed from params
+def osType = "centos" // OS type
+def osVersion = "8"   // OS Version
+currentBuild.description = "Upstream-branch: ${upstreamVersion}  Distro: ${osType}-${osVersion}"
 
 // Pipeline script entry point
 node("rhel-9-medium") {
@@ -40,11 +43,6 @@ node("rhel-9-medium") {
             }
 
             stage('updateRecipeFile') {
-                echo "${params.releaseName}"
-
-                osType = "${params.osType}" ?: "centos" // Get OS type
-                osVersion = "${params.osVersion}" ?: "8"  // Get OS Version
-
                 try{
                     sharedLib.updateUpstreamFile(upstreamVersion, osType, osVersion) //Updates upstream.yaml
                 } catch(Exception err) {
@@ -79,12 +77,13 @@ node("rhel-9-medium") {
             subject += "\n Jenkins URL: ${env.BUILD_URL}"
             googlechatnotification(url: "id:rhcephCIGChatRoom", message: subject)
         }
+    } finally {
         if ( upstreamVersion == "main" ) {
-                build ([
-                    wait: false,
-                    job: "rhceph-upstream-listener",
-                    parameters: [string(name: 'releaseName', value: "quincy")]
-                ])
-            }
+            build ([
+                wait: false,
+                job: "rhceph-upstream-listener",
+                parameters: [string(name: 'releaseName', value: "quincy")]
+            ])
+        }
     }
 }


### PR DESCRIPTION
**Issue:** 

> + /home/jenkins-build/workspace/rhceph-upstream-listener/.venv/bin/python3 pipeline/scripts/ci/upstream_cli.py build main --os-type null --os-version null
> Traceback (most recent call last):
>   File "/home/jenkins-build/workspace/rhceph-upstream-listener/pipeline/scripts/ci/upstream_cli.py", line 231, in <module>
>     method(**args)
>   File "/home/jenkins-build/workspace/rhceph-upstream-listener/pipeline/scripts/ci/upstream_cli.py", line 167, in fetch_upstream_build
>     check_status(response)
>   File "/home/jenkins-build/workspace/rhceph-upstream-listener/pipeline/scripts/ci/upstream_cli.py", line 163, in check_status
>     resp.raise_for_status()
>   File "/home/jenkins-build/workspace/rhceph-upstream-listener/.venv/lib64/python3.9/site-packages/requests/models.py", line 1021, in raise_for_status
>     raise HTTPError(http_error_msg, response=self)
> requests.exceptions.HTTPError: 504 Server Error: Gateway Timeout for url: https://shaman.ceph.com/api/repos/ceph/main/latest/null/null

**Fix:**
https://jenkins.ceph.redhat.com/job/rhceph-upstream-listener/639/console