### PR TITLE
Test to configure rbd compression hint settings at multiple levels

### DIFF
--- a/cephci/prereq.py
+++ b/cephci/prereq.py
@@ -1,0 +1,190 @@
+import pickle
+import re
+
+from docopt import docopt
+from utils.configs import (
+    get_configs,
+    get_packages,
+    get_registry_credentials,
+    get_repos,
+    get_subscription_credentials,
+)
+from utils.configure import setup_ssh_keys
+
+from cli.exceptions import NodeConfigError
+from cli.utilities.containers import Registry
+from cli.utilities.packages import Package
+from cli.utilities.packages import SubscriptionManager as sm
+from cli.utilities.packages import SubscriptionManagerError
+from cli.utilities.utils import os_major_version
+from cli.utilities.waiter import WaitUntil
+from utility.log import Log
+
+log = Log(__name__)
+
+doc = """
+Utility to configure prerequisites for deployed cluster
+    Usage:
+        cephci/prereq.py --cluster <FILE>
+            (--build <BUILD>)
+            (--subscription <SUBSCRIPTION>)
+            (--registry <REGISTRY>)
+            [--setup-ssh-keys <BOOL>]
+            [--config <FILE>]
+            [--log-level <LOG>]
+
+        cephci/prereq.py --help
+
+    Options:
+        -h --help                   Help
+        -c --cluster <FILE>         Cluster config file
+        -b --build <BUILD>          Build type [rh|ibm]
+        -s --subscription <CRED>    Subscription manager server
+        -r --registry <STR>         Container registry server
+        -k --setup-ssh-keys <BOOL>  Setup SSH keys on cluster
+        -f --config <FILE>          CephCI configuration file
+        -l --log-level <LOG>        Log level for log utility
+"""
+
+
+def _set_log(level):
+    log.logger.setLevel(level.upper())
+
+
+def _load_cluster_config(config):
+    cluster_conf = None
+    with open(config, "rb") as f:
+        cluster_conf = pickle.load(f)
+
+    for _, cluster in cluster_conf.items():
+        [node.reconnect() for node in cluster]
+
+    return cluster_conf
+
+
+def setup_subscription_manager(node, server):
+    # Get configuration details from cephci configs
+    configs = get_subscription_credentials(server)
+    configs["force"] = True
+
+    # Get timeout and interval
+    timeout = configs.get("timeout")
+    retry = configs.get("retry")
+    interval = int(timeout / retry)
+
+    # Remove timeout and try configs
+    configs.pop("timeout")
+    configs.pop("retry")
+
+    # Subscribe to server
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        try:
+            sm(node).register(**configs)
+            log.info(f"Subscribed to '{server}' server successfully")
+            return True
+        except SubscriptionManagerError:
+            log.error(f"Failed to subscribe to '{server}' server. Retrying")
+
+    # Check if node subscribe to subscription manager
+    if w.expired:
+        log.error(f"Failed to subscribe to '{server}' server.")
+
+    log.info(f"Logined to subscription manager '{server}' successfully")
+    return False
+
+
+def subscription_manager_status(node):
+    # Get subscription manager status
+    status = sm(node).status()
+
+    # Check for overall status
+    expr = ".*Overall Status:(.*).*"
+    match = re.search(expr, status)
+    if not match:
+        msg = "Unexpected subscription manager status"
+        log.error(msg)
+        raise SubscriptionManagerError(msg)
+
+    return match.group(0)
+
+
+def setup_local_repos(node, distro):
+    # Get repos from cephci config
+    repos = get_repos("local", distro)
+
+    # Add local repositories
+    for repo in repos:
+        Package(node).add_repo(repo=repo)
+
+    log.info("Added local RHEL repos successfully")
+    return True
+
+
+def registry_login(node, server, build):
+    # Get registry config from cephci config
+    config = get_registry_credentials(server, build)
+
+    # Login to container registry
+    Registry(node).login(**config)
+
+    log.info(f"Logined to container registry '{server}' successfully")
+    return True
+
+
+def enable_rhel_repos(node, server, distro):
+    # Get RHEL repos from cephci config
+    repos = get_repos(server, distro)
+
+    # Enable RHEL repos
+    sm(node).repos.enable(repos)
+
+    log.info(f"Enabled repos '{server}' for '{distro}'")
+    return True
+
+
+def prereq(cluster, build, subscription, registry, ssh=False):
+    nodes = cluster.get_nodes()
+    packages = " ".join(get_packages())
+    for node in nodes:
+        distro = f"rhel-{os_major_version(node)}"
+        if subscription == "skip":
+            enable_rhel_repos(node, "local", distro)
+
+        elif subscription in ["cdn", "stage"]:
+            setup_subscription_manager(node, subscription)
+
+            status = subscription_manager_status(node)
+            if status == "Unknown":
+                msg = f"Subscription manager is in '{status}' status"
+                log.error(msg)
+                raise NodeConfigError(msg)
+
+            enable_rhel_repos(node, subscription, distro)
+
+        Package(node).install(packages)
+
+        if registry != "skip":
+            registry_login(node, registry, build)
+
+    if ssh:
+        installer = cluster.get_ceph_object("installer")
+        setup_ssh_keys(installer, nodes)
+
+
+if __name__ == "__main__":
+    args = docopt(doc)
+
+    cluster = args.get("--cluster")
+    build = args.get("--build")
+    subscription = args.get("--subscription")
+    registry = args.get("--registry")
+    setup_ssh = args.get("--setup-ssh-keys")
+    config = args.get("--config")
+    log_level = args.get("--log-level")
+
+    _set_log(log_level)
+    get_configs(config)
+
+    cluster_dict = _load_cluster_config(cluster)
+    for cluster_name in cluster_dict:
+        prereq(cluster_dict.get(cluster_name), build, subscription, registry, setup_ssh)

