### PR TITLE
Integrate CEPH-83575142 to cephCI

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
@@ -285,6 +285,19 @@ tests:
       name: create non-tenanted user
 
   - test:
+      name: Bucket Granular Sync policy test for prefix and tag
+      desc: Bucket sync policy test for prefix and tag
+      polarion-id: CEPH-83575142
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_syncpolicy_prefix_tag.py
+            config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+
+  - test:
       name: Granular multisite sync policy group transition
       desc: Test multisite sync policy group transition
       polarion-id: CEPH-83575135


### PR DESCRIPTION
On a bucket granular sync policy at bucket level , we have added filtering objects through prefix and tag.

Pass log :
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-ZS9433/

