### PR TITLE
Stretch_clusters: Adding Site reboot, Maintenance mode tests.

### DIFF
--- a/conf/pacific/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/pacific/rados/stretch-mode-host-location-attrs.yaml
@@ -29,6 +29,7 @@ globals:
           - mon
           - mgr
           - osd
+          - nfs
         no-of-volumes: 4
         disk-size: 25
       node4:
@@ -56,8 +57,12 @@ globals:
         role:
           - osd
           - mds
+          - nfs
         no-of-volumes: 4
         disk-size: 25
       node8:
+        image-name:
+          openstack: RHEL-8.8.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
         role:
           - client

--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -28,6 +28,7 @@ globals:
         role:
           - mon
           - mgr
+          - nfs
           - osd
         no-of-volumes: 4
         disk-size: 25
@@ -55,9 +56,13 @@ globals:
       node7:
         role:
           - osd
+          - nfs
           - mds
         no-of-volumes: 4
         disk-size: 25
       node8:
+        image-name:
+          openstack: RHEL-9.2.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         role:
           - client

--- a/suites/pacific/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/pacific/rados/deploy-stretch-cluster-mode.yaml
@@ -155,7 +155,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: test_deploy_stretch_cluster_baremetal.py
-      polarion-id: CEPH-83573621, CEPH-83572692
+      polarion-id: CEPH-83573625
       config:
         stretch_rule_name: "stretch_rule"
         site1:

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -19,8 +19,9 @@ tests:
           verbose: true
         args:
           registry-json: registry.redhat.io
-          custom_image: true
           mon-ip: node1
+          skip-dashboard: true
+          orphan-initial-daemons: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host
@@ -130,7 +131,9 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node8                       # client node
+        nodes:
+          - node8:
+              release: 5                    # client node
         install_packages:
           - ceph-common
           - ceph-base
@@ -140,6 +143,7 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+      abort-on-fail: true
 
   - test:
       name: Enable logging to file
@@ -151,20 +155,55 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: test_stretch_deployment_with_placement.py
-      polarion-id: CEPH-83573621
+      polarion-id: CEPH-83573621, CEPH-83572692
       config:
-        no_affinity: true
+        no_affinity: false
         stretch_rule_name: stretch_rule
         tiebreaker_mon_site_name: arbiter
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: test stretch Cluster site down - Data site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574975
       config:
-        pool_name: test_stretch_pool
+        pool_name: test_stretch_pool6
         shutdown_site: DC1
         tiebreaker_mon_site_name: arbiter
         delete_pool: true
@@ -176,9 +215,55 @@ tests:
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974
       config:
-        pool_name: test_stretch_pool
+        pool_name: test_stretch_pool5
         shutdown_site: arbiter
         tiebreaker_mon_site_name: arbiter
         delete_pool: true
       desc: Test the cluster when the arbiter site is shut down
       abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - data site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool1
+        affected_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the Data site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - arbiter site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool2
+        affected_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site reboot - Data site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool3
+        affected_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the data site is rebooted
+
+  - test:
+      name: test stretch Cluster site reboot - Arbiter site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool4
+        affected_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is rebooted

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -19,8 +19,9 @@ tests:
           verbose: true
         args:
           registry-json: registry.redhat.io
-          custom_image: true
           mon-ip: node1
+          orphan-initial-daemons: true
+          skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
             - service_type: host
@@ -130,7 +131,9 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node8                       # client node
+        nodes:
+          - node8:
+              release: 6
         install_packages:
           - ceph-common
           - ceph-base
@@ -140,6 +143,7 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+      abort-on-fail: true
 
   - test:
       name: Enable logging to file
@@ -151,20 +155,56 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: test_stretch_deployment_with_placement.py
-      polarion-id: CEPH-83573621
+      polarion-id: CEPH-83573621, CEPH-83572692
       config:
-        no_affinity: true
+        no_affinity: false
         stretch_rule_name: stretch_rule
         tiebreaker_mon_site_name: arbiter
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
+
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
 
   - test:
       name: test stretch Cluster site down - Data site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574975
       config:
