### PR TITLE
integrating rgw testing through curl

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
@@ -160,3 +160,24 @@ tests:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_s3copyObj_admin_user.yaml
         timeout: 500
+
+ # testing rgw through curl
+  - test:
+      name: Test rgw through CURL
+      desc: Test rgw through CURL
+      polarion-id: CEPH-83575572
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
+        timeout: 500
+
+  - test:
+      name: Test rgw put object through curl using transfer_encoding chunked
+      desc: Test rgw put object through curl using transfer_encoding chunked
+      polarion-id: CEPH-83575572
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_curl_transfer_encoding_chunked.yaml
+        timeout: 500


### PR DESCRIPTION
This PR is to add support for testing rgw features using curl and also to automate testing of customer defect getting "MissingContentLength" error while uploading object using "Transfer-Encoding:chunked" header instead of content length through curl.
Seeing "SignatureDoesNotMatch" error while performing versioning, lc, notifications, policy... operations through curl. refer [BZ2184756](https://bugzilla.redhat.com/show_bug.cgi?id=2184756) for more details. Will automate testing those features through curl once the issue in the bz is solved.

bugzilla: [BZ2152801](https://bugzilla.redhat.com/show_bug.cgi?id=2152801)
polarion id: [CEPH-83575572](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575572)
ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/477


The reason for adding same polarion id for multiple tests is because they are test steps of same polarion testcase
pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/curl_missing_content_len_automation/cephci-run-OS7XT3/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
