### PR TITLE
[LibFix] Add failed TC details in xUnit results

### DIFF
--- a/run.py
+++ b/run.py
@@ -780,6 +780,12 @@ def run(args):
                 )
             except BaseException as be:  # noqa
                 log.exception(be)
+
+                # Set failure details
+                tc["err_msg"] = str(be)
+                tc["traceback"] = traceback.format_exc()
+
+                # Set return code to 1
                 rc = 1
             finally:
                 collect_recipe(ceph_cluster_dict[cluster_name])

--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -8,7 +8,7 @@ from utility.log import Log
 log = Log(__name__)
 
 
-def generate_test_case(name, duration, status, polarion_id=None):
+def generate_test_case(name, duration, status, msg=None, text=None, polarion_id=None):
     """Create test case object.
 
     Args:
@@ -28,7 +28,9 @@ def generate_test_case(name, duration, status, polarion_id=None):
         test_case.time = 0.0
 
     if status != "Pass":
-        test_case.result = [Failure("test failed")]
+        _result = Failure(msg, "exception")
+        _result.text = text
+        test_case.result = [_result]
 
     if polarion_id:
         props = Properties()
@@ -71,6 +73,8 @@ def create_xunit_results(suite_name, test_cases, test_run_metadata):
         pol_ids = tc.get("polarion-id")
         test_status = tc["status"]
         elapsed_time = tc.get("duration")
+        err_msg = tc.get("err_msg")
+        _traceback = tc.get("traceback")
 
         if pol_ids:
             _ids = pol_ids.split(",")
@@ -80,15 +84,15 @@ def create_xunit_results(suite_name, test_cases, test_run_metadata):
                         test_name,
                         elapsed_time,
                         test_status,
+                        msg=err_msg,
+                        text=_traceback,
                         polarion_id=_id,
                     )
                 )
         else:
             suite.add_testcase(
                 generate_test_case(
-                    test_name,
-                    elapsed_time,
-                    test_status,
+                    test_name, elapsed_time, test_status, msg=err_msg, text=_traceback
                 )
             )
 


### PR DESCRIPTION
Add support to update results with error message in case test case fails. This will help to update report portal with exception as shown below

![Screenshot from 2023-08-23 18-26-22](https://github.com/red-hat-storage/cephci/assets/41667569/875577f0-6454-44d1-bc03-78122f27b5e6)

