### PR TITLE
Adding extra params to reimage node

### DIFF
--- a/pipeline/scripts/ci/prepare-bm-node.sh
+++ b/pipeline/scripts/ci/prepare-bm-node.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# This utility performs a reimage operation on the provided set of nodes.
+#
+# The script allows performs the additional configuration changes on the provided nodes.
+#
+#   - Enables SSH access to root user
+#   - Wipes the data disks
+#   - Forces the nodes to use shortname instead of FQDN
+#
+#   Usage
+#       $ bash reimage-octo-node.sh \
+#           --platform [8.5|8.6|9.0] \
+#           --nodes node1,node2,node3 \
+#           [--node_username username] \
+#           [--node_password password] \
+#           [--wipe_drives] \
+#           [--set_hostnames_repo]
+#
+#
+
+set -eux -o pipefail
+
+source pipeline/scripts/ci/server_setup_utils.sh
+
+# Define the variables used in the script here.
+OS_VER=""
+NODES=""
+NODE_USERNAME=${USERNAME:-root}
+NODE_PASSWORD=${PASSWORD:-passwd}
+REIMAGE_CMD=${HOME}/.tthlg/bin/teuthology-reimage
+INITIAL_SETUP=false
+WIPE_DRIVES=false
+SET_HOSTNAMES_REPO=false
+REIMAGE=false
+
+function usage {
+    echo "Usage: ${0} [-p | --platform os_version] [-n | --nodes node1] [--node_username username][--node_password password] [--wipe_drives] [--set_hostnames_repo]"
+    exit 2
+}
+
+CLI_OPTS=$(getopt -o hn:p: --long platform:,nodes:,node_username:,node_password:,help,initial_setup,wipe_drives,set_hostnames_repo -- "$@" )
+
+if [ $? != 0 ] || [ $# -lt 4 ] ; then
+    usage
+fi
+
+eval set -- "${CLI_OPTS}"
+while true; do
+    case ${1} in
+        -h | --help) usage ;;
+        -n | --nodes) NODES="${2//,/ }"; shift 2 ;;
+        -p | --platform) OS_VER="${2}"; shift 2 ;;
+        --node_username) NODE_USERNAME="${2}"; shift 2 ;;
+        --node_password) NODE_PASSWORD="${2}"; shift 2 ;;
+        --initial_setup) INITIAL_SETUP=true; shift ;;
+        --wipe_drives) WIPE_DRIVES=true; shift ;;
+        --set_hostnames_repo) SET_HOSTNAMES_REPO=true; shift ;;
+        --) shift; break ;;
+        *) usage ;;
+    esac
+done
+
+if [[ "$WIPE_DRIVES" = true ]]; then
+    echo "Wiping data disks"
+    for node in ${NODES} ; do
+        wipe_drives "${node}" "${NODE_USERNAME}" "${NODE_PASSWORD}"
+    done
+fi
+
+if [[ "$SET_HOSTNAMES_REPO" = true ]]; then
+    echo "Wiping data disks"
+    for node in ${NODES} ; do
+        set_hostnames_repos "${node}" "${NODE_USERNAME}" "${NODE_PASSWORD}"
+    done
+fi

