### PR TITLE
[Lib] Add library to setup pre-install steps

### DIFF
--- a/cephci/prereq.py
+++ b/cephci/prereq.py
@@ -1,0 +1,190 @@
+import pickle
+import re
+
+from docopt import docopt
+from utils.configs import (
+    get_configs,
+    get_packages,
+    get_registry_credentials,
+    get_repos,
+    get_subscription_credentials,
+)
+from utils.configure import setup_ssh_keys
+
+from cli.exceptions import NodeConfigError
+from cli.utilities.containers import Registry
+from cli.utilities.packages import Package
+from cli.utilities.packages import SubscriptionManager as sm
+from cli.utilities.packages import SubscriptionManagerError
+from cli.utilities.utils import os_major_version
+from cli.utilities.waiter import WaitUntil
+from utility.log import Log
+
+log = Log(__name__)
+
+doc = """
+Utility to configure prerequisites for deployed cluster
+    Usage:
+        cephci/prereq.py --cluster <FILE>
+            (--build <BUILD>)
+            (--subscription <SUBSCRIPTION>)
+            (--registry <REGISTRY>)
+            [--setup-ssh-keys <BOOL>]
+            [--config <FILE>]
+            [--log-level <LOG>]
+
+        cephci/prereq.py --help
+
+    Options:
+        -h --help                   Help
+        -c --cluster <FILE>         Cluster config file
+        -b --build <BUILD>          Build type [rh|ibm]
+        -s --subscription <CRED>    Subscription manager server
+        -r --registry <STR>         Container registry server
+        -k --setup-ssh-keys <BOOL>  Setup SSH keys on cluster
+        -f --config <FILE>          CephCI configuration file
+        -l --log-level <LOG>        Log level for log utility
+"""
+
+
+def _set_log(level):
+    log.logger.setLevel(level.upper())
+
+
+def _load_cluster_config(config):
+    cluster_conf = None
+    with open(config, "rb") as f:
+        cluster_conf = pickle.load(f)
+
+    for _, cluster in cluster_conf.items():
+        [node.reconnect() for node in cluster]
+
+    return cluster_conf
+
+
+def setup_subscription_manager(node, server):
+    # Get configuration details from cephci configs
+    configs = get_subscription_credentials(server)
+    configs["force"] = True
+
+    # Get timeout and interval
+    timeout = configs.get("timeout")
+    retry = configs.get("retry")
+    interval = int(timeout / retry)
+
+    # Remove timeout and try configs
+    configs.pop("timeout")
+    configs.pop("retry")
+
+    # Subscribe to server
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        try:
+            sm(node).register(**configs)
+            log.info(f"Subscribed to '{server}' server successfully")
+            return True
+        except SubscriptionManagerError:
+            log.error(f"Failed to subscribe to '{server}' server. Retrying")
+
+    # Check if node subscribe to subscription manager
+    if w.expired:
+        log.error(f"Failed to subscribe to '{server}' server.")
+
+    log.info(f"Logined to subscription manager '{server}' successfully")
+    return False
+
+
+def subscription_manager_status(node):
+    # Get subscription manager status
+    status = sm(node).status()
+
+    # Check for overall status
+    expr = ".*Overall Status:(.*).*"
+    match = re.search(expr, status)
+    if not match:
+        msg = "Unexpected subscription manager status"
+        log.error(msg)
+        raise SubscriptionManagerError(msg)
+
+    return match.group(0)
+
+
+def setup_local_repos(node, distro):
+    # Get repos from cephci config
+    repos = get_repos("local", distro)
+
+    # Add local repositories
+    for repo in repos:
+        Package(node).add_repo(repo=repo)
+
+    log.info("Added local RHEL repos successfully")
+    return True
+
+
+def registry_login(node, server, build):
+    # Get registry config from cephci config
+    config = get_registry_credentials(server, build)
+
+    # Login to container registry
+    Registry(node).login(**config)
+
+    log.info(f"Logined to container registry '{server}' successfully")
+    return True
+
+
+def enable_rhel_repos(node, server, distro):
+    # Get RHEL repos from cephci config
+    repos = get_repos(server, distro)
+
+    # Enable RHEL repos
+    sm(node).repos.enable(repos)
+
+    log.info(f"Enabled repos '{server}' for '{distro}'")
+    return True
+
+
+def prereq(cluster, build, subscription, registry, ssh=False):
+    nodes = cluster.get_nodes()
+    packages = " ".join(get_packages())
+    for node in nodes:
+        distro = f"rhel-{os_major_version(node)}"
+        if subscription == "skip":
+            enable_rhel_repos(node, "local", distro)
+
+        elif subscription in ["cdn", "stage"]:
+            setup_subscription_manager(node, subscription)
+
+            status = subscription_manager_status(node)
+            if status == "Unknown":
+                msg = f"Subscription manager is in '{status}' status"
+                log.error(msg)
+                raise NodeConfigError(msg)
+
+            enable_rhel_repos(node, subscription, distro)
+
+        Package(node).install(packages)
+
+        if registry != "skip":
+            registry_login(node, registry, build)
+
+    if ssh:
+        installer = cluster.get_ceph_object("installer")
+        setup_ssh_keys(installer, nodes)
+
+
+if __name__ == "__main__":
+    args = docopt(doc)
+
+    cluster = args.get("--cluster")
+    build = args.get("--build")
+    subscription = args.get("--subscription")
+    registry = args.get("--registry")
+    setup_ssh = args.get("--setup-ssh-keys")
+    config = args.get("--config")
+    log_level = args.get("--log-level")
+
+    _set_log(log_level)
+    get_configs(config)
+
+    cluster_dict = _load_cluster_config(cluster)
+    for cluster_name in cluster_dict:
+        prereq(cluster_dict.get(cluster_name), build, subscription, registry, setup_ssh)

