### PR TITLE
Multisite deployment with multipe rgws via HAproxy.

### DIFF
--- a/conf/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy_conf.yaml
+++ b/conf/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy_conf.yaml
@@ -1,0 +1,128 @@
+# System Under Test environment configuration for RGW multi site suites with archive zone
+globals:
+  - ceph-cluster:
+      name: ceph-pri
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+          - rgw
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client
+
+  - ceph-cluster:
+      name: ceph-sec
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client
+  - ceph-cluster:
+      name: ceph-arc
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+          - rgw
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -769,6 +769,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
+        - name: "test-rgw-ms-deployment-via-Haproxy-with-archive"
+          execution_time: "2h 29m 53s"
+          suite: "suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml"
+          global-conf: "conf/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy_conf.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
         - name: "test-rgw-ssl-ecpool-ms-bucket-listing-versioning-on-secondary"
           execution_time: "3h 20m 34s"
           suite: "suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -698,6 +698,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "test-rgw-ms-deployment-via-Haproxy-with-archive"
+          execution_time: "2h 29m 53s"
+          suite: "suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml"
+          global-conf: "conf/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy_conf.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
         - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
           execution_time: "2h 14m 3s"
           suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -726,6 +726,17 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "test-rgw-ms-deployment-via-Haproxy-with-archive"
+          execution_time: "2h 29m 53s"
+          suite: "suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml"
+          global-conf: "conf/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy_conf.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
+
         - name: "RADOS regression testing for stretched Clusters"
           execution_time: "3h 15m 14s"
           suite: "suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml"

--- a/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
@@ -1,0 +1,445 @@
+# This test to verify the archive zone with multisite where all the zones are configured behind a Load Balancer.
+
+tests:
+
+  # Cluster deployment stage
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+                        - node4
+
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+                        - node4
+
+        ceph-arc:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.arc
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+                        - node4
+
+      desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83573386
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+
+# cofiguring clients for all the clusters on node-6
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-arc:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80,http://{node_ip:node4}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80,http://{node_ip:node4}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key a123 --secret s123 --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key a123 --secret s123"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.shared.pri rgw_realm india"
+              - "ceph config set client.rgw.shared.pri rgw_zonegroup shared"
+              - "ceph config set client.rgw.shared.pri rgw_zone primary"
+              - "ceph orch restart rgw.shared.pri"
+              - "radosgw-admin zonegroup modify --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node6}:5000"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node6}:5000"
+              - "radosgw-admin period update --rgw-realm india --commit"
+      desc: Setting up primary site in a multisite.
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+
+# configuring HAproxy on the client node 'node6' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node4:80
+              - node5:80
+
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node4:80
+              - node5:80
+        ceph-arc:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node4:80
+              - node5:80
+
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+
+#configuring the secondary zone and archive zone from the Primary's Haproxy.
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph orch restart rgw.shared.pri"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node6}:5000 --access-key a123 --secret s123 --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node6}:5000 --access-key a123 --secret s123"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80,http://{node_ip:node4}:80 --access-key a123 --secret s123"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.shared.sec rgw_realm india"
+              - "ceph config set client.rgw.shared.sec rgw_zonegroup shared"
+              - "ceph config set client.rgw.shared.sec rgw_zone secondary"
+              - "ceph orch restart rgw.shared.sec"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node6}:5000"
+              - "radosgw-admin period update --rgw-realm india --commit"
+
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node6}:5000 --access-key a123 --secret s123 --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node6}:5000 --access-key a123 --secret s123"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://{node_ip:node5}:80,http://{node_ip:node4}:80 --access-key a123 --secret s123 --tier-type=archive"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.shared.arc rgw_realm india"
+              - "ceph config set client.rgw.shared.arc rgw_zonegroup shared"
+              - "ceph config set client.rgw.shared.arc rgw_zone archive"
+              - "ceph orch restart rgw.shared.arc"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://{node_ip:node6}:5000"
+              - "radosgw-admin period update --rgw-realm india --commit"
+
+      desc: Setting up RGW multisite replication environment with archive zone
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+
+
+### create a tenanted user for secondary site
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create tenanted user
+      module: sanity_rgw_multisite.py
+      name: create tenanted user
+      polarion-id: CEPH-83575199
+
+### create a tenanted user for archive site
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-arc
+            timeout: 300
+      desc: create tenanted user
+      module: sanity_rgw_multisite.py
+      name: create tenanted user
+      polarion-id: CEPH-83575199
+
+# configuring vault agent on all the sites
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-sec:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-arc:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/cephTransit "
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.sec}"
+            timeout: 120
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/cephTransit "
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.pri}"
+            timeout: 120
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_prefix /v1/cephTransit "
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.arc}"
+            timeout: 120
+      desc: Setting vault configs for sse-s3 on multisite archive
+      module: exec.py
+      name: set sse-s3 vault configs on multisite
+
+#Performing IOs via the HAproxy node
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            set-env: true
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
+            run-on-haproxy: true
+            timeout: 300
+      desc: test M buckets multipart uploads on haproxy node
+      module: sanity_rgw_multisite.py
+      name: test M buckets multipart uploads on haproxy node
+      polarion-id: CEPH-9801
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            set-env: true
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
+            run-on-haproxy: true
+            monitor-consistency-bucket-stats: true
+            timeout: 300
+      desc: test M buckets compression on haproxy node
+      polarion-id: CEPH-83575199
+      module: sanity_rgw_multisite.py
+      name: test M buckets compression on haproxy node
+
+# creating a test bucket on the primary site
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets.yaml
+            run-on-haproxy: true
+            timeout: 300
+      desc: test M buckets on haproxy node
+      module: sanity_rgw_multisite.py
+      name: test M buckets on haproxy node
+      polarion-id: CEPH-83575199

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -96,10 +96,19 @@ def run(ceph_cluster, **kw):
         if ceph_cluster.rhcs_version.version[0] == 4
         else config.get("run-on-rgw", False)
     )
