### PR TITLE
Splitted  RBD mirror regression suites into feature wise test suite

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -1123,10 +1123,30 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - dmfg
-        - name: "Tier-2 test suite for 5x - RBD mirroring functionality"
-          execution_time: "2h 9m 13s"
-          suite: "suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml"
-          global-conf: "conf/pacific/rbd/tier-2_rbd_mirror.yaml"
+        - name: "Tier-2 test suite for 5x - RBD mirroring image functionality"
+          execution_time: "1h 57m 13s"
+          suite: "suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml"
+          global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 test suite for 5x - RBD mirroring image trash functionality"
+          execution_time: "1h 57m"
+          suite: "suites/pacific/rbd/tier-2_rbd_mirror_image_trash_purge.yaml"
+          global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Tier-2 test suite for 5x - RBD mirroring failover functionality"
+          execution_time: "7h 34m"
+          suite: "suites/pacific/rbd/tier-2_rbd_mirror_failover_recovery.yaml"
+          global-conf: "conf/pacific/rbd/tier-1_rbd_mirror.yaml"
           platform: "rhel-8"
           inventory:
             openstack: "conf/inventory/rhel-8-latest.yaml"

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -962,9 +962,29 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - rados
-        - name: "Testing RBD-mirror tier-2 regression scenarios"
-          execution_time: "2h 9m 13s"
-          suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
+        - name: "Testing RBD-mirror image operations regression scenarios"
+          execution_time: "1h 57m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD-mirror image trash regression scenarios"
+          execution_time: "1h 57m"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD-mirror failover regression scenarios"
+          execution_time: "9h 30m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml"
           global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
           platform: "rhel-9"
           inventory:

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -958,9 +958,29 @@ pipelines:
             openstack: "conf/inventory/rhel-9-latest.yaml"
           metadata:
             - rados
-        - name: "Testing RBD-mirror tier-2 regression scenarios"
-          execution_time: "2h 9m 13s"
-          suite: "suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml"
+        - name: "Testing RBD-mirror image operations regression scenarios"
+          execution_time: "1h 57m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD-mirror image trash regression scenarios"
+          execution_time: "1h 57m"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml"
+          global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rbd
+        - name: "Testing RBD-mirror failover regression scenarios"
+          execution_time: "9h 30m 13s"
+          suite: "suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml"
           global-conf: "conf/quincy/rbd/5-node-2-clusters.yaml"
           platform: "rhel-9"
           inventory:

--- a/suites/pacific/rbd/tier-2_rbd_mirror_failover_recovery.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_failover_recovery.yaml
@@ -1,0 +1,208 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_failover_recovery.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    6-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - Mon, Mgr, OSD
+#     Node4 - OSD, Mon
+#     Node5 - OSD,
+#     Node6 - RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Recovery of abrupt failure of primary cluster
+      module: test_9470.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9470
+      desc: Test unplanned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown primary cluster
+      module: test_9471.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9471
+      desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of abrupt failure of secondary cluster
+      module: test_9474.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9474
+      desc: Recovery of abrupt failure of secondary cluster
+
+  - test:
+      name: Recovery of shutdown secondary cluster
+      module: test_9475.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9475
+      desc: Testing secondary cluster unplanned failover test
+
+  - test:
+      name: Mirroring in same cluster should be prevented
+      module: test_rbd_mirror_reconfig.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9511
+      desc: Verify configuring mirror to same source and target should fail

--- a/suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -1,12 +1,19 @@
 #===============================================================================================
 # Tier-level: 2
-# Test-Suite: tier-2_rbd_mirror_regression.yaml
-# Suite contains rbd-mirror tier-2 testcases
+# Test-Suite: tier-2_rbd_mirror_image_operations.yaml
 #
 # Cluster Configuration:
-#    Conf file - conf/quincy/rbd/5-node-2-clusters.yaml
+#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
 #    No of Clusters : 2
-#    Node 2 must to be a client node
+#    Each cluster configuration
+#    6-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - Mon, Mgr, OSD
+#     Node4 - OSD, Mon
+#     Node5 - OSD,
+#     Node6 - RBD Mirror
 #===============================================================================================
 tests:
   - test:
