### PR TITLE
Integrate bucket notifications testcases into cephci

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -916,7 +916,7 @@ pipelines:
             - rados
             - again
         - name: "Tier-2 RGW bucket notification"
-          execution_time: "1h 39m 47s"
+          execution_time: "2h 38m 12s"
           suite: "suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
           platform: "rhel-8"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -697,7 +697,7 @@ pipelines:
           metadata:
             - rados
         - name: "Tier-2 RGW bucket notification on the latest development build"
-          execution_time: "52m 12s"
+          execution_time: "1h 30m 38s"
           suite: "suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -446,6 +446,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "testing rhcs6.1 rgw fixes or new features"
+          execution_time: "51m 24s"
+          suite: "suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
       stage-6:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "41m 19s"

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -95,10 +95,10 @@ tests:
 
   # kafka broker type broker with persistent flag enabled
   - test:
-      name: notify put,delete events with kafka_broker_persistent
-      desc: notify put,delete events with kafka_broker_persistent
+      name: notify put,delete events with kafka_broker_persistent and test bucket deletion deletes notification
+      desc: notify put,delete events with kafka_broker_persistent and test bucket deletion deletes notification
       module: sanity_rgw.py
-      polarion-id: CEPH-83574066
+      polarion-id: CEPH-83574798
       config:
         run-on-rgw: true
         extra-pkgs:
@@ -109,9 +109,9 @@ tests:
         timeout: 300
 
   - test:
-      name: notify copy events with kafka_broker_persistent
-      desc: notify copy events with kafka_broker_persistent
-      polarion-id: CEPH-83574066
+      name: notify copy events with kafka_broker_persistent and verify details of event record
+      desc: notify copy events with kafka_broker_persistent and verify details of event record
+      polarion-id: CEPH-83574085
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -133,10 +133,10 @@ tests:
   # kafka broker type none with persistent flag enabled
 
   - test:
-      name: notify put,delete events with kafka_none_persistent
-      desc: notify put,delete events with kafka_none_persistent
+      name: notify put,delete events with kafka_none_persistent and delete kafka topic
+      desc: notify put,delete events with kafka_none_persistent and delete kafka topic
       module: sanity_rgw.py
-      polarion-id: CEPH-83574070
+      polarion-id: CEPH-83574076
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -171,7 +171,7 @@ tests:
       name: notify put,delete events with kafka_none
       desc: notify put,delete events with kafka_none
       module: sanity_rgw.py
-      polarion-id: CEPH-83574064
+      polarion-id: CEPH-83574074
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -206,7 +206,7 @@ tests:
       name: notify put,delete events with kafka_broker
       desc: notify put,delete events with kafka_broker
       module: sanity_rgw.py
-      polarion-id: CEPH-83574069
+      polarion-id: CEPH-83574073
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -244,6 +244,94 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_with_tenant_user.yaml
+        timeout: 300
+
+  - test:
+      name: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
+      desc: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
+      polarion-id: CEPH-83574420
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_filter.yaml
+        timeout: 300
+
+  - test:
+      name: test kafka_broker_persistent notifications for copy, delete events when kafka server is down
+      desc: test kafka_broker_persistent notifications for copy, delete events when kafka server is down
+      polarion-id: CEPH-83574417
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
+        timeout: 300
+
+  - test:
+      name: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
+      desc: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
+      polarion-id: CEPH-83574078
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
+        timeout: 300
+
+  - test:
+      name: test kafka_none_persistent notifications for copy, delete events when kafka server is down
+      desc: test kafka_none_persistent notifications for copy, delete events when kafka server is down
+      polarion-id: CEPH-83574417
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_down_none_persistent.yaml
+        timeout: 300
+
+  - test:
+      name: test kafka_none_persistent notifications for multipart upload events when kafka server is down
+      desc: test kafka_none_persistent notifications for multipart upload events when kafka server is down
+      polarion-id: CEPH-83574078
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_down_none_persistent_multipart.yaml
+        timeout: 300
+
+  - test:
+      name: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
+      desc: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
+      polarion-id: CEPH-83574419
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
+        timeout: 300
+
+  - test:
+      name: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
+      desc: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
+      polarion-id: CEPH-83574419
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
+        timeout: 300
+
+  - test:
+      name: put empty bucket notifications
+      desc: put empty bucket notifications
+      module: sanity_rgw.py
+      polarion-id: CEPH-83575036
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_empty_bucket_notification_kafka_broker.yaml
         timeout: 300
 
   - test:

--- a/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
@@ -1,0 +1,118 @@
+#
+# Objective: Test rgw features fixed or added in rhcs6.1
+#
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.all
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83573713
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  # test persistent bucket notifications when kafka server is unreachable
+
+  - test:
+      name: test kafka_broker_persistent notifications for copy, delete events when kafka server is down
+      desc: test kafka_broker_persistent notifications for copy, delete events when kafka server is down
+      polarion-id: CEPH-83574417
+      module: sanity_rgw.py
+      config:
+        extra-pkgs:
+          - java
+        install_start_kafka: true
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
+        timeout: 300
+
+  - test:
+      name: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
+      desc: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
+      polarion-id: CEPH-83574078
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
+        timeout: 300
+
+  - test:
+      name: notify on multipart upload events with kafka_broker_persistent
+      desc: notify on multipart upload events with kafka_broker_persistent
+      polarion-id: CEPH-83574066
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
+        timeout: 300
+
+  - test:
+      name: notify on multipart upload events with kafka_broker
+      desc: notify on multipart upload events with kafka_broker
+      polarion-id: CEPH-83574069
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_multipart.yaml
+        timeout: 300
+
+  - test:
+      name: check-ceph-health
+      module: exec.py
+      config:
+        cephadm: true
+        commands:
+          - "ceph -s"
+      desc: Check for ceph health debug info
+      polarion-id: CEPH-83575200

