### PR TITLE
Enhance NVMeOF namespace limit test case and handle fio

### DIFF
--- a/ceph/nvmeof/gateway.py
+++ b/ceph/nvmeof/gateway.py
@@ -40,6 +40,20 @@ def kill_spdk_process(node: CephNode):
         node.exec_command(cmd=f"kill -9 {pid}", check_ec=False, sudo=True)
 
 
+def fetch_gateway_log(node: CephNode):
+    """fetch GW server logs.
+
+    Args:
+        node: Gateway node
+    """
+    out, _ = node.exec_command(
+        sudo=True,
+        cmd=f"cd {REPO_PATH}; cat output.log",
+        check_ec=False,
+    )
+    LOG.debug(out)
+
+
 def configure_spdk(node: CephNode, rbd_pool):
     """SPDK installation on Gateway node.
 

--- a/conf/quincy/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
+++ b/conf/quincy/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
@@ -37,3 +37,10 @@ globals:
       node7:
         role:
           - client
+      node8:
+        role:
+          - client
+      node9:
+        role:
+          - client
+

--- a/suites/quincy/nvmeof/tier-2_nvmeof_namespace_limit.yaml
+++ b/suites/quincy/nvmeof/tier-2_nvmeof_namespace_limit.yaml
@@ -67,6 +67,8 @@ tests:
           - node5
           - node6
           - node7
+          - node8
+          - node9
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -94,7 +96,7 @@ tests:
           allow_host: "*"
         namespaces:
           start_count: 1
-          end_count: 1000
+          end_count: 2500
           sub_nqn: nqn.2016-06.io.spdk:cnode1
           size: 50M
         initiators:
@@ -107,7 +109,7 @@ tests:
       desc: test namespace limitations
       destroy-cluster: false
       module: test_ceph_nvmeof_ns_limit.py
-      name: test 1k namespace with 1 subsystem in Single GW
+      name: test 2.5k namespace with 1 subsystem in Single GW
       polarion-id:
 
   - test:
@@ -120,8 +122,8 @@ tests:
         rep_pool_config:
           pool: rbd
         namespaces:
-          start_count: 1001
-          end_count: 2000
+          start_count: 2501
+          end_count: 5000
           sub_nqn: nqn.2016-06.io.spdk:cnode1
           size: 50M
         initiators:
@@ -133,7 +135,60 @@ tests:
           io_type: write
       desc: test namespace limitations
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: test 2k namespace with 1 subsystem in Single GW
+      module: test_ceph_nvmeof_ns_limit.py
+      name: test 5k namespace with 1 subsystem in Single GW
       polarion-id:
 
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        namespaces:
+          start_count: 5001
+          end_count: 7500
+          sub_nqn: nqn.2016-06.io.spdk:cnode1
+          size: 50M
+        initiators:
+          subnqn: nqn.2016-06.io.spdk:cnode1
+          listener_port: 5001
+          node: node8
+        run_io:
+          node: node8
+          io_type: write
+      desc: test namespace limitations
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_limit.py
+      name: test 7.5k namespace with 1 subsystem in Single GW
+      polarion-id:
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        namespaces:
+          start_count: 7501
+          end_count: 10000
+          sub_nqn: nqn.2016-06.io.spdk:cnode1
+          size: 50M
+        initiators:
+          subnqn: nqn.2016-06.io.spdk:cnode1
+          listener_port: 5001
+          node: node9
+        run_io:
+          node: node9
+          io_type: write
+      desc: test namespace limitations
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_limit.py
+      name: test 10k namespace with 1 subsystem in Single GW
+      polarion-id:

--- a/tests/nvmeof/test_ceph_nvmeof_ns_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_ns_limit.py
@@ -6,7 +6,12 @@ to find namespace limitations
 import json
 
 from ceph.ceph import Ceph
-from ceph.nvmeof.gateway import Gateway, configure_spdk, delete_gateway
+from ceph.nvmeof.gateway import (
+    Gateway,
+    configure_spdk,
+    delete_gateway,
+    fetch_gateway_log,
+)
 from ceph.nvmeof.initiator import Initiator
 from ceph.utils import get_node_by_id
 from tests.rbd.rbd_utils import initial_rbd_config
@@ -57,7 +62,7 @@ def initiators(ceph_cluster, gateway, config):
     LOG.debug(initiator.connect(**cmd_args))
 
 
-@retry(Exception, tries=5, delay=10)
+@retry(Exception, tries=3, delay=10)
 def run_io(ceph_cluster, num, io):
     """Run IO on newly added namespace.
 
@@ -73,12 +78,6 @@ def run_io(ceph_cluster, num, io):
     # List NVMe targets.
     targets, _ = initiator.list(**json_format)
     data = json.loads(targets)
-    filtered_namespace = {
-        "Devices": [device for device in data["Devices"] if device["NameSpace"] == num]
-    }
-    if filtered_namespace is None:
-        raise Exception("nvme volume not found")
-    LOG.debug(filtered_namespace)
     device_path = next(
         (
             device["DevicePath"]
@@ -87,16 +86,22 @@ def run_io(ceph_cluster, num, io):
         ),
         None,
     )
+    LOG.debug(device_path)
 
-    io_args = {
-        "device_name": device_path,
-        "client_node": client,
-        "run_time": "10",
-        "long_running": True,
-        "io_type": io["io_type"],
-        "cmd_timeout": "notimeout",
-    }
-    run_fio(**io_args)
+    if device_path is None:
+        raise Exception("nvme volume not found")
+    else:
+        io_args = {
+            "device_name": device_path,
+            "client_node": client,
+            "run_time": "10",
+            "long_running": True,
+            "io_type": io["io_type"],
+            "cmd_timeout": "notimeout",
+        }
+        result = run_fio(**io_args)
+        if result == 1:
+            raise Exception("FIO failure")
 
 
 def cleanup(ceph_cluster, rbd_obj, config):
@@ -210,6 +215,8 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     except Exception as err:
         LOG.error(err)
     finally:
+        gw_node = get_node_by_id(ceph_cluster, config["gw_node"])
+        fetch_gateway_log(gw_node)
         if config.get("cleanup"):
             rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
             cleanup(ceph_cluster, rbd_obj, config)


### PR DESCRIPTION
Enhance https://github.com/red-hat-storage/cephci/blob/master/tests/nvmeof/test_ceph_nvmeof_ns_limit.py and handle fio
key things - 
a. Display GW server log irrespective of test pass or failure
b. handle fio - 1) if no file_name/ debice_name is fetched 2) if FIO output is a failure / exit status 1

Test run log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XE1GZF/test_2.5k_namespace_with_1_subsystem_in_Single_GW_0.log

Test run log without https://github.com/red-hat-storage/cephci/blob/master/tests/nvmeof/test_ceph_nvmeof_ns_limit.py#L61 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UFA597/test_2.5k_namespace_with_1_subsystem_in_Single_GW_0.log

Complete log at http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VJMG60