### PR TITLE
Fix for client configuration for RBD - tier-2_rbd_encryption

### DIFF
--- a/suites/quincy/rbd/tier-2_rbd_encryption.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_encryption.yaml
@@ -61,7 +61,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node6
+        node: node4
         install_packages:
           - ceph-common
           - fio


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-8607
pipeline failure for client configuration : 
https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/7918/201441 

Fix : trying to configure client on wrong node6, it should be node4.

file modified : suites/quincy/rbd/tier-2_rbd_encryption.yaml 