### PR TITLE
CEPH-83571646: Test to verify BlueStore Checksum algorithms

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
@@ -132,4 +132,16 @@ tests:
                  rados_read_duration: 50
           desc: Verification of the bluestore pinned tests
 
-
+  - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -132,4 +132,16 @@ tests:
                  rados_read_duration: 50
           desc: Verification of the bluestore pinned tests
 
-
+  - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -294,13 +294,16 @@ def run(ceph_cluster, **kw):
     return 0
 
 
-def wait_for_clean_pg_sets(rados_obj: RadosOrchestrator, timeout: Any = 9000) -> bool:
+def wait_for_clean_pg_sets(
+    rados_obj: RadosOrchestrator, timeout: Any = 9000, _sleep: Any = 120
+) -> bool:
     """
     Waiting for up to 2.5 hours for the PG's to enter active + Clean state after stretch changes
     Automation for bug : [1] & [2]
     Args:
         rados_obj: RadosOrchestrator object to run commands
         timeout: timeout in seconds or "unlimited"
+        _sleep: sleep timeout in seconds (default: 120)
 
     Returns:  True -> pass, False -> fail
 
@@ -338,9 +341,9 @@ def wait_for_clean_pg_sets(rados_obj: RadosOrchestrator, timeout: Any = 9000) ->
         log.info(
             f"Waiting for active + clean. Active aletrs: {status_report['health']['checks'].keys()},"
             f"PG States : {status_report['num_pg_by_state']}"
-            f" checking status again in 2 minutes"
+            f" checking status again in {_sleep} seconds"
         )
-        time.sleep(120)
+        time.sleep(_sleep)
 
     log.error("The cluster did not reach active + Clean state")
     return False

--- a/tests/rados/test_bluestore_configs.py
+++ b/tests/rados/test_bluestore_configs.py
@@ -1,0 +1,111 @@
+""" Module to verify scenarios related to BlueStore config changes"""
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Common test module to verify BlueStore config changes
+    and functionalities.
+    Currently, covers the following tests:
+     - CEPH-83571646: Checksum Algorithms
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+
+    def restart_osd_service():
+        osd_services = rados_obj.list_orch_services(service_type="osd")
+        for osd_service in osd_services:
+            cephadm.shell(args=[f"ceph orch restart {osd_service}"])
+        time.sleep(30)
+
+    def create_pool_write_iops(param, pool_type):
+        pool_name = f"{pool_type}_pool_{param}"
+        assert (
+            rados_obj.create_pool(pool_name=pool_name)
+            if "repli" in pool_type
+            else rados_obj.create_erasure_pool(
+                name=pool_name, **{"pool_name": pool_name}
+            )
+        )
+
+        if param == checksum:
+            # set checksum value for the pool
+            cephadm.shell([f"ceph osd pool set {pool_name} csum_type {param}"])
+        # rados bench will perform IOPs and also verify the num of objs written
+        assert rados_obj.bench_write(pool_name=pool_name, **{"max_objs": 500})
+        assert rados_obj.detete_pool(pool=pool_name)
+
+    if config.get("checksums"):
+        doc = (
+            "\n #CEPH-83571646"
+            "\n\t Apply all the applicable different checksum algorithms on pools backed by bluestore"
+            "\n\t\t Valid algos: none, crc32c, crc32c_16, crc32c_8, xxhash32, xxhash64"
+            "\n\t 1. Create individual replicated pools for each checksum"
+            "\n\t 2. Verify the default checksum algorithm is crc32c"
+            "\n\t 3. Set different checksum algorithm as global and for each pool"
+            "\n\t 4. Verify the checksum algo being set correctly"
+            "\n\t 5. Write data to each pool using rados bench"
+            "\n\t 6. cleanup - Remove all the pools created"
+        )
+        log.info(doc)
+        log.info("Running test case to verify BlueStore checksum algorithms")
+        checksum_list = config.get("checksums")
+
+        try:
+            # verify default checksum value
+            out, _ = cephadm.shell(["ceph config get osd bluestore_csum_type"])
+            log.info(f"BlueStore OSD default checksum: {out} | Expected: crc32c")
+            assert "crc32c" in out
+
+            for checksum in checksum_list:
+                # set the global checksum value
+                cfg = {
+                    "section": "osd",
+                    "name": "bluestore_csum_type",
+                    "value": checksum,
+                }
+                assert mon_obj.set_config(**cfg)
+
+                # verify the newly set global checksum value
+                out = mon_obj.get_config(section="osd", param="bluestore_csum_type")
+                assert checksum in out
+                log.info(f"global checksum set verified - {out}")
+
+                # restart osd services
+                restart_osd_service()
+
+                # create pools with given config
+                create_pool_write_iops(
+                    param=checksum, pool_type="replicated"
+                ) if "crc" in checksum else create_pool_write_iops(
+                    param=checksum, pool_type="ec"
+                )
+
+        except Exception as E:
+            log.error(f"Verification failed with exception: {E.__doc__}")
+            log.error(E)
+            log.exception(E)
+            return 1
+        finally:
+            # reset global checksum config
+            assert mon_obj.remove_config(
+                **{"section": "osd", "name": "bluestore_csum_type"}
+            )
+
+            # restart osd services
+            restart_osd_service()
+            wait_for_clean_pg_sets(rados_obj, timeout=300, _sleep=10)
+
+        log.info("BlueStore Checksum algorithm verification completed.")
+        return 0


### PR DESCRIPTION
[CEPH-83571646](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571646): Tier-2 test to implement different types of checksum algorithms applicable for BlueStore.

References: 
- https://docs.ceph.com/en/quincy/rados/configuration/bluestore-config-ref/#checksums
- https://issues.redhat.com/browse/RHCEPHQE-8211


Test modules modified:
- ceph/rados/core_workflows.py

Test suites modified:
- suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
- suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml

Test modules added:
- tests/rados/test_bluestore_checksum.py

Steps:
1. Create individual replicated pools for each checksum
2. Verify the default checksum algorithm is crc32c
3. Set different checksum algorithm as global and for each pool
4. Verify the checksum algo being set correctly
5. Write data to each pool using rados bench
6. cleanup - Remove all the pools created

Logs:
- RHCS 6.1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-34VMHC
- RHCS 5.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W0JT22
[Updated]
- RHCS 6.1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DU93H4
- RHCS 5.3: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FA8I94

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