@@ -14,6 +21,7 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
       abort-on-fail: true
       clusters:
@@ -103,6 +111,7 @@ tests:
       destroy-clster: false
       module: test_cephadm.py
       name: deploy cluster
+
   - test:
         abort-on-fail: true
         clusters:
@@ -126,6 +135,7 @@ tests:
         destroy-cluster: false
         module: test_client.py
         name: configure client
+
   - test:
       abort-on-fail: true
       clusters:
@@ -142,135 +152,6 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
-
-  - test:
-      name: test-image-delete-from-primary-site
-      module: test-image-delete-primary-site.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9501
-      desc: Verify that image deleted at primary site updated at secondary
-
-  - test:
-      name: test mirror on image having snap and clone after restoring from trash
-      module: test_mirror_move_primary_trash_restore.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-11417
-      desc: Verify that image is restore and mirroring is intact
-
-  - test:
-      name: test image delete from secondary after multiple promote and demote
-      module: test-image-delete-from-secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            repeat_count: 1
-      polarion-id: CEPH-83574741
-      desc: Verify that deleting primary image also delete the secondary image
-
-  - test:
-      name: image removal from secondary after journaling feature disable
-      module: test_image_removal_from_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            repeat_count: 10
-      polarion-id: CEPH-10470
-      desc: verify that image removal from secondary after disabling journaling feature
-
-  - test:
-      name: Attempt expanding or shrinking secondary image
-      module: test_expand_or_shrink_img_at_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            ec_pool_config:
-              imagesize: 2G
-              io-total: 200M
-            rep_pool_config:
-              imagesize: 2G
-              io-total: 200M
-      polarion-id: CEPH-9500
-      desc: Verify that resizing secondary image fails
-
-  - test:
-      name: Attempt moving secondary image to trash
-      module: test_mirror_move_secondary_trash.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-11416
-      desc: Verify that moving secondary to trash fails
-
-  - test:
-      name: test image meta operations sync to secondary
-      module: test_rbd_image_meta_mirroring.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            key: ping
-            value: pong
-      polarion-id: CEPH-9524
-      desc: Verify removal of image meta gets mirrored
-
-  - test:
-      name: Recovery of abrupt failure of primary cluster
-      module: test_9470.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9470
-      desc: Test unplanned failover and failback scenario
-
-  - test:
-      name: Recovery of shutdown primary cluster
-      module: test_9471.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9471
-      desc: Test planned failover and failback scenario
-
-  - test:
-      name: Recovery of abrupt failure of secondary cluster
-      module: test_9474.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9474
-      desc: Recovery of abrupt failure of secondary cluster
-
-  - test:
-      name: Recovery of shutdown secondary cluster
-      module: test_9475.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9475
-      desc: Testing secondary cluster unplanned failover test
 
   - test:
       name: Mirroring of cloned image
@@ -293,14 +174,32 @@ tests:
       desc: Testing journal mirroring to snapshot mirroring
 
   - test:
-      name: Mirroring in same cluster should be prevented
-      module: test_rbd_mirror_reconfig.py
+      name: Attempt expanding or shrinking secondary image
+      module: test_expand_or_shrink_img_at_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io-total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io-total: 200M
+      polarion-id: CEPH-9500
+      desc: Verify that resizing secondary image fails
+
+  - test:
+      name: test image meta operations sync to secondary
+      module: test_rbd_image_meta_mirroring.py
       clusters:
         ceph-rbd1:
           config:
             imagesize: 2G
-      polarion-id: CEPH-9511
-      desc: Verify configuring mirror to same source and target should fail
+            io-total: 200M
+            key: ping
+            value: pong
+      polarion-id: CEPH-9524
+      desc: Verify removal of image meta gets mirrored
 
   - test:
       name: Image shrink in primary cluster
@@ -330,6 +229,17 @@ tests:
       desc: Verify image size at secondary when image shrink at primary cluster
 
   - test:
