### PR TITLE
CEPH-9185 - RADOS: Degraded object improvements:Testing the cluster b…

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -359,3 +359,18 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
+
+  - test:
+      name: Verify degraded pool behaviour at min_size
+      module: pool_tests.py
+      polarion-id: CEPH-9185
+      config:
+        Verify_degraded_pool_min_size_behaviour:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: pool_degraded_test
+              pg_num: 1
+              disable_pg_autoscale: true
+      desc: On a degraded cluster verify that clients can read and write data into pools with min_size OSDs
+      abort-on-fail: false

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -334,3 +334,18 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
+
+  - test:
+      name: Verify degraded pool behaviour at min_size
+      module: pool_tests.py
+      polarion-id: CEPH-9185
+      config:
+        Verify_degraded_pool_min_size_behaviour:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: pool_degraded_test
+              pg_num: 1
+              disable_pg_autoscale: true
+      desc: On a degraded cluster verify that clients can read and write data into pools with min_size OSDs
+      abort-on-fail: false


### PR DESCRIPTION
CEPH-9185 - RADOS: Degraded object improvements:Testing the cluster behaviour by reducing the min_size count in a cluster which is already degraded

Steps:
1. Create a replicated pool with default replicas, pg=1 and disable autoscaler. i.e size=3 and min_size=2, pg_num = 1 
2. Trigger rados bench to write to the created pool.
3. Bring down 2 OSDs from the acting set of the pg so that cluster is in degraded state with OSDs less than the min_size
4. Verify IOs cannot be served by triggering rados PUT operation.
5. Modify the min_Size value to 1 matching the no. of OSDs active in the acting set of the pg.
6. Verify IOs can be served post modification of min_size equal to no. of OSDs in the acting set of the pg using rados PUT operation.
7. Resatrt the OSDs that were brought down earlier.
8. Delete the created pool.

Files modified:
suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml tests/rados/pool_tests.py

Logs:
RHCS 5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5ZY9C4/ 
RHCS 6.1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YMPDLF/

Latest log:
RHCS 5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3RRHEK/
RHCS 6.1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DKIATW/ 

Updated log:
RHCS 6.1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PH9ZS0

Polarion link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9185 