### PR TITLE
Fix failure related to rate limit test case in pacific

### DIFF
--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -453,8 +453,8 @@ pipelines:
       stage-6:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          suite: "suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"
           inventory:
             openstack: "conf/inventory/rhel-9-latest.yaml"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -429,8 +429,8 @@ pipelines:
       stage-6:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          suite: "suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"
           inventory:
             openstack: "conf/inventory/rhel-9-latest.yaml"

--- a/pipeline/metadata/archived/6.0.yaml
+++ b/pipeline/metadata/archived/6.0.yaml
@@ -848,8 +848,8 @@ pipelines:
       stage-1:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          suite: "suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"
           inventory:
             openstack: "conf/inventory/rhel-9-latest.yaml"

--- a/pipeline/metadata/archived/6.1.yaml
+++ b/pipeline/metadata/archived/6.1.yaml
@@ -812,8 +812,8 @@ pipelines:
       stage-1:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"
-          suite: "suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          suite: "suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"
           inventory:
             openstack: "conf/inventory/rhel-9-latest.yaml"

--- a/suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -1,4 +1,4 @@
-# RHCS 5.x(5.1 and above) sanity test suite for RGW daemon with S3CMD.
+# RHCS 6.x sanity test suite for RGW daemon with S3CMD.
 
 # Runs the Object Gateway tests from https://github.com/red-hat-storage/ceph-qe-scripts/tree/master/rgw
 # each script under the above repo has a yaml ( config defined ) which is actually a test
@@ -189,4 +189,44 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
+        timeout: 300
+
+  - test:
+      name: Test Ratelimit at global scope
+      desc: Test Ratelimit at global scope
+      polarion-id: CEPH-83574915 # also CEPH-83574916
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_ratelimit_global.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
+        timeout: 300
+
+  - test:
+      name: Test Ratelimit for regular buckets
+      desc: Test Ratelimit for regular buckets
+      polarion-id: CEPH-83574910
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
+        timeout: 300
+
+  - test:
+      name: Test Ratelimit for versioned buckets
+      desc: Test Ratelimit for versioned buckets
+      polarion-id: CEPH-83574912
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
+        timeout: 300
+
+  - test:
+      name: Test Ratelimit for tenanted users
+      desc: Test Ratelimit for tenanted users
+      polarion-id: CEPH-83574914
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
         timeout: 300


### PR DESCRIPTION
# Description

Since rate limit feature is GA on ceph >=6.0
But test cases are included in common pacific test-suite: suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
and same is included in pacific and quincy pipeline execution.

In this PR:
1. Removed rate limit test csaes from pacific tier-2_rgw_test-using-s3cmd.yaml test-suite
2. Created quincy test suite with rate-limit test-cases suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
3. Changed reference to quincy suite in 6.0 and 6.1 metadata file

Log: 
pacific:  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-xp7iz/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-nuk5y/

Failure in quincy log not related to current PR, this failure is analysed in different ticket

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