+      name: Test to change of mirror pool replica size
+      module: test_rbd_mirror_replica_count.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io_total: 200M
+      polarion-id: CEPH-9518
+      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
+
+  - test:
       desc: Enable and disable image feature from primary gets reflected to secondary
       module: test_rbd_mirror_image_features.py
       clusters:
@@ -357,32 +267,6 @@ tests:
       polarion-id: CEPH-9520
 
   - test:
-      name: Delete parent snap for mirrored image
-      module: test_rbd_mirror_delete_parent_snap.py
-      clusters:
-        ceph-rbd1:
-          config:
-            ec_pool_config:
-              imagesize: 2G
-              io_total: 200M
-            rep_pool_config:
-              imagesize: 2G
-              io_total: 200M
-      polarion-id: CEPH-9515
-      desc: Testing parent snapshot deletion for mirrored image
-
-  - test:
-      name: Test to change of mirror pool replica size
-      module: test_rbd_mirror_replica_count.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io_total: 200M
-      polarion-id: CEPH-9518
-      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
-
-  - test:
       name: Testing image live migration of mirrored image
       module: test_rbd_mirror_image_migration.py
       clusters:
@@ -391,46 +275,46 @@ tests:
             pool_based:
               source:
                 ec_pool_config:
-                  pool: rbd_ECpool_src1
-                  data_pool: data_pool_src1
-                  image: rbd_ec_image_src1
+                  pool: rbd_ECpool1
+                  data_pool: data_pool_ec1
+                  image: rbd_ec_image
                   size: 2G
                   io_total: 200M
                 rep_pool_config:
-                  pool: rbd_RepPool_src1
-                  image: rbd_rep_image_src1
+                  pool: rbd_RepPool1
+                  image: rbd_rep_image
                   size: 2G
                   io_total: 200M
               destination:
                 do_not_create_image: True
                 ec_pool_config:
-                  pool: rbd_ECpool_dst1
-                  data_pool: data_pool_dst1
+                  pool: rbd_ECpool2
+                  data_pool: data_pool_ec2
                 rep_pool_config:
-                  pool: rbd_RepPool_dst1
+                  pool: rbd_RepPool2
             image_based:
               source:
                 ec_pool_config:
                   mode: image
-                  pool: rbd_ECpool_src2
-                  data_pool: data_pool_src2
-                  image: rbd_ec_image_src2
+                  pool: rbd_ECpool1
+                  data_pool: data_pool_ec1
+                  image: rbd_ec_image
                   size: 2G
                   io_total: 200M
                 rep_pool_config:
                   mode: image
-                  pool: rbd_RepPool_src2
-                  image: rbd_rep_image_src2
+                  pool: rbd_RepPool1
+                  image: rbd_rep_image
                   size: 2G
                   io_total: 200M
               destination:
                 do_not_create_image: True
                 ec_pool_config:
                   mode: image
-                  pool: rbd_ECpool_dst2
-                  data_pool: data_pool_dst2
+                  pool: rbd_ECpool2
+                  data_pool: data_pool_ec2
                 rep_pool_config:
                   mode: image
-                  pool: rbd_RepPool_dst2
+                  pool: rbd_RepPool2
       polarion-id: CEPH-83573320
       desc: Image migration of mirrored image

--- a/suites/pacific/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
@@ -1,0 +1,226 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_image_trash_purge.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    6-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - Mon, Mgr, OSD
+#     Node4 - OSD, Mon
+#     Node5 - OSD,
+#     Node6 - RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: test-image-delete-from-primary-site
+      module: test-image-delete-primary-site.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9501
+      desc: Verify that image deleted at primary site updated at secondary
+
+  - test:
+      name: test mirror on image having snap and clone after restoring from trash
+      module: test_mirror_move_primary_trash_restore.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11417
+      desc: Verify that image is restore and mirroring is intact
+
+  - test:
+      name: test image delete from secondary after promote and demote
+      module: test-image-delete-from-secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            repeat_count: 1
+      polarion-id: CEPH-83574741
+      desc: Verify that deleting primary image also delete the secondary image
+
+  - test:
+      name: image removal from secondary after journaling feature disable
+      module: test_image_removal_from_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            repeat_count: 10
+      polarion-id: CEPH-10470
+      desc: verify that image removal from secondary after disabling journaling feature
+
+  - test:
+      name: Attempt moving secondary image to trash
+      module: test_mirror_move_secondary_trash.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11416
+      desc: Verify that moving secondary to trash fails
+
+  - test:
+      name: Delete parent snap for mirrored image
+      module: test_rbd_mirror_delete_parent_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io_total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io_total: 200M
+      polarion-id: CEPH-9515
+      desc: Testing parent snapshot deletion for mirrored image

