### PR TITLE
Optimize wait time required for OMAP entries to get reflected | Temporarily exclude pool data migration tests

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1213,16 +1213,18 @@ class RadosOrchestrator:
         """
         return self.node.shell([f"ceph config set {osd} osd_mclock_profile {profile}"])
 
-    def get_cephdf_stats(self, pool_name: str = None) -> dict:
+    def get_cephdf_stats(self, pool_name: str = None, detail: bool = False) -> dict:
         """
         Retrieves and returns the output ceph df command
         as a dictionary
         Args:
             pool_name: name of the pool whose stats are
             specifically required
-        Returns:  dictionary output of ceph df
+            detail: enables ceph df detail command (default: False)
+        Returns:  dictionary output of ceph df/ceph df detail
         """
-        cephdf_stats = self.run_ceph_command(cmd="ceph df", client_exec=True)
+        _cmd = "ceph df detail" if detail else "ceph df"
+        cephdf_stats = self.run_ceph_command(cmd=_cmd, client_exec=True)
 
         if pool_name:
             try:

--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -898,6 +898,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rados
+        - name: "RADOS regression for testing OMAP related scenarios"
+          execution_time: "1h 10m 56s"
+          suite: "suites/pacific/rados/tier-2_rados_test_omap.yaml"
+          global-conf: "conf/pacific/rados/7-node-cluster.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rados
       stage-4:
         - name: "Tier-2 test suite for 5x - RBD Snapshot mirroring functionality"
           execution_time: "3h 56m 3s"

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -888,6 +888,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rados
+        - name: "RADOS regression for testing OMAP related scenarios"
+          execution_time: "1h 10m 56s"
+          suite: "suites/quincy/rados/tier-2_rados_test_omap.yaml"
+          global-conf: "conf/quincy/rados/7-node-cluster.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rados
         - name: "Testing RGW multisite Bucket granular sync policy from primary"
           execution_time: ""
           suite: "suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml"

--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -200,38 +200,27 @@ tests:
       module: test_omap_entries.py
       polarion-id: CEPH-83571702
       config:
-        verify_osd_omap_entries:
-          pool_config:
-            # EC pool config is commented out because
-            # omap entries is not working on an EC pool
-#            pool-1:
-#              pool_name: ec_pool_3
-#              pool_type: erasure
-#              pg_num: 1
-#              k: 8
-#              m: 4
-#              plugin: jerasure
-#              crush-failure-domain: osd
-#              disable_pg_autoscale: true
-            pool-2:
-              pool_type: replicated
-              pool_name: re_pool_3
-              pg_num: 1
-              disable_pg_autoscale: true
-          omap_config:
-            small_omap:
-              large_warn: false
-              obj_start: 0
-              obj_end: 5
-              normal_objs: 400
-              num_keys_obj: 200000
-            large_omap:
-              large_warn: true
-              obj_start: 0
-              obj_end: 5
-              normal_objs: 400
-              num_keys_obj: 200001
-      desc: Large number of omap creations on objects backed by bluestore
+        # EC pool config is commented out because omaps can be written only on RE pools
+        omap_config:
+          small_omap:
+            pool_name: re_pool_small_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: false
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200000
+          large_omap:
+            pool_name: re_pool_large_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: true
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200001
+      desc: Large number of omap creation on objects and OSD resiliency
 
   - test:
       name: client pg access
@@ -255,49 +244,53 @@ tests:
               disable_pg_autoscale: true
       desc: many clients clients accessing same PG with bluestore as backend
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: replicated
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-2
-      desc: Migrating data between different pools. Scenario-1. RE -> RE
+# Following tests has been commented till RCA is complete for massive increase
+# in test completion time
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: replicated
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-2
+#      desc: Migrating data between different pools. Scenario-1. RE -> RE
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-3
-      desc: Migrating data between different pools. Scenario-2. RE -> EC
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-3
+#      desc: Migrating data between different pools. Scenario-2. RE -> EC
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: erasure
-        pool-2-type: replicated
-        pool-1-conf: sample-pool-3
-        pool-2-conf: sample-pool-3
-      desc: Migrating data between different pools. Scenario-3. EC -> RE
-
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: erasure
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-2
-        pool-2-conf: sample-pool-3
-      desc: Migrating data between different pools. Scenario-4. Ec -> EC
+# Following tests has been commented till RCA is complete for massive increase
+# in test completion time
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: erasure
+#        pool-2-type: replicated
+#        pool-1-conf: sample-pool-3
+#        pool-2-conf: sample-pool-3
+#      desc: Migrating data between different pools. Scenario-3. EC -> RE
+#
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: erasure
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-2
+#        pool-2-conf: sample-pool-3
+#      desc: Migrating data between different pools. Scenario-4. Ec -> EC
 
   - test:
       name: Pg autoscaler bulk flag

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -208,27 +208,27 @@ tests:
       module: test_omap_entries.py
       polarion-id: CEPH-83571702
       config:
-        verify_osd_omap_entries:
-          pool_config:
-            # EC pool config is commented out because omaps can be written only on RE pools
-            pool-1:
-              pool_type: replicated
-              pool_name: re_pool_3
-              pg_num: 1
-          omap_config:
-            small_omap:
-              large_warn: false
-              obj_start: 0
-              obj_end: 5
-              normal_objs: 400
-              num_keys_obj: 200000
-            large_omap:
-              large_warn: true
-              obj_start: 0
-              obj_end: 5
-              normal_objs: 400
-              num_keys_obj: 200001
-      desc: Large number of omap creations on objects backed by bluestore
+        # EC pool config is commented out because omaps can be written only on RE pools
+        omap_config:
+          small_omap:
+            pool_name: re_pool_small_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: false
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200000
+          large_omap:
+            pool_name: re_pool_large_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: true
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200001
+      desc: Large number of omap creation on objects and OSD resiliency
 
   - test:
       name: client pg access
@@ -252,49 +252,53 @@ tests:
               disable_pg_autoscale: true
       desc: many clients clients accessing same PG with bluestore as backend
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: replicated
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-2
-      desc: Migrating data between different pools. Scenario-1. RE -> RE
+# Following test has been commented till RCA is complete for massive increase
+# in test completion time
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: replicated
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-2
+#      desc: Migrating data between different pools. Scenario-1. RE -> RE
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-3
-      desc: Migrating data between different pools. Scenario-2. RE -> EC
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-3
+#      desc: Migrating data between different pools. Scenario-2. RE -> EC
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: erasure
-        pool-2-type: replicated
-        pool-1-conf: sample-pool-3
-        pool-2-conf: sample-pool-3
-      desc: Migrating data between different pools. Scenario-3. EC -> RE
-
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: erasure
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-2
-        pool-2-conf: sample-pool-3
-      desc: Migrating data between different pools. Scenario-4. Ec -> EC
+# Following testd has been commented till RCA is complete for massive increase
+# in test completion time
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: erasure
+#        pool-2-type: replicated
+#        pool-1-conf: sample-pool-3
+#        pool-2-conf: sample-pool-3
+#      desc: Migrating data between different pools. Scenario-3. EC -> RE
+#
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: erasure
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-2
+#        pool-2-conf: sample-pool-3
+#      desc: Migrating data between different pools. Scenario-4. Ec -> EC
 
   - test:
       name: Pg autoscaler bulk flag


### PR DESCRIPTION
### Part-1 : OMAP entries wait time optimization
Reference Jira story - [RHCEPHQE-9423](https://issues.redhat.com/browse/RHCEPHQE-9423)
Originally OMAP entries used to get reflected in the cluster statistic in these three cases:
- OMAP entries made on a pool show up automatically in the ceph df stats if enough number of omaps are written to the pool (observed previously and is still true)
Explanation for this is available here and is still true - https://bugzilla.redhat.com/show_bug.cgi?id=2139021#c36
- Ideally, OMAP stats should show up if deep-scrub is performed on a pool
- Even without deep-scrub, if OSDs which are part of the pool's acting pg set were restarted, OMAP entries were observed to recognized and displayed in the ceph df stats.

Our automation was following case number 3 as the standard workflow to verify OMAP entries on a cluster, now, lately case 2 and case 3 were no longer working and the only working case was found to be case 1
Upon further trial and error it had been observed that now combination of case 2 and case 3 was required for OMAP data to get reflected in the cluster stats.

With the PR #2597, we modified the verification of OMAP to include a combination of case 2 and case 3, for this we performed deep-scrub, waited for deep-scrub to complete and then restart the concerned OSDs and further checked for existence of OMAPs
This change in workflow resulted in test execution time increasing from 50 mins to 4 hours.
Old logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CNPDR5/

With the current PR, workflow has been changed to start deep-scrub on the concerned pool and perform OSD restart immediately after, instead of waiting for deep-scrub to complete. This whole process has been encapsulated in a smart wait _while loop_ which looks for OMAP entries to become available and restarts the OSDs otherwise.
As soon as OMAP entries get reflected, we are no longer waiting for deep-scrub to get completed, even though it is still running in the background. Rest of the test workflow remains the same.

Test modules modified:
- ceph/rados/pool_workflows.py
- ceph/rados/core_workflows.py
- tests/rados/test_omap_entries.py

Test suites modified:
- suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
- suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml

Logs:
RHCS 6.1 (mClock) - http://magna002.ceph.redhat.com/ceph-qe-logs/harsh/migrate-data-pools-mclock/
RHCS 6.1 (WPQ) - http://magna002.ceph.redhat.com/ceph-qe-logs/harsh/migrate-data-pools-wpq/

As seen from the above logs, the test execution time for the test case [Omap creations on objects](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571702) is back to ~50 mins.

Execution of compete test suite _**tier-2_rados_test-pool-functionalities.yaml**_ is in-progress and logs will be attached shortly

### Part-2 : Migration of data between pools takes huge amount of time
The pool functionalities test suite contains 4 test cases verifying the different scenarios for migration of data between pools, out these 4, 3 were observed to be taking 3-4 hours each for completion.
Initial review indicated that this degradation could be due to the introduction of mClock Scheduler as the default OSD OP Queue which wasn't part of RHCS 6.0 where these test were working fine.
However, it is pretty evident that changing the OSD OP Queue back to WPQ on a 6.1 build had no impact on this degradation and test execution time was still 2-4 hours each. The results for reference are available in the pass logs attached above.

As RCA for this degradation is still under way, the 3 concerned test cases have been commented out for the time being.
The test cases will be included again once a automation fix and / or code fix is available depending on RCA

Signed-off-by: Harsh Kumar <hakumar@redhat.com>