--- a/cephci/utils/configure.py
+++ b/cephci/utils/configure.py
@@ -1,0 +1,78 @@
+from cli.utilities.packages import Package
+
+ETC_HOSTS = "/etc/hosts"
+
+SSH = "~/.ssh"
+SSH_CONFIG = f"{SSH}/config"
+SSH_ID_RSA_PUB = f"{SSH}/id_rsa.pub"
+SSH_KNOWN_HOSTS = f"{SSH}/known_hosts"
+
+SSH_KEYGEN = f"ssh-keygen -b 2048 -f {SSH}/id_rsa -t rsa -q -N ''"
+SSH_COPYID = "ssh-copy-id -f -i {} {}@{}"
+SSH_KEYSCAN = "ssh-keyscan {}"
+
+CHMOD_CONFIG = f"chmod 600 {SSH_CONFIG}"
+SSHPASS = "sshpass -p {}"
+
+
+def setup_ssh_keys(installer, nodes):
+    """Set up SSH keys
+
+    Args:
+        installer (Node): Cluster installer node object
+        nodes (List): List of Node objects
+    """
+    hosts, config = (
+        "",
+        "Host *\n\tStrictHostKeyChecking no\n\tServerAliveInterval 2400\n",
+    )
+    for node in nodes:
+        config += f"\nHost {node.ip_address}"
+        config += f"\n\tHostname {node.hostname}"
+        config += "\n\tUser root"
+
+        hosts += f"\n{node.ip_address}"
+        hosts += f"\t{node.hostname}"
+        hosts += f"\t{node.shortname}"
+
+        node.exec_command(cmd=f"rm -rf {SSH}", check_ec=False)
+        node.exec_command(cmd=SSH_KEYGEN)
+
+        node.exec_command(sudo=True, cmd=f"rm -rf {SSH}", check_ec=False)
+        node.exec_command(sudo=True, cmd=SSH_KEYGEN)
+
+    installer.exec_command(sudo=True, cmd=f"echo -e '{hosts}' >> {ETC_HOSTS}")
+    installer.exec_command(
+        cmd=f"touch {SSH_CONFIG} && echo -e '{config}' > {SSH_CONFIG}"
+    )
+    installer.exec_command(cmd=CHMOD_CONFIG)
+    Package(installer).install("sshpass")
+
+    for node in nodes:
+        installer.exec_command(
+            cmd="{} >> {}".format(SSH_KEYSCAN.format(node.hostname), SSH_KNOWN_HOSTS),
+        )
+        installer.exec_command(
+            sudo=True,
+            cmd="{} >> {}".format(SSH_KEYSCAN.format(node.hostname), SSH_KNOWN_HOSTS),
+        )
+
+        installer.exec_command(
+            cmd="{} {}".format(
+                SSHPASS.format(node.password),
+                SSH_COPYID.format(SSH_ID_RSA_PUB, node.username, node.hostname),
+            ),
+        )
+        installer.exec_command(
+            cmd="{} {}".format(
+                SSHPASS.format(node.root_passwd),
+                SSH_COPYID.format(SSH_ID_RSA_PUB, "root", node.hostname),
+            ),
+        )
+        installer.exec_command(
+            sudo=True,
+            cmd="{} {}".format(
+                SSHPASS.format(node.root_passwd),
+                SSH_COPYID.format(SSH_ID_RSA_PUB, "root", node.hostname),
+            ),
+        )

