### PR TITLE
[Test] Add test to validate spam log not present in cephadm log

### DIFF
--- a/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
@@ -38,6 +38,7 @@
 #   (6) Deploy NFS service using spec file,
 #       (a) Create OSD pool 'nfs-rgw-pool'
 #       (b) Deploy NFS on node4 using 'nfs-rgw-pool' pool.
+#   (7) Verify spam logs not present in cephadm logs
 #===============================================================================================
 tests:
   - test:
@@ -263,3 +264,8 @@ tests:
       config:
         nodes:
           - node2
+  - test:
+      name: Verify spam logs not present in cephadm logs
+      desc: Verify spam logs such as 'DEBUG sestatus' not present in cephadm logs (customer_bz)
+      polarion-id: CEPH-83575589
+      module: test_cephadm_log_spam.py

--- a/tests/cephadm/test_cephadm_log_spam.py
+++ b/tests/cephadm/test_cephadm_log_spam.py
@@ -1,0 +1,29 @@
+from cli.exceptions import OperationFailedError
+
+CEPHADM_LOG_PATH = "/var/log/ceph/cephadm.log"
+
+
+def run(ceph_cluster, **kw):
+    """Verify spam logs not present in cephadm.log
+    Args:
+        **kw: Key/value pairs of configuration information
+              to be used in the test.
+    """
+    node = ceph_cluster.get_nodes(role="_admin")[0]
+    admin = node.ssh
+    with admin().open_sftp().open(CEPHADM_LOG_PATH, "r") as file:
+        content = file.read()
+        # Spam logs were being generated as part of 'gather-facts'
+        # Validate 'gather-facts' related logs are present in the log file
+        if b"gather-facts" not in content:
+            OperationFailedError(
+                f"Failed: Expected log 'gather-facts' not found in {CEPHADM_LOG_PATH}"
+            )
+        # Spam logs had the string 'DEBUG sestatus' in them
+        # Validate spam logs are not present in the log file
+        if b"DEBUG sestatus:" in content:
+            OperationFailedError(
+                f"Failed: Spam log 'DEBUG sestatus' found in {CEPHADM_LOG_PATH}"
+            )
+
+    return 0


### PR DESCRIPTION
This patch covers the test case : CEPH-83575589

Test steps:

- Deploy ceph cluster with hosts and services
- Check cephadm log not contains unnecessary log message of "gather-facts" such as "DEBUG sestatus"