### PR TITLE
[CephMgr][Tier2] Verify enabling and disabling ceph-mgr plugins

### DIFF
--- a/suites/quincy/cephmgr/tier-2-cephmgr.yaml
+++ b/suites/quincy/cephmgr/tier-2-cephmgr.yaml
@@ -208,3 +208,10 @@ tests:
       desc: Verify  Module 'pg_autoscaler' has failed 'op' error with crush rule set
       polarion-id: 83575456
       module: test_cephmgr_validate_crush_rule.py
+
+  - test:
+      name: Verify ceph-mgr plugins
+      desc: Verify enabling and disabling ceph-mgr plugins
+      polarion-id: CEPH-11389
+      module: test_cephmgr_plugins.py
+

--- a/tests/mgr/test_cephmgr_plugins.py
+++ b/tests/mgr/test_cephmgr_plugins.py
@@ -1,0 +1,38 @@
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError
+
+
+def run(ceph_cluster, **kw):
+    """Verify Ceph Mgr plugins
+    Args:
+        **kw: Key/value pairs of configuration information
+              to be used in the test.
+    """
+    node = ceph_cluster.get_nodes(role="mgr")[0]
+    plugins = [
+        "influx",
+        "k8sevents",
+        "prometheus",
+        "restful",
+        "rook",
+        "stats",
+        "telegraf",
+        "telemetry",
+        "zabbix",
+    ]
+
+    for plugin in plugins:
+        # Enable ceph-mgr plugin
+        if CephAdm(node).ceph.mgr.module(action="enable", module=plugin, force=True):
+            OperationFailedError(f"Failed to enable {plugin} plugin")
+
+        # Verify ceph-mgr plugin being listed under enabled modules
+        out = CephAdm(node).ceph.mgr.module(action="ls")
+        if plugin not in out:
+            OperationFailedError(f"{plugin} plug-in not listed under enabled_modules")
+
+        # Disable ceph-mgr plugin
+        if CephAdm(node).ceph.mgr.module(action="disable", module=plugin):
+            OperationFailedError(f"Failed to disable {plugin} plugin")
+
+    return 0


### PR DESCRIPTION
CEPH-11389
Verify enabling and disabling ceph-mgr plugins

- Deploy cluster
- Enable and disable the ceph-mgr plugins such as zabbix, prometheus, restful, influx, etc.
