### PR TITLE
TESCO: rgw segfaults on s3CopyObj with an admin user.

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
@@ -327,7 +327,7 @@ tests:
   - test:
       name: listing flat unordered buckets on secondary
       desc: test_bucket_listing_flat_unordered.yaml on secondary
-      polarion-id: CEPH-83573545
+      polarion-id: CEPH-83573545  #CEPH-83574826
       module: sanity_rgw_multisite.py
       clusters:
         ceph-sec:

--- a/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5.3_specific_fixes.yaml
@@ -131,3 +131,12 @@ tests:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
         timeout: 500
+  - test:
+      name: Test s3_copy_obj on user with admin flag through AWS
+      desc: TESCO-Segfault with s3CopyObj with admin user
+      polarion-id: CEPH-83575562
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_sts_rename_large_object.py
+        config-file-name: ../../aws/configs/test_s3copyObj_admin_user.yaml
+        timeout: 500


### PR DESCRIPTION
# Description
TESCO: rgw segfaults on s3CopyObj with an admin user.


CEPH-83575562

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RCXE9U/Test_s3_copy_obj_on_user_with_admin_flag_through_AWS_0.log

[Bug 2177220] [CEE/sd][RGW-Multisite][Ceph Upgrade] RGW crashes with Segmentation fault on s3:copy_obj
TEST case: CEPH-83575562

Also adding test coverage. CEPH-83574826 - Multisite: During ongoing I/O operations, perform metadata operations & Verify sync status



