### PR TITLE
[Utility] Add support to collect cluster information

### DIFF
--- a/cephci/cluster_conf.py
+++ b/cephci/cluster_conf.py
@@ -1,0 +1,139 @@
+import yaml
+from docopt import docopt
+from utils.configs import get_cloud_credentials, get_configs
+
+from cli.cloudproviders import CloudProvider
+from cli.cluster.node import Node
+from cli.cluster.volume import Volume
+from cli.exceptions import ConfigError
+from utility.log import Log
+
+LOG = Log(__name__)
+
+ROOT_PASSWD = "passwd"
+
+
+doc = """
+Utility to generate cluster conf based on global-conf
+
+    Usage:
+        cephci/cluster_conf.py --cloud-type <CLOUD>
+            (--global-conf <YAML>)
+            (--prefix <STR>)
+            (--log-level <LOG>)
+            (--cluster-conf <YAML>)
+            [--config <YAML>]
+
+        cephci/cluster_conf.py --help
+
+    Options:
+        -h --help                   Help
+        -t --cloud-type <CLOUD>     Cloud type [openstack|ibmc|baremetal]
+        --global-conf <YAML>        Global config file with node details
+        -p --prefix <STR>           Resource name prefix
+        -l --log-level <LOG>        Log level for log utility
+        --cluster-conf <YAML>       Cluster config file path
+        --config <YAML>             Config file with cloud credentials
+"""
+
+
+def _set_log(level):
+    """Set log level"""
+    LOG.logger.setLevel(level.upper())
+
+
+def _load_config(config):
+    LOG.info(f"Loading config file - {config}")
+    with open(config, "r") as _stream:
+        try:
+            return yaml.safe_load(_stream)
+        except yaml.YAMLError:
+            raise ConfigError(f"Invalid configuration file '{config}'")
+
+
+def write_output(_file, data):
+    LOG.info(f"Writing cluster details to {_file}")
+    with open(_file, "w") as fp:
+        try:
+            yaml.dump(data, fp, default_flow_style=False)
+        except yaml.YAMLError:
+            raise ConfigError(f"Invalid configuration file '{_file}'")
+
+
+def collect_conf(cloud, prefix, config):
+    _conf = {}
+    for _c in config:
+        cluster = _c.get("ceph-cluster")
+        name = cluster.get("name")
+        _conf[name] = {}
+
+        LOG.info(f"Gathering info for cluster '{name}'")
+        for key in cluster.keys():
+            if "node" not in key:
+                continue
+
+            # Create node
+            node_name = f"{name}-{prefix}-{key}"
+
+            LOG.info(f"Collecting info for node '{node_name}'")
+            node = Node(node_name, cloud)
+            if not node.state:
+                LOG.error(f"Failed to get status for node '{node_name}'")
+                continue
+
+            # Update node details
+            _conf[name][node_name] = {}
+            _conf[name][node_name]["hostname"] = node.name
+            _conf[name][node_name]["id"] = key
+            _conf[name][node_name]["credentials"] = [
+                {"user": "root", "password": ROOT_PASSWD}
+            ]
+            _conf[name][node_name]["roles"] = cluster.get(key, {}).get("role")
+
+            if node.private_ips:
+                _conf[name][node_name]["private_ips"] = node.private_ips
+
+            if node.public_ips:
+                _conf[name][node_name]["public_ips"] = node.public_ips
+
+            if node.volumes:
+                _conf[name][node_name]["devices"] = [
+                    d for v in node.volumes for d in Volume(v, cloud).device
+                ]
+
+    return _conf
+
+
+if __name__ == "__main__":
+    # Set user parameters
+    args = docopt(doc)
+
+    # Get user parameters
+    config = args.get("--config")
+    cloud = args.get("--cloud-type")
+    global_conf = args.get("--global-conf")
+    prefix = args.get("--prefix")
+    log_level = args.get("--log-level")
+    cluster_conf = args.get("--cluster-conf")
+
+    # Set log level
+    _set_log(log_level)
+
+    # Read configuration for cloud
+    get_configs(config)
+
+    # Read configurations
+    cloud_configs = get_cloud_credentials(cloud)
+    global_configs = _load_config(global_conf).get("globals")
+
+    # Connect to cloud
+    cloud = CloudProvider(cloud, **cloud_configs)
+
+    # Cleanup cluster
+    data = collect_conf(cloud, prefix, global_configs)
+
+    # Log cluster configuration
+    LOG.info(f"\nCluster configuration details -\n{data}")
+
+    # write output to yaml
+    write_output(cluster_conf, data) if cluster_conf else None

--- a/cephci/provision.py
+++ b/cephci/provision.py
@@ -1,6 +1,7 @@
 import multiprocessing as mp
 
 import yaml
+from cluster_conf import collect_conf, write_output
 from docopt import docopt
 from utils.configs import get_cloud_credentials, get_configs
 
@@ -24,6 +25,7 @@ Utility to cleanup cluster from cloud
             (--inventory <YAML>)
             (--prefix <STR>)
             (--log-level <LOG>)
