### PR TITLE
[Test] Add test to validate OSD spec with limit filter

### DIFF
--- a/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
@@ -151,6 +151,7 @@ tests:
                     data_devices:
                       all: "true"                         # boolean as string
                     encrypted: "true"                     # boolean as string
+                    unmanaged: "true"
           - config:
               command: shell
               args:                 # sleep to get all services deployed
@@ -269,6 +270,55 @@ tests:
               args:              # sleep to get all services deployed
                 - sleep
                 - "120"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node5
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW,RBD client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      name: Deploy OSD with limit filter spec
+      desc: Deploy OSD with limit filter spec
+      module: test_cephadm.py
+      config:
+        steps:                          # Deploy OSD with limit filter
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: osd
+                  service_id: small_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+                - service_type: osd
+                  service_id: big_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+          - config:
+              command: shell
+              args:                 # sleep to get all services deployed
+                - sleep
+                - "300"
+  - test:
+      name: Verify OSD deployed with limit filter spec
+      desc: Verify OSD deployed with limit filter spec
+      polarion-id: CEPH-83575588
+      module: test_osd_limit_filter.py
   - test:
       name: test_remove_service
       desc: Perform removal of RBD mirroring service from the cluster

--- a/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
@@ -161,6 +161,7 @@ tests:
                     data_devices:
                       all: "true"                         # boolean as string
                     encrypted: "true"                     # boolean as string
+                    unmanaged: "true"
           - config:
               command: shell
               args:                 # sleep to get all services deployed
@@ -269,3 +270,52 @@ tests:
       desc: Verify spam logs such as 'DEBUG sestatus' not present in cephadm logs (customer_bz)
       polarion-id: CEPH-83575589
       module: test_cephadm_log_spam.py
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node5
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW,RBD client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      name: Deploy OSD with limit filter spec
+      desc: Deploy OSD with limit filter spec
+      module: test_cephadm.py
+      config:
+        steps:                          # Deploy OSD with limit filter
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: osd
+                  service_id: small_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+                - service_type: osd
+                  service_id: big_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+          - config:
+              command: shell
+              args:                 # sleep to get all services deployed
+                - sleep
+                - "300"
+  - test:
+      name: Verify OSD deployed with limit filter spec
+      desc: Verify OSD deployed with limit filter spec
+      polarion-id: CEPH-83575588
+      module: test_osd_limit_filter.py

--- a/tests/cephadm/test_osd_limit_filter.py
+++ b/tests/cephadm/test_osd_limit_filter.py
@@ -1,0 +1,57 @@
+from json import loads
+
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from cli.cephadm.exceptions import CephadmOpsExecutionError
+from cli.exceptions import ResourceNotFoundError, UnexpectedStateError
+from cli.utilities.operations import wait_for_cluster_health
+from cli.utilities.utils import get_disk_list, get_service_id, get_service_state
+
+
+def run(ceph_cluster, **kw):
+    """Verify OSDs deployed using limit filter in the spec file
+    Args:
+        **kw: Key/value pairs of configuration information
+              to be used in the test.
+    """
+    admin = ceph_cluster.get_nodes(role="_admin")[0]
+    client = ceph_cluster.get_nodes(role="client")[0]
+    nodes = ceph_cluster.get_nodes(role="osd")
+
+    # Verify healthy cluster
+    if not client:
+        raise ResourceNotFoundError("Client node is missing, add a client node")
+    health = wait_for_cluster_health(client, "HEALTH_OK", 120, 10)
+    if not health:
+        raise UnexpectedStateError("Cluster is not in HEALTH_OK state")
+
+    # Verify if there are 12 OSDs listed as per the limit filter spec deployment
+    expected_ids = list(range(0, 12))
+    actual_ids = []
+    timeout, interval = 120, 2
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        osd_ps = loads(CephAdm(admin).ceph.orch.ps(daemon_type="osd", format="json"))
+        for key in osd_ps:
+            actual_ids.append(int(key["daemon_id"]))
+            actual_ids.sort()
+        if len(osd_ps) == 12 and expected_ids == actual_ids:
+            break
+    if w.expired:
+        raise ResourceNotFoundError(
+            "The count of OSDs does not match the expected count"
+        )
+
+    for node in nodes:
+        # Verify if OSD disks are being listed
+        osd_disks, _ = get_disk_list(sudo=True, node=node, expr="osd")
+        if not osd_disks:
+            raise CephadmOpsExecutionError("OSD disks not listed")
+
+        # Verify that the OSD services are not inactive
+        osd_id = get_service_id(node, "osd")
+        for id in osd_id:
+            status = get_service_state(node, id)
+            if "inactive" in status:
+                raise UnexpectedStateError(f"OSD {id} not in active state")
+
+    return 0


### PR DESCRIPTION
This patch covers the test case: CEPH-83575588

Test steps:

- Deploy ceph cluster with hosts and services
- Create osd spec yaml with limit filter
- Apply osd spec yaml
- Check service applied successfully and OSDs created