### PR TITLE
Addition of missing Polarion IDs to Rados Test Suites

### DIFF
--- a/suites/pacific/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/pacific/rados/tier-2-rados-basic-regression.yaml
@@ -130,7 +130,9 @@ tests:
   - test:
       name: Test configuration Assimilation
       module: test_config_assimilation.py
-      polarion-id: CEPH-83573480
+      # CEPH-83573805 is generic polarion test
+      # for generic rados test with cephadm module
+      polarion-id: CEPH-83573480, CEPH-83573805
       config:
         cluster_conf_path: "conf/pacific/rados/test-confs/cluster-configs"
         Verify_config_parameters:
@@ -298,7 +300,7 @@ tests:
   - test:
       name: Compression algorithm tuneables
       module: rados_prep.py
-      polarion-id: CEPH-83571669
+      polarion-id: CEPH-83571671
       config:
         enable_compression:
           pool_name: re_pool_compress

--- a/suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/pacific/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -155,7 +155,7 @@ tests:
   - test:
       name: EC pool with Overwrites
       module: rados_prep.py
-      polarion-id: CEPH-83571730
+      polarion-id: CEPH-83571730, CEPH-11684
       config:
         ec_pool:
           create: true

--- a/suites/pacific/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -160,7 +160,7 @@ tests:
   - test:
       name: Automatic trimming of Mon DB
       module: customer_scenarios.py
-      polarion-id: CEPH-83574095, CEPH-10311
+      polarion-id: CEPH-83574095, CEPH-10311, CEPH-83574466
       config:
         mondb_trim_config:
           paxos_service_trim_min: 10

--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -93,7 +93,7 @@ tests:
       name: Robust rebalancing - osd replacement
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration
-      polarion-id: CEPH-9205, CEPH-9170
+      polarion-id: CEPH-9205, CEPH-83571676
       abort-on-fail: true
       config:
         create_pools:

--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -125,7 +125,6 @@ tests:
         pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
-
   - test:
       name: Autoscaler test - pool target size ratio
       module: pool_tests.py
@@ -260,7 +259,7 @@ tests:
 #  - test:
 #      name: Migrate data bw pools.
 #      module: test_data_migration_bw_pools.py
-#      polarion-id: CEPH-83574768
+#      polarion-id: CEPH-83574768, CEPH-10326
 #      config:
 #        pool-1-type: replicated
 #        pool-2-type: erasure
@@ -329,7 +328,6 @@ tests:
         Verify_pool_min_size_behaviour:
           pool_name: test-pool-3
       desc: Verify that Clients can read and write data into pools with min_size OSDs
-      abort-on-fail: true
 
   - test:
       name: Compression test - replicated pool
@@ -352,6 +350,16 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
+
+# Blocked due to BZ 2172795
+#  - test:
+#      name: Verify cluster behaviour during PG autoscaler warn
+#      module: pool_tests.py
+#      polarion-id:  CEPH-83573413
+#      config:
+#        verify_autoscaler_warn:
+#          pool_name: test-pool-10
+#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
   - test:
       name: Verify degraded pool behaviour at min_size

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -134,7 +134,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: stretch_cluster.py
-      polarion-id: CEPH-83573621
+      polarion-id: CEPH-83573621, CEPH-83572692
       config:
         site1: site-A
         site2: site-B
@@ -181,7 +181,7 @@ tests:
       name: Upgrade ceph
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791
+      polarion-id: CEPH-83573791, CEPH-83574982
       config:
         command: start
         service: upgrade

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
@@ -114,7 +114,12 @@ tests:
   - test:
       name: Replicated pool LC
       module: rados_prep.py
-      polarion-id: CEPH-83571632
+      # CEPH-83573626 is added here as it is
+      # a prerequistite for replicated pool
+      # creation
+      # CEPH-83573626: covers mons, OSDs in
+      # stretch cluster mode
+      polarion-id: CEPH-83571632, CEPH-83573626
       config:
         replicated_pool:
           create: true
@@ -136,7 +141,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: stretch_cluster.py
-      polarion-id: CEPH-83573621
+      polarion-id: CEPH-83573621, CEPH-83574968
       config:
         site1: site-A
         site2: site-B
@@ -170,7 +175,7 @@ tests:
           size: 10G
         io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
-      polarion-id: CEPH-9876
+      polarion-id: CEPH-9876, CEPH-83574972
 
   - test:
       name: rgw sanity tests

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -155,7 +155,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: test_stretch_deployment_with_placement.py
-      polarion-id: CEPH-83573621, CEPH-83572692
+      polarion-id: CEPH-83572692, CEPH-83573625
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -116,7 +116,9 @@ tests:
   - test:
       name: Test configuration Assimilation
       module: test_config_assimilation.py
-      polarion-id: CEPH-83573480
+      # CEPH-83573805 is generic polarion test
+      # for generic rados test with cephadm module
+      polarion-id: CEPH-83573480, CEPH-83573805
       config:
         cluster_conf_path: "conf/quincy/rados/test-confs/cluster-configs"
         Verify_config_parameters:
@@ -323,7 +325,7 @@ tests:
   - test:
       name: Compression algorithm tuneables
       module: rados_prep.py
