### PR TITLE
Calculate maximum storage in a pool that is available to be used

### DIFF
--- a/tests/misc_env/cosbench.py
+++ b/tests/misc_env/cosbench.py
@@ -196,6 +196,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     drivers = get_nodes_by_ids(ceph_cluster, kwargs["config"]["drivers"]["hosts"])
 
     try:
+        client.exec_command(cmd="sudo yum install -y --nogpgcheck ceph-common")
         install(controllers)
         for ctrl in controllers:
             enable_ports(ctrl, port=19088)

--- a/tests/misc_env/push_cosbench_workload.py
+++ b/tests/misc_env/push_cosbench_workload.py
@@ -195,7 +195,7 @@ def run(ceph_cluster, **kwargs) -> int:
     Returns:
         0 on Success and raises Exception on Failure.
     """
-    LOG.info("preaparing and pushing cosbench workload to fill 30% of the cluster")
+    LOG.info("preparing and pushing cosbench workload to fill 30% of the cluster")
     controller = get_nodes_by_ids(ceph_cluster, kwargs["config"]["controllers"])[0]
     client = ceph_cluster.get_nodes(role="installer")[0]
     rgw = ceph_cluster.get_nodes(role="rgw")[0]

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1884,12 +1884,46 @@ def clone_the_repo(config, node, path_to_clone):
 
 
 def calculate_available_storage(node):
-    log.info("Calculate current storage present in cluster")
-    out, err = node.exec_command(cmd="sudo ceph df --format json")
+    """
+    Calculate maximum storage that is available to be used.
+    It is the amount of data that can be used before the first OSD becomes full.
+    This is implicitly divided by replication factor or erasure code
+
+    Ceph uses below given formula to calculate MAX AVAIL value :
+    [min(osd.avail for osd in OSD_up) - ( min(osd.avail for osd in OSD_up).total_size * (1 - mon_osd_full_ratio)) ]
+      * len(osd.avail for osd in OSD_up) /pool.size()
+    min(osd.avail for osd in OSD_up) : Minimum space left in an OSD in up set in pool crush ruleset.
+      your usage is bounded by osd.X.
+    len(osd.avail for osd in OSD_up) : Number of OSDs in UP set in pool crush ruleset
+    pool.size() : pool replication size
+    refer https://access.redhat.com/solutions/2273951
+
+    Args:
+        node: node on which ceph commands are executed
+
+    Returns:
+        Max available space in bytes
+    """
     import json
 
+    log.info(
+        "Calculate maximum storage that is available to be used."
+        + " It is the amount of data that can be used before the first OSD becomes full."
+        + " This is implicitly divided by replication factor or erasure code"
+    )
+    out, err = node.exec_command(cmd="sudo radosgw-admin zone get --format json")
     out = json.loads(out)
-    return out["stats"]["total_avail_bytes"]
+    zone_name = out["name"]
+    rgw_bucket_data_pool = f"{zone_name}.rgw.buckets.data"
+    out, err = node.exec_command(cmd="sudo ceph df --format json")
+    if rgw_bucket_data_pool not in out:
+        node.exec_command(cmd=f"sudo ceph osd pool create {rgw_bucket_data_pool}")
+        time.sleep(10)
+        out, err = node.exec_command(cmd="sudo ceph df --format json")
+    ceph_df_json = json.loads(out)
+    for pool in ceph_df_json["pools"]:
+        if pool["name"] == rgw_bucket_data_pool:
+            return pool["stats"]["max_avail"]
 
 
 def perform_env_setup(config, node, ceph_cluster):


### PR DESCRIPTION
We have seen issue of fill workload with 30 percent fill is actually filling the entire cluster and the ceph status went into error state.
The issue is because, total_avail_bytes in ceph df does not consider replication factor, max available space until the first osd becomes full, mon_osd_full_ratio etc.. 

**MAX AVAIL**  gives us maximum storage in a pool that is available to be used. ceph calculates it by considering all the above factors. So we are going with that value for maximum avail space
[Raw](https://access.redhat.com/solutions/2273951#)
[min(osd.avail for osd in OSD_up) - ( min(osd.avail for osd in OSD_up).total_size * (1 - mon_osd_full_ratio)) ]* len(osd.avail for osd in OSD_up) /pool.size()

refer below ceph df output:
```
[root@folio01 ~]# ceph df
--- RAW STORAGE ---
CLASS    SIZE   AVAIL     USED  RAW USED  %RAW USED
hdd    24 TiB  24 TiB   71 GiB    71 GiB       0.28
ssd    68 TiB  68 TiB  142 GiB   142 GiB       0.20
TOTAL  93 TiB  93 TiB  213 GiB   213 GiB       0.22
 
--- POOLS ---
POOL                       ID  PGS   STORED  OBJECTS     USED  %USED  MAX AVAIL
.mgr                        1    1  3.2 MiB        2  9.6 MiB      0     29 TiB
.rgw.root                   2   32  9.6 KiB       22  252 KiB      0     29 TiB
default.rgw.log             3   32  3.6 KiB      177  408 KiB      0     29 TiB
default.rgw.control         4   32      0 B        8      0 B      0     29 TiB
default.rgw.meta            5   32    382 B        2   24 KiB      0     29 TiB
primary.rgw.log             6   32   81 MiB    1.51k  247 MiB      0     29 TiB
primary.rgw.control         7   32      0 B        8      0 B      0     29 TiB
primary.rgw.meta            8   32   34 KiB       91  1.0 MiB      0     29 TiB
primary.rgw.otp             9   32      0 B        0      0 B      0     29 TiB
primary.rgw.buckets.index  14   32   33 MiB       77   99 MiB      0     29 TiB
primary.rgw.buckets.data   15   32   56 GiB  496.43k  172 GiB   0.19     29 TiB
```


pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/calc_avail_space_on_pool/cephci-run-ST0XU7-folio-fill-10-percent/push_cosbench_fill_workload_0.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
