### PR TITLE
CEPH-10792: Verify functionality of OSD config parameter 'osd_scrub_chunk_max'

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1750,3 +1750,25 @@ class RadosOrchestrator:
         stretch_details = osd_dump["stretch_mode"]
         log.debug(f"Stretch mode dump : {stretch_details}")
         return stretch_details
+
+    def get_ceph_pg_dump(self, pg_id: str) -> dict:
+        """
+        Fetches ceph pg dump in json format and returns the data
+        for input PG
+        Args:
+            pg_id: Placement Group ID for which pg dump has to be fetched
+
+        Returns: dictionary output of ceph pg dump for input PG ID
+        """
+        _cmd = "ceph pg dump_json pgs"
+        dump_out_str, _ = self.client.exec_command(cmd=_cmd)
+        if dump_out_str.isspace():
+            return {}
+        dump_out = json.loads(dump_out_str)
+        pg_stats = dump_out["pg_map"]["pg_stats"]
+        for pg_stat in pg_stats:
+            if pg_stat["pgid"] == pg_id:
+                return pg_stat
+
+        log.error(f"PG {pg_id} not found in ceph pg dump output")
+        raise KeyError(f"PG {pg_id} not found in ceph pg dump output")

--- a/suites/pacific/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-scrubbing.yaml
@@ -43,6 +43,39 @@ tests:
       name: deploy cluster
 
   - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: verify scrub chunk max
+      polarion-id: CEPH-10792
+      module: test_scrub_chunk_max.py
+      config:
+        delete_pool: true
+      desc: Scrub Chunk max validation
+
+  - test:
       name: Default scheduled scrub
       polarion-id: CEPH-9361
       module: scheduled_scrub_scenarios.py

--- a/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
@@ -1,6 +1,6 @@
 tests:
 
-  # Cluster deployment stage
+   # Cluster deployment stage
 
   - test:
       abort-on-fail: true
@@ -43,12 +43,46 @@ tests:
       name: deploy cluster
 
   - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: verify scrub chunk max
+      polarion-id: CEPH-10792
+      module: test_scrub_chunk_max.py
+      config:
+        delete_pool: true
+      desc: Scrub Chunk max validation
+
+  - test:
       name: Default scheduled scrub
       polarion-id: CEPH-9361
       module: scheduled_scrub_scenarios.py
       desc: Scheduled scrub validation
       config:
         scenario: "default"
+
   - test:
       name: Begin Time = End Time
       polarion-id: CEPH-9362
@@ -56,6 +90,7 @@ tests:
       desc: Scheduled scrub validation
       config:
         scenario: "begin_end_time_equal"
+
   - test:
       name: Begin time > End time
       polarion-id: CEPH-9363
@@ -63,6 +98,7 @@ tests:
       desc: Scheduled scrub validation
       config:
         scenario: "beginTime gt endTime"
+
   - test:
       name: Begin Time >End time<current
       polarion-id: CEPH-9365
@@ -70,6 +106,7 @@ tests:
       desc: Scheduled scrub validation
       config:
         scenario: "beginTime gt endTime lt currentTime"
+
   - test:
       name: Begin Time & End time > current
       polarion-id: CEPH-9368
@@ -77,6 +114,7 @@ tests:
       desc: Scheduled scrub validation
       config:
         scenario: "beginTime and endTime gt currentTime"
+
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371
@@ -84,6 +122,7 @@ tests:
       desc: Scheduled scrub validation
       config:
         scenario: "decreaseTime"
+
   - test:
       name: Unsetting scrubbing
       polarion-id: CEPH-9374

--- a/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
@@ -43,6 +43,39 @@ tests:
       name: deploy cluster
 
   - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: verify scrub chunk max
+      polarion-id: CEPH-10792
+      module: test_scrub_chunk_max.py
+      config:
+        delete_pool: true
+      desc: Scrub Chunk max validation
+
+  - test:
       name: Default scheduled scrub
       polarion-id: CEPH-9361
       module: scheduled_scrub_scenarios.py

