### PR TITLE
[Pipeline] - Splitting tier-2_rbd_regression test suite into feature-wise test suite

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -284,6 +284,36 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
+        - name: "Tier-2 test suite for 5x - RBD functionality"
+          execution_time: "57m 0s"
+          suite: "suites/pacific/rbd/tier-2_rbd_regression.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 test suite for 5x - RBD image migration"
+          execution_time: "50m 13s"
+          suite: "suites/pacific/rbd/tier-2_rbd_regression_Image_migration.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 test suite for 5x - RBD trash feature"
+          execution_time: "46m 52s"
+          suite: "suites/pacific/rbd/tier-2_rbd_regression_trash.yaml"
+          global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
         - name: "test-lc-process-single-bucket"
           execution_time: "57m 49s"
           suite: "suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml"
@@ -695,9 +725,9 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rados
-        - name: "Tier-2 test suite for 5x - RBD functionality"
-          execution_time: "42m 41s"
-          suite: "suites/pacific/rbd/tier-2_rbd_regression.yaml"
+        - name: "Tier-2 test suite for 5x - RBD trash purge functionality"
+          execution_time: "98m 10s"
+          suite: "suites/pacific/rbd/tier-2_rbd_trash_purge.yaml"
           global-conf: "conf/pacific/rbd/tier-0_rbd.yaml"
           platform: "rhel-8"
           inventory:

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -257,16 +257,6 @@ pipelines:
           metadata:
             - rados
       stage-2:
-        - name: "Testing RBD tier-2 regression scenarios"
-          execution_time: "37m 6s"
-          suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
-          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - rbd
         - name: "Tier-2 Cephfs test Nfs"
           execution_time: "33m 49s"
           suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
@@ -308,6 +298,46 @@ pipelines:
           metadata:
             - dmfg
       stage-3:
+        - name: "Testing RBD tier-2 regression scenarios"
+          execution_time: "57m 0s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD tier-2 image live migration"
+          execution_time: "50m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression_Image_migration.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD tier-2 rbd trash feature"
+          execution_time: "46m 52s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression_trash.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD tier-2 rbd trash purge functionality"
+          execution_time: "1h 38m 10s"
+          suite: "suites/quincy/rbd/tier-2_rbd_trash_purge.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
         - name: "Tier-2 RGW cloud transitions"
           execution_time: "47m 35s"
           suite: "suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -253,16 +253,6 @@ pipelines:
           metadata:
             - rados
       stage-2:
-        - name: "Testing RBD tier-2 regression scenarios"
-          execution_time: "37m 6s"
-          suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
-          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
-          platform: "rhel-9"
-          inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
-          metadata:
-            - rbd
         - name: "Tier-2 Cephfs test Nfs"
           execution_time: "33m 49s"
           suite: "suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml"
@@ -304,6 +294,46 @@ pipelines:
           metadata:
             - dmfg
       stage-3:
+        - name: "Testing RBD tier-2 regression scenarios"
+          execution_time: "57m 0s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD tier-2 live image migration"
+          execution_time: "50m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression_Image_migration.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD tier-2 trash feature"
+          execution_time: "46m 52s"
+          suite: "suites/quincy/rbd/tier-2_rbd_regression_trash.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD tier-2 trash purge functionality"
+          execution_time: "1h 38m 10s"
+          suite: "suites/quincy/rbd/tier-2_rbd_trash_purge.yaml"
+          global-conf: "conf/quincy/rbd/4-node-cluster-with-1-client.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
         - name: "Tier-2 RGW cloud transitions"
           execution_time: "47m 35s"
           suite: "suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml"

--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -1,15 +1,24 @@
 # Tier2: Extended RBD acceptance testing
 #
 # This test suite runs addition test scripts to evaluate the existing functionality of
-# Ceph RBD component.
+# Ceph RBD component like clone, snapshot and image feature.
 #
 # Conf File - conf/pacific/rbd/tier-0_rbd.yaml
 #
 # The following tests are covered
 #   - CEPH-9230 - verification snap and clone on an imported image
-#   - CEPH-83573308, CEPH-83573307 - clones creation with v2clone format and deletion
-#   - CEPH-83573289 - Verify force remove on trash images
-#   - CEPH-83573298 - Move images to trash, restore them and verify
+#   - CEPH-11408 - If the image has an exclusive-lock on it, verify the behaviour on delayed deletion
+#   - CEPH-11409 - Delayed Deletion - Create a clone of a RBD image, and then try to delete the parent image while the relationship is active
+#   - CEPH-83573309 - Verify deletion of parent Image when clone is flattened
+#   - CEPH-83573650 - Create image with Deep Flattening enabled,take snap,protect,clone,snap,flatten the clone, unprotect the parent snap, delete the parent snap
+#   - CEPH-9833 - Create multiple snapshot from Parent and its clone Image, rename all the snapshot one-by-one
+#   - CEPH-9835 - Create multiple snapshot, on top create clone image, then try to rename the snapshot which hosts the clone (Negative)
+#   - CEPH-9836 - [Rbd] - Rename the snapshot when different operations on the clone/parent image is in progress
+#   - CEPH-9224 - RBD-Kernel_Client: Try to delete a protected snapshot
+#   - CEPH-9862 - Perform flatten operations while changing the image feature
+#   - CEPH-9861 - Perform resize operations while changing the image feature
+#   - CEPH-83574644 - set "rbd_compression_hint" globally, per-pool, or per-image and check the behaviour
+
 tests:
 
   # Setup the cluster