-        pool_name: test_stretch_pool
+        pool_name: test_stretch_pool6
         shutdown_site: DC1
         tiebreaker_mon_site_name: arbiter
         delete_pool: true
@@ -176,9 +216,55 @@ tests:
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974
       config:
-        pool_name: test_stretch_pool
+        pool_name: test_stretch_pool5
         shutdown_site: arbiter
         tiebreaker_mon_site_name: arbiter
         delete_pool: true
       desc: Test the cluster when the arbiter site is shut down
       abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - data site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool1
+        affected_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the Data site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - arbiter site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool2
+        affected_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site reboot - Data site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool3
+        affected_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the data site is rebooted
+
+  - test:
+      name: test stretch Cluster site reboot - Arbiter site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool4
+        affected_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is rebooted

--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -124,6 +124,12 @@ def add(cls, config: Dict) -> None:
                 for repos in cdn_ceph_repo[rhel_version][rhcs_version]:
                     _node.exec_command(sudo=True, cmd=f"{enable_cmd}{repos}")
 
+                # Clearing the release preference set and cleaning all yum repos
+                # Observing selinux package dependency issues for ceph-base
+                wa_cmds = ["subscription-manager release --unset", "yum clean all"]
+                for wa_cmd in wa_cmds:
+                    _node.exec_command(sudo=True, cmd=wa_cmd)
+
             # Copy the keyring to client
             _node.exec_command(sudo=True, cmd="mkdir -p /etc/ceph")
             put_file(_node, client_file, cnt_key, "w")

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -264,7 +264,7 @@ class MonConfigMethods:
     def verify_set_config(self, **kwargs):
         """
         Verifies the values of configurations set in the mon config db via ceph config dump command
-         Args:
+        Args:
             **kwargs: Any other param that needs to be set
                 1. section: which section of daemons to target
                     allowed values: global, mon, mgr, osd, mds, client
@@ -275,45 +275,53 @@ class MonConfigMethods:
                 5. device_class: Value for location_type
                 6. location_value: value for location_type
         Returns: True -> Pass, False -> fail
-
         """
         cmd = "ceph config dump"
         config_dump = self.rados_obj.run_ceph_command(cmd)
         for entry in config_dump:
             if (
-                entry["name"] == kwargs["name"]
-                and entry["section"] == kwargs["section"]
+                entry["name"].lower() == kwargs["name"].lower()
+                and entry["section"].lower() == kwargs["section"].lower()
             ):
                 entry["value"] = str(entry["value"]).strip("\n").strip()
                 kwargs["value"] = str(kwargs["value"]).strip("\n").strip()
-                if not entry["value"] == kwargs["value"]:
+                if not entry["value"].lower() == kwargs["value"].lower():
                     log.error(
                         f"Value for config: {entry['name']} does not match in the ceph config\n"
                         f"sent value : {kwargs['value']}, Set value : {entry['value']}"
                     )
                     return False
                 if kwargs.get("location_type"):
-                    if kwargs.get("location_type") != "class":
-                        if not entry["location_type"] == kwargs["location_type"]:
+                    if kwargs.get("location_type").lower() != "class":
+                        if (
+                            not entry["location_type"].lower()
+                            == kwargs["location_type"].lower()
+                        ):
                             log.error(
                                 f"Value for config: {entry['name']} does not match in the ceph config\n"
                                 f"sent value : {kwargs['location_type']}, Set value : {entry['location_type']}"
                             )
                             return False
-                        if not entry["location_value"] == kwargs["location_value"]:
+                        if (
+                            not entry["location_value"].lower()
+                            == kwargs["location_value"].lower()
+                        ):
                             log.error(
                                 f"Value for config: {entry['name']} does not match in the ceph config\n"
                                 f"sent value : {kwargs['location_value']}, Set value : {entry['location_value']}"
                             )
                             return False
                     else:
-                        if not entry["device_class"] == kwargs["location_value"]:
+                        if (
+                            not entry["device_class"].lower()
+                            == kwargs["location_value"].lower()
+                        ):
                             log.error(
                                 f"Value for config: {entry['name']} does not match in the ceph config\n"
                                 f"sent value : {kwargs['location_value']}, Set value : {entry['device_class']}"
                             )
                             return False