--- a/cli/exceptions.py
+++ b/cli/exceptions.py
@@ -33,3 +33,9 @@ class OperationFailedError(Exception):
     """
     Custom exception thrown when any operation fails.
     """
+
+
+class NodeConfigError(Exception):
+    """
+    Custom exception thrown when node configuration fails
+    """

--- a/cli/utilities/containers.py
+++ b/cli/utilities/containers.py
@@ -1,0 +1,43 @@
+from cli import Cli
+
+
+class ContainerRegistryError(Exception):
+    pass
+
+
+class Registry(Cli):
+    """This module provides CLI interface for container registry operations"""
+
+    def __init__(self, nodes, package="podman"):
+        super(Registry, self).__init__(nodes)
+        self.base_cmd = package
+
+    def login(
+        self, registry, username=None, password=None, authfile=None, tls_verify=False
+    ):
+        """Login to registry
+
+        Args:
+            registry (str): Registry url
+            username (str): Registry username
+            password (str): Registry password
+            authfile (str): File with authentication details
+            tls_verify (boot): TLS verification flag
+        """
+        cmd = f"{self.base_cmd} login"
+        if tls_verify:
+            cmd += f" --tls-verify={tls_verify}"
+
+        if authfile:
+            cmd += f" --authfile {authfile}"
+        elif username and password:
+            cmd += f" --username {username} --password {password}"
+        else:
+            raise ContainerRegistryError("Authentication details needs to be provided")
+
+        cmd += f" {registry}"
+
+        if self.execute(sudo=True, long_running=True, cmd=cmd):
+            raise ContainerRegistryError(
+                f"Failed to login to container registry '{registry}'"
+            )

--- a/suites/pacific/cephfs/tier-0_fs.yaml
+++ b/suites/pacific/cephfs/tier-0_fs.yaml
@@ -125,6 +125,12 @@ tests:
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false
+  - test:
+      name: nfs-ha-sanity
+      module: nfs_ha_sanity.py
+      desc: Deploy NFS HA and validate the services are UP.
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
   -
     test:
       desc: "generate sosreport"

--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -13,11 +13,11 @@
 tests:
 
   # Setup the cluster
-
   - test:
       abort-on-fail: true
       module: install_prereq.py
       name: install ceph pre-requisites
+
   - test:
       abort-on-fail: true
       config:
@@ -374,3 +374,15 @@ tests:
             data_pool: data_pool_ec2
       name: Test image migration from namespace for read-only client
       polarion-id: CEPH-83573341
