### PR TITLE
splitting of test accroding to feature wise

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_failover_recovery.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_failover_recovery.yaml
@@ -1,0 +1,208 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_failover_recovery.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier-2_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Recovery of abrupt failure of primary cluster
+      module: test_9470.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9470
+      desc: Test unplanned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown primary cluster
+      module: test_9471.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9471
+      desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of abrupt failure of secondary cluster
+      module: test_9474.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9474
+      desc: Recovery of abrupt failure of secondary cluster
+
+  - test:
+      name: Recovery of shutdown secondary cluster
+      module: test_9475.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9475
+      desc: Testing secondary cluster unplanned failover test
+
+  - test:
+      name: Mirroring in same cluster should be prevented
+      module: test_rbd_mirror_reconfig.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9511
+      desc: Verify configuring mirror to same source and target should fail
+

--- a/suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -1,0 +1,266 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_image_operations.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier-2_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Mirroring of cloned image
+      module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9521
+      desc: Testing mirroring of cloned image
+
+  - test:
+      name: Mirroring from journal to snapshot
+      module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-83573618
+      desc: Testing journal mirroring to snapshot mirroring
+
+  - test:
+      name: Attempt expanding or shrinking secondary image
+      module: test_expand_or_shrink_img_at_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io-total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io-total: 200M
+      polarion-id: CEPH-9500
+      desc: Verify that resizing secondary image fails
+
+  - test:
+      name: test image meta operations sync to secondary
+      module: test_rbd_image_meta_mirroring.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            key: ping
+            value: pong
+      polarion-id: CEPH-9524
+      desc: Verify removal of image meta gets mirrored
+
+  - test:
+      name: Image shrink in primary cluster
+      module: test_rbd_mirror_shrink_image_primary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            journal:
+              ec_pool_config:
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                size: 2G
+                io_total: 10
+            snapshot:
+              ec_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+      polarion-id: CEPH-9499
+      desc: Verify image size at secondary when image shrink at primary cluster
+
+  - test:
+      name: Test to change of mirror pool replica size
+      module: test_rbd_mirror_replica_count.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io_total: 200M
+      polarion-id: CEPH-9518
+      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
+
+  - test:
+      desc: Enable and disable image feature from primary gets reflected to secondary
+      module: test_rbd_mirror_image_features.py
+      clusters:
+        ceph-rbd1:
+          config:
+            journal:
+              ec_pool_config:
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                size: 2G
+                io_total: 10
+            snapshot:
+              ec_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+      name: Testing change of image feature reflection from primary to secondary
+      polarion-id: CEPH-9520

--- a/suites/pacific/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
@@ -1,0 +1,225 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_image_trash_purge.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier-2_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: test-image-delete-from-primary-site
+      module: test-image-delete-primary-site.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9501
+      desc: Verify that image deleted at primary site updated at secondary
+
+  - test:
+      name: test mirror on image having snap and clone after restoring from trash
+      module: test_mirror_move_primary_trash_restore.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11417
+      desc: Verify that image is restore and mirroring is intact
+
+  - test:
+      name: test image delete from secondary after promote and demote
+      module: test-image-delete-from-secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            repeat_count: 1
+      polarion-id: CEPH-83574741
+      desc: Verify that deleting primary image also delete the secondary image
+
+  - test:
+      name: image removal from secondary after journaling feature disable
+      module: test_image_removal_from_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            repeat_count: 10
+      polarion-id: CEPH-10470
+      desc: verify that image removal from secondary after disabling journaling feature
+
+  - test:
+      name: Attempt moving secondary image to trash
+      module: test_mirror_move_secondary_trash.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11416
+      desc: Verify that moving secondary to trash fails
+
+  - test:
+      name: Delete parent snap for mirrored image
+      module: test_rbd_mirror_delete_parent_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io_total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io_total: 200M
+      polarion-id: CEPH-9515
+      desc: Testing parent snapshot deletion for mirrored image

--- a/suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
@@ -1,0 +1,208 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_failover_recovery.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD, 1 RBD MIRROR service daemon(s) and 1 Client
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Recovery of abrupt failure of primary cluster
+      module: test_9470.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9470
+      desc: Test unplanned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown primary cluster
+      module: test_9471.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9471
+      desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of abrupt failure of secondary cluster
+      module: test_9474.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9474
+      desc: Recovery of abrupt failure of secondary cluster
+
+  - test:
+      name: Recovery of shutdown secondary cluster
+      module: test_9475.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9475
+      desc: Testing secondary cluster unplanned failover test
+
+  - test:
+      name: Mirroring in same cluster should be prevented
+      module: test_rbd_mirror_reconfig.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9511
+      desc: Verify configuring mirror to same source and target should fail
+

