### PR TITLE
[Test] Add test to check dashboard URL

### DIFF
--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -99,6 +99,18 @@ def start_container(node, container_id):
     return node.exec_command(cmd=cmd, sudo=True)
 
 
+def restart_container(node, container_id):
+    """
+    Restarts a given container
+    Args:
+        node (ceph): ceph node object
+        container_id: id/name of the container
+    """
+    cmd = f"podman restart {container_id}"
+
+    return node.exec_command(cmd=cmd, sudo=True)
+
+
 def exec_command_on_container(node, ctr, cmd, **kw):
     """Execute command on container
 

--- a/suites/quincy/cephmgr/tier-2-cephmgr.yaml
+++ b/suites/quincy/cephmgr/tier-2-cephmgr.yaml
@@ -75,6 +75,20 @@ tests:
       name: Deploy cluster using cephadm
 
   - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the client system
+      destroy-cluster: false
+      module: test_client.py
+      name: Configure client
+
+  - test:
       name: Enable ceph insights on a ceph cluster
       desc: Enables ceph insights
       polarion-id: CEPH-83573683
@@ -215,3 +229,8 @@ tests:
       polarion-id: CEPH-11389
       module: test_cephmgr_plugins.py
 
+  - test:
+      name: Verify dashboard URL
+      desc: Verify dashboard URL does not bind to host.containers.internal
+      polarion-id: CEPH-83575611
+      module: test_dashboard_url.py

--- a/tests/mgr/test_dashboard_url.py
+++ b/tests/mgr/test_dashboard_url.py
@@ -1,0 +1,70 @@
+import re
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError, ResourceNotFoundError
+from cli.utilities.utils import (
+    get_running_containers,
+    get_service_id,
+    restart_container,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def check_dashboard_url(ceph_cluster):
+    """
+    Get dashboard URL from mgr service and check if dashboard URL does not
+    bind to host.containers.internal
+    """
+    url = ceph_cluster.get_mgr_services().get("dashboard")
+    if not url:
+        raise ResourceNotFoundError("Dashboard not configured")
+
+    if "host.containers.internal" in url:
+        log.error(f"Dashboard URL {url} is not binding to IP of hostname")
+        return False
+
+    log.info(f"Dashboard URL is {url}")
+    return True
+
+
+def run(ceph_cluster, **kw):
+    """
+    Check if the Ceph dashboard URL consists of host IP and
+    does not bind to host.containers.internal before and after
+    container restart and mgr failover is performed
+    """
+    # Get mgr node
+    node = ceph_cluster.get_nodes(role="mgr")[0]
+
+    # Check if dashboard URL does not bind to host.containers.internal
+    check_dashboard_url(ceph_cluster)
+    log.info("Dashboard URL does not bind to host.containers.internal")
+
+    # Get container id for mgr daemon
+    container_id = get_running_containers(
+        sudo=True, node=node, format="{{.ID}}", expr="name=mgr"
+    )[0]
+
+    # Restart container for mgr daemon
+    restart_container(node, container_id)
+
+    # Check if dashboard URL does not bind to host.containers.internal
+    check_dashboard_url(ceph_cluster)
+    log.info("Dashboard URL does not bind to host.containers.internal")
+
+    # Refresh the ceph orch ps command
+    CephAdm(node).ceph.orch.ps(refresh="True")
+
+    # Fail mgr service
+    regex = r"(?<=@mgr\.)[\w.-]+(?=\.service)"
+    out = get_service_id(node, "mgr")[0]
+    mgr_service = re.findall(regex, out)[0]
+    if CephAdm(node).ceph.mgr.fail(mgr=mgr_service):
+        raise OperationFailedError("Failed to execute `ceph mgr fail` command")
+
+    # Check if dashboard URL does not bind to host.containers.internal
+    check_dashboard_url(ceph_cluster)
+    log.info("Dashboard URL does not bind to host.containers.internal")
+    return 0


### PR DESCRIPTION
Test case covered - CEPH-83575611
Test steps -
1) Deploy ceph cluster with dashboard
2) Perform mgr container restart and mgr service failure 3) Verify the dashboard service does not bind to
host.containers.internal

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
