### PR TITLE
integrating CEPH-83574669 into cephci

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
@@ -304,6 +304,19 @@ tests:
       name: Dynamic Resharding on versioned buckets
       polarion-id: CEPH-83571740
       module: sanity_rgw_multisite.py
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            config-file-name: test_dynamic_resharding_quota_exceed.yaml
+            script-name: test_dynamic_bucket_resharding.py
+            timeout: 300
+      desc: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
+      name: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
+      polarion-id: CEPH-83574669
+      module: sanity_rgw_multisite.py
+
   - test:
       clusters:
         ceph-pri:


### PR DESCRIPTION
testing the buckets are accessible if the num_objects quota exceeds on a dynamically resharded bucket

ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/470
polarion id: [CEPH-83574669](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574669)
pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/quota_dynamic_reshrding/cephci-run-B5QCPC/
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
