### PR TITLE
[Fix] Avoid validating '/etc/ceph' dir after rm-cluster

### DIFF
--- a/tests/cephadm/test_remove_cluster.py
+++ b/tests/cephadm/test_remove_cluster.py
@@ -105,9 +105,11 @@ def run(ceph_cluster, **kw):
             )
 
     # Validate ceph config director, disks and containers
-    validate_ceph_config_dir(
-        nodes=nodes, dir_path=CEPH_CONFIG_DIR, roles=["mon", "osd"]
-    )
+
+    # Note (vamahaja): Skipping `/etc/ceph` dir due to bz #2129252
+    # validate_ceph_config_dir(
+    #     nodes=nodes, dir_path=CEPH_CONFIG_DIR, roles=["mon", "osd"]
+    # )
     validate_ceph_config_dir(nodes=nodes, dir_path=CEPH_LIB_DIR, roles=["mon", "osd"])
     validate_ceph_config_dir(nodes=nodes, dir_path=CEPHADM_LIB_DIR, ignore=[".ssh"])
 


### PR DESCRIPTION
rm-cluster test case validation fails due to bz #2129252. Commenting code to validate '/etc/ceph' dir after rm-cluster execution