### PR TITLE
RADOS Sanity Test Suite cleanup

### DIFF
--- a/suites/pacific/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/pacific/rados/tier-2-rados-basic-regression.yaml
@@ -114,11 +114,25 @@ tests:
       desc: Configure email alerts on ceph cluster
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verify osd heartbeat no reply
+      desc: heartbeat_check log entries should contain hostname:port
+      polarion-id: CEPH-10839
+      module: test_osd_heartbeat.py
+      destroy-cluster: false
+
+  - test:
       name: Test configuration Assimilation
       module: test_config_assimilation.py
       polarion-id: CEPH-83573480
       config:
-        cluster_conf_path: "conf/quincy/rados/test-confs/cluster-configs"
+        cluster_conf_path: "conf/pacific/rados/test-confs/cluster-configs"
         Verify_config_parameters:
           configurations:
             - config-1:
@@ -142,21 +156,6 @@ tests:
                 name: "mds_op_history_size"
                 value: "40"
       desc: Verify config assimilation into ceph mon configuration database
-
-  - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
-      name: Verify osd heartbeat no reply
-      desc: heartbeat_check log entries should contain hostname:port
-      polarion-id: CEPH-10839
-      module: test_osd_heartbeat.py
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Monitor configuration - section and masks changes
@@ -206,31 +205,6 @@ tests:
                 name: "debug_ms"
                 value: "10/10"
       desc: Verify config changes for section & masks like device class, host etc
-
-  - test:
-      name: Monitor configuration - msgrv2 compression modes
-      module: rados_prep.py
-      polarion-id: CEPH-83574961
-      config:
-        Verify_config_parameters:
-          configurations:
-            - config-1:
-                section: "mon"
-                name: "ms_osd_compress_mode"
-                value: "force"
-            - config-2:
-                section: "mon"
-                name: "ms_osd_compress_min_size"
-                value: "512"
-            - config-3:
-                section: "mon"
-                name: "ms_osd_compress_mode"
-                value: "none"
-            - config-4:
-                section: "mon"
-                name: "ms_osd_compress_min_size"
-                value: "1024"
-      desc: Verify the health status of the cluster by randomly changing the compression configuration values
 
   - test:
       name: Replicated pool LC
@@ -429,28 +403,6 @@ tests:
       module: test_mon_config_reset.py
       polarion-id: CEPH-83573478
       desc: Config sources - Verify config source changes and reset config
-
-  - test:
-      name: Compression test - replicated pool
-      module: pool_tests.py
-      polarion-id: CEPH-83571673
-      config:
-        Compression_tests:
-          verify_compression_ratio_set: true          # TC : CEPH-83571672
-          pool_type: replicated
-          pool_config:
-            pool-1: test_compression_repool-1
-            pool-2: test_compression_repool-2
-            rados_write_duration: 200
-            byte_size: 400KB
-            pg_num: 32
-          compression_config:
-            compression_mode: aggressive
-            compression_algorithm: snappy
-            compression_required_ratio: 0.3
-            compression_min_blob_size: 1B
-            byte_size: 10KB
-      desc: Verification of the effect of compression on replicated pools
 
   - test:
       name: autoscaler flags

--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -337,3 +337,25 @@ tests:
           pool_name: test-pool-3
       desc: Verify that Clients can read and write data into pools with min_size OSDs
       abort-on-fail: true
+
+  - test:
+      name: Compression test - replicated pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571673
+      config:
+        Compression_tests:
+          verify_compression_ratio_set: true          # TC : CEPH-83571672
+          pool_type: replicated
+          pool_config:
+            pool-1: test_compression_repool-1
+            pool-2: test_compression_repool-2
+            rados_write_duration: 200
+            byte_size: 400KB
+            pg_num: 32
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.3
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on replicated pools

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -114,26 +114,11 @@ tests:
       desc: Configure email alerts on ceph cluster
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
-      name: Verify osd heartbeat no reply
-      desc: heartbeat_check log entries should contain hostname:port
-      polarion-id: CEPH-10839
-      module: test_osd_heartbeat.py
-      destroy-cluster: false
-      abort-on-fail: true
-
-  - test:
       name: Test configuration Assimilation
       module: test_config_assimilation.py
       polarion-id: CEPH-83573480
       config:
-        cluster_conf_path: "conf/pacific/rados/test-confs/cluster-configs"
+        cluster_conf_path: "conf/quincy/rados/test-confs/cluster-configs"
         Verify_config_parameters:
           configurations:
             - config-1:
@@ -157,6 +142,20 @@ tests:
                 name: "mds_op_history_size"
                 value: "40"
       desc: Verify config assimilation into ceph mon configuration database
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verify osd heartbeat no reply
+      desc: heartbeat_check log entries should contain hostname:port
+      polarion-id: CEPH-10839
+      module: test_osd_heartbeat.py
+      destroy-cluster: false
 
   - test:
       name: Monitor configuration - section and masks changes
@@ -206,6 +205,31 @@ tests:
                 name: "debug_ms"
                 value: "10/10"
       desc: Verify config changes for section & masks like device class, host etc
+
+  - test:
+      name: Monitor configuration - msgrv2 compression modes
+      module: rados_prep.py
+      polarion-id: CEPH-83574961
+      config:
+        Verify_config_parameters:
+          configurations:
+            - config-1:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "force"
+            - config-2:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "512"
+            - config-3:
+                section: "mon"
+                name: "ms_osd_compress_mode"
+                value: "none"
+            - config-4:
+                section: "mon"
+                name: "ms_osd_compress_min_size"
+                value: "1024"
+      desc: Verify the health status of the cluster by randomly changing the compression configuration values
 
   - test:
       name: Replicated pool LC
@@ -404,28 +428,6 @@ tests:
       module: test_mon_config_reset.py
       polarion-id: CEPH-83573478
       desc: Config sources - Verify config source changes and reset config
-
-  - test:
-      name: Compression test - replicated pool
-      module: pool_tests.py
-      polarion-id: CEPH-83571673
-      config:
-        Compression_tests:
-          verify_compression_ratio_set: true          # TC : CEPH-83571672
-          pool_type: replicated
-          pool_config:
-            pool-1: test_compression_repool-1
-            pool-2: test_compression_repool-2
-            rados_write_duration: 200
-            byte_size: 400KB
-            pg_num: 32
-          compression_config:
-            compression_mode: aggressive
-            compression_algorithm: snappy
-            compression_required_ratio: 0.3
-            compression_min_blob_size: 1B
-            byte_size: 10KB
-      desc: Verification of the effect of compression on replicated pools
 
   - test:
       name: autoscaler flags

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -312,3 +312,25 @@ tests:
         Verify_osd_alloc_size:
           allocation_size: 4096
       desc: Verify the minimum allocation size for OSDs along with fragmentation scores.
+
+  - test:
+      name: Compression test - replicated pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571673
+      config:
+        Compression_tests:
+          verify_compression_ratio_set: true          # TC : CEPH-83571672
+          pool_type: replicated
+          pool_config:
+            pool-1: test_compression_repool-1
+            pool-2: test_compression_repool-2
+            rados_write_duration: 200
+            byte_size: 400KB
+            pg_num: 32
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.3
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on replicated pools


### PR DESCRIPTION
RADOS Tier-2 test suite `tier-2-rados-basic-regression.yaml` will be part of Sanity Pipeline.

This PR cleans up the test suite to make it sanity appropriate.
Changes made:
1. Test case [CEPH-83571673 - Compression test - replicated pool] has been moved out of basic regression test suite and added to Pool functionalities test suite; this has been done because as part of Sanity, we would like to verify only the config changes and basic deployment. The concerned test case was also verifying the compression functionality and hence it was moved away.
2. Test suite has been renamed: 

- `suites/pacific/rados/tier-2_rados_basic_regression.yaml` -> `suites/pacific/rados/tier-2-rados-basic-regression.yaml`
- `suites/quincy/rados/tier-2_rados_basic_regression.yaml` -> `suites/quincy/rados/tier-2-rados-basic-regression.yaml`

Logs:
RHCS 5.3:
rhel-8: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UKGU75/
rhel-9: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NXWRUM/
RHCS 6.1:
rhel-9: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GL3HHP/

Signed-off-by: Harsh Kumar <hakumar@redhat.com> 