### PR TITLE
hotfix[square-ecommerce][CEPH-83575573]: Test sync with 0 num_shards

### DIFF
--- a/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
@@ -457,3 +457,46 @@ tests:
       name: test LC from primary to secondary
       polarion-id: CEPH-10737
       comments: bug-1991808, test LC rules from primary to secondary
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.sec rgw_sync_lease_period 10"
+              - "ceph orch restart rgw.shared.sec"
+            timeout: 120
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.pri rgw_sync_lease_period 10"
+              - "ceph orch restart rgw.shared.pri"
+            timeout: 120
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.arc rgw_sync_lease_period 10"
+              - "ceph orch restart rgw.shared.arc"
+            timeout: 120
+      desc: Setting rgw_sync_lease_period to 100 on multisite archive
+      module: exec.py
+      name: Setting rgw_sync_lease_period to 100 on multisite archive
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
+            run-on-haproxy: true
+            monitor-consistency-bucket-stats: true
+            timeout: 300
+      desc: test sync on bucket with 0 shards
+      module: sanity_rgw_multisite.py
+      name: test sync on bucket with 0 shards
+      polarion-id: CEPH-83575573
+      comments: bug-2188022, 2180549 HotFix for Square eCommerce
+


### PR DESCRIPTION
hotfix:[square-ecommerce]: automate num_shards 0 sync issue.

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575573

logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LMY20F