### PR TITLE
update new client node

### DIFF
--- a/suites/quincy/integrations/ocs_rgw_ssl.yaml
+++ b/suites/quincy/integrations/ocs_rgw_ssl.yaml
@@ -97,7 +97,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node1
+        node: node8
         install_packages:
           - ceph-common
         copy_admin_keyring: true


### PR DESCRIPTION
Updating new client node in test case as per the cluster configuration, which provide basic Ceph RPMs.
 
As per the https://github.com/red-hat-storage/cephci/blob/master/conf/quincy/integrations/7_node_ceph.yaml#L58
`node8` is a client node.

https://jenkins.ceph.redhat.com/job/rhceph-deploy-cluster/190/console