### PR TITLE
integrating sts,lc and policy testcases into cephci

### DIFF
--- a/pipeline/metadata/5.3.yaml
+++ b/pipeline/metadata/5.3.yaml
@@ -591,6 +591,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
           metadata:
             - rgw
+        - name: "Tier-2 RGW test sts aswi"
+          execution_time: ""
+          suite: "suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml"
+          global-conf: "conf/pacific/rgw/tier-0_rgw.yaml"
+          platform: "rhel-8"
+          inventory:
+            openstack: "conf/inventory/rhel-8-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-8-latest.yaml"
+          metadata:
+            - rgw
   # Marking these suites as obsolete as we moved to new pipeline.
   obsolete-schedule:
     tier-1:

--- a/pipeline/metadata/6.0.yaml
+++ b/pipeline/metadata/6.0.yaml
@@ -560,6 +560,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "Tier-2 RGW test sts aswi"
+          execution_time: ""
+          suite: "suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
   schedule:
     tier-1:
       stage-1:

--- a/pipeline/metadata/6.1.yaml
+++ b/pipeline/metadata/6.1.yaml
@@ -589,6 +589,16 @@ pipelines:
             ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
           metadata:
             - rgw
+        - name: "Tier-2 RGW test sts aswi"
+          execution_time: ""
+          suite: "suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml"
+          global-conf: "conf/quincy/rgw/tier-0_rgw.yaml"
+          platform: "rhel-9"
+          inventory:
+            openstack: "conf/inventory/rhel-9-latest.yaml"
+            ibmc: "conf/inventory/ibm-vpc-rhel-9-latest.yaml"
+          metadata:
+            - rgw
   # Marking these suites as obsolete as we moved to new pipeline.
   obsolete-schedule:
     tier-1:

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -432,7 +432,7 @@ tests:
   - test:
       name: test bucket policy with condition blocks
       desc: test bucket policy with condition blocks
-      polarion-id: CEPH-11590
+      polarion-id: CEPH-11589
       module: sanity_rgw.py
       config:
         script-name: test_bucket_policy_ops.py

--- a/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
@@ -1,0 +1,125 @@
+# Tier 2: RGW STS assume role with web identity tests
+
+# The primary objective of the test suite is to evaluate the STS assume role with web identity functionality of RGW.
+
+# Requires a 5 node cluster layout having only one node with RGW role.
+
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.all
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83573713
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
+
+  # STS aswi tests
+
+  - test:
+      name: test STS assume role with web identity
+      desc: test STS assume role with web identity without any conditions
+      polarion-id: CEPH-83575817
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi.yaml
+        timeout: 500
+  - test:
+      name: STS aswi Tests to test azp fields in the web token
+      desc: STS aswi Tests to test azp fields in the web token
+      polarion-id: CEPH-83574501
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_azp_claim.yaml
+        timeout: 500
+  - test:
+      name: STS aswi Tests to test sub fields in the web token
+      desc: STS aswi Tests to test sub fields in the web token
+      polarion-id: CEPH-83574500
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_sub_claim.yaml
+        timeout: 500

--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -197,6 +197,16 @@ tests:
         config-file-name: test_lc_rule_conflict_transition_actions.yaml
         timeout: 500
 
+  - test:
+      name: test bucket lc rules with same ruleid but different rules
+      desc: test bucket lc rules with same ruleid but different rules
+      polarion-id: CEPH-11183
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
+        timeout: 500
+
   # swift container operation
   - test:
       name: test swift enable version on conatainer of different user

--- a/suites/quincy/baremetal_pipeline/tier-2_rgw_regression.yaml
+++ b/suites/quincy/baremetal_pipeline/tier-2_rgw_regression.yaml
@@ -318,7 +318,7 @@ tests:
   - test:
       name: test bucket policy with condition blocks
       desc: test bucket policy with condition blocks
-      polarion-id: CEPH-11590
+      polarion-id: CEPH-11589
       module: sanity_rgw.py
       config:
         script-name: test_bucket_policy_ops.py

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -352,7 +352,7 @@ tests:
   - test:
       name: test bucket policy with condition blocks
       desc: test bucket policy with condition blocks
-      polarion-id: CEPH-11590
+      polarion-id: CEPH-11589
       module: sanity_rgw.py
       config:
         script-name: test_bucket_policy_ops.py


### PR DESCRIPTION
integrating sts and lc testcases which are automated in below PR's:
sts: https://github.com/red-hat-storage/ceph-qe-scripts/pull/488
lc: https://github.com/red-hat-storage/ceph-qe-scripts/pull/489

also replacing already automated testcase with the correct polarion id ([CEPH-11589](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11589)):
This testcase is already automated while automating bucket policy with condition block
this is the yaml config: https://github.com/red-hat-storage/ceph-qe-scripts/blob/master/rgw/v2/tests/s3_swift/configs/test_bucket_policy_condition.yaml

pass logs:

- sts: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/sts_aswi/
- lc: http://magna002.ceph.redhat.com/ceph-qe-logs/HemanthSai/lc-same-rule-id/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
