### PR TITLE
Fixing error with test suite tier-1_rbd_mirroring_upgrade-5-to-latest

### DIFF
--- a/tests/rbd_mirror/test_sync_point_snapshot_deletion.py
+++ b/tests/rbd_mirror/test_sync_point_snapshot_deletion.py
@@ -50,7 +50,7 @@ def run(**kw):
     with parallel() as p:
         for imagespec in imagespecs:
             p.spawn(mirror2.promote, force=True, imagespec=imagespec)
-            write_data(mirror2, imagespecs, "100M")
+            write_data(mirror2, [imagespec], "100M")
 
         for imagespec in imagespecs:
             p.spawn(prepare_for_failback, mirror1, imagespec)


### PR DESCRIPTION
The test suite tier-1_rbd_mirroring_upgrade-5-to-latest was failing in the pipeline with error - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/RHCEPH-5.3-RHEL-8-20230627.0/Regression/rbd/4/tier-1_rbd_mirroring_upgrade-5-to-latest/ 

The error has been fixed with the changes in this PR.

Success logs validating the fix - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-I4FE6A/ 