### PR TITLE
Fixing reimage to handle multiple clusters

### DIFF
--- a/pipeline/baremetal/6.1.yaml
+++ b/pipeline/baremetal/6.1.yaml
@@ -2,7 +2,7 @@
 -
   cluster_conf: conf/quincy/upi/octo_11_node_env.yaml
   name: "Tier-1: End to End scenarios executed on greenfield deployment"
-  os_version: 9.1
+  os_version: 9.2
   platform: rhel-9
   rhbuild: "6.1"
   scenario: 1

--- a/pipeline/vars/v3.groovy
+++ b/pipeline/vars/v3.groovy
@@ -1143,11 +1143,13 @@ def getBuildUser() {
 
 def getNodeList(def clusterConf){
     def conf = yamlToMap(clusterConf, env.WORKSPACE)
-    def nodesMap = conf.globals[0]["ceph-cluster"].nodes
     def nodeList = []
 
-    nodesMap.eachWithIndex { item, index ->
-        nodeList.add(item.hostname)
+    conf.globals.each { globalConfig ->
+        def nodesMap = globalConfig["ceph-cluster"].nodes
+        nodesMap.each { item ->
+            nodeList.add(item.hostname)
+        }
     }
 
     return nodeList


### PR DESCRIPTION
# Description
Fixing reimage to handle multiple clusters

Problem:
Reimage script collect nodes from the first element.
error log : https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-upi-test-executor/57/

Solution:
Iterating it through all the ceph clusters and creating the nodelist

Pass Log :
https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-upi-test-executor/62/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
