### PR TITLE
Adding numpy and scipy as part of prepareclients

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -70,7 +70,7 @@ class FsUtils(object):
             cmd = "yum install -y --nogpgcheck " + " ".join(pkgs)
             client.node.exec_command(sudo=True, cmd=cmd, long_running=True)
             client.node.exec_command(
-                sudo=True, cmd="pip3 install xattr", long_running=True
+                sudo=True, cmd="pip3 install xattr numpy scipy", long_running=True
             )
             out, rc = client.node.exec_command(sudo=True, cmd="ls /home/cephuser")
             if "smallfile" not in out:


### PR DESCRIPTION
# Description
Adding numpy and scipy as part of prepareclients

Problem :
numpy and scipy are required for smallfile_rsptimes_stats.py to calculate the performance between fuse and kernel mounts

Solution:
As part of preparing clients we are adding numpy and scipy
pip3 install xattr numpy scipy

passed Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FU9PJI
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
