### PR TITLE
Fix tox issue with value type comparison

### DIFF
--- a/tests/rados/test_osd_args.py
+++ b/tests/rados/test_osd_args.py
@@ -51,7 +51,7 @@ def run(ceph_cluster, **kw):
         out, err = cephadm.shell(args=[exec_cmd], check_status=False)
         log.debug(f"stdout: {out}")
         log.debug(f"stderr: {err}")
-        if type(value) == str and (
+        if isinstance(value, str) and (
             f"Invalid command: {value} doesn't represent a float" in err
             or f"Invalid command: {value} doesn't represent an int"
         ):


### PR DESCRIPTION
Fix tox issue, This is because newer update in the flake8 version

https://github.com/red-hat-storage/cephci/actions/runs/5712253957/job/15475385088
```
./tests/rados/test_osd_args.py:54:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