--- a/cephci/utils/configure.py
+++ b/cephci/utils/configure.py
@@ -1,0 +1,78 @@
+from cli.utilities.packages import Package
+
+ETC_HOSTS = "/etc/hosts"
+
+SSH = "~/.ssh"
+SSH_CONFIG = f"{SSH}/config"
+SSH_ID_RSA_PUB = f"{SSH}/id_rsa.pub"
+SSH_KNOWN_HOSTS = f"{SSH}/known_hosts"
+
+SSH_KEYGEN = f"ssh-keygen -b 2048 -f {SSH}/id_rsa -t rsa -q -N ''"
+SSH_COPYID = "ssh-copy-id -f -i {} {}@{}"
+SSH_KEYSCAN = "ssh-keyscan {}"
+
+CHMOD_CONFIG = f"chmod 600 {SSH_CONFIG}"
+SSHPASS = "sshpass -p {}"
+
+
+def setup_ssh_keys(installer, nodes):
+    """Set up SSH keys
+
+    Args:
+        installer (Node): Cluster installer node object
+        nodes (List): List of Node objects
+    """
+    hosts, config = (
+        "",
+        "Host *\n\tStrictHostKeyChecking no\n\tServerAliveInterval 2400\n",
+    )
+    for node in nodes:
+        config += f"\nHost {node.ip_address}"
+        config += f"\n\tHostname {node.hostname}"
+        config += "\n\tUser root"
+
+        hosts += f"\n{node.ip_address}"
+        hosts += f"\t{node.hostname}"
+        hosts += f"\t{node.shortname}"
+
+        node.exec_command(cmd=f"rm -rf {SSH}", check_ec=False)
+        node.exec_command(cmd=SSH_KEYGEN)
+
+        node.exec_command(sudo=True, cmd=f"rm -rf {SSH}", check_ec=False)
+        node.exec_command(sudo=True, cmd=SSH_KEYGEN)
+
+    installer.exec_command(sudo=True, cmd=f"echo -e '{hosts}' >> {ETC_HOSTS}")
+    installer.exec_command(
+        cmd=f"touch {SSH_CONFIG} && echo -e '{config}' > {SSH_CONFIG}"
+    )
+    installer.exec_command(cmd=CHMOD_CONFIG)
+    Package(installer).install("sshpass")
+
+    for node in nodes:
+        installer.exec_command(
+            cmd="{} >> {}".format(SSH_KEYSCAN.format(node.hostname), SSH_KNOWN_HOSTS),
+        )
+        installer.exec_command(
+            sudo=True,
+            cmd="{} >> {}".format(SSH_KEYSCAN.format(node.hostname), SSH_KNOWN_HOSTS),
+        )
+
+        installer.exec_command(
+            cmd="{} {}".format(
+                SSHPASS.format(node.password),
+                SSH_COPYID.format(SSH_ID_RSA_PUB, node.username, node.hostname),
+            ),
+        )
+        installer.exec_command(
+            cmd="{} {}".format(
+                SSHPASS.format(node.root_passwd),
+                SSH_COPYID.format(SSH_ID_RSA_PUB, "root", node.hostname),
+            ),
+        )
+        installer.exec_command(
+            sudo=True,
+            cmd="{} {}".format(
+                SSHPASS.format(node.root_passwd),
+                SSH_COPYID.format(SSH_ID_RSA_PUB, "root", node.hostname),
+            ),
+        )

