### PR TITLE
Including 10s sleep before verification of io in MS

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -295,8 +295,8 @@ def run(**kw):
                 verify_io_on_site_node = clusters.get(site).get_ceph_object("rgw").node
                 log.info(f"Check sync status on {site}")
                 verify_sync_status(verify_io_on_site_node)
-                # adding sleep for 60 seconds before verification of data starts
-                time.sleep(60)
+                # adding sleep for 80 seconds before verification of data starts
+                time.sleep(80)
                 log.info(f"verification IO on {site}")
                 if test_site != site:
                     copy_file_from_node_to_node(


### PR DESCRIPTION
# Description
Its an intermittent issue with verification io on another site, so adding 10s more before verifing

issue: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8h9qz/Dynamic_Resharding_tests_on_Primary_cluster_0.log

log: https://reportportal-ocs3.apps.ocp-c1.prod.psi.redhat.com/ui/#rhcs/launches/-1/592/46295/46448/log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
