### PR TITLE
Fixing FS create utility function

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1138,30 +1138,16 @@ class FsUtils(object):
         Returns:
 
         """
-        output, err = client.exec_command(sudo=True, cmd="ceph version")
-        output_split = output.split()
-        if "nautilus" in output_split:
-            fs_cmd = f"ceph fs volume create {vol_name}"
-            cmd_out, cmd_rc = client.exec_command(
-                sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
-            )
-            if validate:
-                out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
-                volname_ls = json.loads(out)
-                if vol_name not in [i["name"] for i in volname_ls]:
-                    raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
-            return cmd_out, cmd_rc
-        if "pacific" in output_split or "quincy" in output_split:
-            fs_cmd = f"ceph fs volume create {vol_name}"
-            cmd_out, cmd_rc = client.exec_command(
-                sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
-            )
-            if validate:
-                out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
-                volname_ls = json.loads(out)
-                if vol_name not in [i["name"] for i in volname_ls]:
-                    raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
-            return cmd_out, cmd_rc
+        fs_cmd = f"ceph fs volume create {vol_name}"
+        cmd_out, cmd_rc = client.exec_command(
+            sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
+        )
+        if validate:
+            out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
+            volname_ls = json.loads(out)
+            if vol_name not in [i["name"] for i in volname_ls]:
+                raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
+        return cmd_out, cmd_rc
 
     def create_subvolumegroup(
         self, client, vol_name, group_name, validate=True, **kwargs


### PR DESCRIPTION
# Description
Fixing FS create Utility function
We are seeing failures in cephfs_bugs suite and snapshot clone suite in Reef

Passed Logs : 

[tier-4_cephfs_recovery](http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.1.2-1/Weekly/cephfs/1/tier-4_cephfs_recovery/)  Passed Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JB9MN5/
[tier-2_cephfs_test-snapshot-clone](http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.1.2-1/Regression/cephfs/1/tier-2_cephfs_test-snapshot-clone/) -PASS Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6E6TXU/ 

	
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