+
+  - test:
+      desc: Verify rbd_compression_hint config settings
+      config:
+        compression_algorithm: snappy
+        compression_mode: passive
+        compression_ratio: 0.7
+        io_total: 1G
+      module: test_rbd_compression.py
+      name: Test to verify data compression on global, pool and image level
+      polarion-id: CEPH-83574644
+

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -14,11 +14,12 @@
 
 tests:
 
-   #Setup the cluster
+  # Setup the cluster
   - test:
       abort-on-fail: true
       module: install_prereq.py
       name: install ceph pre-requisites
+
   - test:
       abort-on-fail: true
       config:
@@ -66,7 +67,8 @@ tests:
       destroy-clster: false
       module: test_cephadm.py
       name: deploy cluster
-# # Test cases to be executed
+
+  # Test cases to be executed
   - test:
       abort-on-fail: true
       config:
@@ -355,7 +357,7 @@ tests:
       polarion-id: CEPH-9861
 
   - test:
-      desc: Image migration pool namespace
+      desc: Image migration from namespace for read-only client
       module: readonly_namespace_image_migration.py
       config:
         source:
@@ -372,5 +374,17 @@ tests:
           ec_pool_config:
             pool: rbd_ECpool1
             data_pool: data_pool_ec2
-      name: Test image migration from pool namespace
+      name: Test image migration from namespace for read-only client
       polarion-id: CEPH-83573341
+
+  - test:
+      desc: Verify rbd_compression_hint config settings
+      config:
+        compression_algorithm: snappy
+        compression_mode: passive
+        compression_ratio: 0.7
+        io_total: 1G
+      module: test_rbd_compression.py
+      name: Test to verify data compression on global, pool and image level
+      polarion-id: CEPH-83574644
+

--- a/tests/cephfs/nfs_ha_sanity.py
+++ b/tests/cephfs/nfs_ha_sanity.py
@@ -1,0 +1,72 @@
+import json
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+from utility.retry import retry
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    Validating basic commands for configuring NFS HA
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. Create nfs cluster with placement
+    2.
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        virtual_ip = config.get("virtual_ip", "10.0.209.126/30")
+        build = config.get("build", config.get("rhbuild"))
+
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+
+        client1 = clients[0]
+        nfs_servers = ceph_cluster.get_ceph_objects("nfs")
+        nfs_name = "cephnfs"
+        client1.exec_command(
+            sudo=True,
+            cmd=f'ceph nfs cluster create {nfs_name} "1 {nfs_servers[0].node.hostname} {nfs_servers[1].node.hostname}" '
+            f"--ingress --virtual-ip {virtual_ip}",
+        )
+
+        log.info("validate the services hace started on nfs")
+        validate_services(client1, f"nfs.{nfs_name}")
+        validate_services(client1, f"ingress.nfs.{nfs_name}")
+        return 0
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        commands = [
+            f"ceph nfs cluster rm {nfs_name}",
+        ]
+        for command in commands:
+            client1.exec_command(sudo=True, cmd=command)
+
+
+@retry(CommandFailed, tries=3, delay=60)
+def validate_services(client, service_name):
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"ceph orch ls --service_name={service_name} --format json"
+    )
+    service_ls = json.loads(out)
+    log.info(service_ls)
+    if service_ls[0]["status"]["running"] != service_ls[0]["status"]["size"]:
+        raise CommandFailed(f"All {service_name} are Not UP")

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -1196,6 +1196,37 @@ def verify_image_size(rbd, pool, image, size):
     return 1
 
 
