### PR TITLE
Fix TFA issue RHCEPHQE-8789

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -353,7 +353,7 @@ tests:
       polarion-id: CEPH-10737
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name:  test_bucket_lifecycle_object_expiration_transition.py
             config-file-name:  test_lc_rule_prefix_and_tag.yaml


### PR DESCRIPTION
# Description

Previously execution was done from secondary site:
in which at the end while deleting an user execution was failing since it s not recommended to delete user from secondary site,
""Removing user'
2023-05-18 08:46:24,306 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.ceph.ceph.py:1520 - b'2023-05-18 08:46:25,060 INFO: executing cmd: radosgw-admin user rm --purge-keys --purge-data --uid=rafaeld.323'
2023-05-18 08:46:25,054 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.ceph.ceph.py:1520 - b'2023-05-18 08:46:25,809 ERROR: cmd execution failed'
2023-05-18 08:46:25,054 (cephci.sanity_rgw_multisite) [DEBUG] - cephci.ceph.ceph.py:1520 - b'2023-05-18 08:46:25,809 ERROR: error: Please run the command on master zone. Performing this operation on non-master zone leads to inconsistent metadata between zones'""

since user remove is not successful during verification it went ahead and looking for verification of existence of objects,
since LC has already removed an objects we are getting an error key not found and test-case was failing.

"botocore.errorfactory.NoSuchKey: An error occurred (NoSuchKey) when calling the GetObject operation: Unknown'"

for now changing workflow to be execute from PRIMARY site.

Pass-log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-u3utb/Test_LC_Expiration_on_multisite_3.log


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
