### PR TITLE
Including support for v1 ceph-qe-script in cephci for rgw-ms

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -68,11 +68,16 @@ from utility.utils import (
 log = Log(__name__)
 
 TEST_DIR = {
+    "v1": {
+        "script": "/ceph-qe-scripts/rgw/v1/tests/multisite/",
+        "lib": "/ceph-qe-scripts/rgw/v1/lib/",
+        "config": "/ceph-qe-scripts/rgw/v1/tests/multisite/yamls/",
+    },
     "v2": {
         "script": "/ceph-qe-scripts/rgw/v2/tests/s3_swift/",
         "lib": "/ceph-qe-scripts/rgw/v2/lib/",
         "config": "/ceph-qe-scripts/rgw/v2/tests/s3_swift/multisite_configs/",
-    }
+    },
 }
 
 


### PR DESCRIPTION
# Description
Including support for v1 ceph-qe-script in cephci for rgw-ms
fix for : https://issues.redhat.com/browse/RHCEPHQE-10041. --> TC: Basic_ACLs_Test

Error:  File "run.py", line 778, in run run_config=run_config, File "/home/jenkins/ceph-builds/[RHCEPH-5](https://issues.redhat.com/browse/RHCEPH-5).3-RHEL-8-20230706.0/Regression/rgw/5/cephci/tests/rgw/sanity_rgw_multisite.py", line 170, in run script_dir = TEST_DIR[test_version]["script"] KeyError: 'v1'

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Anuchaithra/cephci-run-MHECX8/


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
