### PR TITLE
Adding test - Concurrent writes with exclusive lock. persistent write cache

### DIFF
--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -7,286 +7,312 @@
 
 tests:
 
-# Set up the cluster
-  - test:
-      abort-on-fail: true
-      module: install_prereq.py
-      name: install ceph pre-requisites
-  - test:
-      abort-on-fail: true
-      config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: bootstrap
-              service: cephadm
-              args:
-                mon-ip: node1
-                registry-url: registry.redhat.io
-                allow-fqdn-hostname: true
-          - config:
-              command: add_hosts
-              service: host
-              args:
-                attach_ip_address: true
-                labels: apply-all-labels
-          - config:
-              command: apply
-              service: mgr
-              args:
-                placement:
-                  label: mgr
-          - config:
-              command: apply
-              service: mon
-              args:
-                placement:
-                  label: mon
-          - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
-      desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
-      module: test_cephadm.py
-      name: deploy cluster
+# # # Set up the cluster
+#   - test:
+#       abort-on-fail: true
+#       module: install_prereq.py
+#       name: install ceph pre-requisites
+#   - test:
+#       abort-on-fail: true
+#       config:
+#         verify_cluster_health: true
+#         steps:
+#           - config:
+#               command: bootstrap
+#               service: cephadm
+#               args:
+#                 mon-ip: node1
+#                 registry-url: registry.redhat.io
+#                 allow-fqdn-hostname: true
+#           - config:
+#               command: add_hosts
+#               service: host
+#               args:
+#                 attach_ip_address: true
+#                 labels: apply-all-labels
+#           - config:
+#               command: apply
+#               service: mgr
+#               args:
+#                 placement:
+#                   label: mgr
+#           - config:
+#               command: apply
+#               service: mon
+#               args:
+#                 placement:
+#                   label: mon
+#           - config:
+#               command: apply
+#               service: osd
+#               args:
+#                 all-available-devices: true
+#       desc: RHCS cluster deployment using cephadm
+#       destroy-clster: false
+#       module: test_cephadm.py
+#       name: deploy cluster
 
-#  Test cases to be executed
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        node: node6
-        install_packages:
-          - ceph-common
-          - fio
-        copy_admin_keyring: true
-      desc: Configure client node
-      destroy-cluster: false
-      module: test_client.py
-      name: configure client
-      polarion-id: CEPH-83573758
+# #  Test cases to be executed
+#   - test:
+#       abort-on-fail: true
+#       config:
+#         command: add
+#         id: client.1
+#         node: node5
+#         install_packages:
+#           - ceph-common
+#           - fio
+#           - rbd-nbd
+#         copy_admin_keyring: true
+#       desc: Configure client node
+#       destroy-cluster: false
+#       module: test_client.py
+#       name: configure client
+#       polarion-id: CEPH-83573758
 
-  - test:
-      name: RBD PWL cache validation.
-      desc: PWL Cache validation at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574707
-      abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdb
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: PWL validation at client level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: RBD Persistent Cache - Client level configuration
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdc
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: PWL validation at pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: RBD Persistent Cache - Pool level configuration
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdd
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: PWL validation at image level
-          module: test_rbd_persistent_write_back_cache.py
-          name: RBD Persistent Cache - image level configuration
+#   - test:
+#       name: RBD PWL cache validation.
+#       desc: PWL Cache validation at client pool and image level.
+#       module: test_parallel.py
+#       polarion-id: CEPH-83574707
+#       abort-on-fail: true
+#       parallel:
+#       - test:
+#           abort-on-fail: true
+#           config:
+#             level: client                        # PWL at client
+#             cache_file_size: 1073741824          # 1 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node5
+#             drive: /dev/nvme0n1
+#             cleanup: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool1
+#               image: image1
+#               size: 10G
+#             fio:
+#               image_name: image1
+#               pool_name: pool1
+#               runtime: 120
+#           desc: PWL validation at client level
+#           destroy-cluster: false
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: RBD Persistent Cache - Client level configuration
+#       - test:
+#           config:
+#             level: pool                          # PWL at Pool level
+#             cache_file_size: 2147483648          # 2 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node5
+#             drive: /dev/nvme0n1
+#             cleanup: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool2
+#               image: image2
+#               size: 20G
+#             fio:
+#               image_name: image2
+#               pool_name: pool2
+#               runtime: 120
+#           desc: PWL validation at pool level
+#           destroy-cluster: false
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: RBD Persistent Cache - Pool level configuration
+#       - test:
+#           config:
+#             level: image                         # PWL at image level
+#             cache_file_size: 4294967296          # 4 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node5
+#             drive: /dev/nvme0n1
+#             cleanup: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool3
+#               image: image3
+#               size: 40G
+#             fio:
+#               image_name: image3
+#               pool_name: pool3
+#               runtime: 120
+#           desc: PWL validation at image level
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: RBD Persistent Cache - image level configuration
 
