### PR TITLE
Fix haproxy lc testcase failure

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -451,6 +451,7 @@ tests:
             set-env: true
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
+            run-on-haproxy: true
             timeout: 300
       desc: test LC from primary to secondary
       module: sanity_rgw_multisite.py


### PR DESCRIPTION
# Description

add missing config "run-on-haproxy: true" to the testcase:test LC from primary to secondary
in suite cephci/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml

fail log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-6I2WO0/test_LC_from_primary_to_secondary_0.log

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-QTQDR5/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
