### PR TITLE
fixing tfa issues upload object failed and sync stuck for gc suites

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -625,10 +625,10 @@ pipelines:
           execution_time: "3h 16m 59s"
           suite: "suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml"
           global-conf: "conf/pacific/rgw/rgw_multisite.yaml"
-          platform: "rhel-9"
+          platform: "rhel-8"
           inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
         - name: "test-rgw-upgrade-4-to-latest"
@@ -655,10 +655,10 @@ pipelines:
           execution_time: "3h 51m 55s"
           suite: "suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml"
           global-conf: "conf/pacific/rgw/ms-ec-profile-4+2-cluster.yaml"
-          platform: "rhel-9"
+          platform: "rhel-8"
           inventory:
-            openstack: "conf/inventory/rhel-9-latest.yaml"
-            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
       stage-3:

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -168,67 +168,10 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: apply_spec
-                  service: orch
-                  validate-spec-services: true
-                  specs:
-                    - service_type: prometheus
-                      placement:
-                        count: 1
-                        nodes:
-                          - node1
-                    - service_type: grafana
-                      placement:
-                        nodes:
-                          - node1
-                    - service_type: alertmanager
-                      placement:
-                        count: 1
-                    - service_type: node-exporter
-                      placement:
-                        host_pattern: "*"
-                    - service_type: crash
-                      placement:
-                        host_pattern: "*"
-        ceph-sec:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: apply_spec
-                  service: orch
-                  validate-spec-services: true
-                  specs:
-                    - service_type: prometheus
-                      placement:
-                        count: 1
-                        nodes:
-                          - node1
-                    - service_type: grafana
-                      placement:
-                        nodes:
-                          - node1
-                    - service_type: alertmanager
-                      placement:
-                        count: 1
-                    - service_type: node-exporter
-                      placement:
-                        host_pattern: "*"
-                    - service_type: crash
-                      placement:
-                        host_pattern: "*"
-      name: Monitoring Services deployment
-      desc: Add monitoring services using spec file.
-      module: test_cephadm.py
-      polarion-id: CEPH-83574727
+
+# Monitoring services are slowing down large object upload, and it fails with timeout. hence removing that test.
+# refer https://issues.redhat.com/browse/RHCEPHQE-9210
+
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -113,67 +113,10 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
       polarion-id: CEPH-83575222
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: apply_spec
-                  service: orch
-                  validate-spec-services: true
-                  specs:
-                    - service_type: prometheus
-                      placement:
-                        count: 1
-                        nodes:
-                          - node1
-                    - service_type: grafana
-                      placement:
-                        nodes:
-                          - node1
-                    - service_type: alertmanager
-                      placement:
-                        count: 1
-                    - service_type: node-exporter
-                      placement:
-                        host_pattern: "*"
-                    - service_type: crash
-                      placement:
-                        host_pattern: "*"
-        ceph-sec:
-          config:
-            verify_cluster_health: true
-            steps:
-              - config:
-                  command: apply_spec
-                  service: orch
-                  validate-spec-services: true
-                  specs:
-                    - service_type: prometheus
-                      placement:
-                        count: 1
-                        nodes:
-                          - node1
-                    - service_type: grafana
-                      placement:
-                        nodes:
-                          - node1
-                    - service_type: alertmanager
-                      placement:
-                        count: 1
-                    - service_type: node-exporter
-                      placement:
-                        host_pattern: "*"
-                    - service_type: crash
-                      placement:
-                        host_pattern: "*"
-      name: Monitoring Services deployment
-      desc: Add monitoring services using spec file.
-      module: test_cephadm.py
-      polarion-id: CEPH-83574727
+
+# Monitoring services are slowing down large object upload, and it fails with timeout. hence removing that test.
+# refer https://issues.redhat.com/browse/RHCEPHQE-9210
+
   - test:
       abort-on-fail: true
       clusters:


### PR DESCRIPTION
commenting out monitoring tests and update rhel-8 os for gc test suites execution
and adding check for input/output error in sync status. restart rgw and wait for sync_lease_period seconds for 3 iterations.

regd the issue in this tfa ticket: https://issues.redhat.com/browse/RHCEPHQE-9210
LargeObjectGC test is getting passed after removing monitoring services test and using platform as rhel-8
Not seeing sync stuck issue as well on rhel-8

pass logs:
tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/tfa_upload_object_failed/cephci-run-MCBZKL-gc-on-secondary-latest/
tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-wjvkb/


Found out the actual issue of sync stuck. sync status is showing "failed to retrieve sync info: (5) Input/output error" and we are not handling that case in verify_sync_status. That issue is resolved after restarting rgw daemons and waiting for sync_lease_period i.e., 120 seconds. Added a check for it as well in the code.
refer below sync status output after create_non_tenanted_user test:

```
realm 26f7c34b-0d3b-487b-870c-b1375e1e1930 (india)
      zonegroup fd84aed4-20c1-4115-ac64-b5026975a2ac (shared)
           zone 19273d53-981e-4e52-a4c3-227bc493e79d (secondary)
   current time 2023-07-14T14:49:42Z
zonegroup features enabled: resharding
  metadata sync syncing
                full sync: 0/64 shards
                failed to fetch master sync status: (5) Input/output error
      data sync source: 0bffd954-a652-4eb8-b495-42639fb773bd (primary)
                        failed to retrieve sync info: (5) Input/output error
```

updated pass logs:

- suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-vjwo5/
- suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml(triggered twice):
  -   http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3yr4x/
  - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-315mz/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
