### PR TITLE
Introduce notimeout on exec command

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1487,7 +1487,7 @@ class CephNode(object):
         self.id_rsa_pub, _ = self.exec_command(cmd="cat ~/.ssh/id_rsa.pub")
 
     def long_running(self, **kw):
-        """Method to execute long running command.
+        """Method to execute long-running command.
 
         Args:
             **kw: execute command configuration
@@ -1497,8 +1497,11 @@ class CephNode(object):
         """
         ssh = self.rssh if kw.get("sudo") else self.ssh
         cmd = kw["cmd"]
-        timeout = kw.get("timeout", 3600)
-        logger.info(f"long running command on {self.ip_address} -- {cmd}")
+        timeout = None if kw.get("timeout") == "notimeout" else kw.get("timeout", 3600)
+
+        logger.info(
+            f"long running command on {self.ip_address} -- {cmd} with {timeout} seconds"
+        )
 
         try:
             channel = ssh().get_transport().open_session()
@@ -1531,7 +1534,7 @@ class CephNode(object):
             raise CommandFailed(be)
 
     def exec_command(self, **kw):
-        """execute a command on the vm.
+        """execute a command.
 
         Attributes:
             kw (Dict): execute command configuration

--- a/suites/quincy/nvmeof/ceph_nvmeof_baremetal_sanity.yaml
+++ b/suites/quincy/nvmeof/ceph_nvmeof_baremetal_sanity.yaml
@@ -120,14 +120,14 @@ tests:
             serial: 1
             bdevs:
               count: 10
-              size: 2G
+              size: 10G
             listener_port: 5001
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 2
             bdevs:
               count: 10
-              size: 3G
+              size: 15G
             listener_port: 5002
             allow_host: "*"
         initiators:                             # Configure Initiators with all pre-req

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -99,6 +99,7 @@ def initiators(ceph_cluster, gateway, config):
                 "size": "100%",
                 "client_node": client,
                 "long_running": True,
+                "cmd_timeout": "notimeout",
             }
             p.spawn(run_fio, **io_args)
 

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1799,6 +1799,7 @@ def run_fio(**fio_args):
         long_running(bool): True for long running required
         client_node: node where fio needs to be run
         size: 'size' for file size/io size
+        cmd_timeout: command timeout in seconds eg., 'notimeout' | 1200
     Prerequisite: fio package must have been installed on the client node.
     One of device_name, filename, (rbdname,pool) is required.
     """
@@ -1836,9 +1837,15 @@ def run_fio(**fio_args):
         f" --group_reporting {opt_args}"
     )
 
-    return fio_args["client_node"].exec_command(
-        cmd=cmd, long_running=long_running, sudo=True
-    )
+    exec_args = {
+        "cmd": cmd,
+        "long_running": long_running,
+        "sudo": True,
+    }
+    if fio_args.get("cmd_timeout"):
+        exec_args.update({"timeout": fio_args["cmd_timeout"]})
+
+    return fio_args["client_node"].exec_command(**exec_args)
 
 
 def fetch_image_tag(rhbuild):


### PR DESCRIPTION
- Set timeout to `None` unlimited time on exec_command to execute command.
- This code helps to run any large IOs from any CephNode on longer duration.

