### PR TITLE
Replacing upstream test cli_generic.sh with its downstream counterpart rbd_tier0.py to avoid environment related failures

### DIFF
--- a/suites/quincy/cephadm/sanity-test.yaml
+++ b/suites/quincy/cephadm/sanity-test.yaml
@@ -112,9 +112,36 @@ tests:
             polarion-id: CEPH-11293  # also applies to [CEPH-11296,CEPH-11297,CEPH-11295]
   - test:
       config:
-        script: cli_generic.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD CLI Generic scenarios"
-      module: test_rbd.py
-      name: Executes RBD CLI generic operations
-      polarion-id: CEPH-83574241
+        ec-pool-k-m: 2,1
+        ec-pool-only: False
+        ec_pool_config:
+          pool: rbd_pool
+          data_pool: rbd_ec_pool
+          ec_profile: rbd_ec_profile
+          image: rbd_image
+          image_thick_provision: rbd_thick_image
+          snap_thick_provision: rbd_thick_snap
+          clone_thick_provision: rbd_thick_clone
+          thick_size: 2G
+          size: 10G
+          snap: rbd_ec_pool_snap
+          clone: rbd_ec_pool_clone
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          image_thick_provision: rbd_rep_thick_image
+          snap_thick_provision: rbd_rep_thick_snap
+          clone_thick_provision: rbd_rep_thick_clone
+          thick_size: 2G
+          size: 10G
+          snap: rbd_rep_pool_snap
+          clone: rbd_rep_pool_clone
+        operations:
+          map: true
+          io: true
+          nounmap: false
+      desc: Run RBD tier-0 operations
+      polarion-id: CEPH-83575401
+      destroy-cluster: false
+      module: rbd_tier0.py
+      name: Run RBD tier-0 operations


### PR DESCRIPTION
Since the environment and the OS version being used for an upstream script is different from cephci RHOSD env, we sometimes encounter failures where certain commands which work perfectly fine in upstream fail in downstream.

Ex: Issue - https://issues.redhat.com/browse/RHCEPHQE-9034

Originally our upstream test execution for the test suite suites/quincy/cephadm/sanity-test.yaml is running the upstream RBD script https://github.com/ceph/ceph/blob/v18.0.0/qa/workunits/rbd/cli_generic.sh . This script was failing in upstream pipeline with error that jq package is not installed - https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-upstream-test-executor/168/    https://reportportal-rhcephqe.apps.ocp-c1.prod.psi.redhat.com/ui/#cephci/launches/all/8574

I tried to fix this issue by installing jq while configuring client and when I tried to execute the suite with the fix, it started failing while fetching MON ip addresses from ceph mon dump output. - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7ULX7N/Executes_RBD_CLI_generic_operations_0.log

The following command fetches the right ceph mon ip addresses while executing in upstream teuthology runs - http://qa-proxy.ceph.com/teuthology/yuriw-2023-06-02_17:51:14-rbd-reef-distro-default-smithi/7295069/teuthology.log , however in our environment it fetches an empty value
```
[cephuser@ceph-test-ups-7ulx7n-node4 ~]$ readarray -t MON_ADDRS < <(ceph mon dump | sed -n 's/^[0-9]: \(.*\) mon\.[a-z]$/\1/p')
dumped monmap epoch 3
[cephuser@ceph-test-ups-7ulx7n-node4 ~]$ ceph mon dump 
epoch 3 fsid 6a0e9826-061e-11ee-9054-fa163e73c91e last_changed 2023-06-08T17:09:17.331578+0000 created 2023-06-08T17:04:04.065266+0000 min_mon_release 18 (reef) election_strategy: 1 0: [v2:10.0.209.213:3300/0,v1:10.0.209.213:6789/0] mon.ceph-test-ups-7ulx7n-node1-installer 1: [v2:10.0.208.70:3300/0,v1:10.0.208.70:6789/0] mon.ceph-test-ups-7ulx7n-node3 2: [v2:10.0.208.110:3300/0,v1:10.0.208.110:6789/0] mon.ceph-test-ups-7ulx7n-node2
```

Replacing the upstream test cli_generic.sh with its downstream counterpart rbd_tier0.py to avoid such failures.

Success Logs post fix - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JVMPCP/
