### PR TITLE
Adding clone resize to luks encryption tests

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_encryption.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_encryption.yaml
@@ -91,9 +91,9 @@ tests:
            - luks2,luks1
            - luks2,luks2
            - luks2,NA
-           - NA,luks1 # scenario gives error while mounting existing filesystem in clone
-           - NA,luks2 # scenario gives error while mounting existing filesystem in clone
-           - luks1,luks2 # scenario gives error while mounting existing filesystem in clone
+           - NA,luks1
+           - NA,luks2
+           - luks1,luks2
       destroy-cluster: false
       module: test_rbd_encryption.py
       name: Encrypt image and clone using combinations of encryption type

--- a/suites/quincy/rbd/tier-2_rbd_encryption.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_encryption.yaml
@@ -61,7 +61,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node6
+        node: node4
         install_packages:
           - ceph-common
           - fio
@@ -91,9 +91,9 @@ tests:
            - luks2,luks1
            - luks2,luks2
            - luks2,NA
-           - NA,luks1 # scenario gives error while mounting existing filesystem in clone
-           - NA,luks2 # scenario gives error while mounting existing filesystem in clone
-           - luks1,luks2 # scenario gives error while mounting existing filesystem in clone
+           - NA,luks1
+           - NA,luks2
+           - luks1,luks2
       destroy-cluster: false
       module: test_rbd_encryption.py
       name: Encrypt image and clone using combinations of encryption type


### PR DESCRIPTION
This PR is to fix the issues faced while testing out the following combinations in luks encryption

1) Parent not encrypted, clone is luks1/luks2 encrypted
2) Parent luks1 encrypted, clone luks2 encrypted

Scenarios and corresponding steps
    1) Parent and clone are luks1 encrypted
        Resize parent at beginning to compensate for header size,
        clone resize not required
    2) Parent luks1/luks2 and clone is not encrypted
        Resize parent at beginning to compensate for header size,
        clone resize not required since it has no header
    3) Parent luks2 and clone luks1
        Resize parent at beginning to compensate for header size,
        resize clone with --allow-shrink since luks2 header is bigger than luks1
    4) Parent not encrypted and clone is luks1/luks2
        Resize not required before clone since parent is not encrypted, resize
        clone with --allow-shrink post cloning to compensate for header
    5) Parent luks1 and clone luks2
        Resize parent before clone, resize both parent and
        clone with --allow-shrink post cloning

    Justification:
    Since LUKS2 header is usually bigger than LUKS1 header, the rbd resize command at
    the beginning temporarily grows the parent image to reserve some extra space in the
    parent snapshot and consequently the cloned image. This is necessary to make all parent
    data accessible in the cloned image. The rbd resize command at the end shrinks the
    parent image back to its original size and does not impact the parent snapshot and
    the cloned image to get rid of the unused reserved space

    The same applies to creating a formatted clone of an unformatted image,
    since an unformatted image does not have a header at all.

Reference: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/5/html/block_device_guide/image-encryption 

Success logs : 
5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-m6hfb/
6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-xmp7r/