--- a/pipeline/scripts/ci/server_setup_utils.sh
+++ b/pipeline/scripts/ci/server_setup_utils.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Function to perform initial setup on node
+# Arguments:
+#   node: The node to perform setup on
+#   password: The password to set for the root user (default: "passwd")
+function initial_setup {
+  # This function performs initial setup on a given node. It takes two arguments:
+  #   node: The name or IP address of the node to perform setup on
+  #   password: The password to set for the root user (default: "passwd")
+  # The function uses sshpass to login to the node with root privileges and sets the root password to the provided value.
+  # It then checks if PermitRootLogin is set to yes in /etc/ssh/sshd_config and if not, adds the setting to the file.
+  # Finally, the sshd service is restarted on the node.
+  local node="$1"
+  local password="${2:-passwd}"
+  ssh ${node} 'echo "passwd" | sudo passwd --stdin root; \
+  grep -qxF "PermitRootLogin yes" /etc/ssh/sshd_config || \
+  echo "PermitRootLogin yes" | sudo tee -a /etc/ssh/sshd_config'
+  ssh ${node} 'sudo systemctl restart sshd &'
+  sleep 2
+}
+
+# Function to wipe data disks clean
+# Arguments:
+#   node: The node to wipe disks on
+#   password: The password to use to access the node (default: "passwd")
+function wipe_drives {
+    # This function wipes all data disks clean on a given node. It takes two arguments:
+    #   node: The name or IP address of the node to wipe disks on
+    #   password: The password to use to access the node (default: "passwd")
+    # The function first retrieves the list of data disks on the node using lsblk.
+    # It then identifies the root disk by looking for the disk that has the / mount point.
+    # The function then iterates through all disks except the root disk and uses the wipefs command to wipe them clean.
+    # If the root disk cannot be found or more than one root disk is found, an error message is printed
+    # and the function exits.
+    local node="$1"
+    local username="${2:-root}"
+    local password="${3:-passwd}"
+    echo "Wipe all data disks clean."
+    disks=$(sshpass -p ${password} ssh ${username}@${node} 'lsblk -o NAME -d | tail -n +2')
+    root_disk=$(sshpass -p ${password} ssh ${username}@${node} 'eval $(lsblk -o PKNAME,MOUNTPOINT -P | grep "MOUNTPOINT=\"/\""); echo $PKNAME')
+
+    if [ -z "${root_disk}" ]; then
+        echo "ERR: Unable to find root disk on ${node}"
+        exit 2
+    fi
+
+    if [ "$(echo ${root_disk} | wc -l)" != "1" ]; then
+        echo "ERR: More than one root disk found on ${node}"
+        exit 2
+    fi
+
+    for disk in ${disks} ; do
+      # shellcheck disable=SC2076
+      if [[ "${root_disk}" =~ "${disk}" ]]; then
+        continue
+      else
+    sshpass -p ${password} ssh ${username}@${node} "wipefs -a --force /dev/${disk}"
+    fi
+    done
+}
+
+# This function sets the hostname of a node to its shortname and cleans the default repo files to avoid conflicts.
+# Arguments:
+#   node: The node to perform setup on
+#   password: The password to set for the root user (default: "passwd")
+function set_hostnames_repos {
+    local node="$1"
+    local username="${2:-root}"
+    local password="${3:-passwd}"
+    echo 'Setting the systems to use shortnames'
+    sshpass -p ${password} ssh ${username}@${node} 'sudo hostnamectl set-hostname $(hostname -s)'
+    sshpass -p ${password} ssh ${username}@${node} 'sudo sed -i "s/$(hostname)/$(hostname -s)/g" /etc/hosts'
+
+    echo 'Cleaning default repo files to avoid conflicts'
+    sshpass -p ${password} ssh ${username}@${node} 'sudo rm -f /etc/yum.repos.d/*; sudo yum clean all'
+}


### PR DESCRIPTION
# Description
Adding extra params to reimage node
As part of refactoring we have added below parameters to reimage sh script

1. node_password : if not provide defaulted to passwd
2. reimage 
3. inital_setup :  
4. wipe_drives
5. set_hostnames_repo

if none of the arguments are provided it performs all the operations.
if specific arguments are provided it does only those operations

Note: reimage only works for octo nodes

This helps if you have nodes  from DSAL or OCTO labs and want to wipedrives on all the nodes are set hostname
Usage :
bash /home/jenkins-build/workspace/rhceph-upi-pipeline-executor/pipeline/scripts/ci/reimage-octo-node.sh --platform 9.1 --nodes XXXXX.lab.eng.pek2.redhat.com --node_password XXXXX --wipe_drives --set_hostnames_repo

logs : http://magna002.ceph.redhat.com/ceph-qe-logs/amar/reimage_node/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
