### PR TITLE
Fixing test_rbd_mirror_daemon_restart_imagesync.py module in 5x to 6x upgrade test suite

### DIFF
--- a/tests/rbd_mirror/test_rbd_mirror_daemon_restart_imagesync.py
+++ b/tests/rbd_mirror/test_rbd_mirror_daemon_restart_imagesync.py
@@ -129,7 +129,9 @@ def run(**kw):
     def generate_background_ios():
         for i in range(1, 3):
             for i in range(1, 10):
-                mirror1.benchwrite(imagespec=decoy_imagespec + f"{i}", io="10M")
+                # Since images are being created at mirror2 in decoy_setup()
+                # IOs can run only from mirror2
+                mirror2.benchwrite(imagespec=decoy_imagespec + f"{i}", io="10M")
             time.sleep(5)
         return 0
 
@@ -140,7 +142,7 @@ def run(**kw):
 
     with parallel() as p:
         for img_spec in [rep_image_spec, ec_image_spec]:
-            p.spawn(mirror1.benchwrite, image_spec=img_spec, io="100M")
+            p.spawn(mirror1.benchwrite, imagespec=img_spec, io="100M")
             p.spawn(initiate_resync_and_wait_sync_to_start, img_spec)
 
         for each_rc in p:


### PR DESCRIPTION
The test module - test_rbd_mirror_daemon_restart_imagesync.py had a few automation issues given below because of which the test failed while executing along with an upgrade test suite.

1) benchwrite method expects a variable imagespec instead image_spec was given as variable name which has now been modified

2) Images for generating background IOs were created at mirror2 but their IOs were being run from mirror1 which will give an error that the images are read only at mirror1 which is their secondary site. Modified the method generate_background_ios to run IOs from mirror2 instead.

Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5p99u/test_rbd_mirror_daemon_restartwith_resync_0.log 

Success log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CKPYSW/