-  - test:
-      name: RBD PWL cache size validation.
-      desc: PWL cache size validation at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574722
-      abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdb
-            cleanup: true
-            validate_cache_size: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: RBD Persistent Cache cache size validation Client level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name:  PWL cache size validation at client level
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdc
-            cleanup: true
-            validate_cache_size: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: RBD Persistent Cache cache size validation pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache size validation at pool level
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdd
-            cleanup: true
-            validate_cache_size: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: RBD Persistent Cache cache size validation image level
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache size validation at image level
+#   - test:
+#       name: RBD PWL cache size validation.
+#       desc: PWL cache size validation at client pool and image level.
+#       module: test_parallel.py
+#       polarion-id: CEPH-83574722
+#       abort-on-fail: true
+#       parallel:
+#       - test:
+#           abort-on-fail: true
+#           config:
+#             level: client                        # PWL at client
+#             cache_file_size: 1073741824          # 1 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node6
+#             drive: /dev/sdb
+#             cleanup: true
+#             validate_cache_size: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool1
+#               image: image1
+#               size: 10G
+#             fio:
+#               image_name: image1
+#               pool_name: pool1
+#               runtime: 120
+#           desc: RBD Persistent Cache cache size validation Client level
+#           destroy-cluster: false
+#           module: test_rbd_persistent_write_back_cache.py
+#           name:  PWL cache size validation at client level
+#       - test:
+#           config:
+#             level: pool                          # PWL at Pool level
+#             cache_file_size: 2147483648          # 2 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node6
+#             drive: /dev/sdc
+#             cleanup: true
+#             validate_cache_size: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool2
+#               image: image2
+#               size: 20G
+#             fio:
+#               image_name: image2
+#               pool_name: pool2
+#               runtime: 120
+#           desc: RBD Persistent Cache cache size validation pool level
+#           destroy-cluster: false
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: PWL cache size validation at pool level
+#       - test:
+#           config:
+#             level: image                         # PWL at image level
+#             cache_file_size: 4294967296          # 4 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node6
+#             drive: /dev/sdd
+#             cleanup: true
+#             validate_cache_size: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool3
+#               image: image3
+#               size: 40G
+#             fio:
+#               image_name: image3
+#               pool_name: pool3
+#               runtime: 120
+#           desc: RBD Persistent Cache cache size validation image level
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: PWL cache size validation at image level
 
