### PR TITLE
Adding tests to perform cache flush with IOs stopped abruptly

### DIFF
--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -312,3 +312,28 @@ tests:
       module: test_rbd_persistent_write_back_cache.py
       name: PWL cache creation with exclusive lock
       polarion-id: CEPH-83574719
+
+  - test:
+      abort-on-fail: true
+      config:
+        level: client                        # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node5
+        drive: /dev/nvme0n1
+        cleanup: true
+        # validate_exclusive_lock: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool2
+          image: image2
+          size: 10G
+        fio:
+          image_name: image2
+          pool_name: pool2
+          runtime: 120
+      desc: Validate cache flush with persistent cache enabled
+      destroy-cluster: false
+      module: test_rbd_persistent_writeback_cache_flush.py
+      name: Validate cache flush with persistent cache enabled
+      polarion-id: CEPH-83574893

--- a/tests/rbd/rbd_peristent_writeback_cache.py
+++ b/tests/rbd/rbd_peristent_writeback_cache.py
@@ -182,8 +182,14 @@ class PersistentWriteAheadLog:
                 f"{self.client.hostname}:{self.pwl_path} cache file did not found!!!"
             )
 
-    def flush(self, image):
-        pass
+    def flush(self, image_spec):
+        """Perform cache flush on the image
+        Args:
+            image_spec: <pool>/<image> where cache flush needs to be performed.
+        """
+        log.info(f"Perform cache flush on image {image_spec}....")
+        cmd = f"rbd persistent-cache flush {image_spec}"
+        return self.client.exec_command(cmd=cmd, sudo=True)
 
     def invalidate(self, image):
         pass

--- a/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
+++ b/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
@@ -1,0 +1,123 @@
+"""RBD Persistent write back cache, Test concurrent writes to same image
+
+Test Case Covered:
+CEPH-83574893 - Verify cache flush command when IO is stopped abruptly
+with persistent cache enables via same or different IO tools in SSD mode
+
+Steps :
+1) Setup persistent write cache for an image
+2) Write data to the image using fio jobs
+3) Stop fio abruplty and verify that cache flush command
+
+Environment and limitations:
+ - The cluster should have 5 nodes + 1 SSD cache node
+ - cluster/global-config-file: config/quincy/upi/octo-5-node-env.yaml
+ - Should be Bare-metal.
+
+Support
+- Configure cluster with PWL Cache.
+- Only replicated pool supported, No EC pools.
+"""
+import re
+from time import sleep
+
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id
+from tests.rbd.rbd_peristent_writeback_cache import (
+    PersistentWriteAheadLog,
+    fio_ready,
+    get_entity_level,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def kill_fio(rbd):
+    """
+    Kill the fio process running on the client
+    """
+    sleep(60)
+    cmd = "ps -ef | grep fio"
+    out = rbd.exec_cmd(cmd=cmd, sudo=True, output=True)
+    if out and "fio --name=" in out:
+        proc_id = re.search(r"\d+", out).group()
+        cmd = f"kill -9 {proc_id}"
+        rbd.exec_cmd(cmd=cmd, sudo=True)
+
+
+def validate_cache_flush(cache, cfg, client):
+    """
+    Kill an IO process in between and perform cache flush
+
+    Args:
+        cache: PersistentWriteAheadLog object
+        cfg: test config
+        client: cache client node
+    """
+    config_level, entity = get_entity_level(cfg)
+
+    cache.configure_pwl_cache(
+        cfg["rbd_persistent_cache_mode"],
+        config_level,
+        entity,
+        cfg["cache_file_size"],
+    )
+
+    with parallel() as p:
+        p.spawn(run_fio, **fio_ready(cfg, client))
+        p.spawn(kill_fio, cache.rbd)
+
+    out, err = cache.flush(cfg["image_spec"])
+    if not out:
+        log.info(f"Cache flush for image {cfg['image_spec']} is success")
+    else:
+        log.error(f"Cache flush failed for image {cfg['image_spec']} with error {err}")
+        raise Exception(
+            f"Cache flush failed for image {cfg['image_spec']} with error {err}"
+        )
+
+
+def run(ceph_cluster, **kw):
+    """Concurrent writes with exclusive lock. persistent write cache
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test parameters
+
+    Pre-requisites :
+        - need client node with ceph-common package, conf and keyring files
+        - FIO should be installed on the client.
+
+    """
+    log.info(
+        "Running test - Concurrent writes with exclusive lock. persistent write cache"
+    )
+    config = kw.get("config")
+    rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
+    cache_client = get_node_by_id(ceph_cluster, config["client"])
+    pool = config["rep_pool_config"]["pool"]
+    image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
+    config["image_spec"] = image
+
+    pwl = PersistentWriteAheadLog(rbd_obj, cache_client, config.get("drive"))
+    config_level, entity = get_entity_level(config)
+
+    try:
+        # Configure PWL
+        pwl.configure_cache_client()
+
+        validate_cache_flush(pwl, config, cache_client)
+
+        return 0
+    except Exception as err:
+        log.error(err)
+    finally:
+        if config.get("cleanup"):
+            pwl.remove_pwl_configuration(config_level, entity)
+            rbd_obj.clean_up(pools=[pool])
+            pwl.cleanup()
+
+    return 1


### PR DESCRIPTION
Automating test case - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574893

Verify cache flush command when IO is stopped abruptly
with persistent cache enables via same or different IO tools in SSD mode

Steps : 
1) Setup persistent write cache for an image
2) Write data to the image using fio jobs
3) Stop fio abruplty and verify that cache flush command

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NSAV96/Validate_cache_flush_with_persistent_cache_enabled_0.log
