### PR TITLE
Enhance NVMeOF subsystem limit exploration test case 

### DIFF
--- a/suites/quincy/nvmeof/tier-2_nvmeof_subsystem_limit.yaml
+++ b/suites/quincy/nvmeof/tier-2_nvmeof_subsystem_limit.yaml
@@ -98,3 +98,28 @@ tests:
       module: test_ceph_nvmeof_sub_limit.py
       name: Scale 500 subsystems in Single GW
       polarion-id:
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true
+        subsystems:
+          start_count: 1
+          end_count: 1100
+          size: 50M
+        initiators:
+          node: node6
+        run_io:
+          node: node6
+          io_type: write
+      desc: test subsystem limitations
+      destroy-cluster: false
+      module: test_ceph_nvmeof_sub_limit.py
+      name: Scale 500 subsystems in Single GW
+      polarion-id:

--- a/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
@@ -5,7 +5,12 @@ to find subsystem limitations
 import json
 
 from ceph.ceph import Ceph
-from ceph.nvmeof.gateway import Gateway, configure_spdk, delete_gateway
+from ceph.nvmeof.gateway import (
+    Gateway,
+    configure_spdk,
+    delete_gateway,
+    fetch_gateway_log,
+)
 from ceph.nvmeof.initiator import Initiator
 from ceph.utils import get_node_by_id
 from tests.rbd.rbd_utils import initial_rbd_config
@@ -159,6 +164,8 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     except Exception as err:
         LOG.error(err)
     finally:
+        gw_node = get_node_by_id(ceph_cluster, config["gw_node"])
+        fetch_gateway_log(gw_node)
         if config.get("cleanup"):
             rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
             cleanup(ceph_cluster, rbd_obj, config)


### PR DESCRIPTION
Enhance https://github.com/red-hat-storage/cephci/blob/master/suites/quincy/nvmeof/tier-2_nvmeof_subsystem_limit.yaml

Depends on https://github.com/red-hat-storage/cephci/pull/2800 w.r.t FIO handling
Fetches Gateway server log at end of each test 