### PR TITLE
[Test] Add support for linux untar tests in nfs

### DIFF
--- a/cli/io/io.py
+++ b/cli/io/io.py
@@ -1,0 +1,39 @@
+from threading import Thread
+
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def linux_untar(clients, mountpoint, dirs=(".")):
+    """
+    Performs Linux untar on the given clients
+    Args:
+        clients (list): Client (s)
+        mountpoint(str): Mount point where the volume is
+                       mounted.
+        dirs(tuple): A tuple of dirs where untar has to
+                    started. (Default:('.'))
+    """
+    threads = []
+    if not isinstance(clients, list):
+        clients = [clients]
+
+    for client in clients:
+        # Download linux untar to root
+        cmd = "wget https://cdn.kernel.org/pub/linux/kernel/" "v5.x/linux-5.4.54.tar.xz"
+        client.exec_command(cmd=cmd, sudo=True)
+
+        for directory in dirs:
+            # copy linux tar to dir
+            cmd = "cp /root/linux-5.4.54.tar.xz {}/{}".format(mountpoint, directory)
+            client.exec_command(cmd=cmd, sudo=True)
+
+            # Start linux untar
+            cmd = "cd {}/{};tar -xvf linux-5.4.54.tar.xz".format(mountpoint, directory)
+            untar = Thread(
+                target=lambda: client.exec_command(cmd=cmd, sudo=True), args=()
+            )
+            untar.start()
+            threads.append(untar)
+    return threads

--- a/conf/quincy/nfs/tier-0.yaml
+++ b/conf/quincy/nfs/tier-0.yaml
@@ -44,3 +44,9 @@ globals:
       node5:
         role:
           - client
+      node6:
+        role:
+          - client
+      node7:
+        role:
+          - client

--- a/suites/quincy/nfs/tier-0_nfs_ganesha.yaml
+++ b/suites/quincy/nfs/tier-0_nfs_ganesha.yaml
@@ -104,6 +104,36 @@ tests:
       name: configure client
 
   - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3
+        node: node6
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      desc: Configure the RGW,RBD client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.4
+        node: node7
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      desc: Configure the RGW,RBD client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
       name: Nfs Ganesha File Lock
       module: nfs_verify_file_lock.py
       desc: Perform locking on same file from 2 different clients
@@ -125,6 +155,16 @@ tests:
       name: Nfs Ganesha Bonnie
       module: nfs_verify_bonnie.py
       desc: Perform bonnie tests on the Nfs cluster
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 4.2
+
+
+  - test:
+      name: Nfs Verify Readdir Ops
+      module: nfs_verify_readdir_ops.py
+      desc: Perform readir operation from clients
       polarion-id:
       abort-on-fail: false
       config:

--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -1,0 +1,95 @@
+from cli.ceph.ceph import Ceph
+from cli.exceptions import OperationFailedError
+from cli.io.io import linux_untar
+from utility.log import Log
+
+log = Log(__name__)
+
+FS_NAME = "cephfs"
+NFS_NAME = "cephfs-nfs"
+NFS_EXPORT = "/export"
+NFS_MOUNT = "/mnt/nfs"
+FS = "cephfs"
+
+
+def setup_nfs_cluster(clients, nfs_node, port, version):
+    # Step 1: Enable nfs
+    Ceph(clients[0]).mgr.module(action="enable", module="nfs", force=True)
+
+    # Step 2: Create an NFS cluster
+    nfs_server_name = nfs_node.hostname
+    Ceph(clients[0]).nfs.cluster.create(name=NFS_NAME, nfs_server=nfs_server_name)
+
+    # Step 3: Perform Export on clients
+    for client in clients:
+        Ceph(client).nfs.export.create(
+            fs_name=FS_NAME, nfs_name=NFS_NAME, nfs_export=NFS_EXPORT, fs=FS
+        )
+
+    # Step 4: Perform nfs mount
+    for client in clients:
+        # Create mount dirs
+        client.exec_command(cmd=f"mkdir -p {NFS_MOUNT}", sudo=True)
+        cmd = f"mount -t nfs -o vers={version},port={port} {nfs_server_name}:{NFS_EXPORT} {NFS_MOUNT}"
+        out, _ = client.exec_command(cmd=cmd, sudo=True)
+        if out:
+            raise OperationFailedError(f"Failed to mount nfs on {client.hostname}")
+
+
+def cleanup_cluster(clients):
+    for client in clients:
+        client.exec_command(sudo=True, cmd=f"rm -rf {NFS_MOUNT}/*")
+        log.info("Unmounting nfs-ganesha mount on client:")
+        client.exec_command(sudo=True, cmd=" umount %s -l" % (NFS_MOUNT))
+        log.info("Removing nfs-ganesha mount dir on client:")
+        client.exec_command(sudo=True, cmd="rm -rf  %s" % (NFS_MOUNT))
+        client.exec_command(
+            sudo=True,
+            cmd=f"ceph nfs export delete {NFS_NAME} {NFS_EXPORT}",
+            check_ec=False,
+        )
+        client.exec_command(
+            sudo=True,
+            cmd=f"ceph nfs cluster delete {NFS_NAME}",
+            check_ec=False,
+        )
+
+
+def run(ceph_cluster, **kw):
+    """Verify readdir ops
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+
+    port = config.get("port", "2049")
+    version = config.get("nfs_version", "4.0")
+    nfs_node = nfs_nodes[0]
+
+    try:
+        setup_nfs_cluster(clients, nfs_node, port, version)
+
+        # Linux untar on client 1
+        _ = linux_untar(clients[0], NFS_MOUNT)
+
+        # Test 1: Perform Linux untar from 1 client and do readir operation from other client (ls -lart)
+        cmd = f"ls -lart {NFS_MOUNT}"
+        clients[1].exec_command(cmd=cmd, sudo=True)
+
+        # Test 2: Perform Linux untar from 1 client and do readir operation from other client (du -sh)
+        cmd = f"du -sh {NFS_MOUNT}"
+        clients[2].exec_command(cmd=cmd, sudo=True)
+
+        # Perform Linux untar from 1 client and do readir operation from other client (finds)
+        cmd = f"find {NFS_MOUNT} -name *.txt"
+        clients[3].exec_command(cmd=cmd, sudo=True)
+
+    except Exception as e:
+        log.error(f"Error : {e}")
+    finally:
+        log.info("Cleaning up")
+        cleanup_cluster(clients)
+        log.info("Cleaning up successfull")
+    return 0


### PR DESCRIPTION
# Description
Tests included

1. Perform Linux untar from 1 client and do readir operation from other client (ls -lart)
2. Perform Linux untar from 1 client and do readir operation from other client (du -sh)
3. Perform Linux untar from 1 client and do readir operation from other client (finds)





Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