@@ -121,50 +130,6 @@ tests:
       polarion-id: CEPH-83573650
 
   - test:
-      desc: Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
-      destroy-cluster: false
-      config:
-        enable: true
-      module: rbd_trash.py
-      name: Check trash if the deleted images are moved to trash automatically
-      polarion-id: CEPH-83573297
-
-  - test:
-      desc: Disable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are not moved to trash automatically
-      destroy-cluster: false
-      config:
-        enable: false
-      module: rbd_trash.py
-      name: Disable Trash and Delete images and check if they are not moved to trash automatically
-      polarion-id: CEPH-83573296
-
-  - test:
-      desc: Verify force remove on trash images
-      destroy-cluster: false
-      module: rbd_trash_remove.py
-      name: Test force remove on trash images
-      polarion-id: CEPH-83573289
-
-  - test:
-      desc: Move images to trash, restore them and verify
-      destroy-cluster: false
-      module: trash_restore.py
-      name: Check trash restore functionality
-      polarion-id: CEPH-83573298
-
-  - test:
-      desc: Move image to trash restore back and try create snap and clone on restored image
-      module: trash_restore_create_clone_snap.py
-      name: Test snap and clone creation on restored image from trash
-      polarion-id: CEPH-11413
-
-  - test:
-      desc: Verify parent-clone relationship and clone IOs are not affected when parent moved to trash
-      module: rbd_trash_restore_image_having_clone.py
-      name: Test parent trash restore with clone IOs
-      polarion-id: CEPH-11414
-
-  - test:
       desc: Rename image snapshots on an image on replicated and ecpools and its clones
       module: rbd_snapshot_rename.py
       name: Test Snapshot Rename functionality
@@ -183,12 +148,6 @@ tests:
       polarion-id: CEPH-9836
 
   - test:
-      desc: Image migration from two different EC pools to EC pool
-      module: rbd_migration_2diff_ec_pool_ec.py
-      name: Test image migration on ecpool with different K_m values
-      polarion-id: CEPH-83573322
-
-  - test:
       desc: Trying to delete a protected snapshot should fail - negative
       config:
         do_not_create_image: True
@@ -201,136 +160,12 @@ tests:
       polarion-id: CEPH-9224
 
   - test:
-      desc: Image migration from replication pools to replication pool
-      module: rbd_image_migration.py
-      config:
-        source:
-          rep-pool-only: True
-          rep_pool_config:
-            pool: rbd_RepPool1
-            image: rbd_image
-            size: 10G
-        destination:
-          rep-pool-only: True
-          do_not_create_image: True
-          rep_pool_config:
-            pool: rbd_RepPool2
-      name: Test image migration on replication pool
-      polarion-id: CEPH-83573293
-
-  - test:
-      desc: Image migration from EC pool to EC pool with default K_m value
-      module: rbd_image_migration.py
-      config:
-        source:
-          ec-pool-only: True
-          ec-pool-k-m: "2,2"
-          crush-failure-domain: osd
-          ec_pool_config:
-            pool: rbd_ECpool1
-            image: rbd_image_ec1
-            data_pool: data_pool_ec1
-            size: 10G
-        destination:
-          ec-pool-only: True
-          ec-pool-k-m: "2,2"
-          do_not_create_image: True
-          crush-failure-domain: osd
-          ec_pool_config:
-            pool: rbd_ECpool2
-            data_pool: data_pool_ec2
-      name: Test image migration on EC pool with default k_m value
-      polarion-id: CEPH-83573327
-
-  - test:
-      desc: Abort image migration from source to destination pool
-      module: rbd_abort_image_migration.py
-      config:
-        source:
-          ec-pool-k-m: "2,2"
-          crush-failure-domain: osd
-          rep_pool_config:
-            pool: rbd_RepPool1
-            image: rbd_image
-            size: 10G
-          ec_pool_config:
-            pool: rbd_ECpool1
-            image: rbd_image_ec1
-            data_pool: data_pool_ec1
-            size: 10G
-        destination:
-          ec-pool-k-m: "2,2"
-          do_not_create_image: True
-          crush-failure-domain: osd
-          rep_pool_config:
-            pool: rbd_RepPool2
-          ec_pool_config:
-            pool: rbd_ECpool2
-            data_pool: data_pool_ec2
-      name: Test abort image migration from source to destination pool
-      polarion-id: CEPH-83573324
-
-  - test:
-      desc: Setting up RGW user for s3 image migration test
-      module: exec.py
-      name: Setup rgw s3 user
-      config:
-        commands:
-          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
-
-  - test:
-      name: Image migration from s3 source
-      desc: Export an image to s3 source and reinstall as new image using migration
-      module: test_rbd_migration_image_s3_object.py
-      polarion-id: CEPH-83574092
-      config:
-        ec_pool_config:
-          pool: rbd_pool
-          data_pool: rbd_ec_pool
-          image: rbd_image
-          size: 100M
-        rep_pool_config:
-          pool: rbd_pool
-          image: rbd_rep_image
-          size: 100M
-
-  - test:
-      desc: Disable the image features on image when image is moved to trash and verify
-      module: rbd_features_disable.py
-      name: Test to disable the image features on image when image is moved to trash
-      polarion-id: CEPH-11415
-
-  - test:
       desc: Perform flatten operations while changing the image feature
       config:
         rbd_op_thread_timeout: 120
       module: rbd_flatten_image_feature_disable.py
       name: Test to disable image feature when flatten operation is performed
       polarion-id: CEPH-9862