--- a/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -62,10 +62,10 @@ tests:
 
   # kafka broker type broker with persistent flag enabled
   - test:
-      name: notify put,delete events with kafka_broker_persistent
-      desc: notify put,delete events with kafka_broker_persistent
+      name: notify put,delete events with kafka_broker_persistent and test bucket deletion deletes notification
+      desc: notify put,delete events with kafka_broker_persistent and test bucket deletion deletes notification
       module: sanity_rgw.py
-      polarion-id: CEPH-83574066
+      polarion-id: CEPH-83574798
       config:
         run-on-rgw: true
         extra-pkgs:
@@ -76,9 +76,9 @@ tests:
         timeout: 300
 
   - test:
-      name: notify copy events with kafka_broker_persistent
-      desc: notify copy events with kafka_broker_persistent
-      polarion-id: CEPH-83574066
+      name: notify copy events with kafka_broker_persistent and verify details of event record
+      desc: notify copy events with kafka_broker_persistent and verify details of event record
+      polarion-id: CEPH-83574085
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -86,25 +86,13 @@ tests:
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
         timeout: 300
 
-  - test:
-      name: notify on multipart upload events with kafka_broker_persistent
-      desc: notify on multipart upload events with kafka_broker_persistent
-      polarion-id: CEPH-83574066
-      comments: known issue (bz-2149259)
-      module: sanity_rgw.py
-      config:
-        run-on-rgw: true
-        script-name: test_bucket_notifications.py
-        config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-        timeout: 300
-
   # kafka broker type none with persistent flag enabled
 
   - test:
-      name: notify put,delete events with kafka_none_persistent
-      desc: notify put,delete events with kafka_none_persistent
+      name: notify put,delete events with kafka_none_persistent and delete kafka topic
+      desc: notify put,delete events with kafka_none_persistent and delete kafka topic
       module: sanity_rgw.py
-      polarion-id: CEPH-83574070
+      polarion-id: CEPH-83574076
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -140,7 +128,7 @@ tests:
       name: notify put,delete events with kafka_none
       desc: notify put,delete events with kafka_none
       module: sanity_rgw.py
-      polarion-id: CEPH-83574064
+      polarion-id: CEPH-83574074
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -176,7 +164,7 @@ tests:
       name: notify put,delete events with kafka_broker
       desc: notify put,delete events with kafka_broker
       module: sanity_rgw.py
-      polarion-id: CEPH-83574069
+      polarion-id: CEPH-83574073
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -195,15 +183,47 @@ tests:
         timeout: 300
 
   - test:
-      name: notify on multipart upload events with kafka_broker
-      desc: notify on multipart upload events with kafka_broker
-      polarion-id: CEPH-83574069
-      comments: known issue (bz-2149259)
+      name: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
+      desc: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
+      polarion-id: CEPH-83574420
       module: sanity_rgw.py
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
-        config-file-name: test_bucket_notification_kafka_broker_multipart.yaml
+        config-file-name: test_bucket_notification_kafka_broker_persistent_filter.yaml
+        timeout: 300
+
+  - test:
+      name: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
+      desc: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
+      polarion-id: CEPH-83574419
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
+        timeout: 300
+
+  - test:
+      name: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
+      desc: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
+      polarion-id: CEPH-83574419
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
+        timeout: 300
+
+  - test:
+      name: put empty bucket notifications
+      desc: put empty bucket notifications
+      module: sanity_rgw.py
+      polarion-id: CEPH-83575036
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_empty_bucket_notification_kafka_broker.yaml
         timeout: 300
 
   - test:


### PR DESCRIPTION
This PR is to integrate below automated polarion testcases of bucket notifications into cephci:

- [CEPH-83574419](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574419) : notifications seen post manual reshard	
- [CEPH-83574420](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574420) : verify notifications are seen on a bucket configured with metadata filter	
- [CEPH-83575036](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575036) - Verify empty configuration is successfully set on a newly created bucket
- [CEPH-83574798](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574798) - Verify deleting a bucket with notification also deletes associated notification
- [CEPH-83574085](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574085) - verify the details of event record seen on broker
- [CEPH-83574076](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574076) - get/delete a topic
- [CEPH-83574074](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574074) - Kafka: Topic creation with kafka-ack-level=none and persistent flag false
- [CEPH-83574073](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574073) - Kafka: Topic creation with kafka-ack-level=broker and persistent flag false
- [CEPH-83574417](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574417) : with persistent flag set to true, notfication should be queued while the server the down and once server is up, the notification should resume. No errors seen
- [CEPH-83574078](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574078) : Kafka: verify object put/delete happens for a topic created with kafka-ack-level=broker & persistent flag =true when the Kafka cluster unreachable

Note: 

- removed multipart upload bucket notifications testcases from 6.0 suite which are failures(known issues). and placed them under new suite suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml as they are fixed in rhcs6.1
- replaced duplicate polarion ids in the suites to include other testcases polarion id's

pass logs:

- suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-qkfl3/
- suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-poak7/
- suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-b7ydk


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
