### PR TITLE
Removed the tests which are taking more execution time

### DIFF
--- a/suites/pacific/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/pacific/rados/tier-2-rados-basic-regression.yaml
@@ -90,7 +90,6 @@ tests:
         node: node7                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -268,66 +267,6 @@ tests:
       desc: Enable/disable different compression algorithms.
 
   - test:
-      name: Compression algorithms - modes
-      module: rados_prep.py
-      polarion-id: CEPH-83571670
-      config:
-        enable_compression:
-          pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
-          configurations:
-            - config-1:
-                compression_mode: force
-                compression_algorithm: snappy
-                compression_required_ratio: 0.3
-                compression_min_blob_size: 1B
-                byte_size: 10KB
-            - config-2:
-                compression_mode: passive
-                compression_algorithm: zlib
-                compression_required_ratio: 0.7
-                compression_min_blob_size: 10B
-                byte_size: 100KB
-            - config-3:
-                compression_mode: aggressive
-                compression_algorithm: zstd
-                compression_required_ratio: 0.5
-                compression_min_blob_size: 1KB
-                byte_size: 100KB
-      desc: Enable/disable different compression modes.
-
-  - test:
-      name: Compression algorithm tuneables
-      module: rados_prep.py
-      polarion-id: CEPH-83571671
-      config:
-        enable_compression:
-          pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
-          configurations:
-            - config-1:
-                compression_mode: force
-                compression_algorithm: snappy
-                compression_required_ratio: 0.3
-                compression_min_blob_size: 1B
-                byte_size: 10KB
-            - config-2:
-                compression_mode: passive
-                compression_algorithm: zlib
-                compression_required_ratio: 0.7
-                compression_min_blob_size: 10B
-                byte_size: 100KB
-            - config-3:
-                compression_mode: aggressive
-                compression_algorithm: zstd
-                compression_required_ratio: 0.5
-                compression_min_blob_size: 1KB
-                byte_size: 100KB
-      desc: Verify and alter different compression tunables.
-
-  - test:
       name: Ceph balancer plugin
       module: rados_prep.py
       polarion-id: CEPH-83573247
@@ -350,12 +289,6 @@ tests:
           target_max_misplaced_ratio: 0.05
           sleep_interval: 60
       desc: Ceph balancer plugins CLI validation in upmap mode
-
-  - test:
-      name: Mute ceph health alerts
-      polarion-id: CEPH-83573854
-      module: mute_alerts.py
-      desc: Mute health alerts
 
   - test:
       name: Ceph PG Autoscaler

--- a/suites/pacific/rados/tier-4_rados_tests.yaml
+++ b/suites/pacific/rados/tier-4_rados_tests.yaml
@@ -81,7 +81,6 @@ tests:
         node: node8                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -112,3 +111,80 @@ tests:
           pool_name: test-max-avail
           obj_nums: 5
           delete_pool: true
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571671
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.
+
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -90,7 +90,6 @@ tests:
         node: node7                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -293,66 +292,6 @@ tests:
       desc: Enable/disable different compression algorithms.
 
   - test:
-      name: Compression algorithms - modes
-      module: rados_prep.py
-      polarion-id: CEPH-83571670
-      config:
-        enable_compression:
-          pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
-          configurations:
-            - config-1:
-                compression_mode: force
-                compression_algorithm: snappy
-                compression_required_ratio: 0.3
-                compression_min_blob_size: 1B
-                byte_size: 10KB
-            - config-2:
-                compression_mode: passive
-                compression_algorithm: zlib
-                compression_required_ratio: 0.7
-                compression_min_blob_size: 10B
-                byte_size: 100KB
-            - config-3:
-                compression_mode: aggressive
-                compression_algorithm: zstd
-                compression_required_ratio: 0.5
-                compression_min_blob_size: 1KB
-                byte_size: 100KB
-      desc: Enable/disable different compression modes.
-
-  - test:
-      name: Compression algorithm tuneables
-      module: rados_prep.py
-      polarion-id: CEPH-83571671
-      config:
-        enable_compression:
-          pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
-          configurations:
-            - config-1:
-                compression_mode: force
-                compression_algorithm: snappy
-                compression_required_ratio: 0.3
-                compression_min_blob_size: 1B
-                byte_size: 10KB
-            - config-2:
-                compression_mode: passive
-                compression_algorithm: zlib
-                compression_required_ratio: 0.7
-                compression_min_blob_size: 10B
-                byte_size: 100KB
-            - config-3:
-                compression_mode: aggressive
-                compression_algorithm: zstd
-                compression_required_ratio: 0.5
-                compression_min_blob_size: 1KB
-                byte_size: 100KB
-      desc: Verify and alter different compression tunables.
-
-  - test:
       name: Ceph balancer plugin
       module: rados_prep.py
       polarion-id: CEPH-83573247
