### PR TITLE
[LibFix] Fix disconnnect library

### DIFF
--- a/cli/ceph/orch/orch.py
+++ b/cli/ceph/orch/orch.py
@@ -120,3 +120,15 @@ class Orch(Cli):
         if isinstance(out, tuple):
             return out[0].strip()
         return out
+
+    def redeploy(self, service):
+        """
+        Redeploy a service.
+        Args:
+          service (str): name of the service to be redeploy
+        """
+        cmd = f"{self.base_cmd} redeploy {service}"
+        out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out


### PR DESCRIPTION
Fix contains:

- Rename argument detach to docker_reg_image
- Remove duplicate validate_trusted_list validation
- Add registry login to a private registry configuration node
- Add support to validate_trusted_list for the secondary node
- Fix start_local_private_registry with image parameter and detach flag 
- Add support for service re-deploy

Logs: http://pastebin.test.redhat.com/1104512