### PR TITLE
Provided parallel execution fix using asyncio for rbd trash purge test

### DIFF
--- a/suites/pacific/interop/test-ceph-sanity.yaml
+++ b/suites/pacific/interop/test-ceph-sanity.yaml
@@ -84,6 +84,8 @@ tests:
         install_packages:
           - ceph-common
           - rbd-nbd
+          - jq
+          - fio
         copy_admin_keyring: true
       desc: Configure the RGW,RBD client system
       destroy-cluster: false

--- a/suites/quincy/interop/test-ceph-sanity.yaml
+++ b/suites/quincy/interop/test-ceph-sanity.yaml
@@ -84,6 +84,8 @@ tests:
         install_packages:
           - ceph-common
           - rbd-nbd
+          - jq
+          - fio
         copy_admin_keyring: true
       desc: Configure the RGW,RBD client system
       destroy-cluster: false

--- a/suites/quincy/rbd/basic-operations-unit-testing.yaml
+++ b/suites/quincy/rbd/basic-operations-unit-testing.yaml
@@ -93,6 +93,8 @@ tests:
         install_packages:
           - ceph-common
           - rbd-nbd
+          - jq
+          - fio
         node: node6
       desc: "Configure the client system"
       destroy-cluster: false

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -166,7 +166,7 @@ class Rbd:
             cmd += " --thick-provision"
         if self.ceph_version > 2 and self.k_m:
             cmd += f" --data-pool {self.datapool}"
-        self.exec_cmd(cmd=cmd)
+        return self.exec_cmd(cmd=cmd)
 
     def set_ec_profile(self, profile):
         self.exec_cmd(cmd="ceph osd erasure-code-profile rm {}".format(profile))

--- a/tests/rbd/test_rbd_trash_purge_schedule.py
+++ b/tests/rbd/test_rbd_trash_purge_schedule.py
@@ -49,7 +49,7 @@ def verify_schedule_add(
     log.debug(f"Verifying purge on pool {pool}")
     while iterations_remaining > 0:
         log.debug(f"Sleeping for {schedule_interval} mins with buffer")
-        time.sleep(schedule_interval * 60 + 5)
+        time.sleep(schedule_interval * 60 + 60)
         trash_list = rbd.trash_list(pool)
         log.debug(f"Trash list: {trash_list}")
         if len(trash_list) > 3:
@@ -99,7 +99,7 @@ def rbd_trash_purge_schedule(rbd, pool_type, **kw):
         )
 
     except Exception as error:
-        log.error(error.message)
+        log.error(error)
         return 1
 
     finally:


### PR DESCRIPTION
# Description
Fixes [RHCEPHQE-10043](https://issues.redhat.com//browse/RHCEPHQE-10043)
Failure logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BZX7MW/

`fio `command is failing on one of the images, bcz before creating image fio is started executing in a parallel thread
This is causing the parallel loop to break with exception
also increased the sleep buffer to get updated results after all trash images got purged successfully.

Success logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Q95H9W

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
