### PR TITLE
Removing TC:"deploying RGW service with cephadm" as its not applicable to 5.x

### DIFF
--- a/suites/pacific/cephadm/tier-2-rgw-with-warn-state.yaml
+++ b/suites/pacific/cephadm/tier-2-rgw-with-warn-state.yaml
@@ -136,13 +136,3 @@ tests:
         timeout: 300
       abort-on-fail: false
       destroy-cluster: false
-
-  - test:
-      name: Verify zone group rgw service with cephadm
-      desc: Defining a zone-group when deploying RGW service with cephadm
-      polarion-id: CEPH-83575108
-      module: test_verify_zone_group_rgw_with_cephadm.py
-      config:
-        realm-name: new_realm
-        zonegroup-name: us_1
-        zone-name: us-east_1


### PR DESCRIPTION
This feature came in 6.1, so not applicable to 5.x
This is bug for the same - https://bugzilla.redhat.com/show_bug.cgi?id=2016288
where BZ raised for 5.0 and taken as "future feature", fixed in 6.1
so removing that testcase from 5.x suite only, testcase exist in quincy : https://github.com/red-hat-storage/cephci/blob/master/suites/quincy/cephadm/tier-2-rgw-with-warn-state.yaml#L140


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
