### PR TITLE
Adding support for multiple clients to run IO in parallel

### DIFF
--- a/tests/cephfs/test_io.py
+++ b/tests/cephfs/test_io.py
@@ -21,10 +21,18 @@ def run(ceph_cluster, **kw):
             fs_util = FsUtils(ceph_cluster)
             fs_util.prepare_clients(clients, build)
             fs_util.auth_list(clients)
-            fs_io_obj = fs_io(
-                client=clients[0], fs_config=config.get("cephfs"), fs_util=fs_util
-            )
-            io_func.append(fs_io_obj.run_fs_io)
+            client_count = config.get("cephfs").get("num_of_clients")
+            if client_count > len(clients):
+                log.error(
+                    f"NFS clients required to perform test is {client_count} but "
+                    f"conf file has only {len(clients)}"
+                )
+                return 1
+            for client in clients[:client_count]:
+                fs_io_obj = fs_io(
+                    client=client, fs_config=config.get("cephfs"), fs_util=fs_util
+                )
+                io_func.append(fs_io_obj.run_fs_io)
         if config.get("rbd"):
             rbd_io_obj = rbd_io(
                 client=clients[0],

--- a/tests/io/fs_io.py
+++ b/tests/io/fs_io.py
@@ -30,6 +30,7 @@ class fs_io:
         self.io_tool = fs_config.get("io_tool")
         self.pool = ""
         self.mounting_dir = fs_config.get("mounting_dir", None)
+        self.batch_size = fs_config.get("batch_size", 10)
         if not self.mounting_dir:
             self.mounting_dir = "".join(
                 random.choice(string.ascii_lowercase + string.digits)
@@ -83,6 +84,12 @@ class fs_io:
         fs_details = FsUtils.get_fs_info(self.client, self.file_system)
         self.pool = fs_details["data_pool_name"]
         mounting_dir = self.mount_fs()
+
         start_io(
-            self, mounting_dir, docker_compose=True, compose_file="fs_compose.yaml"
+            self,
+            mounting_dir,
+            docker_compose=True,
+            compose_file="fs_compose.yaml",
+            batch_size=self.batch_size,
+            **kwargs,
         )

--- a/tests/io/io_utils.py
+++ b/tests/io/io_utils.py
@@ -30,10 +30,11 @@ def smallfile_io(client, **kwargs):
                     {
                         "name": f"{kwargs.get('compose_file')}_smallfile_{i}",
                         "command": f"git clone https://github.com/distributed-system-analysis/smallfile.git;"
-                        f"mkdir -p /app_test_io/dir_{i};python3 smallfile/smallfile_cli.py --operation {op} "
+                        f"mkdir -p /app_test_io/dir_{client.node.hostname}_{i};python3 smallfile/smallfile_cli.py "
+                        f"--operation {op} "
                         f"--threads {int(small_config.get('threads'))} --file-size {small_config.get('file_size')} "
                         f"--files {small_config.get('files')} --top "
-                        f"/app_test_io/dir_{i}",
+                        f"/app_test_io/dir_{client.node.hostname}_{i}",
                         "volumes": [f"{mounting_dir}:/app_test_io"],
                     }
                 )
@@ -46,7 +47,7 @@ def smallfile_io(client, **kwargs):
         )
         services = out.strip().split("\n")
         total_services = len(services) - 1 if len(services) != 1 else 1
-        BATCH_SIZE = 10
+        BATCH_SIZE = kwargs.get("batch_size", 10)
         service_prefix = "fs_compose.yaml_smallfile_"
         failed_containers = []
         for i in range(0, total_services, BATCH_SIZE):
@@ -125,6 +126,7 @@ def start_io(io_obj, mounting_dir, **kwargs):
                     mounting_dir=mounting_dir,
                     docker_compose=kwargs.get("docker_compose", True),
                     compose_file=kwargs.get("compose_file"),
+                    batch_size=kwargs.get("batch_size", 10),
                 )
             return 0
         elif io_obj.timeout:


### PR DESCRIPTION
# Description
Adding support for multiple clients to run IO in parallel


sample suite file :
 - test:
      abort-on-fail: false
      desc: "Fill the cluster with specific percentage"
      name: "Fill Cluster"
      module: test_io.py
      config:
        wait_for_io: True
        cephfs:
          num_of_clients: 2
          batch_size: 5
          "fill_data": 20
          "io_tool": "smallfile"
          "mount": "fuse"
          "filesystem": "cephfs"
          "mount_dir": ""

![image](https://github.com/red-hat-storage/cephci/assets/80021994/68115389-fa98-493a-8121-7558c475148a)


Pass Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-00OO00/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