--- a/suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -1,17 +1,17 @@
 #===============================================================================================
 # Tier-level: 2
-# Test-Suite: tier-2_rbd_mirror_regression.yaml
+# Test-Suite: tier-2_rbd_mirror_image_operations.yaml
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/rbd/tier-2_rbd_mirror.yaml
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
 #    Each cluster configuration
 #    5-Node cluster(RHEL-8.3 and above)
-#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#    3 MONS, 2 MGR, 3 OSD, 1 RBD MIRROR service daemon(s) and 1 Client
 #     Node1 - Mon, Mgr, Installer
 #     Node2 - client
-#     Node3 - OSD
-#     Node4 - OSD
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
 #     Node5 - OSD, RBD Mirror
 #===============================================================================================
 tests:
@@ -110,6 +110,7 @@ tests:
       destroy-clster: false
       module: test_cephadm.py
       name: deploy cluster
+
   - test:
         abort-on-fail: true
         clusters:
@@ -133,6 +134,7 @@ tests:
         destroy-cluster: false
         module: test_client.py
         name: configure client
+
   - test:
       abort-on-fail: true
       clusters:
@@ -149,135 +151,6 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
-
-  - test:
-      name: test-image-delete-from-primary-site
-      module: test-image-delete-primary-site.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9501
-      desc: Verify that image deleted at primary site updated at secondary
-
-  - test:
-      name: test mirror on image having snap and clone after restoring from trash
-      module: test_mirror_move_primary_trash_restore.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-11417
-      desc: Verify that image is restore and mirroring is intact
-
-  - test:
-      name: test image delete from secondary after promote and demote
-      module: test-image-delete-from-secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            repeat_count: 1
-      polarion-id: CEPH-83574741
-      desc: Verify that deleting primary image also delete the secondary image
-
-  - test:
-      name: image removal from secondary after journaling feature disable
-      module: test_image_removal_from_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            repeat_count: 10
-      polarion-id: CEPH-10470
-      desc: verify that image removal from secondary after disabling journaling feature
-
-  - test:
-      name: Attempt expanding or shrinking secondary image
-      module: test_expand_or_shrink_img_at_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            ec_pool_config:
-              imagesize: 2G
-              io-total: 200M
-            rep_pool_config:
-              imagesize: 2G
-              io-total: 200M
-      polarion-id: CEPH-9500
-      desc: Verify that resizing secondary image fails
-
-  - test:
-      name: Attempt moving secondary image to trash
-      module: test_mirror_move_secondary_trash.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-11416
-      desc: Verify that moving secondary to trash fails
-
-  - test:
-      name: test image meta operations sync to secondary
-      module: test_rbd_image_meta_mirroring.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            key: ping
-            value: pong
-      polarion-id: CEPH-9524
-      desc: Verify removal of image meta gets mirrored
-
-  - test:
-      name: Recovery of abrupt failure of primary cluster
-      module: test_9470.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9470
-      desc: Test unplanned failover and failback scenario
-
-  - test:
-      name: Recovery of shutdown primary cluster
-      module: test_9471.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9471
-      desc: Test planned failover and failback scenario
-
-  - test:
-      name: Recovery of abrupt failure of secondary cluster
-      module: test_9474.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9474
-      desc: Recovery of abrupt failure of secondary cluster
-
-  - test:
-      name: Recovery of shutdown secondary cluster
-      module: test_9475.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9475
-      desc: Testing secondary cluster unplanned failover test
 
   - test:
       name: Mirroring of cloned image
@@ -300,14 +173,32 @@ tests:
       desc: Testing journal mirroring to snapshot mirroring
 
   - test:
-      name: Mirroring in same cluster should be prevented
-      module: test_rbd_mirror_reconfig.py
+      name: Attempt expanding or shrinking secondary image
+      module: test_expand_or_shrink_img_at_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io-total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io-total: 200M
+      polarion-id: CEPH-9500
+      desc: Verify that resizing secondary image fails
+
+  - test:
+      name: test image meta operations sync to secondary
+      module: test_rbd_image_meta_mirroring.py
       clusters:
         ceph-rbd1:
           config:
             imagesize: 2G