> **2023-06-05 22:41:24,219** (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'test-1: (g=0): rw=write, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=8'
> 2023-06-05 22:41:24,430 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'fio-3.27'
> 2023-06-05 22:41:24,432 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'Starting 1 process'
> ...
> ...
> **2023-06-06 00:13:51,957** (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'test-1: (groupid=0, jobs=1): err= 0: pid=26556: Mon Jun  5 18:42:43 2023'
> 2023-06-06 00:13:51,958 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  write: IOPS=472, BW=1890KiB/s (1935kB/s)(10.0GiB/5549254msec); 0 zone resets'
> 2023-06-06 00:13:51,958 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'    slat (usec): min=3, max=470, avg= 5.30, stdev= 5.47'
> 2023-06-06 00:13:51,958 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'    clat (usec): min=3, max=825777, avg=14819.52, stdev=54574.56'
> 2023-06-06 00:13:51,959 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     lat (usec): min=8, max=825782, avg=14824.99, stdev=54574.46'
> 2023-06-06 00:13:51,959 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'    clat percentiles (usec):'
> 2023-06-06 00:13:51,959 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     |  1.00th=[    40],  5.00th=[    41], 10.00th=[    41], 20.00th=[    42],'
> 2023-06-06 00:13:51,960 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 30.00th=[    43], 40.00th=[    44], 50.00th=[    46], 60.00th=[    51],'
> 2023-06-06 00:13:51,960 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 70.00th=[    65], 80.00th=[ 29230], 90.00th=[ 47973], 95.00th=[ 58459],'
> 2023-06-06 00:13:51,960 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 99.00th=[ 98042], 99.50th=[534774], 99.90th=[633340], 99.95th=[650118],'
> 2023-06-06 00:13:51,961 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 99.99th=[692061]'
> 2023-06-06 00:13:51,961 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'   bw (  KiB/s): min=   56, max= 8704, per=100.00%, avg=1954.37, stdev=1213.46, samples=10733'
> 2023-06-06 00:13:51,961 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'   iops        : min=   14, max= 2176, avg=488.56, stdev=303.34, samples=10733'
> 2023-06-06 00:13:51,962 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  lat (usec)   : 4=0.01%, 20=0.01%, 50=59.07%, 100=17.20%, 250=1.84%'
> 2023-06-06 00:13:51,962 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  lat (usec)   : 500=0.01%, 750=0.01%'
> 2023-06-06 00:13:51,962 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  lat (msec)   : 10=0.01%, 20=0.43%,'
> 2023-06-06 00:13:51,963 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b' 50=12.47%, 100=7.98%, 250=0.07%'
> 2023-06-06 00:13:51,963 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  lat (msec)   : 500=0.23%, 750=0.68%, 1000=0.01%'
> 2023-06-06 00:13:51,964 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  fsync/fdatasync/sync_file_range:'
> 2023-06-06 00:13:51,964 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'    sync (nsec): min=133, max=96976, avg=596.82, stdev=1313.27'
> 2023-06-06 00:13:51,964 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'    sync percentiles (nsec):'
> 2023-06-06 00:13:51,965 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     |  1.00th=[  382],  5.00th=[  434], 10.00th=[  454], 20.00th=[  478],'
> 2023-06-06 00:13:51,965 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 30.00th=[  494], 40.00th=[  510], 50.00th=[  524], 60.00th=[  540],'
> 2023-06-06 00:13:51,966 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 70.00th=[  564], 80.00th=[  588], 90.00th=[  644], 95.00th=[  692],'
> 2023-06-06 00:13:51,966 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 99.00th=[  836], 99.50th=[  972], 99.90th=[18560], 99.95th=[25728],'
> 2023-06-06 00:13:51,966 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     | 99.99th=[58112]'
> 2023-06-06 00:13:51,967 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  cpu          : usr=0.13%, sys=0.36%, ctx=623770, majf=0, minf=17'
> 2023-06-06 00:13:51,967 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=103.1%, 16=0.0%, 32=0.0%, >=64=0.0%'
> 2023-06-06 00:13:51,967 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%'
> 2023-06-06 00:13:51,968 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     complete  : 0=0.0%, 4=100.0%, 8=0.1%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%'
> 2023-06-06 00:13:51,968 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     issued rwts: total=0,2621440,0,81919 short=0,0,0,0 dropped=0,0,0,0'
> 2023-06-06 00:13:51,968 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b'     latency   : target=0, window=0, percentile=100.00%, depth=8'
> 2023-06-06 00:13:51,969 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.ceph.py:1521 - b''


```
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WCQPCF

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Performs IOs on targets from m   Run IOs on multiple targets                                    1:56:26.767524                   Pass                             
```

