### PR TITLE
[TestFix] Fix indentation for test case to deploy OSD

### DIFF
--- a/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
+++ b/suites/pacific/cephadm/tier-1_5-1_service-apply-spec.yaml
@@ -146,8 +146,9 @@ tests:
                   placement:
                     nodes:
                       - node1
-                  data_devices:
-                    all: "true"                         # boolean as string
+                  spec:
+                    data_devices:
+                      all: "true"                       # boolean as string
                 - service_type: osd
                   service_id: all_other_nodes
                   placement:


### PR DESCRIPTION
 Fix indentation for test case "Service deployment with spec" from test suite  "tier-1_5-1_service-apply-spec" to deploy OSD.