### PR TITLE
Fixes command failure happening due to incorrect node name

### DIFF
--- a/tests/misc_env/push_cosbench_workload.py
+++ b/tests/misc_env/push_cosbench_workload.py
@@ -100,7 +100,7 @@ def prepare_fill_workload(ceph_cluster, client, rgw, controller, config):
     LOG.info(f"workload endpoint: {workload_endpoint}")
     fill_workload = fill_workload.replace("workload_endpoint", workload_endpoint)
 
-    out, err = rgw.exec_command(
+    out, err = controller.exec_command(
         cmd="sh /opt/cosbench/cli.sh info | grep drivers | awk '{print $2}'"
     )
     LOG.info(out)
@@ -197,7 +197,7 @@ def run(ceph_cluster, **kwargs) -> int:
     """
     LOG.info("preaparing and pushing cosbench workload to fill 30% of the cluster")
     controller = get_nodes_by_ids(ceph_cluster, kwargs["config"]["controllers"])[0]
-    client = ceph_cluster.get_nodes(role="client")[0]
+    client = ceph_cluster.get_nodes(role="installer")[0]
     rgw = ceph_cluster.get_nodes(role="rgw")[0]
 
     workload_file_name = prepare_fill_workload(

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1862,7 +1862,7 @@ def clone_the_repo(config, node, path_to_clone):
 
 def calculate_available_storage(node):
     log.info("Calculate current storage present in cluster")
-    out, err = node.exec_command(cmd="ceph df --format json")
+    out, err = node.exec_command(cmd="sudo ceph df --format json")
     import json
 
     out = json.loads(out)


### PR DESCRIPTION
# Description
Fixes command failure happening due to incorrect node name

Log file is still in progress due to major fill operation is in progress. Adding COSBench url link where it shows pushed workload details from cephci
http://10.1.172.221:19088/controller/workload.html?id=w1

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