-                log.info(f"Verified the value set for the config : {entry['name']}")
+                log.info(f"Verified the value set for the config: {entry['name']}")
                 return True
         log.error(f"The Config: {kwargs['name']} not listed under in the dump")
         return False

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -420,7 +420,7 @@ EOF"""
         cmd = "/bin/ceph osd setcrushmap -i /tmp/crush2.map.bin"
         node.exec_command(cmd=cmd, sudo=True)
 
-        log.info(f"Crush rule : {rule_name} added successfully")
+        log.info(f"Crush rule: {rule_name} added successfully")
         return True
     except Exception as err:
         log.error("Failed to set the crush rules")
@@ -628,11 +628,12 @@ def setup_crush_rule_with_no_affinity(node, rule_name: str) -> bool:
     """
     rule = rule_name
     rules = """id 11
-    type replicated
-    step take default
-    step choose firstn 0 type datacenter
-    step chooseleaf firstn 2 type host
-    step emit"""
+type replicated
+min_size 1
+max_size 10
+step choose firstn 0 type datacenter
+step chooseleaf firstn 2 type host
+step emit"""
     if not add_crush_rules(node=node, rule_name=rule, rules=rules):
         log.error("Failed to add the new crush rule")
         return False

--- a/tests/rados/test_stretch_site_maintenance_modes.py
+++ b/tests/rados/test_stretch_site_maintenance_modes.py
@@ -1,0 +1,251 @@
+"""
+This test module is used to test site maintenance mode scenarios with recovery in the stretch environment.
+includes:
+CEPH-83574976 - Data Site and Arbiter site Nodes enter maintenance mode.
+1. Data Sites enter maintenance mode
+2. Arbiter Site hosts enter maintenance mode
+"""
+
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from tests.rados.test_stretch_site_down import (
+    get_stretch_site_hosts,
+    post_site_down_checks,
+    stretch_enabled_checks,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    performs site maintenance mode scenarios in stretch mode
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): ceph cluster
+    """
+
+    log.info(run.__doc__)
+    config = kw.get("config")
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+    pool_name = config.get("pool_name", "test_stretch_io")
+    affected_site = config.get("affected_site", "DC1")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "Arbiter")
+
+    if not stretch_enabled_checks(rados_obj=rados_obj):
+        log.error(
+            "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
+        )
+        raise Exception("Test pre-execution checks failed")
+
+    log.info(
+        f"Starting tests of Moving {affected_site} hosts to maintenance modes. Pre-checks Passed"
+    )
+    osd_tree_cmd = "ceph osd tree"
+    buckets = rados_obj.run_ceph_command(osd_tree_cmd)
+    dc_buckets = [d for d in buckets["nodes"] if d.get("type") == "datacenter"]
+    dc_1 = dc_buckets.pop()
+    dc_1_name = dc_1["name"]
+    dc_2 = dc_buckets.pop()
+    dc_2_name = dc_2["name"]
+    all_hosts = get_stretch_site_hosts(
+        rados_obj=rados_obj, tiebreaker_mon_site_name=tiebreaker_mon_site_name
+    )
+    dc_1_hosts = all_hosts.dc_1_hosts
+    dc_2_hosts = all_hosts.dc_2_hosts
+    tiebreaker_hosts = all_hosts.tiebreaker_hosts
+
+    log.debug(
+        f"Hosts present in Datacenter : {dc_1_name} : {[entry for entry in dc_1_hosts]}"
+    )
+    log.debug(
+        f"Hosts present in Datacenter : {dc_2_name} : {[entry for entry in dc_2_hosts]}"
+    )
+    log.debug(
+        f"Hosts present in Datacenter : {tiebreaker_mon_site_name} : {[entry for entry in tiebreaker_hosts]}"
+    )
+
+    # Checking if the site passed to add into maintenance mode is present in the Cluster CRUSH
+    if affected_site not in [tiebreaker_mon_site_name, dc_1_name, dc_2_name]:
+        log.error(
+            f"Passed site : {affected_site} not part of crush locations on cluster.\n"
+            f"locations present on cluster : {[tiebreaker_mon_site_name, dc_1_name, dc_2_name]}"
+        )
+        raise Exception("Test execution failed")
+
+    # Creating test pool to check the effect of maintenance mode on the Pool IO
+    if not rados_obj.create_pool(pool_name=pool_name):
+        log.error(f"Failed to create pool : {pool_name}")
+        raise Exception("Test execution failed")
+
+    # Sleeping for 10 seconds for pool to be populated in the cluster
+    time.sleep(10)
+
+    # Collecting the init no of objects on the pool, before maintenance mode
+    pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+    init_objects = pool_stat["stats"]["objects"]
+
+    # Checking which DC to be added to maintenance mode is It data site or Arbiter site
+    if affected_site in [dc_1_name, dc_2_name]:
+        log.debug(
+            f"Proceeding to add hosts of the data site {dc_1_name} into maintenance mode"
+        )
+        # Proceeding to add hosts into maintenance mode, adding site 1
+        # Getting the name of the active mgr instance host for failover
+        # Checking for every host as a site might have more than 1 mgr instance, and the mgr can failover in same site
+        for host in dc_1_hosts:
+            log.debug(f"Proceeding to add host : {host} into maintenance mode")
+            mgr_dump = "ceph mgr dump"
+            active_mgr = rados_obj.run_ceph_command(cmd=mgr_dump, client_exec=True)
+            mgr_host = active_mgr["active_name"]
+            if host in mgr_host:
+                log.info(
+                    f"Active Mgr : {mgr_host} is running on host. Preparing to fail over"
+                )
+                cmd = "ceph mgr fail"
+                rados_obj.run_ceph_command(cmd=cmd, client_exec=True)
+                # sleeping for 10 seconds post mgr fail
+                time.sleep(10)
+
+            # Moving host into maintenance mode
+            if not rados_obj.host_maintenance_enter(hostname=host, retry=15):
+                log.error(f"Failed to add host : {host} into maintenance mode")
+                raise Exception("Test execution Failed")
+
+        log.info(
+            f"Completed addition of all the hosts in data site {dc_1_name} into maintenance mode"
+        )
+
+        # sleeping for 10 seconds for the DC to be identified as in maintenance mode and proceeding to next checks
+        time.sleep(10)
+
+        # Checking the health status of the cluster and the active alerts for maintenance mode
+        # These should be generated on the cluster
+        status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)
+        ceph_health_status = list(status_report["health"]["checks"].keys())
+        expected_health_warns = (
+            "OSD_HOST_DOWN",
+            "OSD_DOWN",
+            "OSD_FLAGS",
+            "OSD_DATACENTER_DOWN",
+            "MON_DOWN",
+            "DEGRADED_STRETCH_MODE",
+        )
+        if not all(elem in ceph_health_status for elem in expected_health_warns):
+            log.error(
+                f"We do not have the expected health warnings generated on the cluster.\n"
+                f" Warns on cluster : {ceph_health_status}\n"
+                f"Expected Warnings : {expected_health_warns}\n"
+            )
+
+        log.info(
+            f"The expected health warnings are generated on the cluster. Warnings on cluster: {ceph_health_status}"
+        )
+
+        # Checking is the cluster is marked degraed and operating in degraded mode post data site down
+        stretch_details = rados_obj.get_stretch_mode_dump()
+        if not stretch_details["degraded_stretch_mode"]:
+            log.error(
+                f"Stretch Cluster is not marked as degraded even though we have DC down : {stretch_details}"
+            )
+            raise Exception("Stretch mode degraded test Failed on the provided cluster")
+
+        log.info(
+            f"Cluster is marked degraded post DC Failure {stretch_details},"
+            f"Proceeding to try writes into cluster"
+        )
+
+    else:
+        log.info("Moving host of arbiter mon site into maintenance mode")
+        for host in tiebreaker_hosts:
+            log.debug(f"Proceeding to add host : {host} into maintenance mode")
+            if not rados_obj.host_maintenance_enter(hostname=host, retry=10):
+                log.error(f"Failed to add host : {host} into maintenance mode")
+                raise Exception("Test execution Failed")
+        time.sleep(20)
+
+        # Installer node will be in maintenance mode this point. all operations need to be done at client nodes
+        status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)
+        ceph_health_status = list(status_report["health"]["checks"].keys())
+        expected_health_warns = ("MON_DOWN", "HOST_IN_MAINTENANCE")
+        if not all(elem in ceph_health_status for elem in expected_health_warns):
+            log.error(
+                f"We do not have the expected health warnings generated on the cluster.\n"
+                f" Warns on cluster : {ceph_health_status}\n"
+                f"Expected Warnings : {expected_health_warns}\n"
+            )
+
+        log.info(
+            f"The expected health warnings are generated on the cluster. Warnings : {ceph_health_status}"
+        )
+        log.info(
+            f"Completed addition of hosts into maintenance mode in site {affected_site}."
+            f" Host names :{tiebreaker_hosts}. Proceeding to write"
+        )
+
+    # perform rados put to check if write ops is possible
+    pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=200, timeout=50)
+
+    log.debug("sleeping for 20 seconds for the objects to be displayed in ceph df")
+    time.sleep(20)
+
+    # Getting the number of objects post write, to check if writes were successful
+    pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+    log.debug(pool_stat)
+
+    # Objects should be more than the initial no of objects
+    if pool_stat["stats"]["objects"] <= init_objects:
+        log.error(
+            "Write ops should be possible, number of objects in the pool has not changed"
+        )
+        raise Exception(f"Pool {pool_name} has {pool_stat['stats']['objects']} objs")
+    log.info(
+        f"Successfully wrote {pool_stat['stats']['objects']} on pool {pool_name} in degraded mode\n"
+        f"Proceeding to bring up the nodes and recover the cluster from degraded mode"
+    )
+
+    # Starting to remove the hosts from maintenance mode.
+    if affected_site in [dc_1_name, dc_2_name]:
+        log.debug(
+            f"Proceeding to remove hosts data site {dc_1_name} from maintenance mode"
+        )
+        for host in dc_1_hosts:
+            if not rados_obj.host_maintenance_exit(hostname=host, retry=15):
+                log.error(f"Failed to remove host : {host} from maintenance mode")
+                raise Exception("Test execution Failed")
+        log.info(
+            f"Completed removing all the hosts in site {dc_1_name} from maintenance mode. Host names : {dc_1_hosts}"
+        )
+
+    else:
+        log.info("removing arbiter mon site host from maintenance mode")
+        for host in tiebreaker_hosts:
+            if not rados_obj.host_maintenance_exit(hostname=host, retry=15):
+                log.error(f"Failed to remove host : {host} from maintenance mode")
+                raise Exception("Test execution Failed")
+        time.sleep(20)
+        log.info(
+            f"Completed Restart of all the hosts in site {affected_site}. Host names : {tiebreaker_hosts}"
+        )
+
+    log.info("Proceeding to do checks post Stretch mode site down scenarios")
+
+    if not post_site_down_checks(rados_obj=rados_obj):
+        log.error(f"Checks failed post Site {affected_site} Down and Up scenarios")
+        raise Exception("Post execution checks failed on the Stretch cluster")
+
+    if not rados_obj.run_pool_sanity_check():
+        log.error(f"Checks failed post Site {affected_site} Down and Up scenarios")
+        raise Exception("Post execution checks failed on the Stretch cluster")
+
+    if config.get("delete_pool"):
+        rados_obj.detete_pool(pool=pool_name)
+
+    log.info("All the tests completed on the cluster, Pass!!!")
+    return 0

