### PR TITLE
Configure VMware Esx host and validate NVMeOF subsystem and Esx host connectivity

### DIFF
--- a/ceph/nvmeof/gateway.py
+++ b/ceph/nvmeof/gateway.py
@@ -151,7 +151,7 @@ class Gateway:
 
     def get_subsystems(self):
         """Get all subsystems."""
-        run_control_cli(self.node, "get_subsystems")
+        return run_control_cli(self.node, "get_subsystems")
 
     def create_block_device(self, name, image, pool, block_size):
         """Create block device using rbd image."""

--- a/suites/quincy/nvmeof/tier-0_nvmeof_vmware_esx.yaml
+++ b/suites/quincy/nvmeof/tier-0_nvmeof_vmware_esx.yaml
@@ -3,7 +3,9 @@
 # Test attributes
   #  Single ceph-nvmeof GW colocated with osd on node5
   #  nvmeof GW - configuration as 1 subsystem, 32 bdevs of 512 block size, 32 namespaces,  32 RBD images of 500M size each
-  # Check ceph health at end of test
+  #  Configure VMware esx host with a pre-requisite of Vmware vSphere 7.0U3 installed on host and configured NVMe/TCP on a Physical NIC
+  #  Validates Esx host and target subsystem connection after discovery
+  #  Check ceph health at end of test
 tests:
   - test:
       abort-on-fail: true
@@ -89,8 +91,14 @@ tests:
               bdev_size: 512
             listener_port: 5001
             allow_host: "*"
-      desc: test to setup NVMeOF GW node for VMware clients
+        vmware_clients:
+          - esx_host: argo010
+            ip: 10.8.128.210
+            root_password: VMware1!
+            sub_nqn: nqn.2016-06.io.spdk:cnode1
+            sub_port: 5001
+      desc: test to setup NVMeOF GW node and VMware clients
       destroy-cluster: false
       module: test_ceph_nvmeof_vmware_clients.py
-      name: Configure NvmeOF GW for VMware clients
+      name: Configure NvmeOF GW and VMware clients
       polarion-id:


### PR DESCRIPTION
Test to work with vmware clients as per 7.0 TP requirement. Includes below-

-  Single ceph-nvmeof GW colocated with osd on node5

-  nvmeof GW - configuration as 1 subsystem, 32 bdevs of 512 block size, 32 namespaces,  32 RBD images of 500M size each

-  Configure a static VMware esx host with a pre-requisite of VMware vSphere 7.0U3 installed on host and configured NVMe/TCP on a Physical NIC

-  Validates Esx host and target subsystem connection after discovery 

- Check ceph health at end of test

Test run log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MXF6UQ
