### PR TITLE
Fix for tier-2_rbd_regression - suites failure in regression

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -448,7 +448,9 @@ class Rbd:
             return 1
         return image_info
 
-    def toggle_image_feature(self, pool_name, image_name, feature_name, action):
+    def toggle_image_feature(
+        self, pool_name, image_name, feature_name, action, **kwargs
+    ):
         """
         Enable/disable the provided feature on the given RBD image.
 
@@ -461,7 +463,7 @@ class Rbd:
             exec_cmd response
         """
         cmd = f"rbd feature {action} {pool_name}/{image_name} {feature_name}"
-        return self.exec_cmd(cmd=cmd)
+        return self.exec_cmd(cmd=cmd, **kwargs)
 
     def image_resize(self, pool_name, image_name, size, **kw):
         """


### PR DESCRIPTION
Fix for pipeline issue for tier_2-RBD_regression
issue observed in below test suite :
Test to disable the image features on image when image is moved to trash 
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/7802/198349/198431/log 

fix for issue : 
Modified the method parameter for toggle_image_feature() in rbd_utils.py

successs log: 

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-I67ZWY/ 
