### PR TITLE
core_workflows: Updated command to be executed on client node.

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -977,7 +977,7 @@ class RadosOrchestrator:
             cmd = "ceph config set mon mon_allow_pool_delete true"
             self.client.exec_command(cmd=cmd, sudo=True)
 
-        existing_pools = self.run_ceph_command(cmd="ceph df")
+        existing_pools = self.run_ceph_command(cmd="ceph df", client_exec=True)
         if pool not in [ele["name"] for ele in existing_pools["pools"]]:
             log.error(f"Pool:{pool} does not exist on cluster, cannot delete")
             return True


### PR DESCRIPTION
In Stretch Clusters, while we are testing Arbiter node down scenarios, all commands need to be run on Client node. changed the command execution path. 

Pass logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D00F05 
