### PR TITLE
Include copy and compare validation for Data Integrity tests 

### DIFF
--- a/suites/quincy/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/quincy/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -56,6 +56,8 @@ tests:
           - node7
           - node8
           - node9
+          - node10
+          - node11
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -164,20 +166,57 @@ tests:
       name: Test to run IOs using multiple-initiators against multi-subsystems
       polarion-id:
 
-#  # Cleanup Test Case
+#  Multiple gateways deployment in the cluster
   - test:
       abort-on-fail: true
       config:
-        gw_node: node6
+        gw_node: node10                       # Deploying multiple gateways on the cluster
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        subsystems: # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            serial: 1
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5005
+            allow_host: "*"
+        initiators: # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode5
+            listener_port: 5005
+            node: node11
+      desc: Deploy multiple NVMEoF Gateway on the cluster
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to Deploy multiple NVMEoF Gateway on the cluster
+      polarion-id:
+
+#  # Cleanup Test Case for gateway nodes
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node:
+          - node6
+          - node10
         rbd_pool: rbd
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
         subsystems:
           - nqn: nqn.2016-06.io.spdk:cnode1
+            node: node6
           - nqn: nqn.2016-06.io.spdk:cnode2
+            node: node6
           - nqn: nqn.2016-06.io.spdk:cnode3
+            node: node6
           - nqn: nqn.2016-06.io.spdk:cnode4
+            node: node6
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            node: node10
         initiators:
           - subnqn: nqn.2016-06.io.spdk:cnode1
             node: node7
@@ -187,6 +226,8 @@ tests:
             node: node8
           - subnqn: nqn.2016-06.io.spdk:cnode4
             node: node9
+          - subnqn: nqn.2016-06.io.spdk:cnode5
+            node: node11
         cleanup-only: true                        # clean up only
         cleanup:
           - pool

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -233,6 +233,26 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                         f"Data integrity verification failed for target {target['DevicePath']}."
                     )
                     return 1
+                # copy the file to the local system
+                rbd_obj.exec_cmd(cmd=f"cp {mount_point}/test.txt /tmp/copy.txt")
+                # Rename the file
+                rbd_obj.exec_cmd(
+                    cmd=f"mv {mount_point}/test.txt {mount_point}/test1.txt"
+                )
+                # Copy the file back to the NVMe target
+                rbd_obj.exec_cmd(cmd=f"cp /tmp/copy.txt {mount_point}/test1.txt")
+                # Calculate md5sum after copying the file back to the NVMe target
+                md5sum_copy = rbd_obj.exec_cmd(cmd=f"md5sum {mount_point}/test1.txt")
+                # Compare md5sum values
+                if md5sum_write == md5sum_copy:
+                    LOG.info(
+                        f"Data integrity verified successfully for copy and compare on {target['DevicePath']}."
+                    )
+                else:
+                    LOG.error(
+                        f"Data integrity verification failed for copy and compare on {target['DevicePath']}."
+                    )
+                    return 1
 
         return 0
     except Exception as err:


### PR DESCRIPTION
Description - Include copy and compare validation steps in the exsisting Data Integrity module which does DI verification on the nvme luns. 

Logs are located in the below location 
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EZYN0B
Di test log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EZYN0B/Test_to_perform_Data_Integrity_test_over_NVMe-OF_targets_0.log