### PR TITLE
Include multiple-gateway deployment in the cluster without HA and run IOs on the target

### DIFF
--- a/conf/quincy/nvmeof/ceph_nvmeof_functional.yaml
+++ b/conf/quincy/nvmeof/ceph_nvmeof_functional.yaml
@@ -46,3 +46,10 @@ globals:
       node9:
         role:
           - client
+      node10:
+        role:
+          - client
+          - nvmeof-gw        # Multiple gateways in the cluster
+      node11:
+        role:
+          - client

--- a/suites/quincy/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/quincy/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -56,6 +56,8 @@ tests:
           - node7
           - node8
           - node9
+          - node10
+          - node11
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -164,20 +166,57 @@ tests:
       name: Test to run IOs using multiple-initiators against multi-subsystems
       polarion-id:
 
-#  # Cleanup Test Case
+#  Multiple gateways deployment in the cluster
   - test:
       abort-on-fail: true
       config:
-        gw_node: node6
+        gw_node: node10                       # Deploying multiple gateways on the cluster
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        subsystems: # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            serial: 1
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5005
+            allow_host: "*"
+        initiators: # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode5
+            listener_port: 5005
+            node: node11
+      desc: Deploy multiple NVMEoF Gateway on the cluster
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to Deploy multiple NVMEoF Gateway on the cluster
+      polarion-id:
+
+#  # Cleanup Test Case for gateway nodes
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node:
+          - node6
+          - node10
         rbd_pool: rbd
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
         subsystems:
           - nqn: nqn.2016-06.io.spdk:cnode1
+            node: node6
           - nqn: nqn.2016-06.io.spdk:cnode2
+            node: node6
           - nqn: nqn.2016-06.io.spdk:cnode3
+            node: node6
           - nqn: nqn.2016-06.io.spdk:cnode4
+            node: node6
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            node: node10
         initiators:
           - subnqn: nqn.2016-06.io.spdk:cnode1
             node: node7
@@ -187,6 +226,8 @@ tests:
             node: node8
           - subnqn: nqn.2016-06.io.spdk:cnode4
             node: node9
+          - subnqn: nqn.2016-06.io.spdk:cnode5
+            node: node11
         cleanup-only: true                        # clean up only
         cleanup:
           - pool


### PR DESCRIPTION
Include multiple-gateway deployment in the cluster without HA and run IOs on the target

- Have added a test case to include multiple gateway deployment in the cluster as  per the requirenment we support single subsystem per gateway
- Modified clean up test case code to handle multiple gateways entities deletion


Logs - 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HPBOYT/Test_to_Deploy_multiple_NVMEoF_Gateway_on_the_cluster_0.log ---> Multi-gateway log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-356UX8/Cleanup_the_nvme-of_Gateway_entities_0.log- Clean up log

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-356UX8/ --->full logs

