### PR TITLE
Removing verification as IO file not generated as part of V1

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -387,7 +387,6 @@ tests:
             script-name: test_acls.py
             config-file-name: test_acls.yaml
             timeout: 300
-            verify-io-on-site: ["ceph-sec"]
 
 # please include test cases before below rename testcase as the process is disruptive currently
   - test:


### PR DESCRIPTION
# Description
Issue IO file not found: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4q1so/Basic_ACLs_Test_0.log

Since IO files are not generated as part of v1 in ceph-qe-script, verification failed

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-l9soc/Basic_ACLs_Test_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