+def set_ceph_config(rbd, entity, key, value, **kw):
+    """Override ceph config settings.
+
+    ceph config set <entity> <key> <value>
+
+    Args:
+        entity: config entity (mon, osd)
+        key: config option key (ex., rbd_move_to_trash_on_remove)
+        value: config option value to be set
+        kw: other ceph arguments like config options
+    Returns:
+        exec_cmd response
+    """
+    return rbd.exec_cmd(cmd=f"ceph config set {entity} {key} {value}", **kw)
+
+
+def get_ceph_config(rbd, entity, key, **kw):
+    """Get ceph config settings.
+
+    ceph config get <entity> <key>
+
+    Args:
+        entity: config entity (mon, osd)
+        key: config option key (ex., rbd_move_to_trash_on_remove)
+        kw: other ceph arguments like config options
+    Returns:
+        exec_cmd response
+    """
+    return rbd.exec_cmd(cmd=f"ceph config get {entity} {key}", **kw)
+
+
 def resize_parent_and_clone(rbd, resize_sequence, parent_clone_spec):
     """
     Resize parent and clone images to compensate overhead due to the header size.

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -194,6 +194,8 @@ class Rbd:
         self.exec_cmd(
             cmd="ceph osd pool set {} allow_ec_overwrites true".format(poolname)
         )
+        if self.ceph_version >= 3:
+            self.exec_cmd(cmd="rbd pool init {}".format(poolname))
         return True
 
     def check_pool_exists(self, pool_name: str) -> bool:

--- a/tests/rbd/test_rbd_compression.py
+++ b/tests/rbd/test_rbd_compression.py
@@ -1,0 +1,221 @@
+"""Test case covered -
+    CEPH-83574644 - Validate "rbd_compression_hint" config
+    settings on globally, Pool level, and image level.
+
+    Pre-requisites :
+    1. Cluster must be up and running with capacity to create pool
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+
+    Test Case Flow:
+    1. Create a pool and an Image, write some data on it
+    2. set bluestore_compression_mode to passive to enable rbd_compression_hint feature
+    3. Set compression_algorithm, compression_mode and compression_ratio for the pool
+    4. verify "rbd_compression_hint" to "compressible" on global, pool and image level
+    5. verify "rbd_compression_hint" to "incompressible" on global, pool and image level
+    6. Repeat the above steps for ecpool
+"""
+import json
+
+from tests.rbd.rbd_utils import get_ceph_config, initial_rbd_config, set_ceph_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def validate_compression(self, mode, image_spec, **kw):
+    """
+    Method to validate after setting rbd_compression_hint
+    data is getting compressed or not.
+
+    Args:
+        mode: type of compression hints (compressible or incompressible)
+        image_spec: poolname + imagename
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    config = kw.get("config")
+    io = config.get("io_total", "1G")
+    kw["io"] = io
+    kw["imagespec"] = image_spec
+    pool_name = image_spec.split("/")[0]
+
+    # running io to check compression of data
+    self.rbd_bench(**kw)
+
+    out = self.exec_cmd(cmd="ceph df detail --format json-pretty", output=True)
+    output = json.loads(out.rstrip())
+    pool_info = output["pools"]
+
+    # Iterate over the pools to get compressed data information
+    for pool in pool_info:
+        if pool["name"] == pool_name:
+            compressed_data = pool["stats"]["compress_bytes_used"]
+            break
+    log.debug(
+        f"Pool statistics refer compress_bytes_used for bytes compressed: {pool['stats']}"
+    )
+
+    if mode == "compressible":
+        if compressed_data == 0:
+            log.error("Test Failed: Data did not get compressed in compressible mode")
+            return 1
+        else:
+            log.info(
+                f"Test Passed: Data got compressed, bytes compressed: {compressed_data}"
+            )
+            return 0
+
+    elif mode == "incompressible":
+        if compressed_data != 0:
+            log.error("Test Failed: Data gets compressed in incompressible mode")
+            return 1
+        else:
+            log.info(
+                "Test Passed: Data did not get compressed due to incompressible mode set"
+            )
+            return 0
+    else:
+        log.error(f"Invalid mode: {mode}")
+        return 1
+
+
+def test_compression(rbd, pool_type, **kw):
+    """
+    Run rbd_compression_hint test on supported options,
+    i.e compressible and incompressible.
+
+    Args:
+        rbd: RBD object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    config = kw.get("config")
+
+    pool_name = config[pool_type]["pool"]
+
+    compression_configs = {
+        "compression_algorithm": config.get("compression_algorithm"),
+        "compression_mode": config.get("compression_mode"),
+        "compression_required_ratio": config.get("compression_ratio"),
+    }
+
+    try:
+        # set bluestore_compression_mode to passive
+        set_ceph_config(rbd, "osd", "bluestore_compression_mode", "passive")
+
+        if (
+            get_ceph_config(
+                rbd, "osd", "bluestore_compression_mode", output=True
+            ).strip()
+            != "passive"
+        ):
+            log.error("Not able to set bluestore_compression_mode to passive")
+            return 1
+
+        log.info("bluestore_compression_mode set to passive successfully")
+
+        # commands to set compression related configuration
+        rbd.exec_cmd(
+            cmd=" && ".join(
+                [
+                    f"ceph osd pool set {pool_name} {k} {v}"
+                    for k, v in compression_configs.items()
+                ]
+            )
+        )
+
+        for option in ["compressible", "incompressible"]:
+            # set rbd_compression_hint on global, pool and image level
+            for level in ["global", "pool", "image"]:
+                image_name = rbd.random_string() + "_test_image"
+                # creating separate image for each level to validate compression
+                rbd.create_image(
+                    pool_name,
+                    image_name,
+                    size="10G",
+                )
+                image_spec = pool_name + "/" + image_name
+
+                entity = {"global": "global", "pool": pool_name, "image": image_spec}
+                rbd.set_config(level, entity[level], "rbd_compression_hint", option)
+
+                if (
+                    rbd.get_config(
+                        level, entity[level], "rbd_compression_hint", output=True
+                    ).strip()
+                    != option
+                ):
+                    log.error(
+                        f"Not able to set rbd_compression_hint on {option} mode in {level} level"
+                    )
+                    return 1
+                log.info(
+                    f"Able to set rbd_compression_hint on {option} mode in {level} level"
+                )
+
+                validate_compression(rbd, option, image_spec, **kw)
+
+                # remove rbd_compression_hint on each level
+                rbd.remove_config(level, entity[level], "rbd_compression_hint")
+
+                out, err = rbd.get_config(
+                    level, entity[level], "rbd_compression_hint", all=True
+                )
+                log.debug(err)
+
+                if "rbd: rbd_compression_hint is not set" not in str(err):
+                    log.error(
+                        f"Not able to remove rbd_compression_hint on {option} mode in {level} level"
+                    )
+                    return 1
+                log.info(
+                    f"Able to remove rbd_compression_hint on {option} mode in {level} level"
+                )
+                # deleting the image to test other levels with new image
+                # otherwise older compressed data got retained the same info.
+                rbd.remove_image(pool_name, image_name)
+
+        return 0
+
+    except Exception as error:
+        log.error(str(error))
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
+
+
+def run(**kw):
+    """
+    Test for rbd_compression_hint settings.
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    log.info(
+        "Starting CEPH-83574644 - Validate rbd_compression_hint config "
+        "settings on global level, Pool level, and image level"
+    )
+
+    rbd_obj = initial_rbd_config(**kw)
+
+    if rbd_obj:
+        if "rbd_reppool" in rbd_obj:
+            log.info("Executing test on Replicated pool")
+            if test_compression(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+                return 1
+
+        if "rbd_ecpool" in rbd_obj:
+            log.info("Executing test on EC pool")
+            if test_compression(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+                return 1
+
+    return 0


### PR DESCRIPTION
# Description
Automated below test case: Test to verify "rbd_compression_hint" configs in globally, per-pool, or per-image
[CEPH-83574644](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574644)

Test flow:
1. Create a pool and an Image, write some data on it
2. set bluestore_compression_mode to passive to enable rbd_compression_hint feature
3. verify "rbd_compression_hint" to "compressible" on global, pool and image level
4. verify "rbd_compression_hint" to "incompressible" on global, pool and image level
5. Repeat the above steps for ecpool

Test result:
[Passed] http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-46AKM3

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
