### PR TITLE
Fixing RHCEPHQE-10161

### DIFF
--- a/suites/pacific/cephfs/tier-2_fs.yaml
+++ b/suites/pacific/cephfs/tier-2_fs.yaml
@@ -108,6 +108,7 @@ tests:
       abort-on-fail: false
       desc: "Fill the cluster with specific percentage"
       module: test_io.py
+      name: Fill_Cluster
       config:
         cephfs:
           "fill_data": 60

--- a/tests/cephfs/test_io.py
+++ b/tests/cephfs/test_io.py
@@ -21,7 +21,7 @@ def run(ceph_cluster, **kw):
             fs_util = FsUtils(ceph_cluster)
             fs_util.prepare_clients(clients, build)
             fs_util.auth_list(clients)
-            client_count = config.get("cephfs").get("num_of_clients")
+            client_count = config.get("cephfs").get("num_of_clients", 1)
             if client_count > len(clients):
                 log.error(
                     f"NFS clients required to perform test is {client_count} but "


### PR DESCRIPTION
# Description

Fixing RHCEPHQE-10161
Problem : 
Logs were not present for the run.
When ran locally observed 2 issues which are caused because of recent PR support multiple clients for IO https://github.com/red-hat-storage/cephci/pull/2719

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F114EX/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