--- a/suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
@@ -1,0 +1,207 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_failover_recovery.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD, 1 RBD MIRROR service daemon(s) and 1 Client
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Recovery of abrupt failure of primary cluster
+      module: test_9470.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9470
+      desc: Test unplanned failover and failback scenario
+
+  - test:
+      name: Recovery of shutdown primary cluster
+      module: test_9471.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9471
+      desc: Test planned failover and failback scenario
+
+  - test:
+      name: Recovery of abrupt failure of secondary cluster
+      module: test_9474.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9474
+      desc: Recovery of abrupt failure of secondary cluster
+
+  - test:
+      name: Recovery of shutdown secondary cluster
+      module: test_9475.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9475
+      desc: Testing secondary cluster unplanned failover test
+
+  - test:
+      name: Mirroring in same cluster should be prevented
+      module: test_rbd_mirror_reconfig.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9511
+      desc: Verify configuring mirror to same source and target should fail

--- a/suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -1,0 +1,319 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_image_operations.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    3 MONS, 2 MGR, 3 OSD, 1 RBD MIRROR service daemon(s) and 1 Client
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      name: Mirroring of cloned image
+      module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9521
+      desc: Testing mirroring of cloned image
+
+  - test:
+      name: Mirroring from journal to snapshot
+      module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-83573618
+      desc: Testing journal mirroring to snapshot mirroring
+
+  - test:
+      name: Attempt expanding or shrinking secondary image
+      module: test_expand_or_shrink_img_at_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io-total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io-total: 200M
+      polarion-id: CEPH-9500
+      desc: Verify that resizing secondary image fails
+
+  - test:
+      name: test image meta operations sync to secondary
+      module: test_rbd_image_meta_mirroring.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            key: ping
+            value: pong
+      polarion-id: CEPH-9524
+      desc: Verify removal of image meta gets mirrored
+
+  - test:
+      name: Image shrink in primary cluster
+      module: test_rbd_mirror_shrink_image_primary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            journal:
+              ec_pool_config:
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                size: 2G
+                io_total: 10
+            snapshot:
+              ec_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+      polarion-id: CEPH-9499
+      desc: Verify image size at secondary when image shrink at primary cluster
+
+  - test:
+      name: Test to change of mirror pool replica size
+      module: test_rbd_mirror_replica_count.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io_total: 200M
+      polarion-id: CEPH-9518
+      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
+
+  - test:
+      desc: Enable and disable image feature from primary gets reflected to secondary
+      module: test_rbd_mirror_image_features.py
+      clusters:
+        ceph-rbd1:
+          config:
+            journal:
+              ec_pool_config:
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                size: 2G
+                io_total: 10
+            snapshot:
+              ec_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+      name: Testing change of image feature reflection from primary to secondary
+      polarion-id: CEPH-9520
+
+  - test:
+      name: Testing image live migration of mirrored image
+      module: test_rbd_mirror_image_migration.py
+      clusters:
+        ceph-rbd1:
+          config:
+            pool_based:
+              source:
+                ec_pool_config:
+                  pool: rbd_ECpool1
+                  data_pool: data_pool_ec1
+                  image: rbd_ec_image
+                  size: 2G
+                  io_total: 200M
+                rep_pool_config:
+                  pool: rbd_RepPool1
+                  image: rbd_rep_image
+                  size: 2G
+                  io_total: 200M
+              destination:
+                do_not_create_image: True
+                ec_pool_config:
+                  pool: rbd_ECpool2
+                  data_pool: data_pool_ec2
+                rep_pool_config:
+                  pool: rbd_RepPool2
+            image_based:
+              source:
+                ec_pool_config:
+                  mode: image
+                  pool: rbd_ECpool1
+                  data_pool: data_pool_ec1
+                  image: rbd_ec_image
+                  size: 2G
+                  io_total: 200M
+                rep_pool_config:
+                  mode: image
+                  pool: rbd_RepPool1
+                  image: rbd_rep_image
+                  size: 2G
+                  io_total: 200M
+              destination:
+                do_not_create_image: True
+                ec_pool_config:
+                  mode: image
+                  pool: rbd_ECpool2
+                  data_pool: data_pool_ec2
+                rep_pool_config:
+                  mode: image
+                  pool: rbd_RepPool2
+      polarion-id: CEPH-83573320
+      desc: Image migration of mirrored image