@@ -375,12 +314,6 @@ tests:
           target_max_misplaced_ratio: 0.05
           sleep_interval: 60
       desc: Ceph balancer plugins CLI validation in upmap mode
-
-  - test:
-      name: Mute ceph health alerts
-      polarion-id: CEPH-83573854
-      module: mute_alerts.py
-      desc: Mute health alerts
 
   - test:
       name: Ceph PG Autoscaler

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -81,7 +81,6 @@ tests:
         node: node8                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -112,3 +111,80 @@ tests:
           pool_name: test-max-avail
           obj_nums: 5
           delete_pool: true
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571671
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.
+
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -90,7 +90,6 @@ tests:
         node: node7                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -293,66 +292,6 @@ tests:
       desc: Enable/disable different compression algorithms.
 
   - test:
-      name: Compression algorithms - modes
-      module: rados_prep.py
-      polarion-id: CEPH-83571670
-      config:
-        enable_compression:
-          pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
-          configurations:
-            - config-1:
-                compression_mode: force
-                compression_algorithm: snappy
-                compression_required_ratio: 0.3
-                compression_min_blob_size: 1B
-                byte_size: 10KB
-            - config-2:
-                compression_mode: passive
-                compression_algorithm: zlib
-                compression_required_ratio: 0.7
-                compression_min_blob_size: 10B
-                byte_size: 100KB
-            - config-3:
-                compression_mode: aggressive
-                compression_algorithm: zstd
-                compression_required_ratio: 0.5
-                compression_min_blob_size: 1KB
-                byte_size: 100KB
-      desc: Enable/disable different compression modes.
-
-  - test:
-      name: Compression algorithm tuneables
-      module: rados_prep.py
-      polarion-id: CEPH-83571671
-      config:
-        enable_compression:
-          pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
-          configurations:
-            - config-1:
-                compression_mode: force
-                compression_algorithm: snappy
-                compression_required_ratio: 0.3
-                compression_min_blob_size: 1B
-                byte_size: 10KB
-            - config-2:
-                compression_mode: passive
-                compression_algorithm: zlib
-                compression_required_ratio: 0.7
-                compression_min_blob_size: 10B
-                byte_size: 100KB
-            - config-3:
-                compression_mode: aggressive
-                compression_algorithm: zstd
-                compression_required_ratio: 0.5
-                compression_min_blob_size: 1KB
-                byte_size: 100KB
-      desc: Verify and alter different compression tunables.
-
-  - test:
       name: Ceph balancer plugin
       module: rados_prep.py
       polarion-id: CEPH-83573247
@@ -375,12 +314,6 @@ tests:
           target_max_misplaced_ratio: 0.05
           sleep_interval: 60
       desc: Ceph balancer plugins CLI validation in upmap mode
-
-  - test:
-      name: Mute ceph health alerts
-      polarion-id: CEPH-83573854
-      module: mute_alerts.py
-      desc: Mute health alerts
 
   - test:
       name: Ceph PG Autoscaler

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -81,7 +81,6 @@ tests:
         node: node8                       # client node
         install_packages:
           - ceph-common
-          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps:                             # authorize client capabilities
           mon: "allow *"
@@ -112,3 +111,80 @@ tests:
           pool_name: test-max-avail
           obj_nums: 5
           delete_pool: true
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571671
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          rados_write_duration: 10
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          rados_write_duration: 50
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.
+
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts


### PR DESCRIPTION
# Description
In the regression suite, few test execution is taking execution time. Due to this, the execution of the regression suite is taking more than 5 hours. From the results summary, the team noticed that the following suites are taking more execution time.
Test cases:
1.CEPH-83571670
2. CEPH-83573854
3. CEPH-83571671

This PR is to remove the test cases for the regression suite.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
