### PR TITLE
covered other dm-cache scenarios

### DIFF
--- a/suites/quincy/rbd/tier-2_rbd_cache_scenarios.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_cache_scenarios.yaml
@@ -93,6 +93,7 @@ tests:
           pool: pool_test
           image1: image1
           image2: image2
+          image3: image3
           size: 20G
         fio:
           runtime: 120
@@ -100,4 +101,4 @@ tests:
       destroy-cluster: false
       module: test_rbd_dm_cache.py
       name: DM cache and DM write cache creation
-      polarion-id: CEPH-83574719
+      polarion-id: CEPH-83575581

--- a/suites/reef/rbd/tier-2_rbd_cache_scenarios.yaml
+++ b/suites/reef/rbd/tier-2_rbd_cache_scenarios.yaml
@@ -93,6 +93,7 @@ tests:
           pool: pool_test
           image1: image1
           image2: image2
+          image3: image3
           size: 20G
         fio:
           runtime: 120
@@ -100,4 +101,4 @@ tests:
       destroy-cluster: false
       module: test_rbd_dm_cache.py
       name: DM cache and DM write cache creation
-      polarion-id: CEPH-83574719
+      polarion-id: CEPH-83575581

--- a/utility/lvm_utils.py
+++ b/utility/lvm_utils.py
@@ -18,18 +18,28 @@ def lvm_create(osd, lv_name, vg_name, size):
 
 
 def lvconvert(osd, cache_type, vg_name, cache_name, data_name):
-    if cache_type == "cache":
+    if cache_type == "cache_pool":
         command = (
-            f"echo 'y' | lvconvert --type {cache_type} --cachepool "
+            f"echo 'y' | lvconvert --type cache --cachepool "
             f"{vg_name}/{cache_name} {vg_name}/{data_name}"
         )
-        osd.exec_command(cmd=command, sudo=True)
-    else:
+    elif cache_type == "cache_vol":
         command = (
-            f"echo -e 'y\ny' | lvconvert --type {cache_type} --cachevol "
+            f"echo -e 'y\ny' | lvconvert --type cache --cachevol "
             f"{vg_name}/{cache_name} {vg_name}/{data_name}"
         )
-        osd.exec_command(cmd=command, sudo=True)
+    elif cache_type == "writecache":
+        command = (
+            f"echo -e 'y\ny' | lvconvert --type writecache --cachevol "
+            f"{vg_name}/{cache_name} {vg_name}/{data_name}"
+        )
+
+    osd.exec_command(cmd=command, sudo=True)
+
+
+def lvm_uncache(osd, vg_name):
+    # To flush the cache back to main LV
+    osd.exec_command(cmd=f"sudo lvconvert --uncache {vg_name}")
 
 
 def make_partition(osd, device, start=None, end=None, gpt=False):


### PR DESCRIPTION
# Description
Added dm-cache scenario with `cache-vol` along with flushing the cache test step.
Covered all 3 scenarios suggested by the customer

- read/write operations + dm-cache as Cache pool + RBD image as Main LV
- read/write operations + dm-cache as Cache vol + RBD image as Main LV
- write operations + dm-cache write as Cachevol + RBD image as Main LV

Test results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FUFL5S

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
