### PR TITLE
adding bucket lifecycle and policy testcases into cephci

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -478,6 +478,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
+        - name: "tier-4 rgw suite"
+          execution_time: "1h 18m 52s"
+          suite: "suites/pacific/rgw/tier-4-rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
       stage-7:
         - name: "RGW testing using S3CMD CLI commands"
           execution_time: "45m 21s"
@@ -799,7 +809,7 @@ pipelines:
           metadata:
             - rgw
         - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
-          execution_time: "2h 20m 45s"
+          execution_time: "4h 17m 54s"
           suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
           platform: "rhel-8"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -380,7 +380,7 @@ pipelines:
           metadata:
             - rgw
         - name: "RGW Regression testing"
-          execution_time: "2h 54m 12s"
+          execution_time: "2h 57m 12s"
           suite: "suites/quincy/rgw/tier-2_rgw_regression.yaml"
           global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
           platform: "rhel-9"
@@ -509,6 +509,17 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rbd
+      stage-7:
+        - name: "tier-4 rgw suite"
+          execution_time: "1h 18m 52s"
+          suite: "suites/pacific/rgw/tier-4-rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
   schedule:
     tier-1:
       stage-1:
@@ -768,7 +779,7 @@ pipelines:
           metadata:
             - rgw
         - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
-          execution_time: "2h 14m 3s"
+          execution_time: "4h 17m 54s"
           suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -376,7 +376,7 @@ pipelines:
           metadata:
             - rgw
         - name: "RGW Regression testing"
-          execution_time: "2h 54m 12s"
+          execution_time: "2h 57m 12s"
           suite: "suites/quincy/rgw/tier-2_rgw_regression.yaml"
           global-conf: "conf/pacific/rgw/tier-2_rgw_regression.yaml"
           platform: "rhel-9"
@@ -447,7 +447,7 @@ pipelines:
           metadata:
             - rgw
         - name: "testing rhcs6.1 rgw fixes or new features"
-          execution_time: "51m 24s"
+          execution_time: "1h 51m 47s"
           suite: "suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml"
           global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"
@@ -505,6 +505,17 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rbd
+      stage-7:
+        - name: "tier-4 rgw suite"
+          execution_time: "1h 18m 52s"
+          suite: "suites/pacific/rgw/tier-4-rgw.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
   schedule:
     tier-1:
       stage-1:
@@ -765,7 +776,7 @@ pipelines:
           metadata:
             - rgw
         - name: "test-rgw-lc-expiration-with-prefix-as-special-character"
-          execution_time: "2h 14m 3s"
+          execution_time: "4h 17m 54s"
           suite: "suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml"
           global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
           platform: "rhel-9"

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -409,6 +409,46 @@ tests:
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
         timeout: 300
 
+  - test:
+      name: test bucket policy with multiple statements
+      desc: test bucket policy with multiple statements
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_multiple_statements.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with conflicting statements
+      desc: test bucket policy with conflicting statements
+      polarion-id: CEPH-11217
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with condition blocks
+      desc: test bucket policy with condition blocks
+      polarion-id: CEPH-11590
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_condition.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy condition block with explicit deny
+      desc: test bucket policy condition block with explicit deny
+      polarion-id: CEPH-11590
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_condition_explicit_deny.yaml
+        timeout: 500
+
   # Bucket Lifecycle Tests
 
   - test:

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -172,3 +172,25 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_ecpool_with_prefix_rule.yaml
         timeout: 300
+
+  # bucket lifecycle with resharding
+
+  - test:
+      name: test lifecycle expiration with dynamic resharding
+      desc: test lifecycle expiration with dynamic resharding
+      polarion-id: CEPH-83574679
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_expiration_dynamic_reshard.yaml
+        timeout: 300
+
+  - test:
+      name: test lifecycle expiration with manual resharding
+      desc: test lifecycle expiration with manual resharding
+      polarion-id: CEPH-83574679
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_expiration_manual_reshard.yaml
+        timeout: 300

--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -1,0 +1,198 @@
+# This suite executes Tier 4 RGW tests
+
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgw.ssl
+                  placement:
+                    nodes:
+                      - node5
+                  spec:
+                    ssl: true
+                    rgw_frontend_ssl_certificate: create-cert
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+      polarion-id: CEPH-83573777
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
+
+  # Bucket policy tests
+
+  - test:
+      name: test bucket policy with invalid action
+      desc: test bucket policy with invalid action
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_action.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with invalid conditional in condition blocks
+      desc: test bucket policy with invalid conditional in condition blocks
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_condition_key.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with invalid effect
+      desc: test bucket policy with invalid effect
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_effect.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with invalid key
+      desc: test bucket policy with invalid key
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_key.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with invalid principal
+      desc: test bucket policy with invalid principal
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_principal.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with invalid resource
+      desc: test bucket policy with invalid resource
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_resource.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with invalid version
+      desc: test bucket policy with invalid version
+      polarion-id: CEPH-83572755
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_invalid_version.yaml
+        timeout: 500
+
+  # Bucket lifecycle tests
+
+  - test:
+      name: test bucket lc rule conflict between expiration and transition
+      desc: test bucket lc rule conflict between expiration and transition
+      polarion-id: CEPH-11184
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_conflict_btw_exp_transition.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket lc rule conflict between expiration days
+      desc: test bucket lc rule conflict between expiration days
+      polarion-id: CEPH-11184
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_conflict_exp_days.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket lc rule conflict between transition actions
+      desc: test bucket lc rule conflict between transition actions
+      polarion-id: CEPH-11184
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_conflict_transition_actions.yaml
+        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
@@ -85,6 +85,8 @@ tests:
         config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
         timeout: 300
 
