### PR TITLE
fixing the upstream rados suite

### DIFF
--- a/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
@@ -162,6 +162,11 @@ tests:
       name: rbd-io
       module: rbd_faster_exports.py
       config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
         io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
       polarion-id: CEPH-9876


### PR DESCRIPTION
In the test suite, we have RBD sanity tests performed as well. recently, test coverage was added for the rbd test to include EC pools. Since Stretch Cluster does not support creation of EC pools, the tests were failing.

Updated the test to include RE pools only.

Pass logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W7TASA 