### PR TITLE
Updates to signed listeners to remove IBM dependency and to trigger execution.

### DIFF
--- a/pipeline/signed-compose-listener.groovy
+++ b/pipeline/signed-compose-listener.groovy
@@ -86,7 +86,8 @@ node("rhel-9-medium || ceph-qe-ci") {
             sharedLib.writeToReleaseFile(majorVersion, minorVersion, releaseMap)
 
             def bucket = "ceph-${majorVersion}.${minorVersion}-${platform}"
-            sharedLib.uploadCompose(bucket, cephVersion, composeUrl)
+            // Commenting uploadCompose as IBM environment is not available
+            // sharedLib.uploadCompose(bucket, cephVersion, composeUrl)
 
         }
 


### PR DESCRIPTION
# Description

Updates to signed listeners to remove IBM dependency and to trigger execution.

https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-signed-container-image-listener/132/console
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-test-execution-pipeline/2056/console
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-signed-compose-listener/74/console
