### PR TITLE
CEPH-83571692: ceph-bluestore-tool functionalities

### DIFF
--- a/ceph/rados/bluestoretool_workflows.py
+++ b/ceph/rados/bluestoretool_workflows.py
@@ -1,0 +1,307 @@
+"""
+Module to perform specific functionalities of ceph-bluestore-tool.
+ - ceph-bluestore-tool fsck|repair --path osd path [ --deep ]
+ - ceph-bluestore-tool qfsck --path osd path
+ - ceph-bluestore-tool allocmap --path osd path
+ - ceph-bluestore-tool restore_cfb --path osd path
+ - ceph-bluestore-tool show-label --dev device
+ - ceph-bluestore-tool prime-osd-dir --dev device --path osd path
+ - ceph-bluestore-tool bluefs-export --path osd path --out-dir dir
+ - ceph-bluestore-tool bluefs-bdev-sizes --path osd path
+ - ceph-bluestore-tool bluefs-bdev-expand --path osd path
+ - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
+ - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
+ - ceph-bluestore-tool bluefs-bdev-migrate --path osd path --dev-target new-device --devs-source device1
+ - ceph-bluestore-tool free-dump|free-score --path osd path [ --allocator block/bluefs-wal/bluefs-db/bluefs-slow ]
+ - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
+ - ceph-bluestore-tool show-sharding --path osd path
+ - ceph-bluestore-tool bluefs-stats --path osd path
+"""
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class BluestoreToolWorkflows:
+    """
+    Contains various functions to verify ceph-bluestore-tool commands
+    """
+
+    def __init__(self, node: CephAdmin):
+        """
+        initializes the env to run Ceph-BlueStore-Tool commands
+        Args:
+            node: CephAdmin object
+        """
+        self.rados_obj = RadosOrchestrator(node=node)
+        self.cluster = node.cluster
+        self.client = node.cluster.get_nodes(role="client")[0]
+
+    def run_cbt_command(self, cmd: str, osd_id: int, timeout: int = 300) -> str:
+        """
+        Runs ceph-bluestore-tool commands within OSD container
+        Args:
+            cmd: command that needs to be run
+            osd_id: daemon ID of target OSD
+            timeout: Maximum time allowed for execution.
+        Returns:
+            output of respective ceph-bluestore-tool command in string format
+        """
+        osd_node = self.rados_obj.fetch_host_node(
+            daemon_type="osd", daemon_id=str(osd_id)
+        )
+        base_cmd = f"cephadm shell --name osd.{osd_id} --"
+        _cmd = f"{base_cmd} {cmd} --path /var/lib/ceph/osd/ceph-{osd_id}"
+        try:
+            self.rados_obj.change_osd_state(action="stop", target=osd_id)
+            out, err = osd_node.exec_command(sudo=True, cmd=_cmd, timeout=timeout)
+        except Exception as er:
+            log.error(f"Exception hit while command execution. {er}")
+            raise
+        finally:
+            self.rados_obj.change_osd_state(action="start", target=osd_id)
+        return str(out)
+
+    def help(self, osd_id: int):
+        """Module to run help command with ceph-bluestore-tool to display usage
+         Args:
+            osd_id: OSD ID for which cbt will be executed
+
+        Returns:
+            Output of ceph-bluestore-tool usage
+        """
+        _cmd = "ceph-bluestore-tool --help"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def run_consistency_check(self, osd_id: int, deep: bool = False):
+        """Module to run consistency check on BlueStore metadata.
+        If deep is specified, also read all object data and verify checksums.
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            deep: enables reading of all object data
+        Returns:
+            Returns the output of cbt quick fsck
+        """
+        # Extracting the ceush map from the cluster
+        _cmd = "ceph-bluestore-tool fsck "
+        if deep:
+            _cmd = f"{_cmd} --deep true"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def run_quick_consistency_check(self, osd_id: int):
+        """Module to run consistency check on BlueStore metadata comparing allocator
+         data (from RocksDB CFB when exists and if not uses allocation-file) with ONodes state.
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt quick fsck
+        """
+        _cmd = "ceph-bluestore-tool qfsck"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def repair(self, osd_id: int):
+        """Module to run a consistency check and repair any errors it can.
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt repair cmd
+        """
+        _cmd = "ceph-bluestore-tool repair"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def fetch_allocmap(self, osd_id: int):
+        """Module to perform the same check done by qfsck and then stores
+        a new allocation-file
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt allocmap cmd
+        """
+        _cmd = "ceph-bluestore-tool allocmap"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def restore_cfb(self, osd_id: int):
+        """Module to Reverses changes done by the new NCB code
+        (either through ceph restart or when running allocmap command) and
+        restores RocksDB B Column-Family (allocator-map).
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt restore_cfb cmd
+        """
+        _cmd = "ceph-bluestore-tool restore_cfb"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def do_bluefs_export(self, osd_id: int, output_dir: str):
+        """Module to export the contents of BlueFS (i.e., RocksDB files)
+        to an output directory
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            output_dir: Output directory for export
+        Returns:
+            Returns the output of cbt bluefs-export cmd
+        """
+        _cmd = f"ceph-bluestore-tool bluefs-export --out-dir {output_dir}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def block_device_sizes(self, osd_id: int):
+        """Module to print the device sizes, as understood by BlueFS, to stdout.
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt bluefs-bdev-sizes cmd
+        """
+        _cmd = "ceph-bluestore-tool bluefs-bdev-sizes"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def block_device_expand(self, osd_id: int):
+        """Module to instruct BlueFS to check the size of its block devices and,
+        if they have expanded, make use of the additional space
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt bluefs-bdev-expand cmd
+        """
+        _cmd = "ceph-bluestore-tool bluefs-bdev-expand"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def add_wal_device(self, osd_id: int, new_device):
+        """Module to add WAL device to BlueFS, fails if WAL device already exists.
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt bluefs-bdev-new-wal cmd
+        """
+        _cmd = f"ceph-bluestore-tool bluefs-bdev-new-wal --dev-target {new_device}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def add_db_device(self, osd_id: int, new_device):
+        """Module to add DB device to BlueFS, fails if DB device already exists
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt bluefs-bdev-new-db cmd
+        """
+        _cmd = f"ceph-bluestore-tool bluefs-bdev-new-db --dev-target {new_device}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def block_device_migrate(self, osd_id: int, new_device, device_source):
+        """Module to move BlueFS data from source device(s) to the target one,
+        source devices (except the main one) are removed on success.
+        Target device can be both already attached or new device. In the latter
+        case it’s added to OSD replacing one of the source devices.
+        Following replacement rules apply (in the order of precedence, stop on the first match):
+            - if source list has DB volume - target device replaces it.
+            - if source list has WAL volume - target device replace it.
+            - if source list has slow volume only - operation isn’t permitted,
+             requires explicit allocation via new-db/new-wal command.
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt bluefs-bdev-new-db cmd
+        """
+        _cmd = (
+            f"ceph-bluestore-tool bluefs-bdev-migrate "
+            f"--dev-target {new_device} --devs-source {device_source}"
+        )
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def show_label(self, osd_id: int, device: str = None):
+        """Module to show device label(s).
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            device: device name | e.g. - block, wal, db
+        Returns:
+            Returns the output of cbt show-label cmd
+        """
+        _cmd = "ceph-bluestore-tool show-label"
+        if device:
+            _cmd = f"{_cmd} --dev {device}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def generate_prime_osd_dir(self, osd_id: int, device: str):
+        """Module to generate the content for an OSD data directory that can start up a BlueStore OSD
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            device: device name | e.g. - block, wal, db
+        Returns:
+            Returns the output of cbt prime-osd-dir cmd
+        """
+        _cmd = f"ceph-bluestore-tool prime-osd-dir --dev {device}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_free_dump(self, osd_id: int, allocator_type: str = None):
+        """Module to dump all free regions in allocator
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            allocator_type: type of device | accepted inputs - block,
+                            bluefs-wal, bluefs-db, bluefs-slow
+        Returns:
+            Returns the output of cbt free-dump cmd
+        """
+        _cmd = "ceph-bluestore-tool free-dump"
+        if allocator_type:
+            _cmd = f"{_cmd} --allocator {allocator_type}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_free_score(self, osd_id: int, allocator_type: str = None):
+        """Module to fetch a [0-1] number that represents quality of fragmentation in allocator.
+        0 represents case when all free space is in one chunk.
+        1 represents the worst possible fragmentation
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            allocator_type: type of device | accepted inputs - block,
+             bluefs-wal, bluefs-db, bluefs-slow
+        Returns:
+            Returns the output of cbt free-score cmd
+        """
+        _cmd = "ceph-bluestore-tool free-score"
+        if allocator_type:
+            _cmd = f"{_cmd} --allocator {allocator_type}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def do_reshard(self, osd_id: int, new_shard, control_string: str = None):
+        """Module to change sharding of BlueStore’s RocksDB. Sharding is
+        build on top of RocksDB column families. This option allows to test
+        performance of new sharding without need to redeploy OSD.
+        Resharding is usually a long process, which involves walking through
+        entire RocksDB key space and moving some of them to different column families.
+        Option --resharding-ctrl provides performance control over resharding process.
+        Interrupted resharding will prevent OSD from running. Interrupted resharding
+        does not corrupt data. It is always possible to continue previous resharding,
+        or select any other sharding scheme, including reverting to original one
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+            new_shard:
+            control_string: enables resharding control string
+        Returns:
+            Returns the output of cbt reshard cmd
+        """
+        _cmd = f"ceph-bluestore-tool reshard --sharding {new_shard}"
+        if control_string:
+            _cmd = f"{_cmd} --resharding-ctrl {control_string}"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def show_sharding(self, osd_id: int):
+        """Module to show sharding that is currently applied to
+        BlueStore's RocksDB
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            Returns the output of cbt show-sharding cmd
+        """
+        _cmd = "ceph-bluestore-tool show-sharding"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def show_bluefs_stats(self, osd_id: int):
+        """
+        Args:
+            osd_id:
+        Returns:
+            Returns the output of cbt bluefs-stats cmd
+        """
+        _cmd = "ceph-bluestore-tool bluefs-stats"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)

