### PR TITLE
CEPH-83572758 | BZ-2214864: Verify feasibility of IOPS on a cluster after one OSD reaches FULL state

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -147,3 +147,31 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  # Below test is currently failing, BZ raised #2214864
+  # will be un-commented once fix is available
+#  - test:
+#      name: Perform IOPS on a Cluster with full OSDs
+#      desc: Verify posibility of IOPS on a Cluster with full OSDs
+#      module: test_osd_full.py
+#      polarion-id: CEPH-83572758
+#      config:
+#        iops_with_full_osds:
+#          pool-1:
+#            pool_name: "pool_full_osds"
+#            pool_type: replicated
+#            pg_num: 1
+#            disable_pg_autoscale: true
+#          pool-2:
+#            pool_name: "re_pool_test"
+#            pool_type: replicated
+#            pg_num: 1
+#            disable_pg_autoscale: true
+#          pool-3:
+#            pool_name: "test_ec_pool"
+#            pool_type: erasure
+#            pg_num: 1
+#            k: 4
+#            m: 2
+#            plugin: jerasure
+#            disable_pg_autoscale: true

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -149,3 +149,31 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  # Below test is currently failing, BZ raised #2214864
+  # will be un-commented once fix is available
+#  - test:
+#      name: Perform IOPS on a Cluster with full OSDs
+#      desc: Verify posibility of IOPS on a Cluster with full OSDs
+#      module: test_osd_full.py
+#      polarion-id: CEPH-83572758
+#      config:
+#        iops_with_full_osds:
+#          pool-1:
+#            pool_name: "pool_full_osds"
+#            pool_type: replicated
+#            pg_num: 1
+#            disable_pg_autoscale: true
+#          pool-2:
+#            pool_name: "re_pool_test"
+#            pool_type: replicated
+#            pg_num: 1
+#            disable_pg_autoscale: true
+#          pool-3:
+#            pool_name: "test_ec_pool"
+#            pool_type: erasure
+#            pg_num: 1
+#            k: 4
+#            m: 2
+#            plugin: jerasure
+#            disable_pg_autoscale: true


### PR DESCRIPTION
[CEPH-83572758](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83572758): Tier-2 test to ensure Cluster can still servce IOPs even if one or more OSDs are full through Pool which do not utilize the full OSDs

Currently failing, BZ raised - https://bugzilla.redhat.com/show_bug.cgi?id=2214864

Test modules modified:
- tests/rados/test_osd_full.py

Test suites modified:
- suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
- suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml

Steps:
1. Create a replicated pool with single PG and auto-scaling disabled
2. Retrieve the acting set for pool 1
3. Reweight the OSDs part of acting set of Pool 1 to 0
4. Create another replicated pool and EC pool with single PG and auto-scaling disabled
5. Retrieve the acting set for pool 2 and 3, should not have any OSD from acting set of Pool 1
6. Reweight the OSDs part of acting set of Pool 1 back to 1
7. Perform IOPS using rados bench to fill up Pool 1 up till completely full capacity
8. Perform IOPS on Pool 2 and Pool 3 and ensure IOPS is successful as full OSDs are not part of acting set

No pass logs available

 Signed-off-by: Harsh Kumar <hakumar@redhat.com>
