### PR TITLE
Finds internal ip without providing NIC name of the machine

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1465,7 +1465,7 @@ class CephNode(object):
         set the internal ip of the vm which differs from floating ip
         """
         out, _ = self.exec_command(
-            cmd="/sbin/ifconfig eth0 | grep 'inet ' | awk '{ print $2}'"
+            cmd="ping -c 1 `hostname` | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+'| head -n 1"
         )
         self.internal_ip = out.strip()
 


### PR DESCRIPTION
# Description
Finds internal ip without providing NIC name of the machine. This code is working on bare-metal as well

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