--- a/cli/exceptions.py
+++ b/cli/exceptions.py
@@ -33,3 +33,9 @@ class OperationFailedError(Exception):
     """
     Custom exception thrown when any operation fails.
     """
+
+
+class NodeConfigError(Exception):
+    """
+    Custom exception thrown when node configuration fails
+    """

--- a/cli/utilities/containers.py
+++ b/cli/utilities/containers.py
@@ -1,0 +1,43 @@
+from cli import Cli
+
+
+class ContainerRegistryError(Exception):
+    pass
+
+
+class Registry(Cli):
+    """This module provides CLI interface for container registry operations"""
+
+    def __init__(self, nodes, package="podman"):
+        super(Registry, self).__init__(nodes)
+        self.base_cmd = package
+
+    def login(
+        self, registry, username=None, password=None, authfile=None, tls_verify=False
+    ):
+        """Login to registry
+
+        Args:
+            registry (str): Registry url
+            username (str): Registry username
+            password (str): Registry password
+            authfile (str): File with authentication details
+            tls_verify (boot): TLS verification flag
+        """
+        cmd = f"{self.base_cmd} login"
+        if tls_verify:
+            cmd += f" --tls-verify={tls_verify}"
+
+        if authfile:
+            cmd += f" --authfile {authfile}"
+        elif username and password:
+            cmd += f" --username {username} --password {password}"
+        else:
+            raise ContainerRegistryError("Authentication details needs to be provided")
+
+        cmd += f" {registry}"
+
+        if self.execute(sudo=True, long_running=True, cmd=cmd):
+            raise ContainerRegistryError(
+                f"Failed to login to container registry '{registry}'"
+            )


### PR DESCRIPTION
Add new utility under `cephci/prereq.py` which setup cluster with pre-install steps and includes below libraries -

The utility supports below parameters -
```
Utility to configure prerequisites for deployed cluster
    Usage:
        cephci/prereq.py --cluster <FILE>
            (--build BUILD)
            (--subscription <SUBSCRIPTION>)
            (--registry <REGISTRY>)
            [--setup-ssh-keys <BOOL>]
            [--config <FILE>]
            [--log-level <LOG>]

        cephci/prereq.py --help

    Options:
        -h --help                   Help
        -c --cluster <FILE>         Cluster config file
        -b --build <BUILD>          Build type [rh|ibm]
        -s --subscription <CRED>    Subscription manager server
        -r --registry <STR>         Container registry server
        -k --setup-ssh-keys <BOOL>  Setup SSH keys on cluster
        -f --config <FILE>          CephCI configuration file
        -l --log-level <LOG>        Log level for log utility```