### PR TITLE
CEPH-9849 - Create an Image, take snapshot, create clone, then set meta-data option on that Clone

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -302,6 +302,8 @@ tests:
 
   - test:
       desc: Perform flatten operations while changing the image feature
+      config:
+        rbd_op_thread_timeout: 120
       module: rbd_flatten_image_feature_disable.py
       name: Test to disable image feature when flatten operation is performed
       polarion-id: CEPH-9862

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -302,6 +302,8 @@ tests:
 
   - test:
       desc: Perform flatten operations while changing the image feature
+      config:
+        rbd_op_thread_timeout: 120
       module: rbd_flatten_image_feature_disable.py
       name: Test to disable image feature when flatten operation is performed
       polarion-id: CEPH-9862


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-8478
PR include automation of scenario for adding meta-data value to clone image

File changed :
[suites/pacific/rbd/tier-2_rbd_regression.yaml] - Added test suite
[suites/quincy/rbd/tier-2_rbd_regression.yaml] - Added test suite
tests/rbd/rbd_flatten_image_feature_disable.py

As this very basic scenario , Accommodating this scenario in below  existing automation test case
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9862
[CEPH-9862 - Perform flatten operations while changing the image feature.](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9862)

Will mark the below Polarion test case as inactive.
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9849

success log  : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ICRZTJ 