### PR TITLE
Adding rbd pool init to data pools created for EC pool config

### DIFF
--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -194,6 +194,8 @@ class Rbd:
         self.exec_cmd(
             cmd="ceph osd pool set {} allow_ec_overwrites true".format(poolname)
         )
+        if self.ceph_version >= 3:
+            self.exec_cmd(cmd="rbd pool init {}".format(poolname))
         return True
 
     def check_pool_exists(self, pool_name: str) -> bool:


### PR DESCRIPTION
Automation Bug - https://issues.redhat.com/browse/RHCEPHQE-8603

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1jkgw/Upgrade_along_with_IOs_0.log

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-cfw0y/Upgrade_along_with_IOs_0.log

error: -  Make sure all your pool have an application enabled -

Checked the error mentioned in the above log and it is because the data pool being created for ec pool scenario does not have RBD application enabled to it. 

Made the necessary changes to enable the same and tried execution of upgrade test suite with parallel RBD IOs only. 

https://ceph-downstream-jenkins-csb-storage.apps.ocp-c1.prod.psi.redhat.com/view/RHCS%20QE/job/rhceph-test-executor/3332/console 

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-k57jz/ 

Now the playbook is not failing with the mentioned error. However the playbook is failing with some MGR issue, which is not the scope for the RBD PR.

@tintumathew10 Could you please debug further on the next error, it doesn't look like it relates to RBD. Please let me know.