-
-  - test:
-      desc: Perform trash purge on images with clone and images without clone
-      module: rbd_trash_purge.py
-      config:
-        do_not_create_image: True # to prevent initial_rbd_config from creating an image
-        no_of_images: 10 # number of images to create for testing
-        no_of_clones: 4 # number of images for which clones to be created
-      name: Test to perform trash purge on images with and without clone
-      polarion-id: CEPH-83574482
-
-  - test:
-      desc: Add trash purge schedule and verify the schedule
-      module: test_rbd_trash_purge_schedule.py
-      name: Test to verify trash purge schedule
-      config:
-        do_not_create_image: True
-      polarion-id: CEPH-83573660
-
-  - test:
-      desc: Verify image trash restore when same name image is already present
-      module: trash_restore_same_name_image.py
-      name: Test to verify image restore with same name
-      polarion-id: CEPH-11393
 
   - test:
       desc: Verify image feature disable on image having image meta set on it
@@ -353,27 +188,6 @@ tests:
       module: rbd_resize_image_with_image_feature.py
       name: Test to verify image resize operation while changing image feature
       polarion-id: CEPH-9861
-
-  - test:
-      desc: Image migration from namespace for read-only client
-      module: readonly_namespace_image_migration.py
-      config:
-        source:
-          do_not_create_image: True
-          rep_pool_config:
-            pool: rbd_RepPool1
-          ec_pool_config:
-            pool: rbd_ECpool1
-            data_pool: data_pool_ec1
-        destination:
-          do_not_create_image: True
-          rep_pool_config:
-            pool: rbd_RepPool2
-          ec_pool_config:
-            pool: rbd_ECpool1
-            data_pool: data_pool_ec2
-      name: Test image migration from namespace for read-only client
-      polarion-id: CEPH-83573341
 
   - test:
       desc: Verify rbd_compression_hint config settings