--- a/tests/rados/test_stretch_site_reboot.py
+++ b/tests/rados/test_stretch_site_reboot.py
@@ -1,0 +1,214 @@
+"""
+This test module is used to test site reboot scenarios with recovery in the stretch environment.
+includes:
+CEPH-83574977 - Reboot all the nodes of Site.
+1. Perform Data Site reboots
+2. Perform Arbiter Site hosts reboots
+"""
+
+import re
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from tests.rados.test_stretch_site_down import (
+    get_stretch_site_hosts,
+    post_site_down_checks,
+    stretch_enabled_checks,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    performs site reboot scenarios in stretch mode
+    Args:
+        ceph_cluster (ceph.ceph.Ceph): ceph cluster
+    """
+
+    log.info(run.__doc__)
+    config = kw.get("config")
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+    pool_name = config.get("pool_name", "test_stretch_io")
+    affected_site = config.get("affected_site", "DC1")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "Arbiter")
+
+    if not stretch_enabled_checks(rados_obj=rados_obj):
+        log.error(
+            "The cluster has not cleared the pre-checks to run stretch tests. Exiting..."
+        )
+        raise Exception("Test pre-execution checks failed")
+
+    log.info(f"Starting with tests to reboot {affected_site} hosts. Pre-checks Passed")
+    osd_tree_cmd = "ceph osd tree"
+    buckets = rados_obj.run_ceph_command(osd_tree_cmd)
+    dc_buckets = [d for d in buckets["nodes"] if d.get("type") == "datacenter"]
+    dc_1 = dc_buckets.pop()
+    dc_1_name = dc_1["name"]
+    dc_2 = dc_buckets.pop()
+    dc_2_name = dc_2["name"]
+    all_hosts = get_stretch_site_hosts(
+        rados_obj=rados_obj, tiebreaker_mon_site_name=tiebreaker_mon_site_name
+    )
+    dc_1_hosts = all_hosts.dc_1_hosts
+    dc_2_hosts = all_hosts.dc_2_hosts
+    tiebreaker_hosts = all_hosts.tiebreaker_hosts
+
+    log.debug(
+        f"Hosts present in Datacenter : {dc_1_name} : {[entry for entry in dc_1_hosts]}"
+    )
+    log.debug(
+        f"Hosts present in Datacenter : {dc_2_name} : {[entry for entry in dc_2_hosts]}"
+    )
+    log.debug(
+        f"Hosts present in Datacenter : {tiebreaker_mon_site_name} : {[entry for entry in tiebreaker_hosts]}"
+    )
+
+    # Checking if the site passed to reboot is present in the Cluster CRUSH
+    if affected_site not in [tiebreaker_mon_site_name, dc_1_name, dc_2_name]:
+        log.error(
+            f"Passed site : {affected_site} not part of crush locations on cluster.\n"
+            f"locations present on cluster : {[tiebreaker_mon_site_name, dc_1_name, dc_2_name]}"
+        )
+        raise Exception("Test execution failed")
+
+    # Creating test pool to check the site reboots on the Pool IO
+    if not rados_obj.create_pool(pool_name=pool_name):
+        log.error(f"Failed to create pool : {pool_name}")
+        raise Exception("Test execution failed")
+
+    # Sleeping for 10 seconds for pool to be populated in the cluster
+    time.sleep(10)
+
+    # Collecting the init no of objects on the pool, before reboots
+    pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+    init_objects = pool_stat["stats"]["objects"]
+
+    # Checking which DC to be rebooted
+    if affected_site in [dc_1_name, dc_2_name]:
+        log.debug(f"Proceeding to reboot hosts of the data site {dc_1_name}")
+        # Proceeding to reboot hosts
+        for host in dc_1_hosts:
+            log.debug(f"Proceeding to reboot host : {host}")
+            host_obj = get_host_obj_from_hostname(hostname=host, rados_obj=rados_obj)
+            host_obj.exec_command(cmd="reboot", sudo=True, check_ec=False)
+            time.sleep(2)
+
+        log.info(f"Completed reboot of all the hosts in data site {dc_1_name}")
+
+        # sleeping for 5 seconds for the hosts to reboot and proceeding to next checks
+        time.sleep(5)
+
+        # Checking the health status of the cluster and the active alerts
+        # These should be generated on the cluster
+        status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)
+        ceph_health_status = list(status_report["health"]["checks"].keys())
+        expected_health_warns = (
+            "OSD_HOST_DOWN",
+            "OSD_DOWN",
+            "MON_DOWN",
+        )
+        if not all(elem in ceph_health_status for elem in expected_health_warns):
+            log.error(
+                f"We do not have the expected health warnings generated on the cluster.\n"
+                f" Warns on cluster : {ceph_health_status}\n"
+                f"Expected Warnings : {expected_health_warns}\n"
+            )
+
+        log.info(
+            f"The expected health warnings are generated on the cluster. Warnings on cluster: {ceph_health_status}"
+        )
+
+        log.info("Proceeding to try writes into cluster post reboots")
+
+    else:
+        log.info("Rebooting host of arbiter mon site")
+        for host in tiebreaker_hosts:
+            log.debug(f"Proceeding to reboot host : {host}")
+            host_obj = get_host_obj_from_hostname(hostname=host, rados_obj=rados_obj)
+            host_obj.exec_command(cmd="reboot", sudo=True, check_ec=False)
+            time.sleep(2)
+
+        # Installer node will be in maintenance mode this point. all operations need to be done at client nodes
+        status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)
+        ceph_health_status = list(status_report["health"]["checks"].keys())
+        expected_health_warns = ("MON_DOWN",)
+        if not all(elem in ceph_health_status for elem in expected_health_warns):
+            log.error(
+                f"We do not have the expected health warnings generated on the cluster.\n"
+                f" Warns on cluster : {ceph_health_status}\n"
+                f"Expected Warnings : {expected_health_warns}\n"
+            )
+
+        log.info(
+            f"The expected health warnings are generated on the cluster. Warnings : {ceph_health_status}"
+        )
+        log.info(
+            f"Completed addition of hosts into maintenance mode in site {affected_site}."
+            f" Host names :{tiebreaker_hosts}. Proceeding to write"
+        )
+
+    # perform rados put to check if write ops is possible
+    pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=200, timeout=50)
+
+    log.debug("sleeping for 20 seconds for the objects to be displayed in ceph df")
+    time.sleep(20)
+
+    # Getting the number of objects post write, to check if writes were successful
+    pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+    log.debug(pool_stat)
+
+    # Objects should be more than the initial no of objects
+    if pool_stat["stats"]["objects"] <= init_objects:
+        log.error(
+            "Write ops should be possible, number of objects in the pool has not changed"
+        )
+        raise Exception(f"Pool {pool_name} has {pool_stat['stats']['objects']} objs")
+    log.info(
+        f"Successfully wrote {pool_stat['stats']['objects']} on pool {pool_name} in degraded mode\n"
+        f"Proceeding to bring up the nodes and recover the cluster from degraded mode"
+    )
+
+    log.info("Proceeding to do checks post Stretch mode site reboot scenarios")
+
+    if not post_site_down_checks(rados_obj=rados_obj):
+        log.error(f"Checks failed post Site {affected_site} Down and Up scenarios")
+        raise Exception("Post execution checks failed on the Stretch cluster")
+
+    if not rados_obj.run_pool_sanity_check():
+        log.error(f"Checks failed post Site {affected_site} Down and Up scenarios")
+        raise Exception("Post execution checks failed on the Stretch cluster")
+
+    if config.get("delete_pool"):
+        rados_obj.detete_pool(pool=pool_name)
+
+    log.info("All the tests completed on the cluster, Pass!!!")
+    return 0
+
+
+def get_host_obj_from_hostname(hostname, rados_obj):
+    """
+    returns the host object for the hostname passed
+
+    Args:
+        hostname: name of the host whose host obj is required
+        rados_obj: rados object to perform operations
+
+    Returns:
+        Host object for the hostname passed
+
+    """
+    host_nodes = rados_obj.ceph_cluster.get_nodes()
+    for node in host_nodes:
+        if (
+            re.search(hostname.lower(), node.hostname.lower())
+            or re.search(hostname.lower(), node.vmname.lower())
+            or re.search(hostname.lower(), node.shortname.lower())
+        ):
+            return node


### PR DESCRIPTION
Tests added in the PR:
1. CEPH-83574977 - Site Reboot tests
2. CEPH-83574976 - Maintenance mode tests General enhancements to code 
3. Added custom clients in the suites to avoid ceph-base package dependency errors when working with nightly builds.
4. Changed command execution from the installer node to the client node with optional param, to tackle host down of Installer node scenarios.
5. Added `subscription-manager release --unset` , ` yum clean all ` commands In cases with custom client versions to clean up residues during init.