### PR TITLE
Adding RBD related methods to SDK

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,3 +1,6 @@
+from functools import partialmethod
+
+
 class Cli:
     def __init__(self, ctx):
         self.ctx = ctx
@@ -22,3 +25,5 @@ class Cli:
             return self.ctx.exec_command(
                 cmd=cmd, sudo=sudo, long_running=long_running, check_ec=check_ec
             )
+
+    execute_as_sudo = partialmethod(execute, sudo=True)

--- a/cli/rbd/device.py
+++ b/cli/rbd/device.py
@@ -1,0 +1,150 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Device(Cli):
+    """
+    This Class provides wrappers for rbd device commands.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Device, self).__init__(nodes)
+        self.base_cmd = base_cmd + " device"
+
+    def attach(self, **kw):
+        """Wrapper for rbd device attach.
+
+        Attach image to device.
+        Args:
+        kw: Key value pair of method arguments
+            Example::
+                rbd device attach <image-or-snap-spec> --device-type nbd
+            Supported keys:
+                device-type (str): device type [ggate, krbd (default), nbd]
+                pool(str): pool name
+                namespace(str): namespace name
+                image(str): image name
+                snap(str): snapshot name
+                device(str): specify device path
+                show-cookie(bool): show device cookie
+                cookie(str): specify device cookie
+                read-only(bool): attach read-only
+                force(bool): force attach
+                exclusive(bool): disable automatic exclusive lock transitions
+                quiesce(bool): use quiesce hooks
+                quiesce-hook(str): quiesce hook path
+                options(str): device specific options
+                image-or-snap-spec(str): [<pool-name>/[<namespace>/]]<image-name>[@<snap-name>]
+                See rbd help device attach for more supported keys
+        """
+
+        kw_copy = deepcopy(kw)
+        image_or_snap_spec = kw_copy.pop("image-or-snap-spec", "")
+        cmd = f"{self.base_cmd} attach {image_or_snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def detach(self, **kw):
+        """Wrapper for rbd device detach.
+
+        Detach image from device.
+        Args:
+        kw: Key value pair of method arguments
+            Example::
+                rbd device detach <image-or-snap-spec> --device-type nbd
+            Supported keys:
+                device-type (str): device type [ggate, krbd (default), nbd]
+                pool(str): pool name
+                namespace(str): namespace name
+                image(str): image name
+                snap(str): snapshot name
+                options(str): device specific options
+                image-snap-or-device-spec: [<pool-name>/]<image-name>[@<snap-name>]
+                                            or <device-path>
+                See rbd help device detach for more supported keys
+        """
+
+        kw_copy = deepcopy(kw)
+        image_snap_or_device_spec = kw_copy.pop("image-snap-or-device-spec", "")
+        cmd = f"{self.base_cmd} detach {image_snap_or_device_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def list_(self, **kw):
+        """Wrapper for rbd device list.
+
+        List mapped rbd images.
+        Args:
+        kw: Key value pair of method arguments
+            Example::
+                rbd device list
+            Supported keys:
+                device-type (str): device type [ggate, krbd (default), nbd]
+                format(str): output format (plain, json, or xml) [default: plain]
+                pretty-format(bool): True
+                See rbd help device list for more supported keys
+        """
+        cmd = f"{self.base_cmd} list {build_cmd_from_args(**kw)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def map(self, **kw):
+        """Wrapper for rbd device map.
+
+        Map an image to a block device.
+        Args:
+        kw: Key value pair of method arguments
+            Example::
+                rbd device map <image-or-snap-spec> --device-type nbd
+            Supported keys:
+                device-type (str): device type [ggate, krbd (default), nbd]
+                pool(str): pool name
+                namespace(str): namespace name
+                image(str): image name
+                snap(str): snapshot name
+                device(str): specify device path
+                show-cookie(bool): show device cookie
+                cookie(str): specify device cookie
+                read-only(bool): attach read-only
+                force(bool): force attach
+                exclusive(bool): disable automatic exclusive lock transitions
+                quiesce(bool): use quiesce hooks
+                quiesce-hook(str): quiesce hook path
+                options(str): device specific options
+                image-or-snap-spec(str): [<pool-name>/[<namespace>/]]<image-name>[@<snap-name>]
+                See rbd help device map for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_or_snap_spec = kw_copy.pop("image-or-snap-spec", "")
+        cmd = (
+            f"{self.base_cmd} map {image_or_snap_spec} {build_cmd_from_args(**kw_copy)}"
+        )
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def unmap(self, **kw):
+        """Wrapper for rbd device unmap.
+
+        Unmap a rbd device.
+        Args:
+        kw: Key value pair of method arguments
+            Example::
+                rbd device unmap <image-snap-or-device-spec>
+            Supported keys:
+                device-type (str): device type [ggate, krbd (default), nbd]
+                pool(str): pool name
+                namespace(str): namespace name
+                image(str): image name
+                snap(str): snapshot name
+                options(str): device specific options
+                image-snap-or-device-spec: [<pool-name>/]<image-name>[@<snap-name>]
+                                            or <device-path>
+                See rbd help device unmap for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_snap_or_device_spec = kw_copy.pop("image-snap-or-device-spec", "")
+        cmd = f"{self.base_cmd} unmap {image_snap_or_device_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/mirror/bootstrap.py
+++ b/cli/rbd/mirror/bootstrap.py
@@ -1,0 +1,51 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Bootstrap(Cli):
+    """This module provides CLI interface to manage rbd pool peer bootstrap commands."""
+
+    def __init__(self, nodes, base_cmd):
+        super(Bootstrap, self).__init__(nodes)
+        self.base_cmd = base_cmd + " bootstrap"
+
+    def create(self, **kw):
+        """Wrapper for pool peer bootstrap create.
+        Create a peer bootstrap token to import in a remote cluster.
+        Args:
+            kw: Key value pair of method arguments
+        Example::
+        Supported keys:
+            pool-name: Name of the pool of which peer is to be bootstrapped.
+            site-name: Name of the site for rbd-mirror
+                       name of both sites should be the same
+            See rbd help mirror pool peer bootstrap create for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        cmd = f"{self.base_cmd} create {pool_name} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def import_(self, **kw):
+        """Wrapper for pool peer bootstrap import.
+        Import a peer bootstrap token created from a remote cluster
+        Args:
+            kw: Key value pair of method arguments
+        Example::
+        Supported keys:
+            pool-name: Name of the pool of which peer is to be bootstrapped.
+            site-name: Name of the site for rbd-mirror
+                       name of both sites should be the same
+            token-path: The file name in which the key is stored
+            direction: mirroring direction (rx-only, rx-tx)
+            See rbd help mirror pool peer bootstrap import for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        token_path = kw_copy.pop("token-path", "")
+        cmd = f"{self.base_cmd} import {pool_name} {token_path} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/mirror/image.py
+++ b/cli/rbd/mirror/image.py
@@ -1,0 +1,143 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Image(Cli):
+    """This module provides CLI interface to manage rbd mirror image commands."""
+
+    def __init__(self, nodes, base_cmd):
+        super(Image, self).__init__(nodes)
+        self.base_cmd = base_cmd + " image"
+
+    def demote(self, **kw):
+        """Wrapper for rbd mirror image demote.
+        Args:
+            kw: Key value pair of method arguments
+        Example::
+        Supported keys:
+            image-spec: poolname/[namespace]/imagename
+            pool: Name of the pool.
+            namespace: Name of the namespace.
+            image: Name of the image.
+            See rbd help mirror image demote for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} demote {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def disable(self, **kw):
+        """Wrapper for rbd mirror image disable.
+        Args
+            kw: Key value pair of method arguments
+        Example::
+        Supported keys:
+            image-spec: poolname/[namespace]/imagename
+            pool: Name of the pool.
+            namespace: Name of the namespace.
+            image: Name of the image.
+            See rbd help mirror image disable for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} disable {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def enable(self, **kw):
+        """Wrapper for rbd mirror image enable.
+        Args
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                image-spec: poolname/[namespace]/imagename
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                image: Name of the image.
+                mode: Mode of mirroring(journal/snapshot) [default: journal]
+                See rbd help mirror image enable for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        mode = kw_copy.pop("mode", "")
+        cmd = f"{self.base_cmd} enable {image_spec} {mode} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def promote(self, **kw):
+        """Wrapper for rbd mirror image promote.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                image-spec: poolname/[namespace]/imagename
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                image: Name of the image.
+                force(bool): True - To promote image forcefully
+                See rbd help mirror image promote for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} promote {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def resync(self, **kw):
+        """Wrapper for rbd mirror image resync.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                image-spec: poolname/[namespace]/imagename
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                image: Name of the image.
+                See rbd help mirror image resync for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} resync {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def snapshot(self, **kw):
+        """Wrapper for rbd mirror image snapshot.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                image-spec: poolname/[namespace]/imagename
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                image: Name of the image.
+                See rbd help mirror image snapshot for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} snapshot {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def status(self, **kw):
+        """Wrapper for rbd mirror image status.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                format: output format (plain, json, or xml) [default: plain]
+                pretty-format: true - pretty formatting (json and xml)
+                image-spec: poolname/[namespace]/imagename
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                image: Name of the image.
+                See rbd help mirror image status for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} status {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/mirror/mirror.py
+++ b/cli/rbd/mirror/mirror.py
@@ -1,0 +1,19 @@
+from cli import Cli
+
+from .image import Image
+from .pool import Pool
+from .snapshot import Snapshot
+
+
+class Mirror(Cli):
+    """Base class for all rbd mirror commands.
+    This module provides CLI interface to manage rbd mirror and
+    objects with wrapper for sub-commands.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Mirror, self).__init__(nodes)
+        self.base_cmd = base_cmd + " mirror"
+        self.image = Image(nodes, self.base_cmd)
+        self.pool = Pool(nodes, self.base_cmd)
+        self.snapshot = Snapshot(nodes, self.base_cmd)

--- a/cli/rbd/mirror/peer.py
+++ b/cli/rbd/mirror/peer.py
@@ -1,0 +1,78 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.rbd.mirror.bootstrap import Bootstrap
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Peer(Cli):
+    """This module provides CLI interface to manage rbd mirror pool commands."""
+
+    def __init__(self, nodes, base_cmd):
+        super(Peer, self).__init__(nodes)
+        self.base_cmd = base_cmd + " peer"
+        self.bootstrap = Bootstrap(nodes, self.base_cmd)
+
+    def add_(self, **kw):
+        """Wrapper for rbd mirror pool peer add.
+        Command is used for adding a mirror pool peer
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool-name: Name of the pool.
+                pool: Name of the pool. (--pool <name>)
+                remote-cluster-spec: remote cluster specification - <client-name>@<cluster-name>
+                See rbd help mirror pool peer add for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        remote_cluster_spec = kw_copy.pop("remote-cluster-spec", "")
+        cmd = f"{self.base_cmd} add {pool_name} {remote_cluster_spec} \
+            {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def remove_(self, **kw):
+        """Wrapper for rbd mirror pool peer remove.
+        Command is used to remove a mirroring peer from a pool.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool-name: Name of the pool.
+                pool: Name of the pool. (--pool <name>)
+                uuid: peer uuid
+                See rbd help mirror pool peer remove for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        uuid = kw_copy.pop("uuid", "")
+        cmd = f"{self.base_cmd} remove {pool_name} {uuid} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def set_(self, **kw):
+        """Wrapper for rbd mirror pool peer set.
+        This command is used to update mirroring peer settings.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool-name: Name of the pool.
+                pool: Name of the pool. (--pool <name>)
+                uuid: peer uuid
+                key: peer parameter
+                (direction, site-name, client, mon-host, key-file)
+                value: new value for specified key
+                See rbd help mirror pool peer set for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        uuid = kw_copy.pop("uuid", "")
+        key = kw_copy.pop("key", "")
+        value = kw_copy.pop("value", "")
+        cmd = f"{self.base_cmd} set {pool_name} {uuid} {key} {value} \
+            {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/mirror/pool.py
+++ b/cli/rbd/mirror/pool.py
@@ -1,0 +1,133 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.rbd.mirror.peer import Peer
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Pool(Cli):
+    """This module provides CLI interface to manage rbd mirror pool commands."""
+
+    def __init__(self, nodes, base_cmd):
+        super(Pool, self).__init__(nodes)
+        self.base_cmd = base_cmd + " pool"
+        self.peer = Peer(nodes, self.base_cmd)
+
+    def demote(self, **kw):
+        """Wrapper for rbd mirror pool demote.
+        Command is used to demote all primary images in the pool.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                pool-spec: pool-name/namespace.
+                See rbd help mirror pool demote for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} demote {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def disable(self, **kw):
+        """Wrapper for rbd mirror pool disable.
+        Command is used to disable RBD mirroring by default within a pool.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                pool-spec: pool-name/namespace.
+                See rbd help mirror pool disable for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} disable {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def enable(self, **kw):
+        """Wrapper for rbd mirror pool enable.
+        Command is used to enable RBD mirroring by default within a pool.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                pool-spec: pool-name/namespace.
+                mode: mirror mode [image or pool]
+                site-name: Name of the site.
+                See rbd help mirror pool enable for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        mode = kw_copy.pop("mode", "")
+        cmd = f"{self.base_cmd} enable {pool_spec} {mode} \
+            {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def info(self, **kw):
+        """Wrapper for rbd mirror pool info.
+        Command is used to show information about the pool mirroring configuration.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                pool-spec: pool-name/namespace.
+                format: output format (plain, json, or xml) [default: plain]
+                pretty-format: True - pretty formatting (json and xml)
+                all: True - All information
+                See rbd help mirror pool info for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} info {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def promote(self, **kw):
+        """Wrapper for rbd mirror pool promote.
+        Command is used to promote a secondary image to primary.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                pool-spec: pool-name/namespace.
+                force: True - Bool value to force promote the image.
+                See rbd help mirror pool promote for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} promote {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def status(self, **kw):
+        """Wrapper for rbd mirror pool status.
+        Command is used to display the mirroring status of pool.
+        Args:
+            kw: Key value pair of method arguments
+            Example::
+            Supported keys:
+                pool: Name of the pool.
+                namespace: Name of the namespace.
+                pool-spec: pool-name/namespace.
+                format: output format (plain, json, or xml) [default: plain]
+                pretty-format: pretty formatting (json and xml)
+                verbose: Bool Value - display status of all images.
+                See rbd help mirror pool status for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} status {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/mirror/schedule.py
+++ b/cli/rbd/mirror/schedule.py
@@ -1,0 +1,85 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Schedule(Cli):
+    """
+    This module provides CLI interface to manage the mirror snapshot scheduling.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Schedule, self).__init__(nodes)
+        self.base_cmd = base_cmd + " schedule"
+
+    def add_(self, **kw):
+        """
+        This method is used to create a mirror-snapshot schedule.
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+              pool(str): name of the pool.
+              image(str): name of the image.
+              start-time(str): can be specified using the ISO 8601 time format(Optional).
+              interval(str): schedule interval
+              See rbd help mirror snapshot schedule add for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        interval = kw_copy.pop("interval", "")
+        start_time = kw_copy.pop("start-time", "")
+        cmd = f"{self.base_cmd} add {interval} {start_time} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def ls(self, **kw):
+        """
+        This method is used to list all snapshot schedules for a specific level (global, pool, or image).
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+              pool(str): name of the pool(Optional).
+              image(str): name of the image(Optional).
+              recursive(bool): set this to true to list all schedules at the specified level and below.
+              See rbd help mirror snapshot schedule ls for more supported keys
+        """
+        cmd = f"{self.base_cmd} ls {build_cmd_from_args(**kw)}"
+
+        return self.execute(cmd=cmd)
+
+    def status(self, **kw):
+        """
+        This method is used to view the status for when the next snapshots will be created for snapshot based mirroring.
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+              pool(str): name of the pool(Optional).
+              image(str): name of the image(Optional).
+              See rbd help mirror snapshot schedule status for more supported keys
+        """
+        cmd = f"{self.base_cmd} status {build_cmd_from_args(**kw)}"
+
+        return self.execute(cmd=cmd)
+
+    def remove_(self, **kw):
+        """
+        This method is used to remove a mirror-snapshot schedule.
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+              pool(str): name of the pool.
+              image(str): name of the image.
+              start-time(str): can be specified using the ISO 8601 time format(Optional).
+              interval(str): schedule interval
+              See rbd help mirror snapshot schedule remove for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        interval = kw_copy.pop("interval", "")
+        start_time = kw_copy.pop("start-time", "")
+        cmd = f"{self.base_cmd} remove {interval} {start_time} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/mirror/snapshot.py
+++ b/cli/rbd/mirror/snapshot.py
@@ -1,0 +1,13 @@
+from cli import Cli
+from cli.rbd.mirror.schedule import Schedule
+
+
+class Snapshot(Cli):
+    """
+    This module provides CLI interface to manage the mirror snapshots.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Snapshot, self).__init__(nodes)
+        self.base_cmd = base_cmd + " snapshot"
+        self.schedule = Schedule(nodes, self.base_cmd)

