### PR TITLE
Integrate: Testcase CEPH-9749 to cephci

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -236,6 +236,16 @@ tests:
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
         timeout: 300
 
+  - test:
+      name: delete container with different tenant swift user with same name
+      desc: test delete container with different tenant swift user with same name
+      polarion-id: CEPH-9749
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
+        timeout: 300
+
   # Versioning Tests
 
   - test:

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -206,6 +206,16 @@ tests:
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
         timeout: 300
 
+  - test:
+      name: delete container with different tenant swift user with same name
+      desc: test delete container with different tenant swift user with same name
+      polarion-id: CEPH-9749
+      module: sanity_rgw.py
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
+        timeout: 300
+
   # Versioning Tests
 
   - test:


### PR DESCRIPTION
# Description
CEPH-9749-Createcontainer with a tenant$user. Test if the user with the same name but belonging to a different tenant is able to delete the container. It should fail.

log: 
    5.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-zln3u/delete_container_with_different_tenant_swift_user_with_same_name_0.log
    6.0: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-fe9j0/delete_container_with_different_tenant_swift_user_with_same_name_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
