### PR TITLE
Test to validate rbd data compression hint settings at multiple levels

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -374,3 +374,14 @@ tests:
             data_pool: data_pool_ec2
       name: Test image migration from namespace for read-only client
       polarion-id: CEPH-83573341
+
+  - test:
+      desc: Verify rbd_compression_hint config settings
+      config:
+        compression_algorithm: snappy
+        compression_mode: passive
+        compression_ratio: 0.7
+        io_total: 1G
+      module: test_rbd_compression.py
+      name: Test to verify data compression on global, pool and image level
+      polarion-id: CEPH-83574644

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -374,3 +374,15 @@ tests:
             data_pool: data_pool_ec2
       name: Test image migration from pool namespace
       polarion-id: CEPH-83573341
+
+
+  - test:
+      desc: Verify rbd_compression_hint config settings
+      config:
+        compression_algorithm: snappy
+        compression_mode: passive
+        compression_ratio: 0.7
+        io_total: 1G
+      module: test_rbd_compression.py
+      name: Test to verify data compression on global, pool and image level
+      polarion-id: CEPH-83574644

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -1196,6 +1196,33 @@ def verify_image_size(rbd, pool, image, size):
     return 1
 
 
+def set_ceph_config(rbd, entity, key, value, **kw):
+    """Override ceph config settings.
+    ceph config set <entity> <key> <value>
+    Args:
+        entity: config entity (mon, osd)
+        key: config option key (ex., rbd_move_to_trash_on_remove)
+        value: config option value to be set
+        kw: other ceph arguments like config options
+    Returns:
+        exec_cmd response
+    """
+    return rbd.exec_cmd(cmd=f"ceph config set {entity} {key} {value}", **kw)
+
+
+def get_ceph_config(rbd, entity, key, **kw):
+    """Get ceph config settings.
+    ceph config get <entity> <key>
+    Args:
+        entity: config entity (mon, osd)
+        key: config option key (ex., rbd_move_to_trash_on_remove)
+        kw: other ceph arguments like config options
+    Returns:
+        exec_cmd response
+    """
+    return rbd.exec_cmd(cmd=f"ceph config get {entity} {key}", **kw)
+
+
 def resize_parent_and_clone(rbd, resize_sequence, parent_clone_spec):
     """
     Resize parent and clone images to compensate overhead due to the header size.

--- a/tests/rbd/test_rbd_compression.py
+++ b/tests/rbd/test_rbd_compression.py
@@ -1,0 +1,221 @@
+"""Test case covered -
+    CEPH-83574644 - Validate "rbd_compression_hint" config
+    settings on globally, Pool level, and image level.
+
+    Pre-requisites :
+    1. Cluster must be up and running with capacity to create pool
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+
+    Test Case Flow:
+    1. Create a pool and an Image, write some data on it
+    2. set bluestore_compression_mode to passive to enable rbd_compression_hint feature
+    3. Set compression_algorithm, compression_mode and compression_ratio for the pool
+    4. verify "rbd_compression_hint" to "compressible" on global, pool and image level
+    5. verify "rbd_compression_hint" to "incompressible" on global, pool and image level
+    6. Repeat the above steps for ecpool
+"""
+import json
+
+from tests.rbd.rbd_utils import get_ceph_config, initial_rbd_config, set_ceph_config
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def validate_compression(self, mode, image_spec, **kw):
+    """
+    Method to validate after setting rbd_compression_hint
+    data is getting compressed or not.
+
+    Args:
+        mode: type of compression hints (compressible or incompressible)
+        image_spec: poolname + imagename
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    config = kw.get("config")
+    io = config.get("io_total", "1G")
+    kw["io"] = io
+    kw["imagespec"] = image_spec
+    pool_name = image_spec.split("/")[0]
+
+    # running io to check compression of data
+    self.rbd_bench(**kw)
+
+    out = self.exec_cmd(cmd="ceph df detail --format json-pretty", output=True)
+    output = json.loads(out.rstrip())
+    pool_info = output["pools"]
+
+    # Iterate over the pools to get compressed data information
+    for pool in pool_info:
+        if pool["name"] == pool_name:
+            compressed_data = pool["stats"]["compress_bytes_used"]
+            break
+    log.debug(
+        f"Pool statistics refer compress_bytes_used for bytes compressed: {pool['stats']}"
+    )
+
+    if mode == "compressible":
+        if compressed_data == 0:
+            log.error("Test Failed: Data did not get compressed in compressible mode")
+            return 1
+        else:
+            log.info(
+                f"Test Passed: Data got compressed, bytes compressed: {compressed_data}"
+            )
+            return 0
+
+    elif mode == "incompressible":
+        if compressed_data != 0:
+            log.error("Test Failed: Data gets compressed in incompressible mode")
+            return 1
+        else:
+            log.info(
+                "Test Passed: Data did not get compressed due to incompressible mode set"
+            )
+            return 0
+    else:
+        log.error(f"Invalid mode: {mode}")
+        return 1
+
+
+def test_compression(rbd, pool_type, **kw):
+    """
+    Run rbd_compression_hint test on supported options,
+    i.e compressible and incompressible.
+
+    Args:
+        rbd: RBD object
+        pool_type: pool type (ec_pool_config or rep_pool_config)
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    config = kw.get("config")
+
+    pool_name = config[pool_type]["pool"]
+
+    compression_configs = {
+        "compression_algorithm": config.get("compression_algorithm"),
+        "compression_mode": config.get("compression_mode"),
+        "compression_required_ratio": config.get("compression_ratio"),
+    }
+
+    try:
+        # set bluestore_compression_mode to passive
+        set_ceph_config(rbd, "osd", "bluestore_compression_mode", "passive")
+
+        if (
+            get_ceph_config(
+                rbd, "osd", "bluestore_compression_mode", output=True
+            ).strip()
+            != "passive"
+        ):
+            log.error("Not able to set bluestore_compression_mode to passive")
+            return 1
+
+        log.info("bluestore_compression_mode set to passive successfully")
+
+        # commands to set compression related configuration
+        rbd.exec_cmd(
+            cmd=" && ".join(
+                [
+                    f"ceph osd pool set {pool_name} {k} {v}"
+                    for k, v in compression_configs.items()
+                ]
+            )
+        )
+
+        for option in ["compressible", "incompressible"]:
+            # set rbd_compression_hint on global, pool and image level
+            for level in ["global", "pool", "image"]:
+                image_name = rbd.random_string() + "_test_image"
+                # creating separate image for each level to validate compression
+                rbd.create_image(
+                    pool_name,
+                    image_name,
+                    size="10G",
+                )
+                image_spec = pool_name + "/" + image_name
+
+                entity = {"global": "global", "pool": pool_name, "image": image_spec}
+                rbd.set_config(level, entity[level], "rbd_compression_hint", option)
+
+                if (
+                    rbd.get_config(
+                        level, entity[level], "rbd_compression_hint", output=True
+                    ).strip()
+                    != option
+                ):
+                    log.error(
+                        f"Not able to set rbd_compression_hint on {option} mode in {level} level"
+                    )
+                    return 1
+                log.info(
+                    f"Able to set rbd_compression_hint on {option} mode in {level} level"
+                )
+
+                validate_compression(rbd, option, image_spec, **kw)
+
+                # remove rbd_compression_hint on each level
+                rbd.remove_config(level, entity[level], "rbd_compression_hint")
+
+                out, err = rbd.get_config(
+                    level, entity[level], "rbd_compression_hint", all=True
+                )
+                log.debug(err)
+
+                if "rbd: rbd_compression_hint is not set" not in str(err):
+                    log.error(
+                        f"Not able to remove rbd_compression_hint on {option} mode in {level} level"
+                    )
+                    return 1
+                log.info(
+                    f"Able to remove rbd_compression_hint on {option} mode in {level} level"
+                )
+                # deleting the image to test other levels with new image
+                # otherwise older compressed data got retained the same info.
+                rbd.remove_image(pool_name, image_name)
+
+        return 0
+
+    except Exception as error:
+        log.error(str(error))
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[kw["config"][pool_type]["pool"]])
+
+
+def run(**kw):
+    """
+    Test for rbd_compression_hint settings.
+    Args:
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    log.info(
+        "Starting CEPH-83574644 - Validate rbd_compression_hint config "
+        "settings on global level, Pool level, and image level"
+    )
+
+    rbd_obj = initial_rbd_config(**kw)
+
+    if rbd_obj:
+        if "rbd_reppool" in rbd_obj:
+            log.info("Executing test on Replicated pool")
+            if test_compression(rbd_obj.get("rbd_reppool"), "rep_pool_config", **kw):
+                return 1
+
+        if "rbd_ecpool" in rbd_obj:
+            log.info("Executing test on EC pool")
+            if test_compression(rbd_obj.get("rbd_ecpool"), "ec_pool_config", **kw):
+                return 1
+
+    return 0


### PR DESCRIPTION
# Description
Automated below test case: Test to verify "rbd_compression_hint" configs in globally, per-pool, or per-image
[CEPH-83574644](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574644)

Test flow:
1. Create a pool and an Image, write some data on it
2. set bluestore_compression_mode to passive to enable rbd_compression_hint feature
3. verify "rbd_compression_hint" to "compressible" on global, pool and image level
4. verify "rbd_compression_hint" to "incompressible" on global, pool and image level
5. Repeat the above steps for ecpool

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