--- a/suites/pacific/rbd/tier-2_rbd_regression_Image_migration.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression_Image_migration.yaml
@@ -1,0 +1,208 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component for live image migration.
+#
+# Conf File - conf/pacific/rbd/tier-0_rbd.yaml
+#
+# The following tests are covered
+#   - CEPH-83573322 - Migrate the images from 2 different source pools to destination and check the behaviour
+#   - CEPH-83573293 - Move image from rep pool to rep pool while it is being used and check the behavior
+#   - CEPH-83573327 - Verify when images move from Ec pool to Ec pool with default k_m values
+#   - CEPH-83573324 - Copy the image from source to destination and stop in between and check the appropriate messages
+#   - CEPH-83574092 - Image migration : verify S3 image import as local image as image migration works
+#   - CEPH-83573341 - Set read only for client-X on namespace using cephx caps and migrate the images from namespace and verify migration is not allowed for client-X
+
+tests:
+
+  # Setup the cluster
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  # Test cases to be executed
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      desc: Image migration from two different EC pools to EC pool
+      module: rbd_migration_2diff_ec_pool_ec.py
+      name: Test image migration on ecpool with different K_m values
+      polarion-id: CEPH-83573322
+
+  - test:
+      desc: Image migration from replication pools to replication pool
+      module: rbd_image_migration.py
+      config:
+        source:
+          rep-pool-only: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+            image: rbd_image
+            size: 10G
+        destination:
+          rep-pool-only: True
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+      name: Test image migration on replication pool
+      polarion-id: CEPH-83573293
+
+  - test:
+      desc: Image migration from EC pool to EC pool with default K_m value
+      module: rbd_image_migration.py
+      config:
+        source:
+          ec-pool-only: True
+          ec-pool-k-m: "2,2"
+          crush-failure-domain: osd
+          ec_pool_config:
+            pool: rbd_ECpool1
+            image: rbd_image_ec1
+            data_pool: data_pool_ec1
+            size: 10G
+        destination:
+          ec-pool-only: True
+          ec-pool-k-m: "2,2"
+          do_not_create_image: True
+          crush-failure-domain: osd
+          ec_pool_config:
+            pool: rbd_ECpool2
+            data_pool: data_pool_ec2
+      name: Test image migration on EC pool with default k_m value
+      polarion-id: CEPH-83573327
+
+  - test:
+      desc: Abort image migration from source to destination pool
+      module: rbd_abort_image_migration.py
+      config:
+        source:
+          ec-pool-k-m: "2,2"
+          crush-failure-domain: osd
+          rep_pool_config:
+            pool: rbd_RepPool1
+            image: rbd_image
+            size: 10G
+          ec_pool_config:
+            pool: rbd_ECpool1
+            image: rbd_image_ec1
+            data_pool: data_pool_ec1
+            size: 10G
+        destination:
+          ec-pool-k-m: "2,2"
+          do_not_create_image: True
+          crush-failure-domain: osd
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool2
+            data_pool: data_pool_ec2
+      name: Test abort image migration from source to destination pool
+      polarion-id: CEPH-83573324
+
+  - test:
+      desc: Setting up RGW user for s3 image migration test
+      module: exec.py
+      name: Setup rgw s3 user
+      config:
+        commands:
+          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
+
+  - test:
+      name: Image migration from s3 source
+      desc: Export an image to s3 source and reinstall as new image using migration
+      module: test_rbd_migration_image_s3_object.py
+      polarion-id: CEPH-83574092
+      config:
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          image: rbd_image
+          size: 100M
+        rep_pool_config:
+          pool: rbd_pool
+          image: rbd_rep_image
+          size: 100M
+
+  - test:
+      desc: Image migration from namespace for read-only client
+      module: readonly_namespace_image_migration.py
+      config:
+        source:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec1
+        destination:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec2
+      name: Test image migration from namespace for read-only client
+      polarion-id: CEPH-83573341

--- a/suites/pacific/rbd/tier-2_rbd_regression_trash.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression_trash.yaml
@@ -1,0 +1,145 @@
+# Tier2: Extended RBD trash related testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component feature related to trash.
+#
+# Conf File - conf/pacific/rbd/tier-0_rbd.yaml
+#
+# The following tests are covered
+#   - CEPH-83573297 - Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
+#   - CEPH-83573296 - Disable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are not moved to trash automatically
+#   - CEPH-83573289 - Move images to trash, apply force remove on some of the images and check them
+#   - CEPH-83573298 - Move images to trash, undo them and verify the data which was created previously in it
+#   - CEPH-11413 - Delayed Deletion - In a time based deletion, restore an image which is marked for deletion. Verify if this image can be used as a normal image after. Create snaps on it, and clones from it
+#   - CEPH-11414 - In a parent clone relationship, move parent image to trash. Dont sever the child image from parent, but try to restore the parent, and verify the clone relationship is intact
+#   - CEPH-11415 - Delayed Deletion - Enable the image features on image, and mark for deletion. Now try to enable disable features
+#   - CEPH-11393 - Delayed Deletion - Verify there is no name collision with a trashed image
+
+tests:
+
+  # Setup the cluster
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  # Test cases to be executed
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      desc: Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
+      destroy-cluster: false
+      config:
+        enable: true
+      module: rbd_trash.py
+      name: Check trash if the deleted images are moved to trash automatically
+      polarion-id: CEPH-83573297
+
+  - test:
+      desc: Disable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are not moved to trash automatically
+      destroy-cluster: false
+      config:
+        enable: false
+      module: rbd_trash.py
+      name: Disable Trash and Delete images and check if they are not moved to trash automatically
+      polarion-id: CEPH-83573296
+
+  - test:
+      desc: Verify force remove on trash images
+      destroy-cluster: false
+      module: rbd_trash_remove.py
+      name: Test force remove on trash images
+      polarion-id: CEPH-83573289
+
+  - test:
+      desc: Move images to trash, restore them and verify
+      destroy-cluster: false
+      module: trash_restore.py
+      name: Check trash restore functionality
+      polarion-id: CEPH-83573298
+
+  - test:
+      desc: Move image to trash restore back and try create snap and clone on restored image
+      module: trash_restore_create_clone_snap.py
+      name: Test snap and clone creation on restored image from trash
+      polarion-id: CEPH-11413
+
+  - test:
+      desc: Verify parent-clone relationship and clone IOs are not affected when parent moved to trash
+      module: rbd_trash_restore_image_having_clone.py
+      name: Test parent trash restore with clone IOs
+      polarion-id: CEPH-11414
+
+  - test:
+      desc: Disable the image features on image when image is moved to trash and verify
+      module: rbd_features_disable.py
+      name: Test to disable the image features on image when image is moved to trash
+      polarion-id: CEPH-11415
+
+  - test:
+      desc: Verify image trash restore when same name image is already present
+      module: trash_restore_same_name_image.py
+      name: Test to verify image restore with same name
+      polarion-id: CEPH-11393

