### PR TITLE
[run.py]Fix build type issue.

### DIFF
--- a/run.py
+++ b/run.py
@@ -462,6 +462,9 @@ def run(args):
             base_url, docker_registry, docker_image, docker_tag = fetch_build_artifacts(
                 build, rhbuild, platform, upstream_build
             )
+    else:
+        build = None
+
     store = args.get("--store") or False
 
     docker_insecure_registry = args.get("--insecure-registry")

--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -62,11 +62,6 @@ def add(cls, config: Dict) -> None:
                 rhcs_version = _build["release"]
                 if not isinstance(rhcs_version, str):
                     rhcs_version = str(rhcs_version)
-
-                # Todo: Pointing to RHCS 5 CDN repo rpms, Since 6x not yet GAed
-                #       Revert this commit/code changes once 6x is GAed.
-                if rhcs_version > "5":
-                    rhcs_version = "5"
             elif use_cdn:
                 rhcs_version = default_version
             else:
@@ -89,7 +84,10 @@ def add(cls, config: Dict) -> None:
                     "4": ["rhceph-4-tools-for-rhel-8-x86_64-rpms"],
                     "5": ["rhceph-5-tools-for-rhel-8-x86_64-rpms"],
                 },
-                "9": {"5": ["rhceph-5-tools-for-rhel-9-x86_64-rpms"]},
+                "9": {
+                    "5": ["rhceph-5-tools-for-rhel-9-x86_64-rpms"],
+                    "6": ["rhceph-6-tools-for-rhel-9-x86_64-rpms"],
+                },
             }
 
             rhel_repos = {


### PR DESCRIPTION
- Fix issue with build type when builds args are overrided.
- Revert changes w.r.t client using 5x cdn for 6x builds.
  - Now, we can have clients poinitng to 6x CDN builds.

**Results:**
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L4AG33/
