### PR TITLE
Adding NFS HA basic sanity

### DIFF
--- a/suites/pacific/cephfs/tier-0_fs.yaml
+++ b/suites/pacific/cephfs/tier-0_fs.yaml
@@ -125,6 +125,12 @@ tests:
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false
+  - test:
+      name: nfs-ha-sanity
+      module: nfs_ha_sanity.py
+      desc: Deploy NFS HA and validate the services are UP.
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
   -
     test:
       desc: "generate sosreport"

--- a/tests/cephfs/nfs_ha_sanity.py
+++ b/tests/cephfs/nfs_ha_sanity.py
@@ -1,0 +1,72 @@
+import json
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+from utility.retry import retry
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test Cases Covered:
+    Validating basic commands for configuring NFS HA
+    Pre-requisites :
+    1. We need atleast one client node to execute this test case
+
+    Test Case Flow:
+    1. Create nfs cluster with placement
+    2.
+    """
+    try:
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        virtual_ip = config.get("virtual_ip", "10.0.209.126/30")
+        build = config.get("build", config.get("rhbuild"))
+
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        log.info("checking Pre-requisites")
+        if not clients:
+            log.info(
+                f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
+            )
+            return 1
+
+        client1 = clients[0]
+        nfs_servers = ceph_cluster.get_ceph_objects("nfs")
+        nfs_name = "cephnfs"
+        client1.exec_command(
+            sudo=True,
+            cmd=f'ceph nfs cluster create {nfs_name} "1 {nfs_servers[0].node.hostname} {nfs_servers[1].node.hostname}" '
+            f"--ingress --virtual-ip {virtual_ip}",
+        )
+
+        log.info("validate the services hace started on nfs")
+        validate_services(client1, f"nfs.{nfs_name}")
+        validate_services(client1, f"ingress.nfs.{nfs_name}")
+        return 0
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        commands = [
+            f"ceph nfs cluster rm {nfs_name}",
+        ]
+        for command in commands:
+            client1.exec_command(sudo=True, cmd=command)
+
+
+@retry(CommandFailed, tries=3, delay=60)
+def validate_services(client, service_name):
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"ceph orch ls --service_name={service_name} --format json"
+    )
+    service_ls = json.loads(out)
+    log.info(service_ls)
+    if service_ls[0]["status"]["running"] != service_ls[0]["status"]["size"]:
+        raise CommandFailed(f"All {service_name} are Not UP")


### PR DESCRIPTION
# Description

Adding NFS HA basic sanity

Test steps performed : 
ceph nfs cluster create mycephnfs "2 ceph-amk-nfs-4xj1cp-node4 ceph-amk-nfs-4xj1cp-node6" --ingress --virtual-ip 10.0.209.126/30
ceph orch ls --service_name=ingress.nfs.mycephnfs
NAME                   PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT  
ingress.nfs.mycephnfs  10.0.209.126:2049,9049      4/4  20s ago    34s  count:2    
ceph orch ls --service_name=nfs.mycephnfs
NAME           PORTS    RUNNING  REFRESHED  AGE  PLACEMENT                                                    
nfs.mycephnfs  ?:12049      2/2  65s ago    77s  cxxxxx;count:2  

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G5ADYV


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