--- a/suites/pacific/rbd/tier-2_rbd_trash_purge.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_trash_purge.yaml
@@ -1,0 +1,101 @@
+# Tier2: Extended RBD trash related testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component related to trash purge.
+#
+# Conf File - conf/pacific/rbd/tier-0_rbd.yaml
+#
+# The following tests are covered
+#   - CEPH-83574482 - 'rbd trash purge' should purge all images without snapshots or clones in the pool specified
+#   - CEPH-83573660 - Schedule periodic trash purge operations via the CLI and check the behavior
+
+tests:
+
+  # Setup the cluster
+
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  # Test cases to be executed
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      desc: Perform trash purge on images with clone and images without clone
+      module: rbd_trash_purge.py
+      config:
+        do_not_create_image: True # to prevent initial_rbd_config from creating an image
+        no_of_images: 10 # number of images to create for testing
+        no_of_clones: 4 # number of images for which clones to be created
+      name: Test to perform trash purge on images with and without clone
+      polarion-id: CEPH-83574482
+
+  - test:
+      desc: Add trash purge schedule and verify the schedule
+      module: test_rbd_trash_purge_schedule.py
+      name: Test to verify trash purge schedule
+      config:
+        do_not_create_image: True
+      polarion-id: CEPH-83573660

--- a/suites/quincy/rbd/tier-2_rbd_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression.yaml
@@ -9,8 +9,17 @@
 #
 # The following tests are covered
 #   - CEPH-9230 - verification snap and clone on an imported image
-#   - CEPH-83573308, CEPH-83573307 - clones creation with v2clone format and deletion
-#   - CEPH-83573297 - Check trash if the deleted images are moved to trash automatically
+#   - CEPH-11408 - If the image has an exclusive-lock on it, verify the behaviour on delayed deletion
+#   - CEPH-11409 - Delayed Deletion - Create a clone of a RBD image, and then try to delete the parent image while the relationship is active
+#   - CEPH-83573309 - Verify deletion of parent Image when clone is flattened
+#   - CEPH-83573650 - Create image with Deep Flattening enabled,take snap,protect,clone,snap,flatten the clone, unprotect the parent snap, delete the parent snap
+#   - CEPH-9833 - Create multiple snapshot from Parent and its clone Image, rename all the snapshot one-by-one
+#   - CEPH-9835 - Create multiple snapshot, on top create clone image, then try to rename the snapshot which hosts the clone (Negative)
+#   - CEPH-9836 - [Rbd] - Rename the snapshot when different operations on the clone/parent image is in progress
+#   - CEPH-9224 - RBD-Kernel_Client: Try to delete a protected snapshot
+#   - CEPH-9862 - Perform flatten operations while changing the image feature
+#   - CEPH-9861 - Perform resize operations while changing the image feature
+#   - CEPH-83574644 - set "rbd_compression_hint" globally, per-pool, or per-image and check the behaviour
 
 tests:
 
@@ -121,50 +130,6 @@ tests:
       polarion-id: CEPH-83573650
 
   - test:
-      desc: Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
-      destroy-cluster: false
-      config:
-        enable: true
-      module: rbd_trash.py
-      name: Check trash if the deleted images are moved to trash automatically
-      polarion-id: CEPH-83573297
-
-  - test:
-      desc: Disable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are not moved to trash automatically
-      destroy-cluster: false
-      config:
-        enable: false
-      module: rbd_trash.py
-      name: Disable Trash and Delete images and check if they are not moved to trash automatically
-      polarion-id: CEPH-83573296
-
-  - test:
-      desc: Verify force remove on trash images
-      destroy-cluster: false
-      module: rbd_trash_remove.py
-      name: Test force remove on trash images
-      polarion-id: CEPH-83573289
-
-  - test:
-      desc: Move images to trash, restore them and verify
-      destroy-cluster: false
-      module: trash_restore.py
-      name: Check trash restore functionality
-      polarion-id: CEPH-83573298
-
-  - test:
-      desc: Move image to trash restore back and try create snap and clone on restored image
-      module: trash_restore_create_clone_snap.py
-      name: Test snap and clone creation on restored image from trash
-      polarion-id: CEPH-11413
-
-  - test:
-      desc: Verify parent-clone relationship and clone IOs are not affected when parent moved to trash
-      module: rbd_trash_restore_image_having_clone.py
-      name: Test parent trash restore with clone IOs
-      polarion-id: CEPH-11414
-
-  - test:
       desc: Rename image snapshots on an image on replicated and ecpools and its clones
       module: rbd_snapshot_rename.py
       name: Test Snapshot Rename functionality
