### PR TITLE
[Inditex]bug-1937618, retain bucket policies at archive site

### DIFF
--- a/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
@@ -298,7 +298,7 @@ tests:
       polarion-id: CEPH-10362
 
 
-### create a tenanted user for secondary site
+### create a non-tenanted user for secondary site
 
   - test:
       clusters:
@@ -306,13 +306,13 @@ tests:
           config:
             set-env: true
             script-name: user_create.py
-            config-file-name: tenanted_user.yaml
+            config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
             timeout: 300
-      desc: create tenanted user
-      module: sanity_rgw_multisite.py
-      name: create tenanted user
+      desc: create non-tenanted user
       polarion-id: CEPH-83575199
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
 
 ### create a tenanted user for archive site
 
@@ -540,3 +540,17 @@ tests:
       module: sanity_rgw_multisite.py
       name: m buckets with n objects
       comments: bug-2213138, known failure
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            config-file-name: test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
+            script-name: test_Mbuckets_with_Nobjects.py
+            run-on-haproxy: true
+            timeout: 600
+            test-bucket-pol-retained-archive: true
+      desc: Test bucket policies are reatined at archive site post object uploads
+      polarion-id: CEPH-83575576
+      module: sanity_rgw_multisite.py
+      name: bucket policies retained at archive site
+      comments: bug-1937618, Inditex.

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -55,6 +55,7 @@ from utility.log import Log
 from utility.utils import (
     configure_kafka_security,
     install_start_kafka,
+    retain_bucket_pol_at_archive,
     set_config_param,
     setup_cluster_access,
     test_bucket_stats_with_archive,
@@ -248,6 +249,17 @@ def run(**kw):
                 "Test no duplicate objects created at archive site via bucket stats"
             )
             test_bucket_stats_with_archive(
+                primary_client_node, secondary_client_node, archive_client_node
+            )
+
+        test_retain_bucket_pol_at_archive = config.get(
+            "test-bucket-pol-retained-archive"
+        )
+
+        if test_retain_bucket_pol_at_archive:
+            log.info("test bucket policies are retained at archive site")
+            time.sleep(120)
+            retain_bucket_pol_at_archive(
                 primary_client_node, secondary_client_node, archive_client_node
             )
 


### PR DESCRIPTION
Automate bug-1937618, Retain bucket policies at the archive site

Bucket policies disappear in the archive zone when an object is inserted in the master zone bucket

https://bugzilla.redhat.com/show_bug.cgi?id=1937618
ceph-qe-scripts: https://github.com/red-hat-storage/ceph-qe-scripts/pull/468

https://polarion.engineering.redhat.com/polarion/#/project/https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83575576

logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D764QV