### PR TITLE
data/metadata/bilog generation tests to cephci

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -549,7 +549,7 @@ tests:
   - test:
       name: Mdlog trimming test on primary
       desc: test mdlog trimming on primary
-      polarion-id: CEPH-10544
+      polarion-id: CEPH-10544 #CEPH-10722, CEPH-10547
       module: sanity_rgw_multisite.py
       clusters:
         ceph-pri:
@@ -562,7 +562,7 @@ tests:
   - test:
       name: Datalog trimming test on secondary
       desc: test datalog trimming on secondary
-      polarion-id: CEPH-10540
+      polarion-id: CEPH-10540 #CEPH-10722, CEPH-10547
       module: sanity_rgw_multisite.py
       clusters:
         ceph-sec:
@@ -576,7 +576,7 @@ tests:
   - test:
       name: Bilog trimming test on primary
       desc: test bilog trimming on primary
-      polarion-id: CEPH-83572658
+      polarion-id: CEPH-83572658 #CEPH-10722, CEPH-10547
       module: sanity_rgw_multisite.py
       clusters:
         ceph-pri:


### PR DESCRIPTION
Adding the automation of the below data/metadata/bi log trimming to cephci

- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10722
- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10547

They are already covered in https://github.com/red-hat-storage/ceph-qe-scripts/blob/master/rgw/v2/tests/s3_swift/reusable.py#L1443 [**def test_log_trimming(bucket, config)**]