### PR TITLE
[TestFix] Fix Configure client test failure

### DIFF
--- a/suites/pacific/ceph_volume/tier-2-ceph-volume.yaml
+++ b/suites/pacific/ceph_volume/tier-2-ceph-volume.yaml
@@ -76,13 +76,13 @@ tests:
 
   - test:
       name: Configure client
-      desc: Configure client on node5
+      desc: Configure client on node4
       module: test_client.py
       polarion-id: CEPH-83573758
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node5                       # client node
+        node: node4                       # client node
         install_packages:
           - ceph-common                   # install ceph common packages
         copy_admin_keyring: true          # Copy admin keyring to node


### PR DESCRIPTION
Problem:
The Pacific suite ceph_volume/tier-2-ceph-volume
was failing with AttributeError: 'NoneType' object has no attribute 'distro_info'

Fix:
The reason of this issue is that from the test client5 is being called, where as the conf has only 4 nodes. So marking the client4 in test will resolve the issue

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
