### PR TITLE
[TestFix] Fix test_verify_cluster_health_after_reboot

### DIFF
--- a/tests/cephadm/test_verify_cluster_health_after_reboot.py
+++ b/tests/cephadm/test_verify_cluster_health_after_reboot.py
@@ -17,7 +17,7 @@ class SystemctlFailed(Exception):
 
 def _is_cluster_healthy(node):
     # Verify if the cluster is in healthy state
-    timeout, interval = 100, 10
+    timeout, interval = 300, 10
     for w in WaitUntil(timeout=timeout, interval=interval):
         if CephAdm(node).ceph.health() == "HEALTH_OK":
             return True


### PR DESCRIPTION
The test fails on CI environment whereas works well on different project (usm-qe). Solution identified is to increase the timeout to validate the cluster health status

usm-qe : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5C3SLW/
ceph-jenkins : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-jv9g7/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
