### PR TITLE
Test bucket versioning is never suspended at archive site

### DIFF
--- a/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-3_rgw_multisite_archive_with_haproxy.yaml
@@ -555,3 +555,15 @@ tests:
       module: sanity_rgw_multisite.py
       name: bucket policies retained at archive site
       comments: bug-1937618, Inditex.
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_versioning_with_objects.py
+            config-file-name: test_versioning_objects_suspend_archive_haproxy.yaml
+            run-on-haproxy: true
+            timeout: 300
+      desc: test versioning suspend on archive
+      module: sanity_rgw_multisite.py
+      name: test versioning suspend on archive
+      polarion-id: CEPH-83575578


### PR DESCRIPTION
ceph-qe-scripts : https://github.com/red-hat-storage/ceph-qe-scripts/pull/478

close-loop: Automate bug-2137596 at the archive site

https://polarion.engineering.redhat.com/polarion/#/project/https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83575578

https://bugzilla.redhat.com/show_bug.cgi?id=2137596

log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7HFZ5Y