@@ -183,12 +148,6 @@ tests:
       polarion-id: CEPH-9836
 
   - test:
-      desc: Image migration from two different EC pools to EC pool
-      module: rbd_migration_2diff_ec_pool_ec.py
-      name: Test image migration on ecpool with different K_m values
-      polarion-id: CEPH-83573322
-
-  - test:
       desc: Trying to delete a protected snapshot should fail - negative
       config:
         do_not_create_image: True
@@ -201,136 +160,12 @@ tests:
       polarion-id: CEPH-9224
 
   - test:
-      desc: Image migration from replication pools to replication pool
-      module: rbd_image_migration.py
-      config:
-        source:
-          rep-pool-only: True
-          rep_pool_config:
-            pool: rbd_RepPool1
-            image: rbd_image
-            size: 10G
-        destination:
-          rep-pool-only: True
-          do_not_create_image: True
-          rep_pool_config:
-            pool: rbd_RepPool2
-      name: Test image migration on replication pool
-      polarion-id: CEPH-83573293
-
-  - test:
-      desc: Image migration from EC pool to EC pool with default K_m value
-      module: rbd_image_migration.py
-      config:
-        source:
-          ec-pool-only: True
-          ec-pool-k-m: "2,2"
-          crush-failure-domain: osd
-          ec_pool_config:
-            pool: rbd_ECpool1
-            image: rbd_image_ec1
-            data_pool: data_pool_ec1
-            size: 10G
-        destination:
-          ec-pool-only: True
-          ec-pool-k-m: "2,2"
-          do_not_create_image: True
-          crush-failure-domain: osd
-          ec_pool_config:
-            pool: rbd_ECpool2
-            data_pool: data_pool_ec2
-      name: Test image migration on EC pool with default k_m value
-      polarion-id: CEPH-83573327
-
-  - test:
-      desc: Abort image migration from source to destination pool
-      module: rbd_abort_image_migration.py
-      config:
-        source:
-          ec-pool-k-m: "2,2"
-          crush-failure-domain: osd
-          rep_pool_config:
-            pool: rbd_RepPool1
-            image: rbd_image
-            size: 10G
-          ec_pool_config:
-            pool: rbd_ECpool1
-            image: rbd_image_ec1
-            data_pool: data_pool_ec1
-            size: 10G
-        destination:
-          ec-pool-k-m: "2,2"
-          do_not_create_image: True
-          crush-failure-domain: osd
-          rep_pool_config:
-            pool: rbd_RepPool2
-          ec_pool_config:
-            pool: rbd_ECpool2
-            data_pool: data_pool_ec2
-      name: Test abort image migration from source to destination pool
-      polarion-id: CEPH-83573324
-
-  - test:
-      desc: Setting up RGW user for s3 image migration test
-      module: exec.py
-      name: Setup rgw s3 user
-      config:
-        commands:
-          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
-
-  - test:
-      name: Image migration from s3 source
-      desc: Export an image to s3 source and reinstall as new image using migration
-      module: test_rbd_migration_image_s3_object.py
-      polarion-id: CEPH-83574092
-      config:
-        ec_pool_config:
-          pool: rbd_pool
-          data_pool: rbd_ec_pool
-          image: rbd_image
-          size: 100M
-        rep_pool_config:
-          pool: rbd_pool
-          image: rbd_rep_image
-          size: 100M
-
-  - test:
-      desc: Disable the image features on image when image is moved to trash and verify
-      module: rbd_features_disable.py
-      name: Test to disable the image features on image when image is moved to trash
-      polarion-id: CEPH-11415
-
-  - test:
       desc: Perform flatten operations while changing the image feature
       config:
         rbd_op_thread_timeout: 120
       module: rbd_flatten_image_feature_disable.py
       name: Test to disable image feature when flatten operation is performed
       polarion-id: CEPH-9862
-
-  - test:
-      desc: Perform trash purge on images with clone and images without clone
-      module: rbd_trash_purge.py
-      config:
-        do_not_create_image: True # to prevent initial_rbd_config from creating an image
-        no_of_images: 10 # number of images to create for testing
-        no_of_clones: 4 # number of images for which clones to be created
-      name: Test to perform trash purge on images with and without clone
-      polarion-id: CEPH-83574482
-
-  - test:
-      desc: Add trash purge schedule and verify the schedule
-      module: test_rbd_trash_purge_schedule.py
-      name: Test to verify trash purge schedule
-      config:
-        do_not_create_image: True
-      polarion-id: CEPH-83573660
-
-  - test:
-      desc: Verify image trash restore when same name image is already present
-      module: trash_restore_same_name_image.py
-      name: Test to verify image restore with same name
-      polarion-id: CEPH-11393
 
   - test:
       desc: Verify image feature disable on image having image meta set on it
