### PR TITLE
[nvmeof] normalize dict join without update

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -78,7 +78,8 @@ def initiators(ceph_cluster, gateway, config):
     json_format = {"output-format": "json"}
 
     # Discover the subsystems
-    sub_nqns, _ = initiator.discover(**{**cmd_args | json_format})
+    _disc_cmd = {**cmd_args, **json_format}
+    sub_nqns, _ = initiator.discover(**_disc_cmd)
     LOG.debug(sub_nqns)
     for nqn in json.loads(sub_nqns)["records"]:
         if nqn["trsvcid"] == str(config["listener_port"]):


### PR DESCRIPTION
Normalize dict joining without updating the dict.

> def test(**kwargs):
>     print(kwargs)
>     
> a = {"a": 1}
> b = {"b": 2}
> 
> c = {**a, **b}
> test(**c)
> 
> ❯ python3  /home/sunilkumar/.config/JetBrains/PyCharmCE2022.3/scratches/scratch.py
> {'a': 1, 'b': 2}
> 
