### PR TITLE
Adding skip_tc for skipping the TC

### DIFF
--- a/templates/result-email-template.html
+++ b/templates/result-email-template.html
@@ -135,6 +135,8 @@
                     <td><a style="color: green;" href="{{ test['log-link'] if  use_abs_log_link else test['log-link'].split("/")[-1] }}">{{ test.status }}</a></td>
                 {% elif test.status == 'Failed' %}
                     <td><a style="color: red;" href="{{ test['log-link'] if use_abs_log_link else test['log-link'].split("/")[-1] }}">{{ test.status }}</a></td>
+                {% elif test.status == 'Skipped' %}
+                    <td><a style="color: grey;" href="{{ test['log-link'] if use_abs_log_link else test['log-link'].split("/")[-1] }}">{{ test.status }}</a></td>
                 {% elif test.status == 'Not Executed' %}
                 <td style="color: grey">{{ test.status }}</td>
                 {% endif %}


### PR DESCRIPTION
# Description
Adding skip_tc for skipping the TC

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CP9MDV/ 

Skipped Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BRICUM/
First run logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N1R5IK



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
