### PR TITLE
pipeline fix for delete clone with io test

### DIFF
--- a/tests/rbd/delete_clones_with_io.py
+++ b/tests/rbd/delete_clones_with_io.py
@@ -38,14 +38,13 @@ def run(**kw):
     kw["config"]["ec-pool-k-m"] = "go_with_default"
     scenarios.append(Rbd(**kw))
 
-    config = kw["config"]
-
     pools = ["test_rbd_ec_pool_scenario", "test_rbd_rep_pool"]
-    image = config.get("image_name", "rbd_test_image")
+    images = ["rbd_ec_image", "rbd_rep_image"]
     size = "10G"
 
     for rbd in scenarios:
         pool = pools.pop()
+        image = images.pop()
         kw["rbd_obj"] = rbd
         try:
 
@@ -87,16 +86,16 @@ def run(**kw):
             log.info("Creating image, snaps, clones with IO")
             with parallel() as p:
                 p.spawn(create_clone)
-                time.sleep(10)
+                time.sleep(30)
                 p.spawn(krbd_io_handler, **kw)
 
-            log.info("Deleting image, snaps, clones with IO")
+            log.info("Deleting clones with IO")
             with parallel() as p:
                 p.spawn(delete_clone)
                 p.spawn(krbd_io_handler, **kw)
 
         except RbdBaseException as error:
-            print(error.message)
+            log.error(error.message)
             return 1
 
         finally:


### PR DESCRIPTION
# Description
Fixes [RHCEPHQE-9006](https://issues.redhat.com/browse/RHCEPHQE-9006)
Issue logs http://pastebin.test.redhat.com/1102454

Due to parallel execution even before creating image clone krbd i/o been getting started due to that device map unable to provide image based disk that lead to the below error
```
device_names.append(rbd.image_map(pool_name, image_name)[:-1])
TypeError: 'int' object is not subscriptable
```
Fixed the issue with increased timeout and some glitch with the image name for EC pool test

Test result:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5GKI5L

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
