### PR TITLE
Automated dm-cache and dm-write cache scenario for RBD images

### DIFF
--- a/suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rbd/tier-1_rbd_mirroring_upgrade-5-to-latest.yaml
@@ -220,5 +220,5 @@ tests:
             rep_pool_config:
               pool: sync_snap_del_1
               image: image_rep
-      polarion-id: CEPH-83573332
+      polarion-id: CEPH-10466
       desc: Verify sync point snapshot deletion in journal based

--- a/suites/pacific/rbd/tier-2_rbd_mirror_scale_osd.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_scale_osd.yaml
@@ -220,5 +220,5 @@ tests:
             osds_to_remove:
               - node5
               - node6
-      polarion-id: CEPH-9501
+      polarion-id: CEPH-9489
       desc: Verify that image deleted at primary site updated at secondary

--- a/suites/quincy/rbd/tier-2_rbd_cache_scenarios.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_cache_scenarios.yaml
@@ -1,0 +1,103 @@
+# Tier-2: Extended RBD cache scenario tests.
+#
+# Test-Suite: tier-2_rbd_cache_scenarios.yaml
+#
+# This test suite runs addition test scripts to evaluate the existing functionality of
+# Ceph RBD component involving dm-cache scenarios.
+#
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    1 Node must to be a client node
+
+
+tests:
+
+  # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        level: client
+        client: node4
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool_test
+          image1: image1
+          image2: image2
+          size: 20G
+        fio:
+          runtime: 120
+      desc: Validate dm-cache and dm-write cache for RBD based image disk
+      destroy-cluster: false
+      module: test_rbd_dm_cache.py
+      name: DM cache and DM write cache creation
+      polarion-id: CEPH-83574719

--- a/suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml
@@ -220,5 +220,5 @@ tests:
             osds_to_remove:
               - node5
               - node6
-      polarion-id: CEPH-9501
+      polarion-id: CEPH-9489
       desc: Verify that image deleted at primary site updated at secondary

--- a/tests/rbd/test_rbd_dm_cache.py
+++ b/tests/rbd/test_rbd_dm_cache.py
@@ -1,0 +1,180 @@
+"""Test case covered -
+    CEPH-83575581 - Verify the usage of ceph RBD images as
+    dm-cache and dm-write cache from LVM side to enhance cache mechanism.
+
+    Pre-requisites :
+    1. Cluster must be up and running with capacity to create pool
+    2. We need atleast one client node with ceph-common package,
+       conf and keyring files
+
+    Test Case Flow:
+    1. Create RBD based pool and an Image
+    2. get rbd based image disk using rbd map
+    3. Create physical volume for RBD based disk
+    4. Create volume group for RBD based disk
+    5. Create cache disk, meta disk and data disk for the volume group
+    6. make disk as dm-cache and dm-write cache based type of cache specified
+    7. Create Xfs file system on metadata parted disk for file system purpose
+    8. mount some files on cache disk and write some I/O on it.
+    9. create snapshot of cache disk image
+    10. check ceph health status
+"""
+
+from ceph.utils import get_node_by_id
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.lvm_utils import lvconvert, lvm_create, pvcreate, vgcreate
+from utility.utils import run_fio, run_mkfs
+
+log = Log(__name__)
+
+
+def test_configure_cache(rbd_obj, client_node, pool_name, image_name, cache_type, **kw):
+    """Method to configure cache mechansim as dm-cache
+    and dm-write cache for RBD image based devices.
+
+    Args:
+        rbd_obj: RBD object
+        client_node: cache client node
+        pool_name: name of the pool
+        image_name: name of the image
+        cache_type: type of cache i.e dm-cache and dm-write cache
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+
+    """
+    config = kw.get("config")
+    device_names = []
+    lv_sizes = {"data_disk": "4G", "cache_disk": "2G", "meta_disk": "2G"}
+
+    if cache_type == "cache":
+        vg_name = "test_cache_vg"
+        test_folder_path = "/tmp/test_cache"
+        VG_disk = "/dev/test_cache_vg/data_disk"
+    else:
+        vg_name = "test_write_cache_vg"
+        test_folder_path = "/tmp/test_write_cache"
+        VG_disk = "/dev/test_write_cache_vg/data_disk"
+    try:
+        device_names.append(rbd_obj.image_map(pool_name, image_name)[:-1])
+        pvcreate(client_node, device_names[0])
+        vgcreate(client_node, vg_name, device_names[0])
+
+        for name, size in lv_sizes.items():
+            lvm_create(client_node, name, vg_name, size)
+
+        if cache_type == "cache":
+            # to configure dm-cache pool in LVM by associating a metadata disk with a cache disk
+            command = f"echo 'y' | lvconvert --type cache-pool --poolmetadata {vg_name}/meta_disk {vg_name}/cache_disk"
+            client_node.exec_command(cmd=command, sudo=True)
+
+            lvconvert(client_node, cache_type, vg_name, "cache_disk", "data_disk")
+        else:
+            # Configure dm-write cache
+            command = f"lvchange --activate n {vg_name}/cache_disk"
+            client_node.exec_command(cmd=command, sudo=True)
+
+            lvconvert(client_node, cache_type, vg_name, "cache_disk", "meta_disk")
+
+        # creating XFS filesystem on VG_disk
+        run_mkfs(client_node=client_node, device_name=VG_disk, type="xfs")
+
+        command = f"mkdir -p {test_folder_path}"
+        client_node.exec_command(cmd=command, sudo=True)
+
+        # mount the cached disk and run fio
+        command = f"mount {VG_disk} {test_folder_path}"
+        client_node.exec_command(cmd=command, sudo=True)
+
+        run_fio(
+            client_node=client_node,
+            device_name=VG_disk,
+            runtime=config.get("runtime", 30),
+        )
+
+        # check ceph health
+        out, error = client_node.exec_command(cmd="ceph -s", sudo=True)
+
+        if "HEALTH_ERR" in out:
+            log.debug(out)
+            log.error("Cluster went to error health state")
+            return 1
+
+    except Exception as err:
+        log.error(err)
+        return 1
+
+    finally:
+        log.info("Starting to cleanup cache drive")
+        client_node.exec_command(cmd=f"wipefs -af {device_names[0]}", sudo=True)
+    return 0
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test to configure dm-cache and dm-writecache for RBD images
+    from LVM side to enhance cache mechanism.
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    log.info(
+        "Starting CEPH-83575581 - Verify the usage of ceph RBD images as "
+        "dm-cache and dm-write cache from LVM side to enhance cache mechanism."
+    )
+
+    config = kw.get("config")
+    rbd = initial_rbd_config(**kw)["rbd_reppool"]
+    cache_client = get_node_by_id(ceph_cluster, config["client"])
+
+    pool_name = config["rep_pool_config"]["pool"]
+    image_name_cache = config["rep_pool_config"]["image1"]
+    image_name_writecache = config["rep_pool_config"]["image2"]
+    image_size = config["rep_pool_config"]["size"]
+
+    try:
+        for cache_type, image_name in [
+            ("cache", image_name_cache),
+            ("writecache", image_name_writecache),
+        ]:
+            rbd.create_image(
+                pool_name,
+                image_name,
+                size=image_size,
+            )
+
+            # To configure dm-cache or dm-writecache for rbd image based disk
+            if test_configure_cache(
+                rbd,
+                cache_client,
+                pool_name,
+                image_name,
+                cache_type=cache_type,
+                **kw,
+            ):
+                log.error(f"DM-{cache_type} creation failed")
+                return 1
+            else:
+                log.info(f"Able to make RBD image as DM-{cache_type}")
+
+                # creating snapshot of cache disked image
+                if rbd.snap_create(pool_name, image_name, "cache_snap"):
+                    log.error("Creation of snapshot failed")
+                    return 1
+                else:
+                    log.info("Able to create snapshot of cache based image")
+
+    except Exception as err:
+        log.error(err)
+        return 1
+
+    finally:
+        rbd.clean_up(pools=[pool_name])
+
+    return 0

