### PR TITLE
[LibFix] Fix get_service_id method

### DIFF
--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -393,9 +393,7 @@ def get_service_id(node, service_name):
 
     Returns (str/list): Service ID /ID's
     """
-    out, err = node.exec_command(
-        cmd=f"systemctl --type=service | grep ceph-{service_name}"
-    )
+    out, err = node.exec_command(cmd=f"systemctl --type=service | grep {service_name}")
     if err:
         return None
 


### PR DESCRIPTION
grepping `ceph-{service_name}` returns empty at certain scenarios, hence reverting to `grep {service_name}`

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