+            [--cluster-conf <YAML>]
             [--config <YAML>]
             [--image <STR>]
             [--vmsize <STR>]
@@ -41,6 +43,7 @@ Utility to cleanup cluster from cloud
         --image <STR>               Cloud images to be used for node
         --network <STR>             Cloud network to be attached to node
         --vmsize <STR>              Cloud image flavor
+        --cluster-conf <YAML>       Cluster config file path
         --config <YAML>             Config file with cloud credentials
 """
 
@@ -193,6 +196,7 @@ if __name__ == "__main__":
     image = args.get("--image")
     vmsize = args.get("--vmsize")
     log_level = args.get("--log-level")
+    cluster_conf = args.get("--cluster-conf")
 
     # Set log level
     _set_log(log_level)
@@ -214,3 +218,12 @@ if __name__ == "__main__":
 
     # Provision cluster
     provision(cloud, prefix, global_configs, node_configs, timeout, interval)
+
+    # Cleanup cluster
+    data = collect_conf(cloud, prefix, global_configs)
+
+    # Log cluster configuration
+    log.info(f"\nCluster configuration details -\n{data}")
+
+    # write output to yaml
+    write_output(cluster_conf, data) if cluster_conf else None

--- a/cli/cloudproviders/openstack.py
+++ b/cli/cloudproviders/openstack.py
@@ -352,6 +352,21 @@ class Openstack:
 
         return volume.state if volume else None
 
+    def get_volume_device_by_name(self, name):
+        """Get volume status by name
+
+        Args:
+            name (str): Name of volume
+        """
+        if not self._volumes or name not in self._volumes.keys():
+            self.get_volumes(refresh=True)
+
+        volume = self.get_volume_by_id(self._volumes.get(name))
+        if not volume:
+            return None
+
+        return [v.get("device") for v in volume.extra.get("attachments", [])]
+
     def attach_volume(self, node, volume):
         """Attach volume to node
 

--- a/cli/cluster/volume.py
+++ b/cli/cluster/volume.py
@@ -39,6 +39,11 @@ class Volume:
         """Volume state"""
         return self.cloud.get_volume_state_by_name(self.name)
 
+    @property
+    def device(self):
+        """Volume disk"""
+        return self.cloud.get_volume_device_by_name(self.name)
+
     def create(self, size, timeout=300, interval=10):
         """Create volume on cloud
 

--- a/examples/cluster-conf.yaml
+++ b/examples/cluster-conf.yaml
@@ -1,0 +1,84 @@
+
+<cluster-name>:
+  <node-name-1>:
+    hostname: <fake-hostname>
+    id: <fake-node-id>
+    credentials:
+      - user: <user-root>
+        password: <user-root-password>
+      - user: <user-cephuser>
+        password: <user-cephuser-password>
+    roles:
+      - _admin
+      - installer
+      - osd
+      - mon
+      - rgw
+    private_ips:
+      - 10.x.x.1
+    public_ips:
+      - 11.x.x.1
+    devices:
+      - /dev/sda
+      - /dev/sdb
+      - /dev/sdc
+      - /dev/sdd
+      - /dev/sde
+  <node-name-2>:
+    hostname: <fake-hostname>
+    id: <fake-node-id>
+    credentials:
+      - user: <user-root>
+        password: <user-root-password>
+      - user: <user-cephuser>
+        password: <user-cephuser-password>
+    roles:
+      - osd
+      - mon
+      - rgw
+    private_ips:
+      - 10.x.x.1
+    public_ips:
+      - 11.x.x.1
+    devices:
+      - /dev/sda
+      - /dev/sdb
+      - /dev/sdc
+      - /dev/sdd
+      - /dev/sde
+  <node-name-3>:
+    hostname: <fake-hostname>
+    id: <fake-node-id>
+    credentials:
+      - user: <user-root>
+        password: <user-root-password>
+      - user: <user-cephuser>
+        password: <user-cephuser-password>
+    roles:
+      - osd
+      - mon
+      - rgw
+    private_ips:
+      - 10.x.x.1
+    public_ips:
+      - 11.x.x.1
+    devices:
+      - /dev/sda
+      - /dev/sdb
+      - /dev/sdc
+      - /dev/sdd
+      - /dev/sde
+  <node-name-4>:
+    hostname: <fake-hostname>
+    id: <fake-node-id>
+    credentials:
+      - user: <user-root>
+        password: <user-root-password>
+      - user: <user-cephuser>
+        password: <user-cephuser-password>
+    roles:
+      - client
+    private_ips:
+      - 10.x.x.1
+    public_ips:
+      - 11.x.x.1


### PR DESCRIPTION
Add new utility to generate cluster config based on the global cluster config and node prefix. This changes  includes -

1. Standalone utility `cli/cluster_conf.py`, which will generate cluster config based on input.
2. Update `cli/provisioner.py`, which uses these libraries which generates config after successful provisioning.