### PR TITLE
update client node in ocs_rgw_ssl.yaml

### DIFF
--- a/suites/pacific/integrations/ocs_rgw_ssl.yaml
+++ b/suites/pacific/integrations/ocs_rgw_ssl.yaml
@@ -97,9 +97,10 @@ tests:
       config:
         command: add
         id: client.1
-        node: node1
+        node: node8
         install_packages:
           - ceph-common
+          - cephadm
         copy_admin_keyring: true
       desc: Configure the ceph client
       destroy-cluster: false


### PR DESCRIPTION
Updating the test suite with right client node`(node8)` in OCS RGW SSL as per the `conf/pacific/integrations/7_node_ceph.yaml `.