### PR TITLE
[Conf] Move Permissive tests to scheduled

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -232,26 +232,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rados
-        - name: "Permissive Mode Scenarios"
-          execution_time: "19m 4s"
-          suite: "suites/pacific/cephadm/tier-2-permissive-mode-scenarios.yaml"
-          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-          platform: "rhel-8"
-          inventory:
-            openstack: "conf/inventory/rhel-8-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-          metadata:
-            - dmfg
-        - name: "Permissive Mode Scenarios"
-          execution_time: "19m 4s"
-          suite: "suites/pacific/cephadm/tier-2-permissive-mode-scenarios.yaml"
-          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - dmfg
       stage-2:
         - name: "Tier-2 Cephfs test Volume Management"
           execution_time: "39m 25s"
@@ -1033,6 +1013,26 @@ pipelines:
             openstack: "conf/inventory/rhel-8-latest.yaml"
           metadata:
             - rados
+        - name: "Permissive Mode Scenarios"
+          execution_time: "19m 4s"
+          suite: "suites/pacific/cephadm/tier-2-permissive-mode-scenarios.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - dmfg
+        - name: "Permissive Mode Scenarios"
+          execution_time: "19m 4s"
+          suite: "suites/pacific/cephadm/tier-2-permissive-mode-scenarios.yaml"
+          global-conf: "conf/pacific/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
   rc:
     tier-0:
       stage-1:

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -256,16 +256,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rados
-        - name: "Permissive Mode Scenarios"
-          execution_time: "16m 25s"
-          suite: "suites/quincy/cephadm/tier-2-permissive-mode-scenarios.yaml"
-          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - dmfg
       stage-2:
         - name: "Testing RBD tier-2 regression scenarios"
           execution_time: "37m 6s"
@@ -948,6 +938,16 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - rados
+        - name: "Permissive Mode Scenarios"
+          execution_time: "16m 25s"
+          suite: "suites/quincy/cephadm/tier-2-permissive-mode-scenarios.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
   rc:
     tier-0:
       stage-1:

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -242,16 +242,6 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rados
-        - name: "Permissive Mode Scenarios"
-          execution_time: "16m 25s"
-          suite: "suites/quincy/cephadm/tier-2-permissive-mode-scenarios.yaml"
-          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - dmfg
       stage-2:
         - name: "Testing RBD tier-2 regression scenarios"
           execution_time: "37m 6s"
@@ -903,6 +893,16 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - rados
+        - name: "Permissive Mode Scenarios"
+          execution_time: "16m 25s"
+          suite: "suites/quincy/cephadm/tier-2-permissive-mode-scenarios.yaml"
+          global-conf: "conf/quincy/cephadm/tier-1_5node_cephadm_bootstrap.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - dmfg
   rc:
     tier-0:
       stage-1:


### PR DESCRIPTION
# Description
Summary: 
Moving the unstable test to scheduled.  

Issue:  https://issues.redhat.com/browse/RHCEPHQE-8156
Tried executing the same locally and the result => http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5C3SLW/
(it passed)
But when tried from ci => http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-jv9g7/ (its failing)

The only difference is that the tests were running of different projects (usm-qe and ceph-jenkins). Tried increasing the timeout : https://github.com/red-hat-storage/cephci/pull/2477, still failure is found in jenkins. This seems like a genuine system specific issue and hence moving it out of sanity runs. 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