-  - test:
-      name: RBD PWL cache path validation.
-      desc: PWL cache path validation at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574721
-      abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdb
-            cleanup: true
-            validate_cache_path: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: RBD Persistent Cache path validation Client level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name:  PWL cache path validation at client level
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdc
-            cleanup: true
-            validate_cache_path: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: RBD Persistent Cache cache path validation pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache path validation at pool level
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/sdd
-            cleanup: true
-            validate_cache_path: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: RBD Persistent Cache cache path validation image level
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache path validation at image level
+#   - test:
+#       name: RBD PWL cache path validation.
+#       desc: PWL cache path validation at client pool and image level.
+#       module: test_parallel.py
+#       polarion-id: CEPH-83574721
+#       abort-on-fail: true
+#       parallel:
+#       - test:
+#           abort-on-fail: true
+#           config:
+#             level: client                        # PWL at client
+#             cache_file_size: 1073741824          # 1 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node6
+#             drive: /dev/sdb
+#             cleanup: true
+#             validate_cache_path: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool1
+#               image: image1
+#               size: 10G
+#             fio:
+#               image_name: image1
+#               pool_name: pool1
+#               runtime: 120
+#           desc: RBD Persistent Cache path validation Client level
+#           destroy-cluster: false
+#           module: test_rbd_persistent_write_back_cache.py
+#           name:  PWL cache path validation at client level
+#       - test:
+#           config:
+#             level: pool                          # PWL at Pool level
+#             cache_file_size: 2147483648          # 2 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node6
+#             drive: /dev/sdc
+#             cleanup: true
+#             validate_cache_path: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool2
+#               image: image2
+#               size: 20G
+#             fio:
+#               image_name: image2
+#               pool_name: pool2
+#               runtime: 120
+#           desc: RBD Persistent Cache cache path validation pool level
+#           destroy-cluster: false
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: PWL cache path validation at pool level
+#       - test:
+#           config:
+#             level: image                         # PWL at image level
+#             cache_file_size: 4294967296          # 4 GB
+#             rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#             client: node6
+#             drive: /dev/sdd
+#             cleanup: true
+#             validate_cache_path: true
+#             rep-pool-only: True
+#             rep_pool_config:
+#               pool: pool3
+#               image: image3
+#               size: 40G
+#             fio:
+#               image_name: image3
+#               pool_name: pool3
+#               runtime: 120
+#           desc: RBD Persistent Cache cache path validation image level
+#           module: test_rbd_persistent_write_back_cache.py
+#           name: PWL cache path validation at image level
+
+#   - test:
+#       abort-on-fail: true
+#       config:
+#         level: client                        # PWL at client
+#         cache_file_size: 1073741824          # 1 GB
+#         rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+#         client: node6
+#         drive: /dev/sdb
+#         cleanup: true
+#         validate_exclusive_lock: true
+#         rep-pool-only: True
+#         rep_pool_config:
+#           pool: pool1
+#           image: image1
+#           size: 10G
+#         fio:
+#           image_name: image1
+#           pool_name: pool1
+#           runtime: 120
+#       desc: Validate PWL cache non-working without exclusive lock feature
+#       destroy-cluster: false
+#       module: test_rbd_persistent_write_back_cache.py
+#       name: PWL cache creation with exclusive lock
+#       polarion-id: CEPH-83574719
 
   - test:
       abort-on-fail: true
@@ -294,8 +320,8 @@ tests:
         level: client                        # PWL at client
         cache_file_size: 1073741824          # 1 GB
         rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-        client: node6
-        drive: /dev/sdb
+        client: node5
+        drive: /dev/nvme0n1
         cleanup: true
         validate_exclusive_lock: true
         rep-pool-only: True
@@ -307,8 +333,8 @@ tests:
           image_name: image1
           pool_name: pool1
           runtime: 120
-      desc: Validate PWL cache non-working without exclusive lock feature
+      desc: Validate concurrent writes to exclusive lock feature with persistent cache enabled
       destroy-cluster: false
-      module: test_rbd_persistent_write_back_cache.py
-      name: PWL cache creation with exclusive lock
-      polarion-id: CEPH-83574719
+      module: test_concurrent_writes_rbd_persistent_writeback_cache.py
+      name: PWL cache creation with exclusive lock and concurrent writes
+      polarion-id: CEPH-83574720

--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -116,10 +116,17 @@ def krbd_io_handler(**kw):
                         size=config.get("file_size", "100M"),
                     )
                 else:
+                    fio_args = {
+                        "client_node": rbd.ceph_client,
+                        "device_name": device_names[-1]
+                    }
+                    if config.get("io_size"):
+                        fio_args.update({"size": config.get("io_size")})
+                    else:
+                        fio_args.update({"runtime": config.get("runtime", 30)})
+
                     run_fio(
-                        client_node=rbd.ceph_client,
-                        device_name=device_names[-1],
-                        runtime=config.get("runtime", 30),
+                        **fio_args
                     )
 
             if operations.get("fsck"):
@@ -139,7 +146,7 @@ def krbd_io_handler(**kw):
                         )
                         return_flag = 1
                     if operations.get("device_map"):
