### PR TITLE
adding bucket notification suite for multisite

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -517,6 +517,16 @@ pipelines:
             openstack: "conf/inventory/rhel-8-latest.yaml"
           metadata:
             - rados
+        - name: "RGW bucket notifications testing on Multisite"
+          execution_time: "2h 8m 36s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
   schedule:
     tier-1:
       stage-1:

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -450,6 +450,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "RGW bucket notifications testing on Multisite"
+          execution_time: "2h 8m 36s"
+          suite: "suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml"
+          global-conf: "conf/pacific/rgw/rgw_multisite"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
       stage-6:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -426,6 +426,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "RGW bucket notifications testing on Multisite"
+          execution_time: "1h 47m 4s"
+          suite: "suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml"
+          global-conf: "conf/quincy/rgw/rgw_multisite"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
       stage-6:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"

--- a/suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -1,0 +1,359 @@
+#
+# Objective: Test bucket notifications with kafka endpoint
+#       - with ack_type broker/none
+#       - w/o persistent flag
+#
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+      polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on primary
+      polarion-id: CEPH-83575227
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on secondary
+      polarion-id: CEPH-83575227
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+
+  - test:
+      name: notify copy events with kafka_broker_persistent
+      desc: notify copy events with kafka_broker_persistent
+      polarion-id: CEPH-83574066
+      module: sanity_rgw_multisite.py
+      config:
+        run-on-rgw: true
+        extra-pkgs:
+          - wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm
+        install_start_kafka: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
+        timeout: 300
+
+  - test:
+      name: notify put,delete events with kafka_broker_persistent
+      desc: notify put,delete events with kafka_broker_persistent
+      polarion-id: CEPH-83574086
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
+            timeout: 300
+
+  - test:
+      name: notify on multipart upload events with kafka_broker_persistent
+      desc: notify on multipart upload events with kafka_broker_persistent
+      polarion-id: CEPH-83574086
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
+            timeout: 300
+
+  - test:
+      name: notify copy events with kafka_none
+      desc: notify copy events with kafka_none
+      polarion-id: CEPH-83574066
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_none_copy.yaml
+            timeout: 300
+
+  - test:
+      name: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
+      desc: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
+      polarion-id: CEPH-83574078
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
+            timeout: 300
+
+  - test:
+      name: notify on multipart events with kafka_broker_persistent when kafka is down
+      desc: notify on multipart events with kafka_broker_persistent when kafka is down
+      polarion-id: CEPH-83574417
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
+            timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
@@ -100,7 +100,7 @@ tests:
       name: notify put,copy,delete events with kafka_broker and SSL security
       desc: notify put,copy,delete events with kafka_broker and SSL security
       module: sanity_rgw.py
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       config:
         run-on-rgw: true
         extra-pkgs:
@@ -114,7 +114,7 @@ tests:
   - test:
       name: notify on multipart upload events with kafka_broker and SSL security
       desc: notify on multipart upload events with kafka_broker and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -125,7 +125,7 @@ tests:
   - test:
       name: notify put,copy,delete events with kafka_broker_persistent and SSL security
       desc: notify put,copy,delete events with kafka_broker_persistent and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -137,7 +137,7 @@ tests:
       name: notify on multipart upload events with kafka_broker_persistent and SSL security
       desc: notify on multipart upload events with kafka_broker_persistent and SSL security
       module: sanity_rgw.py
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -149,7 +149,7 @@ tests:
   - test:
       name: notify put,copy,delete events with kafka_none and SSL security
       desc: notify put,copy,delete events with kafka_none and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -160,7 +160,7 @@ tests:
   - test:
       name: notify on multipart upload events with kafka_none and SSL security
       desc: notify on multipart upload events with kafka_none and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -172,7 +172,7 @@ tests:
       name: notify put,copy,delete events with kafka_none_persistent and SSL security
       desc: notify put,copy,delete events with kafka_none_persistent and SSL security
       module: sanity_rgw.py
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -182,7 +182,7 @@ tests:
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
       desc: notify on multipart upload events with kafka_none_persistent and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -1,0 +1,324 @@
