### PR TITLE
Add Test case to clean up the nvme-of gateway entities

### DIFF
--- a/suites/quincy/nvmeof/ceph_nvmeof_deployment.yaml
+++ b/suites/quincy/nvmeof/ceph_nvmeof_deployment.yaml
@@ -77,11 +77,6 @@ tests:
         rep_pool_config:
           pool: rbd
         install: true                           # Run SPDK with all pre-requisites
-        cleanup:
-          - pool
-          - subsystems
-          - initiators
-          - gateway
         subsystems:                             # Configure subsystems with all sub-entities
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
@@ -99,3 +94,26 @@ tests:
       module: test_ceph_nvmeof_gateway.py
       name: configure Ceph NVMEoF Gateway
       polarion-id:
+
+  # Cleanup Test Case
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+        cleanup:
+          pool: rbd
+          subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode1
+          initiators:
+              - subnqn: nqn.2016-06.io.spdk:cnode1
+                node: node7
+          gateway:
+              node: node6
+      desc: Clean up the nvme-of target entities such as pool, subsystem, Initiator, gateway
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to cleanup the nvme-of entities

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -104,6 +104,11 @@ def initiators(ceph_cluster, gateway, config):
             p.spawn(run_fio, **io_args)
 
 
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def cleanup(ceph_cluster, rbd_obj, config):
     """Cleanup the ceph-nvme gw entities.
 
@@ -112,23 +117,36 @@ def cleanup(ceph_cluster, rbd_obj, config):
         rbd_obj: RBD object
         config: test config
     """
-    if "initiators" in config["cleanup"]:
-        for initiator_cfg in config["initiators"]:
-            node = get_node_by_id(ceph_cluster, initiator_cfg["node"])
-            initiator = Initiator(node)
-            initiator.disconnect(**{"nqn": initiator_cfg["subnqn"]})
-
-    if "subsystems" in config["cleanup"]:
-        gw_node = get_node_by_id(ceph_cluster, config["gw_node"])
-        gateway = Gateway(gw_node)
-        for sub_cfg in config["subsystems"]:
-            gateway.delete_subsystem(**{"subnqn": sub_cfg["nqn"]})
+    if "cleanup" in config:
+        if "subsystems" in config["cleanup"]:
+            for sub_cfg in config["cleanup"]["subsystems"]:
+                gw_node = get_node_by_id(
+                    ceph_cluster, config["cleanup"]["gateway"]["node"]
+                )
+                gateway = Gateway(gw_node)
+                logger.info(f"Deleting subsystem {sub_cfg['nqn']} on gateway {gw_node}")
+                gateway.delete_subsystem(subnqn=sub_cfg["nqn"])
 
         if "gateway" in config["cleanup"]:
+            gw_node = get_node_by_id(ceph_cluster, config["cleanup"]["gateway"]["node"])
+            logger.info(f"Deleting gateway {gw_node}")
             delete_gateway(gw_node)
 
-    if "pool" in config["cleanup"]:
-        rbd_obj.clean_up(pools=[config["rbd_pool"]])
+        if "initiators" in config["cleanup"]:
+            for initiator_cfg in config["cleanup"]["initiators"]:
+                node = get_node_by_id(ceph_cluster, initiator_cfg["node"])
+                initiator = Initiator(node)
+                logger.info(
+                    f"Disconnecting initiator {initiator_cfg['subnqn']} on node {initiator_cfg['node']}"
+                )
+                initiator.disconnect(nqn=initiator_cfg["subnqn"])
+
+        if "pool" in config["cleanup"]:
+            pool = config["cleanup"]["pool"]
+            logger.info(f"Cleaning up pool {pool}")
+            rbd_obj.clean_up(pools=[pool])
+    else:
+        logger.info("No cleanup configuration found in the test config.")
 
 
 def run(ceph_cluster: Ceph, **kwargs) -> int:


### PR DESCRIPTION
# Description
Add Test case to clean up the gateway entities 

Test flow- 
Add test case separately for clean up/deletion of gateway properties such as Deletion of subsystem, pool, gateway, initiators

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-47PIU9/Test_to_cleanup_the_nvme-of_entities_0.log