--- a/suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
@@ -1,17 +1,17 @@
 #===============================================================================================
 # Tier-level: 2
-# Test-Suite: tier-2_rbd_mirror_regression.yaml
+# Test-Suite: tier-2_rbd_mirror_image_trash_purge.yaml
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/rbd/tier-2_rbd_mirror.yaml
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
 #    Each cluster configuration
 #    5-Node cluster(RHEL-8.3 and above)
-#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#    3 MONS, 2 MGR, 3 OSD, 1 RBD MIRROR service daemon(s) and 1 Client
 #     Node1 - Mon, Mgr, Installer
 #     Node2 - client
-#     Node3 - OSD
-#     Node4 - OSD
+#     Node3 - OSD, MON, MGR
+#     Node4 - OSD, MON
 #     Node5 - OSD, RBD Mirror
 #===============================================================================================
 tests:
@@ -110,6 +110,7 @@ tests:
       destroy-clster: false
       module: test_cephadm.py
       name: deploy cluster
+
   - test:
         abort-on-fail: true
         clusters:
@@ -133,6 +134,7 @@ tests:
         destroy-cluster: false
         module: test_client.py
         name: configure client
+
   - test:
       abort-on-fail: true
       clusters:
@@ -197,21 +199,6 @@ tests:
       desc: verify that image removal from secondary after disabling journaling feature
 
   - test:
-      name: Attempt expanding or shrinking secondary image
-      module: test_expand_or_shrink_img_at_secondary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            ec_pool_config:
-              imagesize: 2G
-              io-total: 200M
-            rep_pool_config:
-              imagesize: 2G
-              io-total: 200M
-      polarion-id: CEPH-9500
-      desc: Verify that resizing secondary image fails
-
-  - test:
       name: Attempt moving secondary image to trash
       module: test_mirror_move_secondary_trash.py
       clusters:
@@ -221,147 +208,6 @@ tests:
             io-total: 200M
       polarion-id: CEPH-11416
       desc: Verify that moving secondary to trash fails
-
-  - test:
-      name: test image meta operations sync to secondary
-      module: test_rbd_image_meta_mirroring.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-            key: ping
-            value: pong
-      polarion-id: CEPH-9524
-      desc: Verify removal of image meta gets mirrored
-
-  - test:
-      name: Recovery of abrupt failure of primary cluster
-      module: test_9470.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9470
-      desc: Test unplanned failover and failback scenario
-
-  - test:
-      name: Recovery of shutdown primary cluster
-      module: test_9471.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9471
-      desc: Test planned failover and failback scenario
-
-  - test:
-      name: Recovery of abrupt failure of secondary cluster
-      module: test_9474.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9474
-      desc: Recovery of abrupt failure of secondary cluster
-
-  - test:
-      name: Recovery of shutdown secondary cluster
-      module: test_9475.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io-total: 200M
-      polarion-id: CEPH-9475
-      desc: Testing secondary cluster unplanned failover test
-
-  - test:
-      name: Mirroring of cloned image
-      module: test_rbd_clone_mirror.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-9521
-      desc: Testing mirroring of cloned image
-
-  - test:
-      name: Mirroring from journal to snapshot
-      module: test_rbd_mirror_journal_to_snap.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-83573618
-      desc: Testing journal mirroring to snapshot mirroring
-
-  - test:
-      name: Mirroring in same cluster should be prevented
-      module: test_rbd_mirror_reconfig.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-      polarion-id: CEPH-9511
-      desc: Verify configuring mirror to same source and target should fail
-
-  - test:
-      name: Image shrink in primary cluster
-      module: test_rbd_mirror_shrink_image_primary.py
-      clusters:
-        ceph-rbd1:
-          config:
-            journal:
-              ec_pool_config:
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                size: 2G
-                io_total: 10
-            snapshot:
-              ec_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-      polarion-id: CEPH-9499
-      desc: Verify image size at secondary when image shrink at primary cluster
-
-  - test:
-      desc: Enable and disable image feature from primary gets reflected to secondary
-      module: test_rbd_mirror_image_features.py
-      clusters:
-        ceph-rbd1:
-          config:
-            journal:
-              ec_pool_config:
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                size: 2G
-                io_total: 10
-            snapshot:
-              ec_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-              rep_pool_config:
-                mode: image
-                mirrormode: snapshot
-                size: 2G
-                io_total: 10
-      name: Testing change of image feature reflection from primary to secondary
-      polarion-id: CEPH-9520
 
   - test:
       name: Delete parent snap for mirrored image
