### PR TITLE
CEPH-83573339-Set read only on namespace for client-X and run IOs and observe the behavior

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1995,3 +1995,20 @@ def validate_image(conf, cloud_type):
                             f"Node {node} has image-name provided , but no corresponding image given for {cloud_type} "
                             f"Please set the {cloud_type}:image in global conf {validate_image.__doc__}"
                         )
+
+
+def save_client_config_keyring(**kw):
+    """
+    retrieve a user, key, and capabilities and then save the user to a client keyring file
+
+    Args:
+        client_node: node where command needs to be run
+        client_id: id of client which configuration need to save
+        **kw: Any other optional arguement
+
+    Returns:
+        exec_cmd response
+    """
+    return kw["client_node"].exec_command(
+        cmd=f"sudo ceph auth get {kw['client_id']} -o /etc/ceph/ceph.{kw['client_id']}.keyring"
+    )


### PR DESCRIPTION
Ticket : https://issues.redhat.com/browse/RHCEPHQE-8921

Polarion Link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573339 

Above polarion test case marked as inactive and the test scenario is added in already automated test case as below 
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573341 

module file updated :
tests/rbd/rbd_utils.py
tests/rbd/readonly_namespace_image_migration.py

success log : 
5.3 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-bwr63/
6.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-hdg6b/