--- a/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
@@ -106,6 +106,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: BlueStore Checksum algorithms
       module: test_bluestore_configs.py
       polarion-id: CEPH-83571646
@@ -153,3 +160,9 @@ tests:
                  rados_write_duration: 50
                  rados_read_duration: 50
           desc: Verification of the bluestore pinned tests
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -106,6 +106,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: BlueStore Checksum algorithms
       module: test_bluestore_configs.py
       polarion-id: CEPH-83571646
@@ -153,3 +160,9 @@ tests:
                  rados_write_duration: 50
                  rados_read_duration: 50
           desc: Verification of the bluestore pinned tests
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -1,0 +1,293 @@
+"""
+Test Module to perform specific functionalities of ceph-bluestore-tool.
+ - ceph-bluestore-tool fsck|repair --path osd path [ --deep ]
+ - ceph-bluestore-tool qfsck --path osd path
+ - ceph-bluestore-tool allocmap --path osd path
+ - ceph-bluestore-tool show-label --dev device
+ - ceph-bluestore-tool prime-osd-dir --dev device --path osd path
+ - ceph-bluestore-tool bluefs-export --path osd path --out-dir dir
+ - ceph-bluestore-tool bluefs-bdev-sizes --path osd path
+ - ceph-bluestore-tool bluefs-bdev-expand --path osd path
+ - ceph-bluestore-tool free-dump|free-score --path osd path [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+ - ceph-bluestore-tool show-sharding --path osd path
+ - ceph-bluestore-tool bluefs-stats --path osd path
+"""
+import json
+import random
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83571692
+    Test to perform +ve workflows for the ceph-bluestore-tool utility
+    Returns:
+        1 -> Fail, 0 -> Pass
+    *** Currently, covers commands/workflows valid only for collocated OSDs
+    Commands reserved for future coverage with non-collocated OSDs:
+    - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
+    - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
+    - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
+    - ceph-bluestore-tool bluefs-bdev-migrate --path osd path --dev-target new-device --devs-source device1
+    - ceph-bluestore-tool restore_cfb --path osd path
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    rhbuild = config.get("rhbuild")
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+
+    out, _ = cephadm.shell(args=["ceph osd ls"])
+    osd_list = out.strip().split("\n")
+
+    try:
+        # Execute ceph-bluestore-tool --help
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Running cbt help for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.help(osd_id=osd_id)
+        log.info(out)
+
+        # Execute ceph-bluestore-tool fsck --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Running consistency check for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.run_consistency_check(osd_id=osd_id)
+        log.info(out)
+        assert "success" in out
+
+        # Execute ceph-bluestore-tool fsck --deep --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Running deep consistency check for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.run_consistency_check(osd_id=osd_id, deep=True)
+        log.info(out)
+        assert "success" in out
+
+        if rhbuild.startswith("6"):
+            # Execute ceph-bluestore-tool qfsck --path <osd_path>
+            osd_id = random.randrange(len(osd_list))
+            log.info(
+                f"\n --------------------"
+                f"\n Running quick consistency check for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+            log.info(out)
+            assert "success" in out
+
+            # Execute ceph-bluestore-tool allocmap --path <osd_path>
+            osd_id = random.randrange(len(osd_list))
+            log.info(
+                f"\n --------------------"
+                f"\n Fetching allocmap for OSD {osd_id}"
+                f"\n ---------------------"
+            )
+            out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+            log.info(out)
+            assert "success" in out
+
+        # Execute ceph-bluestore-tool repair --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Run BlueFS repair for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.repair(osd_id=osd_id)
+        log.info(out)
+        assert "success" in out
+
+        """
+        # Execute ceph-bluestore-tool restore_cfb --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(f"\n --------------------"
+                 f"\n Restoring Column-Family B for OSD {osd_id}"
+                 f"\n --------------------")
+        out = bluestore_obj.restore_cfb(osd_id=osd_id)
+        log.info(out)
+
+        Execution failed with below msg -
+        restore_cfb failed: (1) Operation not permitted
+        7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::cct->_conf->bluestore_allocation_from_file
+        must be cleared first
+        7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::please change default to false in ceph.conf file>
+        *** Needs further investigation as upstream documentation says this command is supposed to reserve changes
+        done by the new NCB code | restore_cfb: Reverses changes done by the new NCB code (either through
+         ceph restart or when running allocmap command) and restores RocksDB B Column-Family (allocator-map).
+        The failure may only be applicable in certain scenarios, BZ will be raised if found otherwise.
+        https://docs.ceph.com/en/quincy/man/8/ceph-bluestore-tool/#commands
+        """
+
+        # Execute ceph-bluestore-tool bluefs-export --out-dir <dir> --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Exporting BlueFS contents to an output directory for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.do_bluefs_export(osd_id=osd_id, output_dir="/tmp/")
+        log.info(out)
+        assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+
+        # Execute ceph-bluestore-tool bluefs-bdev-sizes --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Print the device sizes, as understood by BlueFS, to stdout for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.block_device_sizes(osd_id=osd_id)
+        log.info(out)
+        assert "device size" in out
+
+        # Execute ceph-bluestore-tool bluefs-bdev-expand --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Checking if size of block device is expanded for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.block_device_expand(osd_id=osd_id)
+        log.info(out)
+        assert "device size" in out and "Expanding" in out
+
+        # Execute ceph-bluestore-tool show-label
+        log.info(
+            f"\n --------------------"
+            f"\n Dump label content for block device for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.show_label(osd_id=osd_id)
+        log.info(out)
+        assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+
+        # Execute ceph-bluestore-tool show-label --dev <device>
+        for device in ["block", "db", "wal"]:
+            osd_id = random.randrange(len(osd_list))
+            osd_node = rados_obj.fetch_host_node(
+                daemon_type="osd", daemon_id=str(osd_id)
+            )
+            lvm_list, _ = osd_node.exec_command(
+                sudo=True,
+                cmd=f"cephadm shell -- ceph-volume lvm list {osd_id} --format json",
+            )
+            lvm_json = json.loads(lvm_list)
+            dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
+            device_type = lvm_json[f"{osd_id}"][0]["type"]
+            if device in device_type:
+                log.info(
+                    f"\n --------------------"
+                    f"\n Dump label content for {device_type} device {dev} for OSD {osd_id}"
+                    f"\n --------------------"
+                )
+                out = bluestore_obj.show_label(osd_id=osd_id, device=dev)
+                log.info(out)
+                assert dev in out
+
+        # Execute ceph-bluestore-tool prime-osd-dir --dev <main_device> --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        osd_node = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=str(osd_id))
+        lvm_list, _ = osd_node.exec_command(
+            sudo=True,
+            cmd=f"cephadm shell -- ceph-volume lvm list {osd_id} --format json",
+        )
+        lvm_json = json.loads(lvm_list)
+        dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
+        log.info(
+            f"\n --------------------"
+            f"\n Generate the content for an OSD data directory "
+            f"that can start up a BlueStore OSD for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.generate_prime_osd_dir(osd_id=osd_id, device=dev)
+        log.info(out)
+
+        # Execute ceph-bluestore-tool free-dump --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Dump all free regions in allocator for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = (
+            bluestore_obj.get_free_dump(osd_id=osd_id)
+            if rhbuild.startswith("6")
+            else bluestore_obj.get_free_dump(osd_id=osd_id, allocator_type="block")
+        )
+        log.debug(out)
+        assert "alloc_name" in out and "extents" in out
+
+        # Execute ceph-bluestore-tool free-score --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Get fragmentation score for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = (
+            bluestore_obj.get_free_score(osd_id=osd_id)
+            if rhbuild.startswith("6")
+            else bluestore_obj.get_free_score(osd_id=osd_id, allocator_type="block")
+        )
+        log.info(out)
+        assert "fragmentation_rating" in out
+
+        # Execute ceph-bluestore-tool show-sharding --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Show sharding that is currently applied to "
+            f"BlueStore’s RocksDB for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.show_sharding(osd_id=osd_id)
+        log.info(out)
+        assert "block_cache" in out
+
+        # Execute ceph-bluestore-tool bluefs-stats --path <osd_path>
+        osd_id = random.randrange(len(osd_list))
+        log.info(
+            f"\n --------------------"
+            f"\n Display BlueFS statistics for OSD {osd_id}"
+            f"\n --------------------"
+        )
+        out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
+        log.info(out)
+        assert (
+            "device size" in out
+            and "wal_total" in out
+            and "db_total" in out
+            and "slow_total" in out
+        )
+
+        # restart OSD services
+        osd_services = rados_obj.list_orch_services(service_type="osd")
+        for osd_service in osd_services:
+            cephadm.shell(args=[f"ceph orch restart {osd_service}"])
+        time.sleep(30)
+        assert rados_obj.run_pool_sanity_check()
+
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    log.info("Completed verification of Ceph-BlueStore-Tool commands.")
+    return 0


### PR DESCRIPTION
[CEPH-83571692](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571692l): Automation of ceph-bluestore-tool functionalities and workflows.

Test modules added:
-  ceph/rados/bluestoretool_workflows.py
- tests/rados/test_bluestoretool_workflows.py

Test suites modified:
- suites/pacific/rados/tier-2_rados_test_bluestore.yaml
- suites/quincy/rados/tier-2_rados_test_bluestore.yaml

ceph-bluestore-tool commands covered:
 - ceph-bluestore-tool fsck|repair --path osd path [ --deep ]
 - ceph-bluestore-tool qfsck --path osd path
 - ceph-bluestore-tool allocmap --path osd path
 - ceph-bluestore-tool show-label --dev device
 - ceph-bluestore-tool prime-osd-dir --dev device --path osd path
 - ceph-bluestore-tool bluefs-export --path osd path --out-dir dir
 - ceph-bluestore-tool free-dump|free-score --path osd path [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
 - ceph-bluestore-tool show-sharding --path osd path
 - ceph-bluestore-tool bluefs-stats --path osd path
 
Logs:
RHCS 6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VJAHIX
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IE75QJ

Updated logs:
RHCS6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ANJF9B
RHCS5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D67LWI

Jira to track the remaining scenarios for non-collocated OSDs - [RHCEPHQE-9439](https://issues.redhat.com/browse/RHCEPHQE-9439)

Signed-off-by: Harsh Kumar <hakumar@redhat.com>