### PR TITLE
[Lib] Add support for fetching images from config

### DIFF
--- a/cephci/utils/configs.py
+++ b/cephci/utils/configs.py
@@ -155,6 +155,17 @@ def _get_packages():
         raise ConfigError("Packages configurations are missing from config")
 
 
+def _get_images():
+    """Get images from config file"""
+    if not CONFIG:
+        raise ConfigError("Configuration is not passed")
+
+    try:
+        return CONFIG["images"]
+    except KeyError:
+        raise ConfigError("Image configurations are missing from config")
+
+
 def get_packages(version=None):
     """Get packages from config for version
 
@@ -170,3 +181,16 @@ def get_packages(version=None):
         return packages
     except KeyError:
         raise ConfigError(f"Insufficient config for '{version}' in package")
+
+
+def get_images(build_type):
+    """Get images from config for build type
+
+    Args:
+        build_type (str): Ceph build version (pacific, quincy)
+    """
+    log.info(f"Loading images for build '{build_type}'")
+    try:
+        return _get_images()[build_type]
+    except KeyError:
+        raise ConfigError(f"Insufficient config for '{build_type}' in images")

--- a/examples/cephci.yaml
+++ b/examples/cephci.yaml
@@ -114,3 +114,14 @@ packages:
     - python-virtualenv
     - lsb-release
     - ntp
+
+images:
+  pacific:
+    - rhceph/rhceph-5-rhel8:latest
+    - openshift4/ose-prometheus-node-exporter:v4.6
+    - rhceph/rhceph-5-dashboard-rhel8
+    - openshift4/ose-prometheus:v4.6
+    - openshift4/ose-prometheus-alertmanager:v4.6
+
+  quincy:
+    - rhceph/rhceph-6-rhel9:latest


### PR DESCRIPTION
Problem:
The disconnected installation requires the images to be added to the private registry created. Currently there is no way to accept these images.

Solution:
The solution proposed is to add the image details in the cephci.yaml file and add support to fetch these images for a given build_type (pacific/quincy etc.# )

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