--- a/cli/rbd/pool.py
+++ b/cli/rbd/pool.py
@@ -1,0 +1,30 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Pool(Cli):
+    """
+    This module provides CLI interface to manage pools in rbd via rbd pool command.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Pool, self).__init__(nodes)
+        self.base_cmd = base_cmd + " pool"
+
+    def init(self, **kw):
+        """
+        Initiates rbd application on specified pool.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool-name(str) : name of the pool
+                See rbd help pool for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        cmd = f"{self.base_cmd} init {pool_name} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -1,0 +1,316 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+from .device import Device
+from .mirror.mirror import Mirror
+from .pool import Pool
+from .snap import Snap
+
+
+class Rbd(Cli):
+    def __init__(self, nodes, base_cmd=""):
+        super(Rbd, self).__init__(nodes)
+        self.base_cmd = f"{base_cmd}rbd"
+        self.pool = Pool(nodes, self.base_cmd)
+        self.mirror = Mirror(nodes, self.base_cmd)
+        self.device = Device(nodes, self.base_cmd)
+        self.snap = Snap(nodes, self.base_cmd)
+
+    def create(self, **kw):
+        """
+        Creates a block device image.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-spec(str) : <pool_name>/<image_name>
+                pool(str) : name of the pool into which image should be stored
+                size(str) : size of image
+                image(str): name of image to be created
+                See rbd help create for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        size = kw_copy.pop("size", "")
+        cmd = f"{self.base_cmd} create {image_spec} --size {size} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def ls(self, **kw):
+        """
+        Lists block device images within pool.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)  : name of the pool(optional)
+                pool-spec(str) : <pool_name>[/<namespace>]
+                See rbd help ls for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} ls {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def list_(self, **kw):
+        """
+        Lists block device images.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)  : name of the pool(optional)
+                pool-spec(str) : <pool_name>[/<namespace>]
+                See rbd help list for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        pool_spec = kw_copy.pop("pool-spec", "")
+        cmd = f"{self.base_cmd} list {pool_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def info(self, **kw):
+        """
+        Retrieves information on the block device image.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-or-snap-spec(str) : [<pool-name>/[<namespace>/]]<image-name>[@<snap-name>]
+                pool(str)  : name of the pool from which info should be retreived(optional)
+                image(str) :  name of the image from which info should be retreived
+                See rbd help info for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_or_snap_spec = kw_copy.pop("image-or-snap-spec", "")
+        cmd = f"{self.base_cmd} info {image_or_snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def status(self, **kw):
+        """
+        Retrieves current state of the block device image.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                See rbd help status for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} status {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def help(self, **kw):
+        """
+        Displays help for a particular rbd command.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                command(str): name of command
+                See rbd help for more supported keys
+        """
+        command = kw.get("command")
+        cmd = f"{self.base_cmd} help {command}"
+
+        return self.execute(cmd=cmd)
+
+    def map(self, **kw):
+        """
+        Maps RBD for one or more RBD images.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-or-snap-spec : [<pool-name>/[<namespace>/]]<image-name>[@<snap-name>]
+                device-type: device type [ggate, krbd (default), nbd, ubbd]
+                pool(str): Name of the pool(default is rbd)
+                image(str): image name
+                options(str): options to be passed
+                See rbd help map for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_or_snap_spec = kw_copy.pop("image-or-snap-spec", "")
+        cmd = (
+            f"{self.base_cmd} map {image_or_snap_spec} {build_cmd_from_args(**kw_copy)}"
+        )
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def unmap(self, **kw):
+        """
+        Unmaps RBD for one or more RBD images.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-or-snap-or-device-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                                                        [@<snap-name>] or <device-path>
+                pool(str): Name of the pool(default is rbd)
+                image(str): image name
+                options(str): options to be passed
+                See rbd help unmap for more supported keys
+        """
+
+        kw_copy = deepcopy(kw)
+        image_or_snap_or_device_spec = kw_copy.pop("image-or-snap-or-device-spec", "")
+        cmd = f"{self.base_cmd} unmap {image_or_snap_or_device_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def resize(self, **kw):
+        """
+        Resize the size of image.
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                image(str): name of the image on which resize should happen
+                size (int)     :  updated size of image
+                encryption_config (list): ["encryption-passphrase-file":<filepath>]
+                See rbd help resize for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} resize {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd, check_ec=False, long_running=False)
+
+    def rm(self, **kw):
+        """
+        Removes the block device image.
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-spec(str) : [<pool-name>/[<namespace>/]]<image-name
+                image(str) : name of the image that should be removed
+                pool(str)  : name of the pool from which image should be retreived(optional)
+                See rbd help rm for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} rm {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def flatten(self, **kw):
+        """
+        Flattens the snapshot.
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)      : name of the pool
+                image(str)     : name of the image
+                encryption-passphrase-file(str)      : file path containing encryption passphrase
+                image-spec(str): <pool>/<image>
+                See rbd help flatten for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} flatten {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def clone(self, **kw):
+        """
+        Clones the snapshot.
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)         : name of the pool
+                snap(str)         : name of the snapshot
+                image(str)        : name of the parent image
+                dest-pool(str)    : name of the destination pool
+                dest(str)         : name of the cloned image
+                source-snap-spec  : <parent_pool>/<parent_image>@<snap>
+                dest-image-spec   : <dest_pool>/<clone>
+                See rbd help clone for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        source_snap_spec = kw_copy.pop("source-snap-spec", "")
+        dest_image_spec = kw_copy.pop("dest-image-spec", "")
+        cmd = f"{self.base_cmd} clone {source_snap_spec} {dest_image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def children(self, **kw):
+        """
+        Lists the children of a snapshot.
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                image-or-snap-spec : [<pool-name>/[<namespace>/]]<image-name>[@<snap-name>]
+                pool(str)  : name of the pool
+                image(str) : name of the image
+                snap(str)  : name of the snapshot
+                See rbd help children for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_or_snap_spec = kw_copy.pop("image-or-snap-spec", "")
+        cmd = f"{self.base_cmd} children {image_or_snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def bench(self, **kw):
+        """
+        This method is used to generate a series of IOs to the image and measure the IO throughput and latency.
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+                image-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                io-type(str): can be read | write | readwrite | rw.
+                image(str): name of the image.
+                pool(str): name of the pool.
+                See rbd help bench for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} bench {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def encryption_format(self, **kw):
+        """
+        This method is used to apply the given encryption format on the image
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+                image-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                format(str) : encryption format [possible values: luks1, luks2]
+                passphrase-file(str) : path of file containing passphrase for unlocking the image
+                See rbd help encryption format for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        passphrase_file = kw_copy.pop("passphrase-file", "")
+        format = kw_copy.pop("format", "")
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} encryption format {image_spec} {format} {passphrase_file} \
+              {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def export(self, **kw):
+        """
+        This method is used to export image to file
+        Args:
+          kw(dict): Key/value pairs that needs to be provided to the installer
+          Example:
+            Supported keys:
+                source-image-or-snap-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                path-name(str) : export file (or '-' for stdout)
+                See rbd help export for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("source-image-or-snap-spec", "")
+        export_path = kw_copy.pop("path-name", "")
+        cmd = f"{self.base_cmd} export {image_spec} {export_path} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/snap.py
+++ b/cli/rbd/snap.py
@@ -1,0 +1,146 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Snap(Cli):
+    """
+    This module provides CLI interface to manage snapshots from images in pool.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Snap, self).__init__(nodes)
+        self.base_cmd = base_cmd + " snap"
+
+    def create(self, **kw):
+        """
+        Creates a snapshot.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    snap(str)  : name of the snapshot
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    snap-spec(str) : <pool>/<image>@<snap>
+                    See rbd help snap create for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        snap_spec = kw_copy.pop("snap-spec", "")
+        cmd = f"{self.base_cmd} create {snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def ls(self, **kw):
+        """
+        Lists snapshots.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    image(str): name of the image
+                    image-spec(str) : <pool>/<image>
+                    See rbd help snap ls for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} ls {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def rollback(self, **kw):
+        """
+        Rollback a snapshot.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    snap(str)  : name of the snapshot
+                    image(str) : name of the image
+                    snap-spec(str) : <pool>/<image>@<snap>
+                    See rbd help snap rollback for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        snap_spec = kw_copy.pop("snap-spec", "")
+        cmd = f"{self.base_cmd} rollback {snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def rm(self, **kw):
+        """
+        Removes the snapshot.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    snap(str)  : name of the snapshot
+                    image(str) : name of the image
+                    snap-spec(str) : <pool>/<image>@<snap>
+                    See rbd help snap rm for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        snap_spec = kw_copy.pop("snap-spec", "")
+        cmd = f"{self.base_cmd} rm {snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def purge(self, **kw):
+        """
+        Purges the snapshot.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)  : name of the pool
+                image(str) : name of the image
+                image-spec(str) : <pool>/<image>
+                See rbd help snap purge for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} purge {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def protect(self, **kw):
+        """
+        Protects the snapshot.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)  : name of the pool
+                snap(str)  : name of the snapshot
+                image(str) : name of the image
+                snap-spec(str) : <pool>/<image>@<snap>
+                See rbd help snap protect for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        snap_spec = kw_copy.pop("snap-spec", "")
+        cmd = f"{self.base_cmd} protect {snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def unprotect(self, **kw):
+        """
+        Unprotects the snapshot.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool(str)  : name of the pool
+                image(str) : name of the image
+                snap(str)  : name of the snapshot
+                snap-spec(str) : <pool>/<image>@<snap>
+                See rbd help snap unprotect for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        snap_spec = kw_copy.pop("snap-spec", "")
+        cmd = f"{self.base_cmd} unprotect {snap_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/utilities/check_data.py
+++ b/cli/utilities/check_data.py
@@ -1,0 +1,78 @@
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+is_list_equal = lambda x: all(i == x[0] for i in x)
+
+
+def get_md5sum_rbd_image(**kw):
+    """
+    Get md5sum of an RBD image.
+    kw: {
+        "image_spec": <pool/image> for which md5sum needs to be fetched,
+        "file_path": <path/filename> to which image is exported/mounted to fetch md5sum,
+        "rbd": <rbd_object>,
+        "client": <client_node>
+    }
+    """
+    rbd = kw.get("rbd", Rbd(kw.get("client")))
+    if kw.get("image_spec"):
+        export_spec = {
+            "source-image-or-snap-spec": kw.get("image_spec"),
+            "path-name": kw.get("file_path"),
+        }
+        if kw.get("rbd").export(**export_spec):
+            log.error(f"Export failed for image {kw.get('image_spec')}")
+            return None
+    elif kw.get("file_path"):
+        out = rbd.execute(cmd="md5sum {}".format(kw.get("file_path")))
+        log.info(f"Output of md5 sum command: {out}")
+        return out.split()[0]
+    else:
+        log.error("Not enough arguments to fetch md5 sum")
+        return None
+
+
+def check_data_integrity_rbd_image(**kw):
+    """
+    Verifies whether the md5sum of the images given in arguments is equal
+
+    Args:
+        kw: {
+            "images":[
+                {
+                    "image_spec": <>,
+                    "file_path": <>,
+                    "rbd":<rbd_object>,
+                    "client":<client_node>
+                },
+                {
+                    "image_spec": <>,
+                    "file_path":<>,
+                    "rbd":<rbd_object>,
+                    "client":<client_node>
+                }
+            ]
+        }
+    """
+    if len(kw.get("images")) < 2:
+        log.error("Provided number of images is not enough for comparison")
+        return 1
+
+    md5_sums = list()
+    for image_spec in kw.get("images"):
+        md5_sum = get_md5sum_rbd_image(**image_spec)
+        if not md5_sum:
+            log.error("Error while fetching md5sum")
+            return 1
+        md5_sums.append(md5_sum)
+
+    if is_list_equal(md5_sums):
+        log.info("md5 sums of all the images specified are equal")
+        return 0
+    else:
+        log.error("md5 sums for the given images don't match")
+        log.error(f"The md5sum values retrieved are : {','.join(md5_sums)}")
+        return 1

--- a/cli/utilities/dictionary.py
+++ b/cli/utilities/dictionary.py
@@ -1,0 +1,50 @@
+from utility.log import Log
+
+log = Log(__name__)
+
+
+# Fetches all the items in a dictionary whole value is also a dictionary
+getdict = lambda x: {k: v for (k, v) in x.items() if isinstance(v, dict)}
+
+# Returns whether an element in the list is a dictionary or not
+isdict = lambda x: [isinstance(i, dict) for i in x]
+
+
+def get_values(key, dictionary):
+    """
+    Find list of values for a particular key from a nested dictionary.
+
+    Args:
+        key: the key for which values need to be found
+        dictionary: the dictionary in which the values needs to be searched
+
+    Returns:
+        The values for the given key from a nested dictionary
+    """
+    for k, v in dictionary.items():
+        if k == key:
+            yield v
+        elif isinstance(v, dict):
+            for result in get_values(key, v):
+                yield result
+        elif isinstance(v, list):
+            for d in v:
+                if isinstance(d, dict):
+                    for result in get_values(key, d):
+                        yield result
+                else:
+                    yield d
+
+
+def get_first_value(key, dictionary):
+    """
+    Retrieve first value of a particular key from a nested dictionary.
+
+    Args:
+        key: the key for which values need to be found
+        dictionary: the dictionary in which the values needs to be searched
+
+    Returns:
+        The first value for the given key from a nested dictionary
+    """
+    return str(list(get_values(key, dictionary))[0])

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -1,5 +1,7 @@
 import os
+import random
 import re
+import string
 from datetime import datetime
 from json import loads
 from subprocess import PIPE, Popen
@@ -290,7 +292,10 @@ def build_cmd_from_args(seperator="=", **kw):
     cmd = ""
     for k, v in kw.items():
         if v is True:
-            cmd += f" {k}"
+            cmd += f" --{k}"
+        elif isinstance(v, list):
+            for val in v:
+                cmd += build_cmd_from_args(**val)
         else:
             if seperator and seperator in k:
                 cmd += f" --{k}{v}"
@@ -656,3 +661,20 @@ def change_permission(client, mount_point, file_count, permissions):
             )
         except Exception:
             raise OperationFailedError(f"failed to change permission for file{i}")
+
+
+def generate_random_string(**kw):
+    """
+    Generates a random string and returns it
+
+    Args:
+        kw: {
+            "len": 20
+        }
+
+    Returns:
+        The generated string
+    """
+    length = kw.get("len", 5)
+    temp_str = "".join([random.choice(string.ascii_letters) for _ in range(length)])
+    return temp_str


### PR DESCRIPTION
Adding some CLI methods and a few other common methods to the SDK module of cephci for use from RBD.

Note: All the CLI options present for RBD have not been added here, adding only the first basic few required for test automation at the moment. 
Will add more as and when the requirement arises.
