### PR TITLE
Adds support of providing custom IP for MON deployment

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -283,11 +283,17 @@ class BootstrapMixin:
         # Todo: need to switch installer node on any other node name provided
         #       other than installer node
         mon_node = get_node_by_id(
-            self.cluster, args.pop("mon-ip", self.installer.node.shortname)
+            self.cluster, args.get("mon-ip", self.installer.node.shortname)
         )
         if not mon_node:
-            raise ResourceNotFoundError(f"Unknown {mon_node} node name.")
-        cmd += f" --mon-ip {mon_node.ip_address}"
+            mon_ip = args.pop("mon-ip", None)
+            if mon_ip:
+                cmd += f" --mon-ip {mon_ip}"
+            else:
+                raise ResourceNotFoundError(f"Unknown {mon_node} node name.")
+        else:
+            args.pop("mon-ip", None)
+            cmd += f" --mon-ip {mon_node.ip_address}"
 
         # Bootstrap with Ceph service specification
         specs = args.get("apply-spec")


### PR DESCRIPTION
# Description
Adds support of providing custom IP for MON deployment

Eg:
  - test:
      abort-on-fail: true
      config:
            verify_cluster_health: true
            steps:
              - config:
                  command: bootstrap
                  service: cephadm
                  args:
                    mon-ip: 123.23.45.136
                    allow-fqdn-hostname: true
                    orphan-initial-daemons: true
                    initial-dashboard-password: admin@123
                    dashboard-password-noupdate: true
                    cluster-network: 123.24.0.0/16


Pass log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SU9BJN/
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
