### PR TITLE
TFA: LC expiration and test sync with 0 shards

### DIFF
--- a/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
@@ -450,7 +450,7 @@ tests:
           config:
             set-env: true
             script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_rule_prefix_non_current_days.yaml
+            config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
             timeout: 300
       desc: test LC from primary to secondary
       module: sanity_rgw_multisite.py


### PR DESCRIPTION
TFA ticket : https://issues.redhat.com/browse/RHCEPHQE-9364

ceph-qe-scrpts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/474
Adding the sync_test_0_shards() that was removed from reusable.py
logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YZTTFM/test_sync_on_bucket_with_0_shards_0.log

Also adding the config file for LC expiration to test from primary to secondary.

logs for http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XT4MC1/test_LC_from_primary_to_secondary_0.log