### PR TITLE
Move Tier-2 RGW bucket_lc_multipart_object_expired under sanity-tier2…

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -284,16 +284,6 @@ pipelines:
           metadata:
             - rgw
       stage-3:
-        - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
-          execution_time: "48m 37s"
-          suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
-          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
-          platform: "rhel-8"
-          inventory:
-            openstack: "conf/inventory/rhel-8-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
-          metadata:
-            - rgw
         - name: "Tier-2 test suite for 5x - RBD functionality"
           execution_time: "57m 0s"
           suite: "suites/pacific/rbd/tier-2_rbd_regression.yaml"
@@ -571,6 +561,16 @@ pipelines:
           execution_time: "2h 8m 36s"
           suite: "suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml"
           global-conf: "conf/pacific/rgw/rgw_multisite"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
+        - name: "Tier-2 RGW bucket_lc_multipart_object_expired"
+          execution_time: "48m 37s"
+          suite: "suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
           platform: "rhel-8"
           inventory:
             openstack: "conf/inventory/rhel-8-latest.yaml"


### PR DESCRIPTION
…-stage-7

In Pipeline execution for a suite : Tier-2 RGW bucket_lc_multipart_object_expired
we are observing issue: "ImportError: libceph-common.so.2: cannot map zero-fill pages"
But we are not observing this issue when we execute the suite individually.
Pass-logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-sfffg/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-px3zr/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-272pr/

Since currently there are 8 testsuites excuting under stage-3, moving this suite under stage-7 to see if this failure is seeing because of any system issue due to multiple resource running in parallel.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
