### PR TITLE
CEPH-83571646: Test to verify tuning of BlueStore Cache Sizes

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
@@ -106,6 +106,28 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms
+
+  - test:
+      name: BlueStore cache size tuning
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571675
+      config:
+        bluestore_cache: true
+      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
       name:  Testing bluestore
       desc: Testing bluestore pinned
       module: test_bluestore_features.py
@@ -131,17 +153,3 @@ tests:
                  rados_write_duration: 50
                  rados_read_duration: 50
           desc: Verification of the bluestore pinned tests
-
-  - test:
-      name: BlueStore Checksum algorithms
-      module: test_bluestore_configs.py
-      polarion-id: CEPH-83571646
-      config:
-        checksums:
-          - none
-          - crc32c
-          - crc32c_16
-          - crc32c_8
-          - xxhash32
-          - xxhash64
-      desc: Verify the different applicable BlueStore Checksum algorithms

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -106,6 +106,28 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms
+
+  - test:
+      name: BlueStore cache size tuning
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571675
+      config:
+        bluestore_cache: true
+      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
       name:  Testing bluestore
       desc: Testing bluestore pinned
       module: test_bluestore_features.py
@@ -131,17 +153,3 @@ tests:
                  rados_write_duration: 50
                  rados_read_duration: 50
           desc: Verification of the bluestore pinned tests
-
-  - test:
-      name: BlueStore Checksum algorithms
-      module: test_bluestore_configs.py
-      polarion-id: CEPH-83571646
-      config:
-        checksums:
-          - none
-          - crc32c
-          - crc32c_16
-          - crc32c_8
-          - xxhash32
-          - xxhash64
-      desc: Verify the different applicable BlueStore Checksum algorithms

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -284,9 +284,11 @@ class MonConfigMethods:
                 entry["name"] == kwargs["name"]
                 and entry["section"] == kwargs["section"]
             ):
+                entry["value"] = str(entry["value"]).strip("\n").strip()
+                kwargs["value"] = str(kwargs["value"]).strip("\n").strip()
                 if not entry["value"] == kwargs["value"]:
                     log.error(
-                        f"Value for config: {entry['name']} does not match in the ceph config"
+                        f"Value for config: {entry['name']} does not match in the ceph config\n"
                         f"sent value : {kwargs['value']}, Set value : {entry['value']}"
                     )
                     return False


### PR DESCRIPTION
[CEPH-83571646:](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571675) Tier-2 test to verify tuning of BlueStore Cache Size for HDDs and SSDs

Test modules modified - 
- tests/rados/monitor_configurations.py
- tests/rados/test_bluestore_configs.py

Test suites modified -
- suites/pacific/rados/tier-2_rados_test_bluestore.yaml
- suites/quincy/rados/tier-2_rados_test_bluestore.yaml

Steps
1. Verify the default value for - bluestore_cache_size(0) | bluestore_cache_size_hdd (1GB) | bluestore_cache_size_ssd (3GB)
2. Modify the value of bluestore_cache_size_ssd and bluestore_cache_size_hdd
3. Verify the values being reflected in ceph config
4. Create replicated and ec pool and perform IOPS
6. cleanup - Remove all the pools created and reset configs modified

Logs - 
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UOHJWG/
RHCS 6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3AVBZX/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>