@@ -353,28 +188,6 @@ tests:
       module: rbd_resize_image_with_image_feature.py
       name: Test to verify image resize operation while changing image feature
       polarion-id: CEPH-9861
-
-  - test:
-      desc: Image migration pool namespace
-      module: readonly_namespace_image_migration.py
-      config:
-        source:
-          do_not_create_image: True
-          rep_pool_config:
-            pool: rbd_RepPool1
-          ec_pool_config:
-            pool: rbd_ECpool1
-            data_pool: data_pool_ec1
-        destination:
-          do_not_create_image: True
-          rep_pool_config:
-            pool: rbd_RepPool2
-          ec_pool_config:
-            pool: rbd_ECpool1
-            data_pool: data_pool_ec2
-      name: Test image migration from pool namespace
-      polarion-id: CEPH-83573341
-
 
   - test:
       desc: Verify rbd_compression_hint config settings

--- a/suites/quincy/rbd/tier-2_rbd_regression_Image_migration.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression_Image_migration.yaml
@@ -1,0 +1,208 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-83573322 - Migrate the images from 2 different source pools to destination and check the behaviour
+#   - CEPH-83573293 - Move image from rep pool to rep pool while it is being used and check the behavior
+#   - CEPH-83573327 - Verify when images move from Ec pool to Ec pool with default k_m values
+#   - CEPH-83573324 - Copy the image from source to destination and stop in between and check the appropriate messages
+#   - CEPH-83574092 - Image migration : verify S3 image import as local image as image migration works
+#   - CEPH-83573341 - Set read only for client-X on namespace using cephx caps and migrate the images from namespace and verify migration is not allowed for client-X
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+# # Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Image migration from two different EC pools to EC pool
+      module: rbd_migration_2diff_ec_pool_ec.py
+      name: Test image migration on ecpool with different K_m values
+      polarion-id: CEPH-83573322
+
+  - test:
+      desc: Image migration from replication pools to replication pool
+      module: rbd_image_migration.py
+      config:
+        source:
+          rep-pool-only: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+            image: rbd_image
+            size: 10G
+        destination:
+          rep-pool-only: True
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+      name: Test image migration on replication pool
+      polarion-id: CEPH-83573293
+
+  - test:
+      desc: Image migration from EC pool to EC pool with default K_m value
+      module: rbd_image_migration.py
+      config:
+        source:
+          ec-pool-only: True
+          ec-pool-k-m: "2,2"
+          crush-failure-domain: osd
+          ec_pool_config:
+            pool: rbd_ECpool1
+            image: rbd_image_ec1
+            data_pool: data_pool_ec1
+            size: 10G
+        destination:
+          ec-pool-only: True
+          ec-pool-k-m: "2,2"
+          do_not_create_image: True
+          crush-failure-domain: osd
+          ec_pool_config:
+            pool: rbd_ECpool2
+            data_pool: data_pool_ec2
+      name: Test image migration on EC pool with default k_m value
+      polarion-id: CEPH-83573327
+
+  - test:
+      desc: Abort image migration from source to destination pool
+      module: rbd_abort_image_migration.py
+      config:
+        source:
+          ec-pool-k-m: "2,2"
+          crush-failure-domain: osd
+          rep_pool_config:
+            pool: rbd_RepPool1
+            image: rbd_image
+            size: 10G
+          ec_pool_config:
+            pool: rbd_ECpool1
+            image: rbd_image_ec1
+            data_pool: data_pool_ec1
+            size: 10G
+        destination:
+          ec-pool-k-m: "2,2"
+          do_not_create_image: True
+          crush-failure-domain: osd
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool2
+            data_pool: data_pool_ec2
+      name: Test abort image migration from source to destination pool
+      polarion-id: CEPH-83573324
+
+  - test:
+      desc: Setting up RGW user for s3 image migration test
+      module: exec.py
+      name: Setup rgw s3 user
+      config:
+        commands:
+          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
+
+  - test:
+      name: Image migration from s3 source
+      desc: Export an image to s3 source and reinstall as new image using migration
+      module: test_rbd_migration_image_s3_object.py
+      polarion-id: CEPH-83574092
+      config:
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          image: rbd_image
+          size: 100M
+        rep_pool_config:
+          pool: rbd_pool
+          image: rbd_rep_image
+          size: 100M
+
+  - test:
+      desc: Image migration pool namespace
+      module: readonly_namespace_image_migration.py
+      config:
+        source:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec1
+        destination:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec2
+      name: Test image migration from pool namespace
+      polarion-id: CEPH-83573341

