### PR TITLE
Fixing TFA Issue 10149

### DIFF
--- a/tests/cephfs/clients/client_fstab_auto_mount.py
+++ b/tests/cephfs/clients/client_fstab_auto_mount.py
@@ -95,14 +95,15 @@ def run(ceph_cluster, **kw):
         client1[0].exec_command(
             sudo=True, cmd="ceph fs set cephfs allow_standby_replay true"
         )
+        fs_name = "cephfs"
         for mon in fs_util_v1.mons:
-            FsUtilsV1.deamon_op(mon, "mon", "restart")
+            FsUtilsV1.deamon_op(mon, "mon.ceph", "restart")
         for mon in fs_util_v1.mons:
-            FsUtilsV1.check_deamon_status(mon, "mon", "active")
+            FsUtilsV1.check_deamon_status(mon, "mon.ceph", "active")
         for mds in fs_util_v1.mdss:
-            FsUtilsV1.deamon_op(mds, "mds", "restart")
+            FsUtilsV1.deamon_op(mds, rf"mds\.{fs_name}\.", "restart")
         for mds in fs_util_v1.mdss:
-            FsUtilsV1.check_deamon_status(mds, "mds", "active")
+            FsUtilsV1.check_deamon_status(mds, rf"mds\.{fs_name}\.", "active")
         client1[0].exec_command(
             cmd="sudo mkdir -p %s%s" % (client_info["mounting_dir"], dir_name)
         )
@@ -328,11 +329,11 @@ def run(ceph_cluster, **kw):
                 sudo=True, cmd="ceph fs set cephfs allow_standby_replay true"
             )
             for mon in fs_util_v1.mons:
-                FsUtilsV1.deamon_op(mon, "mon", "restart")
+                FsUtilsV1.deamon_op(mon, "mon.ceph", "restart")
             for mon in fs_util_v1.mons:
                 FsUtilsV1.check_deamon_status(mon, "mon", "active")
             for mds in fs_util_v1.mdss:
-                FsUtilsV1.deamon_op(mds, "mds", "restart")
+                FsUtilsV1.deamon_op(mds, rf"mds\.{fs_name}\.", "restart")
             for mds in fs_util_v1.mdss:
                 FsUtilsV1.check_deamon_status(mds, "mds", "active")
         else:
@@ -344,11 +345,11 @@ def run(ceph_cluster, **kw):
                 sudo=True, cmd="ceph fs set cephfs allow_standby_replay true"
             )
             for mon in fs_util_v1.mons:
-                FsUtilsV1.deamon_op(mon, "mon", "restart")
+                FsUtilsV1.deamon_op(mon, "mon.ceph", "restart")
             for mon in fs_util_v1.mons:
                 FsUtilsV1.check_deamon_status(mon, "mon", "active")
             for mds in fs_util_v1.mdss:
-                FsUtilsV1.deamon_op(mds, "mds", "restart")
+                FsUtilsV1.deamon_op(mds, rf"mds\.{fs_name}\.", "restart")
             for mds in fs_util_v1.mdss:
                 FsUtilsV1.check_deamon_status(mds, "mds", "active")
 


### PR DESCRIPTION
# Description

Problem :
We had a problem while picking up the mon service from the monitor nodes.
We had the latest push to the deamon_name function where we have removed **.ceph.** which has caused problem.
It was picking other matching service with the name argument.
Recent change PR: https://github.com/red-hat-storage/cephci/pull/2677

Solution:
Added **.ceph** while calling the funtion from test case it self



Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W9ILON/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
