### PR TITLE
Adding re-url parameter to tfacon

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1470,6 +1470,7 @@ def tfacon(launch_id):
     auth_token = tfacon_cfg.get("auth_token")
     platform_url = tfacon_cfg.get("platform_url")
     tfa_url = tfacon_cfg.get("tfa_url")
+    re_url = tfacon_cfg.get("re_url")
     connector_type = tfacon_cfg.get("connector_type")
     cmd = (
         f"~/.local/bin/tfacon run --auth-token {auth_token} "
@@ -1477,6 +1478,7 @@ def tfacon(launch_id):
         f"--platform-url {platform_url} "
         f"--project-name {project_name} "
         f"--tfa-url {tfa_url} "
+        f"--re-url {re_url} -r "
         f"--launch-id {launch_id}"
     )
     log.info(cmd)


### PR DESCRIPTION
# Description
Adding re-url parameter to tfacon

This argument will provide ranks to the recommandations as well
 Ref : https://github.com/RedHatQE/tfacon

This was present earlier but removed as it was under maintenance 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