-      polarion-id: CEPH-9511
-      desc: Verify configuring mirror to same source and target should fail
+            io-total: 200M
+            key: ping
+            value: pong
+      polarion-id: CEPH-9524
+      desc: Verify removal of image meta gets mirrored
 
   - test:
       name: Image shrink in primary cluster
@@ -337,6 +228,17 @@ tests:
       desc: Verify image size at secondary when image shrink at primary cluster
 
   - test:
+      name: Test to change of mirror pool replica size
+      module: test_rbd_mirror_replica_count.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io_total: 200M
+      polarion-id: CEPH-9518
+      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
+
+  - test:
       desc: Enable and disable image feature from primary gets reflected to secondary
       module: test_rbd_mirror_image_features.py
       clusters:
@@ -362,29 +264,3 @@ tests:
                 io_total: 10
       name: Testing change of image feature reflection from primary to secondary
       polarion-id: CEPH-9520
-
-  - test:
-      name: Delete parent snap for mirrored image
-      module: test_rbd_mirror_delete_parent_snap.py
-      clusters:
-        ceph-rbd1:
-          config:
-            ec_pool_config:
-              imagesize: 2G
-              io_total: 200M
-            rep_pool_config:
-              imagesize: 2G
-              io_total: 200M
-      polarion-id: CEPH-9515
-      desc: Testing parent snapshot deletion for mirrored image
-
-  - test:
-      name: Test to change of mirror pool replica size
-      module: test_rbd_mirror_replica_count.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io_total: 200M
-      polarion-id: CEPH-9518
-      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO

--- a/suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
@@ -1,12 +1,18 @@
 #===============================================================================================
 # Tier-level: 2
-# Test-Suite: tier-2_rbd_mirror_regression.yaml
-# Suite contains rbd-mirror tier-2 testcases
+# Test-Suite: tier-2_rbd_mirror_image_trash_purge.yaml
 #
 # Cluster Configuration:
-#    Conf file - conf/quincy/rbd/5-node-2-clusters.yaml
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
-#    Node 2 must to be a client node
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD, 1 RBD MIRROR service daemon(s) and 1 Client
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
+#     Node5 - OSD, RBD Mirror
 #===============================================================================================
 tests:
   - test:
@@ -14,6 +20,7 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
       abort-on-fail: true
       clusters:
@@ -103,6 +110,7 @@ tests:
       destroy-clster: false
       module: test_cephadm.py
       name: deploy cluster
+
   - test:
         abort-on-fail: true
         clusters:
@@ -126,6 +134,7 @@ tests:
         destroy-cluster: false
         module: test_client.py
         name: configure client
+
   - test:
       abort-on-fail: true
       clusters:
@@ -166,7 +175,7 @@ tests:
       desc: Verify that image is restore and mirroring is intact
 
   - test:
-      name: test image delete from secondary after multiple promote and demote
+      name: test image delete from secondary after promote and demote
       module: test-image-delete-from-secondary.py
       clusters:
         ceph-rbd1:
@@ -190,21 +199,6 @@ tests:
       desc: verify that image removal from secondary after disabling journaling feature
 
   - test:
-      name: Attempt expanding or shrinking secondary image
-      module: test_expand_or_shrink_img_at_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            ec_pool_config:
-              imagesize: 2G
-              io-total: 200M
-            rep_pool_config:
-              imagesize: 2G
-              io-total: 200M
-      polarion-id: CEPH-9500
-      desc: Verify that resizing secondary image fails
-
-  - test:
       name: Attempt moving secondary image to trash
       module: test_mirror_move_secondary_trash.py
       clusters:
@@ -214,147 +208,6 @@ tests:
             io-total: 200M
       polarion-id: CEPH-11416
       desc: Verify that moving secondary to trash fails
