### PR TITLE
[Rados] Legacy code: Enable application on OSD pools before IOPS

### DIFF
--- a/tests/rados/radosbench.py
+++ b/tests/rados/radosbench.py
@@ -9,6 +9,7 @@ def run(**kw):
     log.info("Running exec test")
     ceph_nodes = kw.get("ceph_nodes")
     config = kw.get("config")
+    rhbuild = config.get("rhbuild")
 
     clients = []
     role = "client"
@@ -45,8 +46,13 @@ def run(**kw):
     pool_create = "sudo ceph osd pool create {pool_name} {pg_num}".format(
         pool_name=pool_name, pg_num=pg_num
     )
+    pool_enable_app = "sudo ceph osd pool application enable {pool_name} rados".format(
+        pool_name=pool_name
+    )
 
     client.exec_command(cmd=pool_create)
+    if rhbuild and rhbuild.split(".")[0] >= "3":
+        client.exec_command(cmd=pool_enable_app)
     block = str(config.get("size", 4 << 20))
     time = str(config.get("time", 360))
     # block and time parameters are hardcoded to unblock the CI jobs.


### PR DESCRIPTION
[RHCEPHQE-8605](https://issues.redhat.com/browse/RHCEPHQE-8605) : Automation enhancement to enable application of OSD pools before performing IOPS

Pass logs when upgrade is performed along side parallel rados bench IOPS - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EWB6N3

Failed logs when Upgrade test is run parallely with rados_bench_test,  rbd-io, cephfs_upgrade.cephfs_io - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-41HI2O

Signed-off-by: Harsh Kumar <hakumar@redhat.com>