-      polarion-id: CEPH-83571669
+      polarion-id: CEPH-83571671
       config:
         enable_compression:
           pool_name: re_pool_compress

--- a/suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -155,7 +155,7 @@ tests:
   - test:
       name: EC pool with Overwrites
       module: rados_prep.py
-      polarion-id: CEPH-83571730
+      polarion-id: CEPH-83571730, CEPH-11684
       config:
         ec_pool:
           create: true

--- a/suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -160,7 +160,7 @@ tests:
   - test:
       name: Automatic trimming of Mon DB
       module: customer_scenarios.py
-      polarion-id: CEPH-83574095
+      polarion-id: CEPH-83574095, CEPH-10311, CEPH-83574466
       config:
         mondb_trim_config:
           paxos_service_trim_min: 10

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -94,7 +94,7 @@ tests:
       name: Robust rebalancing - osd replacement
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration
-      polarion-id: CEPH-9205
+      polarion-id: CEPH-9205, CEPH-83571676
       abort-on-fail: true
       config:
         create_pools:

--- a/suites/quincy/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -21,8 +21,9 @@ tests:
               base_cmd_args:
                 verbose: true
               args:
-                custom_image: "registry.redhat.io/rhceph/rhceph-5-rhel8:5-184"
-                custom_repo: "https://download.eng.bos.redhat.com/rel-eng/rhel-8/RHCEPH-5/RHCEPH-5.1-RHEL-8-RC-4.1/compose/Tools/x86_64/os/"
+                # using 6.1 rc candidate
+                custom_image: "registry-proxy.engineering.redhat.com/rh-osbs/rhceph:6-177"
+                custom_repo: "http://download-node-02.eng.bos.redhat.com/rhel-9/rel-eng/RHCEPH-6/RHCEPH-6.1-RHEL-9-20230602.0/compose/Tools/x86_64/os/"
                 mon-ip: depressa007
                 allow-fqdn-hostname: true
                 yes-i-know: true

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -268,7 +268,7 @@ tests:
 #  - test:
 #      name: Migrate data bw pools.
 #      module: test_data_migration_bw_pools.py
-#      polarion-id: CEPH-83574768
+#      polarion-id: CEPH-83574768, CEPH-10326
 #      config:
 #        pool-1-type: replicated
 #        pool-2-type: erasure
@@ -349,6 +349,16 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
+
+# Blocked due to BZ 2172795
+#  - test:
+#      name: Verify cluster behaviour during PG autoscaler warn
+#      module: pool_tests.py
+#      polarion-id:  CEPH-83573413
+#      config:
+#        verify_autoscaler_warn:
+#          pool_name: test-pool-10
+#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
   - test:
       name: Verify degraded pool behaviour at min_size

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -134,7 +134,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: stretch_cluster.py
-      polarion-id: CEPH-83573621
+      polarion-id: CEPH-83573621, CEPH-83572692
       config:
         site1: site-A
         site2: site-B
@@ -181,7 +181,7 @@ tests:
       name: Upgrade ceph
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791
+      polarion-id: CEPH-83573791, CEPH-83574982
       config:
         command: start
         service: upgrade

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
@@ -113,7 +113,12 @@ tests:
   - test:
       name: Replicated pool LC
       module: rados_prep.py
-      polarion-id: CEPH-83571632
+      # CEPH-83573626 is added here as it is
+      # a prerequistite for replicated pool
+      # creation
+      # CEPH-83573626: covers mons, OSDs in
+      # stretch cluster mode
+      polarion-id: CEPH-83571632, CEPH-83573626
       config:
         replicated_pool:
           create: true
@@ -135,7 +140,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: stretch_cluster.py
-      polarion-id: CEPH-83573621
+      polarion-id: CEPH-83573621, CEPH-83574968
       config:
         site1: site-A
         site2: site-B
@@ -169,7 +174,7 @@ tests:
           size: 10G
         io-total: 100M
       desc: Perform export during read/write,resizing,flattening,lock operations
-      polarion-id: CEPH-9876
+      polarion-id: CEPH-9876, CEPH-83574972
 
   - test:
       name: rgw sanity tests

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -155,7 +155,7 @@ tests:
   - test:
       name: Deploy stretch Cluster
       module: test_stretch_deployment_with_placement.py
-      polarion-id: CEPH-83573621, CEPH-83572692
+      polarion-id: CEPH-83572692, CEPH-83573625
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule

--- a/suites/quincy/upstream/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/upstream/tier-2-rados-basic-regression.yaml
@@ -296,7 +296,7 @@ tests:
   - test:
       name: Compression algorithm tuneables
       module: rados_prep.py
-      polarion-id: CEPH-83571669
+      polarion-id: CEPH-83571671
       config:
         enable_compression:
           pool_name: re_pool_compress


### PR DESCRIPTION
The PR addresses the changes required to include RADOS Polarion IDs which were marked automated but were missing from the RADOS test suites.

As these are cosmetic changes at suite level, pass logs are not essential.
These changes have been made with the assumption that comma separated Polarion IDs will be considered while logging test run results.

Adding DNM tag as these changes would be need to be made to Reef Test Suites which are being added with #2669 (yet to merge)

Signed-off-by: Harsh Kumar <hakumar@redhat.com>