### PR TITLE
Add Test to run IOs using multiple-initiators against multi-subsystems based NVMe-of targets

### DIFF
--- a/conf/quincy/nvmeof/ceph_nvmeof_cluster.yaml
+++ b/conf/quincy/nvmeof/ceph_nvmeof_cluster.yaml
@@ -37,3 +37,9 @@ globals:
       node7:
         role:
           - client
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client

--- a/suites/quincy/nvmeof/ceph_nvmeof_deployment.yaml
+++ b/suites/quincy/nvmeof/ceph_nvmeof_deployment.yaml
@@ -54,6 +54,8 @@ tests:
         nodes:
           - node6
           - node7
+          - node8
+          - node9
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -94,6 +96,45 @@ tests:
       name: Basic Ceph NVMEoF GW sanity test
       polarion-id:
 
+# Run IOs using multiple-initiators against multi-subsystems based NVMe-OF targets using fio tool
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: false                           # Run SPDK with all pre-requisites
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5002
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5003
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode2
+            listener_port: 5002
+            node: node8
+          - subnqn: nqn.2016-06.io.spdk:cnode3
+            listener_port: 5003
+            node: node9
+      desc: Perform IOs on multi-subsystems with Multiple-Initiators
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to run IOs using multiple-initiators against multi-subsystems
+      polarion-id:
+
   # Cleanup Test Case
   - test:
       abort-on-fail: true
@@ -105,9 +146,15 @@ tests:
         rep_pool_config:
         subsystems:
           - nqn: nqn.2016-06.io.spdk:cnode1
+          - nqn: nqn.2016-06.io.spdk:cnode2
+          - nqn: nqn.2016-06.io.spdk:cnode3
         initiators:
           - subnqn: nqn.2016-06.io.spdk:cnode1
             node: node7
+          - subnqn: nqn.2016-06.io.spdk:cnode2
+            node: node8
+          - subnqn: nqn.2016-06.io.spdk:cnode3
+            node: node9
         cleanup-only: true                        # clean up only
         cleanup:
           - pool


### PR DESCRIPTION
Add Test to run IOs using multiple-initiators against multi-subsystems based NVMe-of targets- 
Addded a new test case to cover multiple initiator scenarios and run Ios on the discovered luns

Logs attached http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VW9B6D