### PR TITLE
Fixing nfs HA sanity virtual IP issue

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1799,6 +1799,48 @@ os.system('sudo systemctl start  network')
             pass
         return 0
 
+    def get_floating_ip(self, node, **kwargs):
+        user = os.getlogin()
+        log.info(f"{user} logged in")
+        new_kwargs = kwargs.copy()
+        if kwargs.get("cloud_type") == "openstack":
+            new_kwargs.pop("cloud_type")
+            driver = get_openstack_driver(**new_kwargs)
+            node_obj = self.get_node_obj(node, **kwargs)
+            network_pool = list(node_obj.extra.get("addresses").keys())
+            floating_ip = driver.ex_create_floating_ip(network_pool[0])
+            return floating_ip
+        elif kwargs.get("cloud_type") == "ibmc":
+            # To DO for IBM
+            pass
+        else:
+            pass
+
+    def get_node_obj(self, node, **kwargs):
+        user = os.getlogin()
+        log.info(f"{user} logged in")
+        new_kwargs = kwargs.copy()
+        if kwargs.get("cloud_type") == "openstack":
+            new_kwargs.pop("cloud_type")
+            driver = get_openstack_driver(**new_kwargs)
+            for node_obj in driver.list_nodes():
+                if node.private_ip in node_obj.private_ips:
+                    return node_obj
+
+    def remove_floating_ip(self, floating_ip, **kwargs):
+        user = os.getlogin()
+        log.info(f"{user} logged in")
+        new_kwargs = kwargs.copy()
+        if kwargs.get("cloud_type") == "openstack":
+            new_kwargs.pop("cloud_type")
+            driver = get_openstack_driver(**new_kwargs)
+            driver.ex_delete_floating_ip(floating_ip)
+        elif kwargs.get("cloud_type") == "ibmc":
+            # To DO for IBM
+            pass
+        else:
+            pass
+
     def create_file_data(self, client, directory, no_of_files, file_name, data):
         """
         This function will write files to the directory with the data given


### PR DESCRIPTION
# Description
Fixing nfs HA sanity virtual IP issue
Problem:
We have virtual IP as part of ceph-ci project(under floating IPs) .
This is not available in ceph-jenkins project and pipeline is running as part of ceph-jenkins project

Solution:
We are requesting floating IP dynamically and we are removing as soon as test is completed

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U8GSQ5

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
