### PR TITLE
Include tests for multiple Initiator to the functional suite

### DIFF
--- a/conf/quincy/nvmeof/ceph_nvmeof_functional.yaml
+++ b/conf/quincy/nvmeof/ceph_nvmeof_functional.yaml
@@ -40,3 +40,9 @@ globals:
       node7:
         role:
           - client
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client

--- a/suites/quincy/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/quincy/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -54,6 +54,8 @@ tests:
         nodes:
           - node6
           - node7
+          - node8
+          - node9
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -123,7 +125,46 @@ tests:
       name: Test to perform Data Integrity test over NVMe-OF targets
       polarion-id:
 
-  # Cleanup Test Case
+# Run IOs using multiple-initiators against multi-subsystems based NVMe-OF targets using fio tool
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: false                           # Run SPDK with all pre-requisites
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5003
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5004
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode3
+            listener_port: 5003
+            node: node8
+          - subnqn: nqn.2016-06.io.spdk:cnode4
+            listener_port: 5004
+            node: node9
+      desc: Perform IOs on multi-subsystems with Multiple-Initiators
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to run IOs using multiple-initiators against multi-subsystems
+      polarion-id:
+
+#  # Cleanup Test Case
   - test:
       abort-on-fail: true
       config:
@@ -135,11 +176,17 @@ tests:
         subsystems:
           - nqn: nqn.2016-06.io.spdk:cnode1
           - nqn: nqn.2016-06.io.spdk:cnode2
+          - nqn: nqn.2016-06.io.spdk:cnode3
+          - nqn: nqn.2016-06.io.spdk:cnode4
         initiators:
           - subnqn: nqn.2016-06.io.spdk:cnode1
             node: node7
           - subnqn: nqn.2016-06.io.spdk:cnode2
             node: node7
+          - subnqn: nqn.2016-06.io.spdk:cnode3
+            node: node8
+          - subnqn: nqn.2016-06.io.spdk:cnode4
+            node: node9
         cleanup-only: true                        # clean up only
         cleanup:
           - pool


### PR DESCRIPTION
Include test for multiple Initiator  in functional suites

-  Covered the multiple initiators accessing multiple subsystems via nvme targets
- Modifed the test suit name as per the disussion

logs attached - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2DLOF0