+#
+# Objective: Test bucket notifications with kafka endpoint
+#       - with ack_type broker/none
+#       - w/o persistent flag
+#
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+      polarion-id: CEPH-83575222
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on primary
+      polarion-id: CEPH-83575227
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on secondary
+      polarion-id: CEPH-83575227
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+
+  - test:
+      name: notify copy events with kafka_broker_persistent
+      desc: notify copy events with kafka_broker_persistent
+      polarion-id: CEPH-83574066
+      module: sanity_rgw_multisite.py
+      config:
+        run-on-rgw: true
+        extra-pkgs:
+          - wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm
+        install_start_kafka: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
+        timeout: 300
+
+  - test:
+      name: notify put,delete events with kafka_broker_persistent
+      desc: notify put,delete events with kafka_broker_persistent
+      polarion-id: CEPH-83574086
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
+            timeout: 300
+
+  - test:
+      name: notify on multipart upload events with kafka_broker_persistent
+      desc: notify on multipart upload events with kafka_broker_persistent
+      polarion-id: CEPH-83574086
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
+            timeout: 300
+
+  - test:
+      name: notify copy events with kafka_none
+      desc: notify copy events with kafka_none
+      polarion-id: CEPH-83574066
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_none_copy.yaml
+            timeout: 300
+
+  - test:
+      name: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
+      desc: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
+      polarion-id: CEPH-83574078
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
+            timeout: 300
+
+  - test:
+      name: notify on multipart events with kafka_broker_persistent when kafka is down
+      desc: notify on multipart events with kafka_broker_persistent when kafka is down
+      polarion-id: CEPH-83574417
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
+            timeout: 300
+
+  - test:
+      name: notify on multisite replication create events with kafka_broker on pri site
+      desc: notify on multisite replication create events with kafka_broker on pri site
+      polarion-id: CEPH-83575571
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
+            timeout: 300
+
+  - test:
+      name: notify on multisite replication create events with kafka_broker on sec site
+      desc: notify on multisite replication create events with kafka_broker on sec site
+      polarion-id: CEPH-83575571
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: test_bucket_notifications.py
+            config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
+            timeout: 300

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
@@ -66,7 +66,7 @@ tests:
       name: notify put,copy,delete events with kafka_broker and SSL security
       desc: notify put,copy,delete events with kafka_broker and SSL security
       module: sanity_rgw.py
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       config:
         run-on-rgw: true
         extra-pkgs:
@@ -80,7 +80,7 @@ tests:
   - test:
       name: notify on multipart upload events with kafka_broker and SSL security
       desc: notify on multipart upload events with kafka_broker and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
@@ -92,7 +92,7 @@ tests:
   - test:
       name: notify put,copy,delete events with kafka_broker_persistent and SSL security
       desc: notify put,copy,delete events with kafka_broker_persistent and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -104,7 +104,7 @@ tests:
       name: notify on multipart upload events with kafka_broker_persistent and SSL security
       desc: notify on multipart upload events with kafka_broker_persistent and SSL security
       module: sanity_rgw.py
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
@@ -117,7 +117,7 @@ tests:
   - test:
       name: notify put,copy,delete events with kafka_none and SSL security
       desc: notify put,copy,delete events with kafka_none and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -128,7 +128,7 @@ tests:
   - test:
       name: notify on multipart upload events with kafka_none and SSL security
       desc: notify on multipart upload events with kafka_none and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
@@ -141,7 +141,7 @@ tests:
       name: notify put,copy,delete events with kafka_none_persistent and SSL security
       desc: notify put,copy,delete events with kafka_none_persistent and SSL security
       module: sanity_rgw.py
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -151,7 +151,7 @@ tests:
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
       desc: notify on multipart upload events with kafka_none_persistent and SSL security
-      polarion-id: CEPH-83575407
+      polarion-id: CEPH-83575471
       comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:


### PR DESCRIPTION
adding this suite for bucket notification testing on Multisite.
Multisite Replication bucket notification events tests are added under quincy for 6.1 only, as the feature support is added in 6.1

Also corrected polarion ids for kafka ssl with CEPH-83575471, previously it is pointing to CEPH-83575407 which is sasl scram one

pass logs:

- 5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ny4z0/
- 6.1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-qq3f2/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
