### PR TITLE
Checking the rados memory pools

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
@@ -140,6 +140,7 @@ tests:
       module: test_bluestore_features.py
       polarion-id: CEPH-83575438
       config:
+          execution-time: 30
           cache_trim_max_skip_pinned:
             configurations:
                pool-1:

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -140,6 +140,7 @@ tests:
       module: test_bluestore_features.py
       polarion-id: CEPH-83575438
       config:
+          execution-time: 30
           cache_trim_max_skip_pinned:
             configurations:
                pool-1:

--- a/suites/reef/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/reef/rados/tier-2_rados_test_bluestore.yaml
@@ -140,6 +140,7 @@ tests:
       module: test_bluestore_features.py
       polarion-id: CEPH-83575438
       config:
+          execution-time: 30
           cache_trim_max_skip_pinned:
             configurations:
                pool-1:

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -283,7 +283,6 @@ def run(ceph_cluster, **kw):
         for osd_service in osd_services:
             cephadm.shell(args=[f"ceph orch restart {osd_service}"])
         time.sleep(30)
-        assert rados_obj.run_pool_sanity_check()
 
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")


### PR DESCRIPTION
# After enabling the scrubbing check the OSD size is getting increased by using the mempools.

As mentioned in the [BZ#1931504](https://bugzilla.redhat.com/show_bug.cgi?id=1931504), during the scrubbing there is drastic growth in the OSD memory. This the reporter observed in two days.

I performed the tests and automated the scenario on 7 node cluster and checked the memory growth up to 2gb. The execution time I mentioned in the suite file is 30 minutes. The steps are updated in the polarion test case.
[Testcase Link ](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitems?query=CEPH-83575438)
  
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
