### PR TITLE
[Reef] Add checks for supporting reef

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -142,7 +142,11 @@ class CephAdmin(BootstrapMixin, ShellMixin):
         rh_build = self.config.get("rhbuild", "6.0-rhel-9")
         os_major_version = rh_build.split("-")[-1]
 
-        if rh_build.startswith("6"):
+        if rh_build.startswith("7"):
+            cdn_repo = {
+                "9": "rhceph-7-tools-for-rhel-9-x86_64-rpms",
+            }
+        elif rh_build.startswith("6"):
             cdn_repo = {
                 "9": "rhceph-6-tools-for-rhel-9-x86_64-rpms",
             }

--- a/tests/cephadm/test_custom_container.py
+++ b/tests/cephadm/test_custom_container.py
@@ -43,7 +43,9 @@ def run(ceph_cluster, **kw):
 
     # Get the rhbuild
     rhbuild = config.get("rhbuild")
-    if rhbuild.startswith("6"):
+    if rhbuild.startswith("7"):
+        rhbuild = "reef"
+    elif rhbuild.startswith("6"):
         rhbuild = "quincy"
     elif rhbuild.startswith("5"):
         rhbuild = "pacific"


### PR DESCRIPTION
Tests are getting aborted for reef as support for RHCS 7 is missing from test workflow. Add checks for reef builds.