-                        if rbd.device_unmap(
+                        if rbd.device_map(
                             "unmap",
                             f"{pool_name}/{image_name}",
                             config.get("device_type", "nbd"),

--- a/tests/rbd/rbd_peristent_writeback_cache.py
+++ b/tests/rbd/rbd_peristent_writeback_cache.py
@@ -206,9 +206,16 @@ def get_entity_level(config):
     return config_level, entity
 
 
-def fio_ready(config, client):
+def fio_ready(config, client, **kw):
     """Method to prepare FIO config args."""
     fio_args = config["fio"]
     fio_args["client_node"] = client
     fio_args["long_running"] = True
+
+    if kw:
+        fio_args.update(kw)
+    # if kw.get("test_name"):
+    #     fio_args["test_name"] = kw["test_name"]
+    # if kw.get("size"):
+    #     fio_args["size"] = kw["size"]
     return fio_args

--- a/tests/rbd/test_concurrent_writes_rbd_persistent_writeback_cache.py
+++ b/tests/rbd/test_concurrent_writes_rbd_persistent_writeback_cache.py
@@ -1,0 +1,210 @@
+"""RBD Persistent write back cache, Test concurrent writes to same image
+
+Test Case Covered:
+CEPH-83574720 - 
+Concurrent writes to check exclusive lock feature with persistent cache enables via same or different IO tools in SSD mode
+
+Steps : 
+1) Setup persistent write cache for an image
+2) Write data to the same image concurrently using two or more long running fio jobs
+3) Verify that data written is not corrupted using rbd status command
+
+Environment and limitations:
+ - The cluster should have 5 nodes + 1 SSD cache node
+ - cluster/global-config-file: config/quincy/upi/octo-5-node-env.yaml
+ - Should be Bare-metal.
+
+Support
+- Configure cluster with PWL Cache.
+- Only replicated pool supported, No EC pools.
+"""
+import json
+import pdb
+
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id
+from tests.rbd.rbd_peristent_writeback_cache import (
+    PersistentWriteAheadLog,
+    PWLException,
+    fio_ready,
+    get_entity_level,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+from tests.rbd.krbd_io_handler import krbd_io_handler
+
+log = Log(__name__)
+
+
+def unmount(rbd, mount_point):
+    """ """
+    flag = 0
+    umount_cmd = f"umount -f {mount_point}"
+    # if kw.get("read_only"):
+    #     umount_cmd += " -o ro,noload"
+    if rbd.exec_cmd(cmd=umount_cmd, sudo=True):
+        log.error(f"Umount failed for {mount_point}")
+        flag = 1
+
+    if rbd.exec_cmd(cmd=f"rm -rf {mount_point}", sudo=True):
+        log.error(f"Remove dir failed for {mount_point}")
+        flag = 1
+
+    return flag
+
+
+def device_cleanup(rbd, **kw):
+    """
+    """
+    cmd = "lsblk --include 43 --json"
+    out = rbd.exec_cmd(cmd=cmd, sudo=True, output=True)
+    if out:
+        nbd_devices = json.loads(out)
+
+        for devices in nbd_devices.get("blockdevices"):
+            device_name = f"/dev/{devices.get('name')}"
+            mount_point = devices.get("mountpoint")
+            unmount(rbd=rbd, mount_point=mount_point)
+            if rbd.device_map(
+                "unmap",
+                f"{device_name}",
+                kw.get("device_type", "nbd"),
+            ):
+                log.error(
+                    f"Device unmap failed for {device_name} "
+                )
+
+
+def validate_concurrent_writes(cache, cfg, client):
+    """
+    Perform concurrent writes to an image with exclusive lock
+    and persistent write back cache enabled, and verify
+
+    Args:
+        cache: PersistentWriteAheadLog object
+        cfg: test config
+        client: cache client node
+    """
+    try:
+        pdb.set_trace()
+        config_level, entity = get_entity_level(cfg)
+        pool, image = cfg["image_spec"].split("/")
+        cache.rbd.toggle_image_feature(
+            pool, image, feature_name="object-map,exclusive-lock", action="enable"
+        )
+        cache.configure_pwl_cache(
+            cfg["rbd_persistent_cache_mode"],
+            config_level,
+            entity,
+            cfg["cache_file_size"],
+        )
+
+        io_config = {
+            "rbd_obj": cache.rbd,
+            "client": client,
+            # "read_only": False,
+            "size": "10G",
+            "do_not_create_image": True,
+            "config": {
+                "file_size": "100M",
+                "image_spec": [cfg["image_spec"]],
+                "operations": {
+                    "fs": "ext4",
+                    "io": False,
+                    "mount": True,
+                    "nounmap": False,
+                    "device_map": True,
+                },
+                "skip_mkfs": False,
+                # "runtime": 30,
+                # "encryption_config": [],
+            },
+        }
+        pdb.set_trace()
+        krbd_io_handler(**io_config)
+
+        io_config["config"]["operations"]["io"] = True
+        io_config["config"]["operations"]["nounmap"] = True
+        io_config["config"]["skip_mkfs"] = True
+
+        with parallel() as p:
+            # p.spawn(run_fio, **fio_ready(cfg, client, test_name="test-1", size="100M"))
+            # p.spawn(run_fio, **fio_ready(cfg, client, test_name="test-2", size="100M"))
+            p.spawn(krbd_io_handler, **io_config)
+            p.spawn(krbd_io_handler, **io_config)
+            try:
+                cache.check_cache_file_exists(
+                    cfg["image_spec"],
+                    cfg["fio"].get("runtime", 120),
+                    **cfg,
+                )
+                log.info(
+                    "PWL Cache file created with exclusive lock for concurrent writes..."
+                )
+            except PWLException as error:
+                log.error(f"{error} in entire FIO execution...")
+                raise Exception(error)
+
+        pdb.set_trace()
+        cmd = f"rbd -p {pool} du --format json"
+        pool_info = json.loads(cache.rbd.exec_cmd(cmd=cmd, output=True))
+        used_size = [
+            img["used_size"] for img in pool_info.get("images", []) if img["name"] == image
+        ][0]
+        used_size = used_size / 1048576  # in MB
+        if int(used_size) != 200:  # 1024:
+            log.error("Writing two 100MB fios but the used size of image is not 200MB")
+            raise Exception(
+                "Writing two 100MB fios but the used size of image is not 200MB"
+            )
+    except Exception as e:
+        log.error(f"Validation of concurrent writes failed with error: {e}")
+        raise Exception(f"Validation of concurrent writes failed with error: {e}")
+    finally:
+        device_cleanup(cache.rbd)
+
+
+def run(ceph_cluster, **kw):
+    """Concurrent writes with exclusive lock. persistent write cache
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test parameters
+
+    Pre-requisites :
+        - need client node with ceph-common package, conf and keyring files
+        - FIO should be installed on the client.
+
+    """
+    pdb.set_trace()
+    log.info("Running PWL....")
+    log.info(
+        "Running test - Concurrent writes with exclusive lock. persistent write cache"
+    )
+    config = kw.get("config")
+    rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
+    cache_client = get_node_by_id(ceph_cluster, config["client"])
+    pool = config["rep_pool_config"]["pool"]
+    image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
+    config["image_spec"] = image
+
+    pwl = PersistentWriteAheadLog(rbd_obj, cache_client, config.get("drive"))
+    config_level, entity = get_entity_level(config)
+
+    try:
+        # Configure PWL
+        pwl.configure_cache_client()
+
+        validate_concurrent_writes(pwl, config, cache_client)
+
+        return 0
+    except Exception as err:
+        log.error(err)
+    finally:
+        if config.get("cleanup"):
+            pwl.remove_pwl_configuration(config_level, entity)
+            rbd_obj.clean_up(pools=[pool])
+            pwl.cleanup()
+
+    return 1

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1920,8 +1920,9 @@ def run_fio(**fio_args):
         opt_args += f" --runtime={run_time} --time_based"
 
     long_running = fio_args.get("long_running", False)
+    test_name = fio_args.get("test_name", "test-1")
     cmd = (
-        "fio --name=test-1  --numjobs=1 --rw=write"
+        f"fio --name={test_name}  --numjobs=1 --rw=write"
         " --iodepth=8 --fsync=32 "
         f" --group_reporting {opt_args}"
     )


### PR DESCRIPTION
Automation of test case - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574720 - Concurrent writes to check exclusive lock feature with persistent cache enables via same or different IO tools in SSD mode

Test Steps :
1. Enable the flags
2. write data to the same image concurrently
3. Make sure 2 or more writes to the image at the same time
E.g. 2 long-running "fio" jobs competing with each other on the same image.

Success Logs - 