-
-  - test:
-      name: test image meta operations sync to secondary
-      module: test_rbd_image_meta_mirroring.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            key: ping
-            value: pong
-      polarion-id: CEPH-9524
-      desc: Verify removal of image meta gets mirrored
-
-  - test:
-      name: Recovery of abrupt failure of primary cluster
-      module: test_9470.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9470
-      desc: Test unplanned failover and failback scenario
-
-  - test:
-      name: Recovery of shutdown primary cluster
-      module: test_9471.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9471
-      desc: Test planned failover and failback scenario
-
-  - test:
-      name: Recovery of abrupt failure of secondary cluster
-      module: test_9474.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9474
-      desc: Recovery of abrupt failure of secondary cluster
-
-  - test:
-      name: Recovery of shutdown secondary cluster
-      module: test_9475.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9475
-      desc: Testing secondary cluster unplanned failover test
-
-  - test:
-      name: Mirroring of cloned image
-      module: test_rbd_clone_mirror.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-9521
-      desc: Testing mirroring of cloned image
-
-  - test:
-      name: Mirroring from journal to snapshot
-      module: test_rbd_mirror_journal_to_snap.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-83573618
-      desc: Testing journal mirroring to snapshot mirroring
-
-  - test:
-      name: Mirroring in same cluster should be prevented
-      module: test_rbd_mirror_reconfig.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-9511
-      desc: Verify configuring mirror to same source and target should fail
-
-  - test:
-      name: Image shrink in primary cluster
-      module: test_rbd_mirror_shrink_image_primary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            journal:
-              ec_pool_config:
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                size: 2G
-                io_total: 10
-            snapshot:
-              ec_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-      polarion-id: CEPH-9499
-      desc: Verify image size at secondary when image shrink at primary cluster
-
-  - test:
-      desc: Enable and disable image feature from primary gets reflected to secondary
-      module: test_rbd_mirror_image_features.py
-      clusters:
-        ceph-rbd1:
-          config:
-            journal:
-              ec_pool_config:
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                size: 2G
-                io_total: 10
-            snapshot:
-              ec_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-      name: Testing change of image feature reflection from primary to secondary
-      polarion-id: CEPH-9520
 
   - test:
       name: Delete parent snap for mirrored image
@@ -370,14 +223,3 @@ tests:
               io_total: 200M
       polarion-id: CEPH-9515
       desc: Testing parent snapshot deletion for mirrored image
-
-  - test:
-      name: Test to change of mirror pool replica size
-      module: test_rbd_mirror_replica_count.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io_total: 200M
-      polarion-id: CEPH-9518
-      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO

--- a/tests/rbd_mirror/test-image-delete-from-secondary.py
+++ b/tests/rbd_mirror/test-image-delete-from-secondary.py
@@ -61,6 +61,10 @@ def test_image_delete_from_secondary(rbd_mirror, pool_type, **kw):
         log.exception(e)
         return 1
 
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
 
 def run(**kw):
     log.info("Starting RBD mirroring test case - CEPH-83574741")

--- a/tests/rbd_mirror/test-image-delete-primary-site.py
+++ b/tests/rbd_mirror/test-image-delete-primary-site.py
@@ -22,6 +22,10 @@ def test_image_delete_from_primary(rbd_mirror, pool_type, **kw):
     except Exception as e:
         log.exception(e)
 
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
     return 1
 
 

--- a/tests/rbd_mirror/test_image_removal_from_secondary.py
+++ b/tests/rbd_mirror/test_image_removal_from_secondary.py
@@ -49,6 +49,10 @@ def test_image_removal_from_secondary(rbd_mirror, pool_type, **kw):
         log.exception(e)
         return 1
 
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
 
 def run(**kw):
     log.info("Starting RBD mirroring test case - CEPH-10470")

--- a/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
+++ b/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
@@ -99,3 +99,7 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_mirror_move_secondary_trash.py
+++ b/tests/rbd_mirror/test_mirror_move_secondary_trash.py
@@ -17,6 +17,7 @@ def test_image_move_secondary_trash(rbd_mirror, pool_type, **kw):
     """
     try:
         mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
         pool = config[pool_type]["pool"]
         image = config[pool_type]["image"]
@@ -40,6 +41,10 @@ def test_image_move_secondary_trash(rbd_mirror, pool_type, **kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
 
 def run(**kw):

--- a/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
+++ b/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
@@ -116,3 +116,7 @@ def run(**kw):
     except Exception as e:
         log.error(e)
         return 1
+
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])


### PR DESCRIPTION
# Description
Fixes Pipeline issue RHCEPHQE-8999

Some of the older test not deleting the pools after completion of it's test,
Hence in further test unable to create pool for the VM size limitation on OSD nodes,

Solution:
Below are the list of test which keep the pool after completion of it's test
- test-image-delete-primary-site.py
- test_mirror_move_primary_trash_restore.py
- test-image-delete-from-secondary.py
- test_image_removal_from_secondary.py
- test_mirror_move_secondary_trash.py
- test_rbd_image_meta_mirroring.py

Hence added pool cleanup in the` Finally` clause.

Also devided the tests in this suite with multiple test suite according to feature-wise 
it also saves test suite completion time along with currently hit such issues will be avoided.

Test result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RNYZFG

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