--- a/utility/lvm_utils.py
+++ b/utility/lvm_utils.py
@@ -12,6 +12,26 @@ def lvcreate(osd, lv_name, vg_name, size):
     return lv_name
 
 
+def lvm_create(osd, lv_name, vg_name, size):
+    osd.exec_command(cmd="sudo lvcreate -n %s -L %s %s " % (lv_name, size, vg_name))
+    return lv_name
+
+
+def lvconvert(osd, cache_type, vg_name, cache_name, data_name):
+    if cache_type == "cache":
+        command = (
+            f"echo 'y' | lvconvert --type {cache_type} --cachepool "
+            f"{vg_name}/{cache_name} {vg_name}/{data_name}"
+        )
+        osd.exec_command(cmd=command, sudo=True)
+    else:
+        command = (
+            f"echo -e 'y\ny' | lvconvert --type {cache_type} --cachevol "
+            f"{vg_name}/{cache_name} {vg_name}/{data_name}"
+        )
+        osd.exec_command(cmd=command, sudo=True)
+
+
 def make_partition(osd, device, start=None, end=None, gpt=False):
     osd.exec_command(
         cmd="sudo parted --script %s mklabel gpt" % device


### PR DESCRIPTION
# Description
Automated dm-cache and dm-write cache scenario for RBD images
Test case covered
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575581

**Test Case Flow:**
    1. Create RBD based pool and an Image
    2. get rbd based image disk using rbd map
    3. Create physical volume for RBD based disk
    4. Create volume group for RBD based disk
    5. Create cache disk, meta disk and data disk for the volume group
    6. make disk as dm-cache and dm-write cache based type of cache specified
    7. Create Xfs file system on metadata parted disk for file system purpose
    8. mount some files on cache disk and write some I/O on it.

Quincy:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8XEQYA

But device mapper has some issue in rhel-8
https://access.redhat.com/solutions/1132333

suggested file not exist to reload /etc/multipath.conf multipath configuration in 
Red Hat Enterprise Linux release 8.8 (Ootpa)

Test got failed in pacific
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VPL6T5/DM_cache_and_DM_write_cache_creation_0.log
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
