### PR TITLE
Adding reef to upstream listener job

### DIFF
--- a/pipeline/upstream_listener.groovy
+++ b/pipeline/upstream_listener.groovy
@@ -84,6 +84,11 @@ node("rhel-9-medium") {
                 job: "rhceph-upstream-listener",
                 parameters: [string(name: 'releaseName', value: "quincy")]
             ])
+            build ([
+                wait: false,
+                job: "rhceph-upstream-listener",
+                parameters: [string(name: 'releaseName', value: "reef")]
+            ])
         }
     }
 }


### PR DESCRIPTION
Adding reef branch into upstream listener build to collect reef build infromation.

https://jenkins.ceph.redhat.com/job/rhceph-upstream-listener/869/console

