### PR TITLE
Integrate CEPH-83574600, CEPH-83574601 to cephCI

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -810,3 +810,13 @@ tests:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_governance.yaml
         timeout: 500
+
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw.py
+      config:
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -601,3 +601,13 @@ tests:
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
         timeout: 500
+
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw.py
+      config:
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+        timeout: 500


### PR DESCRIPTION
Tests to remove NFS exports and delete NFS cluster in the newer NFS architecture port 5.1

Pass log : http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-7V8ZQR/