@@ -377,67 +223,3 @@ tests:
               io_total: 200M
       polarion-id: CEPH-9515
       desc: Testing parent snapshot deletion for mirrored image
-
-  - test:
-      name: Test to change of mirror pool replica size
-      module: test_rbd_mirror_replica_count.py
-      clusters:
-        ceph-rbd1:
-          config:
-            imagesize: 2G
-            io_total: 200M
-      polarion-id: CEPH-9518
-      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
-
-  - test:
-      name: Testing image live migration of mirrored image
-      module: test_rbd_mirror_image_migration.py
-      clusters:
-        ceph-rbd1:
-          config:
-            pool_based:
-              source:
-                ec_pool_config:
-                  pool: rbd_ECpool1
-                  data_pool: data_pool_ec1
-                  image: rbd_ec_image
-                  size: 2G
-                  io_total: 200M
-                rep_pool_config:
-                  pool: rbd_RepPool1
-                  image: rbd_rep_image
-                  size: 2G
-                  io_total: 200M
-              destination:
-                do_not_create_image: True
-                ec_pool_config:
-                  pool: rbd_ECpool2
-                  data_pool: data_pool_ec2
-                rep_pool_config:
-                  pool: rbd_RepPool2
-            image_based:
-              source:
-                ec_pool_config:
-                  mode: image
-                  pool: rbd_ECpool1
-                  data_pool: data_pool_ec1
-                  image: rbd_ec_image
-                  size: 2G
-                  io_total: 200M
-                rep_pool_config:
-                  mode: image
-                  pool: rbd_RepPool1
-                  image: rbd_rep_image
-                  size: 2G
-                  io_total: 200M
-              destination:
-                do_not_create_image: True
-                ec_pool_config:
-                  mode: image
-                  pool: rbd_ECpool2
-                  data_pool: data_pool_ec2
-                rep_pool_config:
-                  mode: image
-                  pool: rbd_RepPool2
-      polarion-id: CEPH-83573320
-      desc: Image migration of mirrored image


### PR DESCRIPTION
# Description
As the existing `tier-2_rbd_mirror_regression.yaml` test suite is taking longer than expected time, we have split this test suite in to different test suite as per the RBD Mirror feature wise, following changes are been done.

modified existing test suite :

- suites/pacific/rbd/tier-2_rbd_mirror_regression.yaml
- suites/quincy/rbd/tier-2_rbd_mirror_regression.yaml

New suites added are:
- suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DS9CDO
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NP4ZV8

- suites/pacific/rbd/tier-2_rbd_mirror_failover_recovery.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PQZSTU

- suites/pacific/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XOY2Z2

- suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-223NT4
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-141ZOL
Regarding `Testing change of image feature reflection from primary to secondary`  test there is bz to it 
https://bugzilla.redhat.com/show_bug.cgi?id=2177167

- suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OW7M3W

- suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-291PMN

Updated it pipeline metadata file also accordingly.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