+  # test event time 0 fix for multipart uploads
+
   - test:
       name: notify on multipart upload events with kafka_broker_persistent
       desc: notify on multipart upload events with kafka_broker_persistent
@@ -105,6 +107,64 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_multipart.yaml
+        timeout: 300
+
+  # Test Bucket notifications for lifecycle events
+
+  - test:
+      name: notify on lifecycle expiration events with upload type multipart
+      desc: notify on lifecycle expiration events with upload type multipart
+      polarion-id: CEPH-83575583
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lc_object_exp_multipart.py
+        config-file-name: test_bucket_lc_object_exp_multipart_notifications.yaml
+        timeout: 300
+
+  - test:
+      name: notify on lifecycle expiration delete marker
+      desc: notify on lifecycle expiration delete marker
+      polarion-id: CEPH-83575583
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_delete_marker_notifications.yaml
+        timeout: 300
+
+  - test:
+      name: notify on lifecycle expiration events
+      desc: notify on lifecycle expiration events
+      polarion-id: CEPH-83575583
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_expiration_notifications.yaml
+        timeout: 300
+
+  - test:
+      name: notify on lifecycle expiration with parallel lc processing
+      desc: notify on lifecycle expiration with parallel lc processing
+      polarion-id: CEPH-83575583
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_expiration_parallel_notifications.yaml
+        timeout: 300
+
+  - test:
+      name: notify on lifecycle expiration non current objects with prefix rule
+      desc: notify on lifecycle expiration non current objects with prefix rule
+      polarion-id: CEPH-83575583
+      module: sanity_rgw.py
+      comments: Known issue BZ-2187982
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_prefix_non_current_days_notifications.yaml
         timeout: 300
 
   - test:

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -329,6 +329,46 @@ tests:
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
         timeout: 300
 
+  - test:
+      name: test bucket policy with multiple statements
+      desc: test bucket policy with multiple statements
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_multiple_statements.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with conflicting statements
+      desc: test bucket policy with conflicting statements
+      polarion-id: CEPH-11217
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy with condition blocks
+      desc: test bucket policy with condition blocks
+      polarion-id: CEPH-11590
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_condition.yaml
+        timeout: 500
+
+  - test:
+      name: test bucket policy condition block with explicit deny
+      desc: test bucket policy condition block with explicit deny
+      polarion-id: CEPH-11590
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_condition_explicit_deny.yaml
+        timeout: 500
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.


### PR DESCRIPTION
this PR is to include bucket policy and bucket lifecycle testcases into cephci

bucket policy PR's and respective polarion id's:

- https://github.com/red-hat-storage/ceph-qe-scripts/pull/413 - [CEPH-11217](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11217)
- https://github.com/red-hat-storage/ceph-qe-scripts/pull/423 - [CEPH-11216](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11216)
- https://github.com/red-hat-storage/ceph-qe-scripts/pull/441 - [CEPH-11590](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11590)
- https://github.com/red-hat-storage/ceph-qe-scripts/pull/448 - [CEPH-83572755](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83572755)

bucket lifecycle PR's and  respective polarion id's:

- https://github.com/red-hat-storage/ceph-qe-scripts/pull/374 - [CEPH-83575583](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575583)
- https://github.com/red-hat-storage/ceph-qe-scripts/pull/410 - [CEPH-83574679](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574679)
- https://github.com/red-hat-storage/ceph-qe-scripts/pull/456 - [CEPH-11184](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11184)


pass logs:

- suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-hklb2/
- suites/pacific/rgw/tier-4-rgw.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9dgeo/
- suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ihkd5/
- suites/quincy/rgw/tier-2_rgw_regression.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-sdtmn/


Note:

-  [test lifecycle expiration with manual resharding and verify attr after 20 min](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574679) failure in suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml is removed from the suite, will investigate and add it in other PR. [Bucket Lifecycle Object_transition_tests to ec pool](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574470) is already existing test in the same suite, and its failure is independent of this PR changes
- similarly [execute s3tests](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575225) is an existing test in suites/quincy/rgw/tier-2_rgw_regression.yaml and its failure is independent of current changes
- refer [bz2187982](https://bugzilla.redhat.com/show_bug.cgi?id=2187982) for [notify on lifecycle expiration non current objects with prefix rule](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574069) failure in suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
