### PR TITLE
[LibFix] Fix 'bootstrap' library to support ibm build

### DIFF
--- a/cephci.yaml.template
+++ b/cephci.yaml.template
@@ -29,7 +29,15 @@
 #  username: <user_name>
 #  password: <user_password>
 
-# registry_credentials:
+# Provide container registry details for redhat and ibm images. Registry keyword should
+# start with 'rh' for redhat and 'ibm' for IBM builds
+
+# rh_registry_credentials:
+#  registry: <registry_url>
+#  username: <user_name>
+#  password: <user_password>
+
+# ibm_registry_credentials:
 #  registry: <registry_url>
 #  username: <user_name>
 #  password: <user_password>

--- a/tests/cephadm/test_cephadm_ansible_wrapper.py
+++ b/tests/cephadm/test_cephadm_ansible_wrapper.py
@@ -102,17 +102,10 @@ def validate_cephadm_ansible_module(installer, playbook, extra_vars, extra_args)
 
 
 def get_registry_details(config):
-    ibm_build = config.get("ibm_build")
-    registry_url = None
-    if ibm_build:
-        _config = get_cephci_config()["registry_credentials"]
-        registry_url = _config["registry"]
+    build_type = "ibm" if config.get("ibm_build") else "rh"
+    _config = get_cephci_config()[f"{build_type}_registry_credentials"]
 
-    else:
-        _config = get_cephci_config()["cdn_credentials"]
-        registry_url = _config.get("docker_registry")
-
-    return registry_url, _config["username"], _config["password"]
+    return _config["registry"], _config["username"], _config["password"]
 
 
 def wait_for_daemon_state(client, type, id, state):


### PR DESCRIPTION
Fix consist of -
  1. Add separate registry parameter to `cephci.yaml` config for RH & IBM build.
  2. Add parameter to `construct_registry` method to identify build type.
  3. Add steps to read registry details based on build type.