### PR TITLE
Adding separate test for rbd mirror daemon deployment to make the test suites compatible with baremetal pipeline

### DIFF
--- a/suites/quincy/baremetal_pipeline/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/baremetal_pipeline/tier-3_rbd_persistent_write_back_cache.yaml
@@ -1,0 +1,339 @@
+# RBD: Persistent write back cache feature
+#
+# Cluster Configuration: ( Need physical systems with SSD/NVME)
+#    Conf file - conf/quincy/upi/octo-5-node-env.yaml
+#    Ensure SSD client has at-least 8GB SSD drive.
+#
+
+tests:
+
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node10
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      name: RBD PWL cache validation.
+      desc: PWL Cache validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574707
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdb
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: PWL validation at client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - Client level configuration
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdc
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: PWL validation at pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - Pool level configuration
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdd
+            cleanup: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: PWL validation at image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: RBD Persistent Cache - image level configuration
+
+  - test:
+      name: RBD PWL cache size validation.
+      desc: PWL cache size validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574722
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdb
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation Client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name:  PWL cache size validation at client level
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdc
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache size validation at pool level
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdd
+            cleanup: true
+            validate_cache_size: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: RBD Persistent Cache cache size validation image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache size validation at image level
+
+  - test:
+      name: RBD PWL cache path validation.
+      desc: PWL cache path validation at client pool and image level.
+      module: test_parallel.py
+      polarion-id: CEPH-83574721
+      abort-on-fail: true
+      parallel:
+      - test:
+          abort-on-fail: true
+          config:
+            level: client                        # PWL at client
+            cache_file_size: 1073741824          # 1 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdb
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool1
+              image: image1
+              size: 10G
+            fio:
+              image_name: image1
+              pool_name: pool1
+              runtime: 120
+          desc: RBD Persistent Cache path validation Client level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name:  PWL cache path validation at client level
+      - test:
+          config:
+            level: pool                          # PWL at Pool level
+            cache_file_size: 2147483648          # 2 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdc
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool2
+              image: image2
+              size: 20G
+            fio:
+              image_name: image2
+              pool_name: pool2
+              runtime: 120
+          desc: RBD Persistent Cache cache path validation pool level
+          destroy-cluster: false
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache path validation at pool level
+      - test:
+          config:
+            level: image                         # PWL at image level
+            cache_file_size: 4294967296          # 4 GB
+            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+            client: node10
+            drive: /dev/sdd
+            cleanup: true
+            validate_cache_path: true
+            rep-pool-only: True
+            rep_pool_config:
+              pool: pool3
+              image: image3
+              size: 40G
+            fio:
+              image_name: image3
+              pool_name: pool3
+              runtime: 120
+          desc: RBD Persistent Cache cache path validation image level
+          module: test_rbd_persistent_write_back_cache.py
+          name: PWL cache path validation at image level
+
+  - test:
+      abort-on-fail: true
+      config:
+        level: client                        # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node10
+        drive: /dev/sdb
+        cleanup: true
+        validate_exclusive_lock: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          runtime: 120
+      desc: Validate PWL cache non-working without exclusive lock feature
+      destroy-cluster: false
+      module: test_rbd_persistent_write_back_cache.py
+      name: PWL cache creation with exclusive lock
+      polarion-id: CEPH-83574719
+
+  - test:
+      abort-on-fail: true
+      config:
+        level: client                        # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node10
+        drive: /dev/nvme0n1
+        cleanup: true
+        # validate_exclusive_lock: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool2
+          image: image2
+          size: 10G
+        fio:
+          image_name: image2
+          pool_name: pool2
+          runtime: 120
+      desc: Validate cache flush with persistent cache enabled
+      destroy-cluster: false
+      module: test_rbd_persistent_writeback_cache_flush.py
+      name: Validate cache flush with persistent cache enabled
+      polarion-id: CEPH-83574893

--- a/suites/quincy/rbd/tier-1_rbd_mirror.yaml
+++ b/suites/quincy/rbd/tier-1_rbd_mirror.yaml
@@ -57,13 +57,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -99,13 +92,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -133,6 +119,33 @@ tests:
         destroy-cluster: false
         module: test_client.py
         name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
   - test:
       abort-on-fail: true
       clusters:

--- a/suites/quincy/rbd/tier-2_rbd_mirror_failback.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_failback.yaml
@@ -58,13 +58,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -99,13 +92,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd3:
           config:
             verify_cluster_health: true
@@ -140,13 +126,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -206,6 +185,44 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
 
   - test:
       abort-on-fail: true

--- a/suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_failover_recovery.yaml
@@ -58,13 +58,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -99,13 +92,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -151,6 +137,34 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
 
   - test:
       name: Recovery of abrupt failure of primary cluster

--- a/suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -58,13 +58,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -99,13 +92,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -151,6 +137,34 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
 
   - test:
       name: Mirroring of cloned image

--- a/suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_image_trash_purge.yaml
@@ -58,13 +58,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -99,13 +92,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -151,6 +137,34 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
 
   - test:
       name: test-image-delete-from-primary-site

--- a/suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_scale_osd.yaml
@@ -88,13 +88,6 @@ tests:
                       spec:
                         data_devices:
                           all: "true"
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node4
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -161,13 +154,6 @@ tests:
                       spec:
                         data_devices:
                           all: "true"
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node4
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -195,6 +181,34 @@ tests:
         destroy-cluster: false
         module: test_client.py
         name: configure client
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
 
   - test:
       name: test-add-remove-osd-with-mirroring

--- a/suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_snapshot_regression.yaml
@@ -50,13 +50,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -91,13 +84,6 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
       desc: RBD Mirror cluster deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
@@ -141,6 +127,35 @@ tests:
       desc: Enable mon_allow_pool_delete to True for deleting the pools
       module: exec.py
       name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
   - test:
       name: test_rbd_mirror_snapshot_pool
       module: test_rbd_mirror_snapshot.py
@@ -173,4 +188,3 @@ tests:
             snapshot_schedule_level: "cluster"
       polarion-id: CEPH-83575376
       desc: Create snapshot based RBD mirrored pools, schedule snapshots at cluster level and verify
-


### PR DESCRIPTION
1. Added new test case to deploy rbd mirror daemon separately and not mix it with regular cluster deployment, since baremetal pipeline requires it so.
2. Added the persistent-writeback-cache test suite to suites/quincy/baremetal_pipeline folder to make sure it gets executed in baremetal pipeline.