+    run_on_haproxy = (
+        True
+        if ceph_cluster.rhcs_version.version[0] == 4
+        else config.get("run-on-haproxy", False)
+    )
+
     distro_version_id = rgw_node.distro_info["VERSION_ID"]
 
     if run_on_rgw:
         exec_from = rgw_node
+        append_param = ""
+    elif run_on_haproxy:
+        exec_from = client_node
         append_param = ""
     else:
         exec_from = client_node

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -101,9 +101,20 @@ def run(**kw):
         if primary_cluster.rhcs_version.version[0] == 4
         else config.get("run-on-rgw", False)
     )
+    run_on_haproxy = (
+        True
+        if primary_cluster.rhcs_version.version[0] == 4
+        else config.get("run-on-haproxy", False)
+    )
+
     if run_on_rgw:
         exec_from = test_site_node
         append_param = ""
+
+    elif run_on_haproxy:
+        exec_from = test_client_node
+        append_param = ""
+
     else:
         exec_from = test_client_node
         append_param = " --rgw-node " + str(test_site_node.ip_address)


### PR DESCRIPTION
# Description
- This PR addresses **T2 automation-CEPH-83574575-RGW MS with HAProxy endpoints.**

- This would also address using multiple rgws listening behind a LoadBalancer.
   and issue : https://github.com/red-hat-storage/ceph-qe-scripts/issues/191

- It would configure multisite with haproxy endpoint and run the IOs via the haproxy node.

- We can use "**run-on-haproxy**" in the config file to run IOs via Haproxy node.

Pass logs: 
1. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LA38TE/ ( the failed test was because rgws were not restarted after haproxy.), hence have included the test in the end (in the suite file as well.)
2. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NKG95F
3. log without HAproxy for script bucket_listing.py --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PJL77R





