### PR TITLE
TFA: RHCEPHQE-8552:Bilog trimming test - is failing in regression

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml
@@ -284,18 +284,6 @@ tests:
       name: create non-tenanted user
       polarion-id: CEPH-83575199
 
-  - test:
-      name: Bilog trimming test
-      desc: test bilog trimming
-      polarion-id: CEPH-83572658
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bilog_trimming.py
-            config-file-name: test_bilog_trimming.yaml
-            timeout: 300
-            verify-io-on-site: ["ceph-sec"]
 
   - test:
       name: bucket creation on primary for crash check


### PR DESCRIPTION
# Description
TFA: RHCEPHQE-8552:Bilog trimming test - is failing in regression

- This failure happened during the verification of the IO. It is expected to fail since in the script, the bucket gets purged.
-  Also, removing the test from tier-1 since all the log trimming tests are in tier-2 and part of the schedule runs
 present here (https://github.com/red-hat-storage/cephci/blob/master/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml)

logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9K1WZ8/Bilog_trimming_test_on_primary_0.log
