### PR TITLE
Provide Flexibility to configure nvmeof initiator from test module

### DIFF
--- a/ceph/nvmeof/initiator.py
+++ b/ceph/nvmeof/initiator.py
@@ -6,4 +6,3 @@ class Initiator(NVMeCLI):
     def __init__(self, node):
         super().__init__(node)
         self.node = node
-        self.configure()

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -70,6 +70,7 @@ def initiators(ceph_cluster, gateway, config):
     """
     client = get_node_by_id(ceph_cluster, config["node"])
     initiator = Initiator(client)
+    initiator.configure()
     cmd_args = {
         "transport": "tcp",
         "traddr": gateway.node.ip_address,

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
@@ -60,6 +60,7 @@ def initiators(ceph_cluster, gateway, config):
     """
     client = get_node_by_id(ceph_cluster, config["node"])
     initiator = Initiator(client)
+    initiator.configure()
     cmd_args = {
         "transport": "tcp",
         "traddr": gateway.node.ip_address,

--- a/tests/nvmeof/test_ceph_nvmeof_ns_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_ns_limit.py
@@ -36,6 +36,7 @@ def initiators(ceph_cluster, gateway, config):
     """
     client = get_node_by_id(ceph_cluster, config["node"])
     initiator = Initiator(client)
+    initiator.configure()
     cmd_args = {
         "transport": "tcp",
         "traddr": gateway.node.ip_address,


### PR DESCRIPTION
Raising this PR to make https://github.com/red-hat-storage/cephci/blob/master/ceph/nvmeof/initiator.py flexible to be consumed by any test module for various implementations

Example - 
1) test modules like below configures initiator twice( https://github.com/red-hat-storage/cephci/blob/master/tests/nvmeof/test_ceph_nvmeof_ns_limit.py#L38 and https://github.com/red-hat-storage/cephci/blob/master/tests/nvmeof/test_ceph_nvmeof_ns_limit.py#L72 ) in on same initiator node which should be avoided

test modules - 
1) [test_ceph_nvmeof_gateway_scale.py](https://github.com/red-hat-storage/cephci/blob/master/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py)
2) [test_ceph_nvmeof_ns_limit.py](https://github.com/red-hat-storage/cephci/blob/master/tests/nvmeof/test_ceph_nvmeof_ns_limit.py)

Observe below from http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GPQZOY/test_10k_namespace_with_1_subsystem_in_Single_GW_0.log

```
**2023-07-18 05:44:43,215 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command yum install -y nvme-cli fio on 10.0.209.30 timeout 600
2023-07-18 05:44:46,567 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command modprobe nvme-fabrics on 10.0.209.30 timeout 600**


2023-07-18 05:44:46,618 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command nvme discover  --transport tcp --traddr 10.0.210.222 --trsvcid 5001 --output-format json on 10.0.209.30 timeout 600
2023-07-18 05:44:46,692 (cephci.test_ceph_nvmeof_ns_limit) [DEBUG] - cephci.tests.nvmeof.test_ceph_nvmeof_ns_limit.py:48 - {
  "genctr":2,
  "records":[
    {
      "trtype":"tcp",
      "adrfam":"ipv4",
      "subtype":"nvme subsystem",
      "treq":"not required",
      "portid":0,
      "trsvcid":"5001",
      "subnqn":"nqn.2016-06.io.spdk:cnode1",
      "traddr":"10.0.210.222",
      "eflags":0,
      "sectype":"none"
    }
  ]
}

2023-07-18 05:44:46,693 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command nvme connect  --transport tcp --traddr 10.0.210.222 --trsvcid 5001 --nqn nqn.2016-06.io.spdk:cnode1 on 10.0.209.30 timeout 600
............
2023-07-18 05:44:46,741 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command rbd create rbd/image1 --size 50M on 10.0.208.141 timeout 600
2023-07-18 05:44:46,856 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1592 - Command completed successfully
2023-07-18 05:44:46,856 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.tests.rbd.rbd_utils.py:105 - Command execution complete
2023-07-18 05:44:46,857 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command cd /tmp/ceph-nvmeof; python3 -m control.cli create_bdev  --image image1 --pool rbd --bdev bdev1 on 10.0.210.222 timeout 600
2023-07-18 05:44:47,053 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1592 - Command completed successfully
2023-07-18 05:44:47,053 (cephci.test_ceph_nvmeof_ns_limit) [DEBUG] - cephci.ceph.nvmeof.gateway.py:127 - ('', 'INFO:__main__:Created bdev bdev1: True\n')
2023-07-18 05:44:47,054 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command cd /tmp/ceph-nvmeof; python3 -m control.cli add_namespace  --subnqn nqn.2016-06.io.spdk:cnode1 --bdev bdev1 on 10.0.210.222 timeout 600
2023-07-18 05:44:47,225 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1592 - Command completed successfully
2023-07-18 05:44:47,226 (cephci.test_ceph_nvmeof_ns_limit) [DEBUG] - cephci.ceph.nvmeof.gateway.py:127 - ('', 'INFO:__main__:Added namespace 1 to nqn.2016-06.io.spdk:cnode1: True\n')
2023-07-18 05:44:47,227 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.tests.nvmeof.test_ceph_nvmeof_ns_limit.py:68 - {'node': 'node6', 'io_type': 'write'}


**2023-07-18 05:44:47,228 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command yum install -y nvme-cli fio on 10.0.209.30 timeout 600
2023-07-18 05:44:48,510 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command modprobe nvme-fabrics on 10.0.209.30 timeout 600**


2023-07-18 05:44:48,566 (cephci.test_ceph_nvmeof_ns_limit) [INFO] - cephci.ceph.ceph.py:1559 - Running command nvme list  --output-format json on 10.0.209.30 timeout 600
2023-07-18 05:44:48,583 (cephci.test_ceph_nvmeof_ns_limit) [DEBUG] - cephci.tests.nvmeof.test_ceph_nvmeof_ns_limit.py:77 - {'Devices': [{'NameSpace': 1, 'DevicePath': '/dev/nvme0n1', 'Firmware': '23.01', 'ModelNumber': 'SPDK bdev Controller', 'SerialNumber': '1', 'UsedBytes': 52428800, 'MaximumLBA': 12800, 'PhysicalSize': 52428800, 'SectorSize': 4096}]}
2023-07-18 05:44:48,584 (cephci.test_ceph_nvmeof_ns_limit) [DEBUG] - cephci.utility.utils.py:1959 - Config Received for fio: {'device_name': '/dev/nvme0n1', 'client_node': <ceph.ceph.CephNode object at 0x7fd4e0127438>, 'run_time': '10', 'long_running': True, 'io_type': 'write', 'cmd_timeout': 'notimeout'}
```