--- a/tests/rados/test_scrub_chunk_max.py
+++ b/tests/rados/test_scrub_chunk_max.py
@@ -1,0 +1,188 @@
+"""
+Module to verify funationality and effect of OSD scrub_chunk_max parameter.
+BZ #1382226 - PG scrub bypasses 'osd_scrub_chunk_max' limit to find hash boundary
+"""
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-10792
+    Test to verify PG scrub is within the 'osd_scrub_chunk_max' limit
+    1. Create a replicated pool with single pg
+    2. Grab the default value of 'osd_scrub_chunk_max'
+    3. Set 'osd_scrub_chunk_max' to a low value, preferably lower than
+    the default. e.g. 5
+    4. Write few objects(>osd_scrub_chunk_max) to the created pool
+    5. Start deep-scrub of the pool with 1 pg having few objects
+    6. Wait for deep-scrub to complete and verify primary OSD logs
+        expected to find logs having entries like below:
+            be_scan_list (0/5 5:18dee445:::obj-12:head deep)
+            be_scan_list (0/5 5:18dee445:::obj-12:head deep)
+    7. Delete the created pools
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    rhbuild = config["rhbuild"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    pool_obj = PoolFunctions(node=cephadm)
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
+    pg_scrub_log_list = []
+    pool_name = "test_scrub_max"
+    log.info(
+        "Running test case to verify PG scrub is within the 'osd_scrub_chunk_max' limit"
+    )
+
+    try:
+        # fetch the custom scrub_chunk_max value from config
+        custom_scrub_chunk_max = config.get("scrub_chunk_max", 5)
+
+        # create a replicated pool with single pg
+        rados_obj.create_pool(pool_name=pool_name, **{"pg_num": 1, "pg_num_max": 1})
+
+        # retrieve default value of osd_scrub_chunk_max
+        org_scrub_chunk_max = mon_obj.get_config(
+            section="osd", param="osd_scrub_chunk_max"
+        )
+        log.info(f"Original value of osd_scrub_chunk_max is {org_scrub_chunk_max}")
+
+        # create 23 objects in the pool, for better validation, total number of objects
+        # in the pool should not be a multiple of the custom value set in 'osd_scrub_chunk_max' parameter
+        # 23 is chosen for sake of convenience, 27, 33, 34, any number which is
+        # not a multiple of 5 can be chosen
+        pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=23)
+
+        # set value of osd_scrub_chunk_max as 5 or whatever input provided
+        mon_obj.set_config(
+            **{
+                "section": "osd",
+                "name": "osd_scrub_chunk_max",
+                "value": custom_scrub_chunk_max,
+            }
+        )
+
+        time.sleep(10)  # blind wait to let ceph df stats account for all the objects
+        objs = rados_obj.get_cephdf_stats(pool_name=pool_name)["stats"]["objects"]
+        if objs < 23:
+            time.sleep(5)  # additional blind sleep to let objs show up in ceph df
+        assert objs == 23
+
+        primary_osd = rados_obj.get_pg_acting_set(pool_name=pool_name)[0]
+        pool_pgid = rados_obj.get_pgid(pool_name=pool_name)[0]
+        pool_id = pool_obj.get_pool_id(pool_name=pool_name)
+        pool_pg_dump = rados_obj.get_ceph_pg_dump(pg_id=pool_pgid)
+
+        log.info(f"last_deep_scrub: {pool_pg_dump['last_deep_scrub']}")
+        log.info(f"last_deep_scrub_stamp: {pool_pg_dump['last_deep_scrub_stamp']}")
+        if rhbuild and rhbuild.split(".")[0] > "5":
+            org_objects_scrubbed = int(pool_pg_dump["objects_scrubbed"])
+            log.info(f"objects_scrubbed: {org_objects_scrubbed}")
+
+        # log entries necessary for validation are present in log level 10
+        # setting log level to 20 for more holistic coverage
+        assert mon_obj.set_config(section="osd", name="debug_osd", value="20/20")
+
+        init_time, _ = installer_node.exec_command(cmd="sudo date '+%Y-%m-%d %H:%M:%S'")
+        rados_obj.run_deep_scrub(pool=pool_name)
+
+        start_time = datetime.datetime.now()
+        while datetime.datetime.now() <= start_time + datetime.timedelta(seconds=600):
+            pool_pg_dump = rados_obj.get_ceph_pg_dump(pg_id=pool_pgid)
+            if rhbuild and rhbuild.split(".")[0] > "5":
+                objects_scrubbed = int(pool_pg_dump["objects_scrubbed"])
+                log.info(f"Objects scrubbed: {objects_scrubbed} | Target: {objs}")
+                if (objects_scrubbed - org_objects_scrubbed) >= objs:
+                    end_time, _ = installer_node.exec_command(
+                        cmd="sudo date '+%Y-%m-%d %H:%M:%S'"
+                    )
+                    break
+                else:
+                    log.info(
+                        f"Objects scrubbed are less than target ({objs}). "
+                        f"Sleeping for 30 secs"
+                    )
+                    time.sleep(30)
+            if (
+                pool_pg_dump["last_deep_scrub"] != "0'0"
+                and pool_pg_dump["state"] == "active+clean"
+            ):
+                log.info(f"Deep-scrub completed, pg state: {pool_pg_dump['state']}")
+                end_time, _ = installer_node.exec_command(
+                    cmd="sudo date '+%Y-%m-%d %H:%M:%S'"
+                )
+                break
+            else:
+                log.info(
+                    f"deep-scrub is yet to complete, pg state: {pool_pg_dump['state']}. "
+                    f"Sleeping for 30 secs"
+                )
+                time.sleep(30)
+        else:
+            log.error(
+                f"All {objs} objects in pool {pool_name} couldn't get scrubbed within 10 mins"
+            )
+            return 1
+
+        log.info(f"Final last_deep_scrub: {pool_pg_dump['last_deep_scrub']}")
+        log.info(
+            f"Final last_deep_scrub_stamp: {pool_pg_dump['last_deep_scrub_stamp']}"
+        )
+        if rhbuild and rhbuild.split(".")[0] > "5":
+            log.info(f"Final objects_scrubbed: {pool_pg_dump['objects_scrubbed']}")
+
+        scrub_logs = rados_obj.get_journalctl_log(
+            start_time=init_time,
+            end_time=end_time,
+            daemon_type="osd",
+            daemon_id=primary_osd,
+        )
+
+        for line in scrub_logs.splitlines():
+            if f"pg[{pool_id}.0(" in line and "be_scan_list" in line:
+                pg_scrub_log_list.append(line)
+
+        pg_scrub_log = "\n".join(pg_scrub_log_list)
+        log.debug(
+            f"\n ==========================================================================="
+            f"\n Scrub log entries: \n {pg_scrub_log}"
+            f"\n ==========================================================================="
+        )
+
+        for i in range(objs % custom_scrub_chunk_max):
+            log.info(
+                f"Verifying existence of log entry 'be_scan_list ({i}/{objs % custom_scrub_chunk_max}'"
+            )
+            assert f"be_scan_list ({i}/{objs % custom_scrub_chunk_max}" in pg_scrub_log
+            log.info("PASS")
+
+        for i in range(custom_scrub_chunk_max):
+            log.info(
+                f"Verifying existence of log entry 'be_scan_list ({i}/{custom_scrub_chunk_max}'"
+            )
+            assert f"be_scan_list ({i}/{custom_scrub_chunk_max}" in pg_scrub_log
+            log.info("PASS")
+
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        mon_obj.remove_config(section="osd", name="osd_scrub_chunk_max")
+        mon_obj.remove_config(section="osd", name="debug_osd")
+        if config.get("delete_pool"):
+            rados_obj.detete_pool(pool=pool_name)
+
+    log.info("Verification of scrub_chunk_max parameter completed")
+    return 0


