### PR TITLE
added pool deletion steps

### DIFF
--- a/tests/rbd_mirror/test-image-delete-from-secondary.py
+++ b/tests/rbd_mirror/test-image-delete-from-secondary.py
@@ -61,6 +61,10 @@ def test_image_delete_from_secondary(rbd_mirror, pool_type, **kw):
         log.exception(e)
         return 1
 
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
 
 def run(**kw):
     log.info("Starting RBD mirroring test case - CEPH-83574741")

--- a/tests/rbd_mirror/test-image-delete-primary-site.py
+++ b/tests/rbd_mirror/test-image-delete-primary-site.py
@@ -22,6 +22,10 @@ def test_image_delete_from_primary(rbd_mirror, pool_type, **kw):
     except Exception as e:
         log.exception(e)
 
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
     return 1
 
 

--- a/tests/rbd_mirror/test_image_removal_from_secondary.py
+++ b/tests/rbd_mirror/test_image_removal_from_secondary.py
@@ -49,6 +49,10 @@ def test_image_removal_from_secondary(rbd_mirror, pool_type, **kw):
         log.exception(e)
         return 1
 
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
+
 
 def run(**kw):
     log.info("Starting RBD mirroring test case - CEPH-10470")

--- a/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
+++ b/tests/rbd_mirror/test_mirror_move_primary_trash_restore.py
@@ -99,3 +99,7 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_mirror_move_secondary_trash.py
+++ b/tests/rbd_mirror/test_mirror_move_secondary_trash.py
@@ -17,6 +17,7 @@ def test_image_move_secondary_trash(rbd_mirror, pool_type, **kw):
     """
     try:
         mirror1 = rbd_mirror.get("mirror1")
+        mirror2 = rbd_mirror.get("mirror2")
         config = kw.get("config")
         pool = config[pool_type]["pool"]
         image = config[pool_type]["image"]
@@ -40,6 +41,10 @@ def test_image_move_secondary_trash(rbd_mirror, pool_type, **kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
 
 def run(**kw):

--- a/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
+++ b/tests/rbd_mirror/test_rbd_image_meta_mirroring.py
@@ -116,3 +116,7 @@ def run(**kw):
     except Exception as e:
         log.error(e)
         return 1
+
+    # Cleans up the pool configuration
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])


### PR DESCRIPTION
# Description
Fixes Pipeline issue RHCEPHQE-8999

Some of the older test not deleting the pools after completion of it's test,
Hence in further test unable to create pool for the VM size limitation on OSD nodes,

Solution:
Below are the list of test which keep the pool after completion of it's test

- test-image-delete-primary-site.py
- test_mirror_move_primary_trash_restore.py
- test-image-delete-from-secondary.py
- test_image_removal_from_secondary.py
- test_mirror_move_secondary_trash.py
- test_rbd_image_meta_mirroring.py

Hence added pool cleanup in the Finally clause.
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
