### PR TITLE
[Enhancement] CEPH-83571710: Tier-2 test to verify parallel IOPs on a pool

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1511,6 +1511,7 @@ class RadosOrchestrator:
             obj_name: name of the object
             obj_size: size of the object in MB
         """
+        obj_name = f"{obj_name}_{obj_size}"
         installer_node = self.ceph_cluster.get_nodes(role="installer")[0]
         put_cmd = f"rados put -p {pool_name} {obj_name} /mnt/sample_1M"
         out, _ = installer_node.exec_command(
@@ -1548,6 +1549,7 @@ class RadosOrchestrator:
             obj_name: name of the object
             obj_size: size of the object in MB
         """
+        obj_name = f"{obj_name}_{obj_size}"
         installer_node = self.ceph_cluster.get_nodes(role="installer")[0]
         try:
             out, rc = installer_node.exec_command(

--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -131,5 +131,6 @@ tests:
         obj_sizes:
           - 45
           - 80
+          - 23
           - 107
       polarion-id: CEPH-83571710

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -131,5 +131,6 @@ tests:
         obj_sizes:
           - 45
           - 80
+          - 23
           - 107
       polarion-id: CEPH-83571710


### PR DESCRIPTION
Follow up PR for tier-2 test case [CEPH-83571710](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571710)

Original PR - https://github.com/red-hat-storage/cephci/pull/2588

This PR addresses few enhancements to
 - ensure unique objects are created for each object size
 - limit the chances of false failures
 - replace blind sleep with smart wait

Test modules modified:
- tests/rados/test_object_ops.py

Test suites modified:
- suites/pacific/rados/tier-2_rados_test_omap.yaml
- suites/quincy/rados/tier-2_rados_test_omap.yaml

Test passed 5/5 times on RHCS 6.1

Logs:
RHCS 6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KKT3KO
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PS8A1D

Signed-off-by: Harsh Kumar <hakumar@redhat.com>