### PR DESCRIPTION
[CEPH-10792](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10792): PG scrub bypasses `osd_scrub_chunk_max` limit to find hash boundary | PG scrub bypasses `osd_scrub_chunk_max` limit to find hash boundary

Bugzilla - [1382226](https://bugzilla.redhat.com/show_bug.cgi?id=1382226)
PG scrub code requires a chunk it's scrubbing to begin and end on a hash boundary.
Test ensures scrubbing occurs in limited chunks defined by the parameter `osd_scrub_chunk_max`

_**Test modules added**_:
- _tests/rados/test_scrub_chunk_max.py_
- _get_ceph_pg_dump_ in _ceph/rados/core_workflows.py_

_**Test suites modified:**_
- _suites/pacific/rados/tier-2_rados_test-scrubbing.yaml_
- _suites/quincy/rados/tier-2_rados_test-scrubbing.yaml_
- _suites/reef/rados/tier-2_rados_test-scrubbing.yaml_

_**Test steps:**_
1. Create a replicated pool with single pg
2. Grab the default value of 'osd_scrub_chunk_max'
3. Set 'osd_scrub_chunk_max' to a low value, preferably lower than the default. e.g. 5
4. Write few objects(>osd_scrub_chunk_max) to the created pool
5. Start deep-scrub of the pool with 1 pg having few objects
6. Wait for deep-scrub to complete and verify primary OSD logs expected to find logs having entries like below:
            ```be_scan_list (0/5 5:18dee445:::obj-12:head deep)```
            ```be_scan_list (0/5 5:18dee445:::obj-12:head deep)```
7. Delete the created pools

_**Logs -**_ 
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TWWYVY/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-S4PA6H/ (old)
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7XRI08

Signed-off-by: Harsh Kumar <hakumar@redhat.com>