### PR TITLE
[Rados] Pipeline metadata updates due to test suite name change

### DIFF
--- a/pipeline/metadata/5.0.yaml
+++ b/pipeline/metadata/5.0.yaml
@@ -311,7 +311,7 @@ suites:
       - rados
       - stage-2
   - name: "test-rados-basic-regression"
-    suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
+    suite: "suites/pacific/rados/tier-2-rados-basic-regression.yaml"
     global-conf: "conf/pacific/rados/7-node-cluster.yaml"
     platform: "rhel-8"
     rhbuild: "5.0"

--- a/pipeline/metadata/5.1.yaml
+++ b/pipeline/metadata/5.1.yaml
@@ -399,7 +399,7 @@ suites:
       - rgw
       - stage-2
   - name: "test-rados-basic-regression"
-    suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
+    suite: "suites/pacific/rados/tier-2-rados-basic-regression.yaml"
     global-conf: "conf/pacific/rados/7-node-cluster.yaml"
     platform: "rhel-8"
     rhbuild: "5.1"

--- a/pipeline/metadata/5.2.yaml
+++ b/pipeline/metadata/5.2.yaml
@@ -260,7 +260,7 @@ suites:
       - stage-2
 
   - name: "Testing RADOS basic regression scenarios"
-    suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
+    suite: "suites/pacific/rados/tier-2-rados-basic-regression.yaml"
     global-conf: "conf/pacific/rados/7-node-cluster.yaml"
     platform: "rhel-9"
     rhbuild: "5.2"

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -337,7 +337,7 @@ pipelines:
             - rbd
         - name: "Testing RADOS basic regression scenarios"
           execution_time: "1h 13m 5s"
-          suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
+          suite: "suites/pacific/rados/tier-2-rados-basic-regression.yaml"
           global-conf: "conf/pacific/rados/7-node-cluster.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -330,7 +330,7 @@ pipelines:
             - rgw
         - name: "Testing RADOS basic regression scenarios"
           execution_time: "1h 15m 45s"
-          suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+          suite: "suites/quincy/rados/tier-2-rados-basic-regression.yaml"
           global-conf: "conf/quincy/rados/7-node-cluster.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -316,7 +316,7 @@ pipelines:
             - rgw
         - name: "Testing RADOS basic regression scenarios"
           execution_time: "1h 15m 45s"
-          suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+          suite: "suites/quincy/rados/tier-2-rados-basic-regression.yaml"
           global-conf: "conf/quincy/rados/7-node-cluster.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/archived/5.3.yaml
+++ b/pipeline/metadata/archived/5.3.yaml
@@ -337,7 +337,7 @@ pipelines:
       stage-4:
         - name: "Testing RADOS basic regression scenarios"
           execution_time: "1h 13m 5s"
-          suite: "suites/pacific/rados/tier-2_rados_basic_regression.yaml"
+          suite: "suites/pacific/rados/tier-2-rados-basic-regression.yaml"
           global-conf: "conf/pacific/rados/7-node-cluster.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/archived/6.0.yaml
+++ b/pipeline/metadata/archived/6.0.yaml
@@ -330,7 +330,7 @@ pipelines:
             - rgw
         - name: "Testing RADOS basic regression scenarios"
           execution_time: "1h 15m 45s"
-          suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+          suite: "suites/quincy/rados/tier-2-rados-basic-regression.yaml"
           global-conf: "conf/quincy/rados/7-node-cluster.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/archived/6.1.yaml
+++ b/pipeline/metadata/archived/6.1.yaml
@@ -326,7 +326,7 @@ pipelines:
             - rgw
         - name: "Testing RADOS basic regression scenarios"
           execution_time: "1h 15m 45s"
-          suite: "suites/quincy/rados/tier-2_rados_basic_regression.yaml"
+          suite: "suites/quincy/rados/tier-2-rados-basic-regression.yaml"
           global-conf: "conf/quincy/rados/7-node-cluster.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/main.yaml
+++ b/pipeline/metadata/main.yaml
@@ -118,7 +118,7 @@ suites:
     - rbd
     - stage-2
 - name: "Upstream Testing For Rados Regression"
-  suite: "suites/quincy/upstream/tier-2_rados_basic_regression.yaml"
+  suite: "suites/quincy/upstream/tier-2-rados-basic-regression.yaml"
   global-conf: "conf/quincy/rados/7-node-cluster.yaml"
   platform: "rhel-9"
   rhbuild: "6.0"

--- a/pipeline/metadata/quincy.yaml
+++ b/pipeline/metadata/quincy.yaml
@@ -118,7 +118,7 @@ suites:
     - rbd
     - stage-2
 - name: "Upstream Testing For Rados Regression"
-  suite: "suites/quincy/upstream/tier-2_rados_basic_regression.yaml"
+  suite: "suites/quincy/upstream/tier-2-rados-basic-regression.yaml"
   global-conf: "conf/quincy/rados/7-node-cluster.yaml"
   platform: "rhel-9"
   rhbuild: "6.0"


### PR DESCRIPTION
PR addresses changes required in Pipeline metadata file due to the name change of following test suites

- suites/pacific/rados/tier-2_rados_basic_regression.yaml -> suites/pacific/rados/tier-2-rados-basic-regression.yaml
- suites/quincy/rados/tier-2_rados_basic_regression.yaml -> suites/quincy/rados/tier-2-rados-basic-regression.yaml

Signed-off-by: Harsh Kumar <hakumar@redhat.com>