### PR TITLE
CEPH-11032: Modification of test module to wait for host reboot

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1487,3 +1487,17 @@ class RadosOrchestrator:
         for service in orch_ls_op:
             service_name_ls.append(service["service_name"])
         return service_name_ls
+
+    def check_host_status(self, hostname) -> bool:
+        """
+        Checks the status of host(offline or online) using
+        ceph orch host ls and return boolean
+        Args:
+            hostname: hostname of host to be checked
+        Returns:
+            (bool) True -> online | False -> offline
+        """
+        host_cmd = f"ceph orch host ls --host_pattern {hostname} -f json"
+        out, _ = self.client.exec_command(cmd=host_cmd, sudo=True)
+        host_status = json.loads(out)[0]["status"]
+        return False if "Offline" in host_status else True


### PR DESCRIPTION
Tier-2 test case [CEPH-11032](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11032) which covers the failure recovery scenario has been observed to be failing due to an edge condition where OSDs to be restarted are already down as the OSD hosts were rebooted in the previous workflow and are yet to come up.

Failure log:
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JNSM1N/

Pass log:
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-S7UN52
RHCS 6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MDD3KZ