--- a/suites/quincy/rbd/tier-2_rbd_regression_trash.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_regression_trash.yaml
@@ -1,0 +1,133 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-83573297 - Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
+#   - CEPH-83573296 - Disable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are not moved to trash automatically
+#   - CEPH-83573289 - Move images to trash, apply force remove on some of the images and check them
+#   - CEPH-83573298 - Move images to trash, undo them and verify the data which was created previously in it
+#   - CEPH-11413 - Delayed Deletion - In a time based deletion, restore an image which is marked for deletion. Verify if this image can be used as a normal image after. Create snaps on it, and clones from it
+#   - CEPH-11414 - In a parent clone relationship, move parent image to trash. Dont sever the child image from parent, but try to restore the parent, and verify the clone relationship is intact
+#   - CEPH-11415 - Delayed Deletion - Enable the image features on image, and mark for deletion. Now try to enable disable features
+#   - CEPH-11393 - Delayed Deletion - Verify there is no name collision with a trashed image
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+# # Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Enable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are moved to trash automatically
+      destroy-cluster: false
+      config:
+        enable: true
+      module: rbd_trash.py
+      name: Check trash if the deleted images are moved to trash automatically
+      polarion-id: CEPH-83573297
+
+  - test:
+      desc: Disable "rbd_move_to_trash_on_remove" config setting, delete images and check if they are not moved to trash automatically
+      destroy-cluster: false
+      config:
+        enable: false
+      module: rbd_trash.py
+      name: Disable Trash and Delete images and check if they are not moved to trash automatically
+      polarion-id: CEPH-83573296
+
+  - test:
+      desc: Verify force remove on trash images
+      destroy-cluster: false
+      module: rbd_trash_remove.py
+      name: Test force remove on trash images
+      polarion-id: CEPH-83573289
+
+  - test:
+      desc: Move images to trash, restore them and verify
+      destroy-cluster: false
+      module: trash_restore.py
+      name: Check trash restore functionality
+      polarion-id: CEPH-83573298
+
+  - test:
+      desc: Move image to trash restore back and try create snap and clone on restored image
+      module: trash_restore_create_clone_snap.py
+      name: Test snap and clone creation on restored image from trash
+      polarion-id: CEPH-11413
+
+  - test:
+      desc: Verify parent-clone relationship and clone IOs are not affected when parent moved to trash
+      module: rbd_trash_restore_image_having_clone.py
+      name: Test parent trash restore with clone IOs
+      polarion-id: CEPH-11414

--- a/suites/quincy/rbd/tier-2_rbd_trash_purge.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_trash_purge.yaml
@@ -1,0 +1,101 @@
+# Tier2: Extended RBD acceptance testing
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-83574482 - 'rbd trash purge' should purge all images without snapshots or clones in the pool specified
+#   - CEPH-83573660 - Schedule periodic trash purge operations via the CLI and check the behavior
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+# # Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Perform trash purge on images with clone and images without clone
+      module: rbd_trash_purge.py
+      config:
+        do_not_create_image: True # to prevent initial_rbd_config from creating an image
+        no_of_images: 10 # number of images to create for testing
+        no_of_clones: 4 # number of images for which clones to be created
+      name: Test to perform trash purge on images with and without clone
+      polarion-id: CEPH-83574482
+
+  - test:
+      desc: Add trash purge schedule and verify the schedule
+      module: test_rbd_trash_purge_schedule.py
+      name: Test to verify trash purge schedule
+      config:
+        do_not_create_image: True
+      polarion-id: CEPH-83573660


### PR DESCRIPTION
As the existing regression test suite is taking longer than expected time, we have split the tier-2_rbd_regression test suite in to different test suite as per the RBD feature, following changes are been done.
modified existing test suite : 
1) suites/quincy/rbd/tier-2_rbd_regression.yaml
2) suites/pacific/rbd/tier-2_rbd_regression.yaml

Added new test suite : 
1) suites/pacific/rbd/tier-2_rbd_regression_Image_migration.yaml
2) suites/pacific/rbd/tier-2_rbd_regression_trash.yaml
3) suites/pacific/rbd/tier-2_rbd_trash_purge.yaml
4) suites/quincy/rbd/tier-2_rbd_regression_Image_migration.yaml
5) suites/quincy/rbd/tier-2_rbd_regression_trash.yaml
6) suites/quincy/rbd/tier-2_rbd_trash_purge.yaml 

following are the time taken by each test suite: 

**tier-2_rbd_regression** : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6iks8/
Total time  : 57 min
**tier-2_rbd_regression_Image_migration** : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-yi1ru/
Total time : 50 mins, 13 secs
**tier2_rbd_regression_trash** : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-f8fvj/ 
Total time : 46 mins, 52 secs
**tier-2_rbd_trash_purge** : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-bd8ao/
Total time : 98 mins, 10 secs