### PR TITLE
Add TC CEPH-83573802

### DIFF
--- a/cli/utilities/operations.py
+++ b/cli/utilities/operations.py
@@ -1,0 +1,26 @@
+from ceph.waiter import WaitUntil
+from cli.ceph.ceph import Ceph
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def wait_for_cluster_health(node, status, timeout=300, interval=20):
+    """
+    Checks if cluster health is in expected status
+    Args:
+        timeout (int): Timeout duration in seconds
+        interval (int): Interval duration in seconds
+        node (ceph): Node to execute the cmd
+        status (str): Expected status, e.g. HEALTH_OK/HEALTH_WARN
+
+    Returns (bool): Based on expected v/s actual status
+    """
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        _status = Ceph(node).health()
+        if status in _status:
+            log.info(f"Cluster status is in expected state {status}")
+            return True
+    if w.expired:
+        log.error(f"Cluster is not in {status} state even after {timeout} secs")
+        return False

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -393,13 +393,15 @@ def get_service_id(node, service_name):
 
     Returns (str/list): Service ID /ID's
     """
-    out, err = node.exec_command(cmd=f"systemctl --type=service | grep {service_name}")
+    out, err = node.exec_command(
+        cmd=f"systemctl --type=service | grep {service_name} | awk '{{print $1}}'"
+    )
     if err:
         return None
 
     service_ids = []
     for item in out.strip().split("\n"):
-        service_ids.append(item.split(" ")[0])
+        service_ids.append(item.strip())
     return service_ids
 
 

--- a/suites/pacific/cephadm/tier-4-service-operations.yaml
+++ b/suites/pacific/cephadm/tier-4-service-operations.yaml
@@ -69,6 +69,20 @@ tests:
       name: Deploy cluster using cephadm
 
   - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the ceph client system
+      destroy-cluster: false
+      module: test_client.py
+      name: Configure client
+
+  - test:
       name: Stopping mon and mgr service
       desc: Test Ceph orch stop mon and mgr services
       module: test_cluster_service_operations.py
@@ -78,5 +92,13 @@ tests:
         service:
           - "mon"
           - "mgr"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD service ops using systemctl
+      desc: Test stop and start OSD service using systemctl
+      module: test_osd_service_operations.py
+      polarion-id: CEPH-83573802
       destroy-cluster: false
       abort-on-fail: true

--- a/suites/quincy/cephadm/tier-4-service-operations.yaml
+++ b/suites/quincy/cephadm/tier-4-service-operations.yaml
@@ -69,6 +69,20 @@ tests:
       name: Deploy cluster using cephadm
 
   - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the ceph client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
       name: Stopping mon and mgr service
       desc: Test Ceph orch stop mon and mgr services
       module: test_cluster_service_operations.py
@@ -78,5 +92,13 @@ tests:
         service:
           - "mon"
           - "mgr"
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD service ops using systemctl
+      desc: Test stop and start OSD service using systemctl
+      module: test_osd_service_operations.py
+      polarion-id: CEPH-83573802
       destroy-cluster: false
       abort-on-fail: true

--- a/tests/cephadm/test_osd_service_operations.py
+++ b/tests/cephadm/test_osd_service_operations.py
@@ -1,0 +1,53 @@
+from cli.exceptions import (
+    OperationFailedError,
+    ResourceNotFoundError,
+    UnexpectedStateError,
+)
+from cli.utilities.operations import wait_for_cluster_health
+from cli.utilities.utils import get_service_id, get_service_state, set_service_state
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    # Check if client node is present
+    client = ceph_cluster.get_nodes(role="client")
+    if not client:
+        raise ResourceNotFoundError("Client node is missing, add a client node")
+    client, osd_id = client[0], list()
+    # Fetch the nodes with osd service daemons
+    osd_node = ceph_cluster.get_nodes(role="osd")
+    for node in osd_node:
+        # Fetch id of osd service
+        osd_id = get_service_id(node, "osd")
+        for id in osd_id:
+            # Stop the service using systemctl command
+            service_state = set_service_state(node, id, "stop")
+            if not service_state:
+                raise OperationFailedError(
+                    f"Failed to stop OSD service on {node.hostname}"
+                )
+            # Check if service has stopped using systemctl
+            status = get_service_state(node, id)
+            if "inactive" in status:
+                log.info("Service has been stopped")
+            # Check the cluster health after service is stopped
+            health = wait_for_cluster_health(client, "HEALTH_WARN", 300, 10)
+            if not health:
+                raise UnexpectedStateError("Cluster is not in expected state")
+            # Start the service using systemctl command
+            service_state = set_service_state(node, id, "start")
+            if not service_state:
+                raise OperationFailedError(
+                    f"Failed to start OSD service on {node.hostname}"
+                )
+            # Check if service has started using systemctl
+            status = get_service_state(node, id)
+            if "active" in status:
+                log.info("Service has been started")
+            # Check the cluster health after service is started
+            health = wait_for_cluster_health(client, "HEALTH_OK", 300, 10)
+            if not health:
+                raise UnexpectedStateError("Cluster is not in expected state")
+    return 0


### PR DESCRIPTION
Adding test case for CEPH-83573802 - Verify the cluster status when ongoing operation are stopped ( abrupt/crash) - Tier4

# Description
1. Bootstrap cluster  using cephadm    
2. Copy SSH keys to nodes and Add them to cluster with address and role labels attached to them    
3. Deploy all daemon services using cephadm   
4. Perform the same steps serially for all daemons and check ceph status:syntax: systemctl stop <ceph-daemon.service>
    Eg: systemctl stop ceph-osd@6.service
5. Check if the service is stopped
    # sytemctl status ceph-osd@6.service    
    The service should be stopped successfully
6. Verify the ceph status
    #ceph -s

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
