### PR TITLE
Adding RBD related workflows for wrapper around the CLI module

### DIFF
--- a/ceph/rbd/initial_config.py
+++ b/ceph/rbd/initial_config.py
@@ -1,0 +1,562 @@
+from ceph.rbd.utils import getdict, random_string
+from ceph.rbd.workflows.rbd import config_rbd_multi_pool
+from ceph.rbd.workflows.rbd_mirror import config_mirror_multi_pool
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def update_config(**kw):
+    """
+    Takes the configuration options given by user and updates it to the following format.
+    If the configuration is given in the below format, it just returns the same,
+    else it creates the formatting based on default values and/or the minimal config provided.
+    Format:
+        Note: pg_num and pgp_num are given as 64, 64 by default. Only if user specifies a value,
+        it will be considered while creating below format, otherwise we let the method to create pool
+        take care of default values
+        config:
+            do_not_create_image: True  # if not set then images will be created by default
+            ec-pool-only: False
+            rep-pool-only: False
+            rep_pool_config:
+                pool_1:
+                    pg_num:
+                    pgp_num:
+                    image_1:
+                        size:
+                        io_total:
+                        is_secondary: # if true the image in this cluster will
+                            # become secondary, else by default it will be primary
+                    image_2:
+                        size:
+                        io_total:
+                pool_2:
+                    pg_num:
+                    pgp_num:
+                    image_1:
+                        size:
+                        io_total:
+                    image_2:
+                        size:
+                        io_total:
+            ec_pool_config:
+                pool_1:
+                    data_pool:
+                    ec-pool-k-m: 2,1
+                    ec_profile:
+                    pg_num:
+                    pgp_num:
+                    ec_pg_num:
+                    ec_pgp_num:
+                    image_1:
+                        size:
+                        io_total:
+                        is_secondary: # if true the image in this cluster will
+                            # become secondary, else by default it will be primary
+                    image_2:
+                        size:
+                        io_total:
+                pool_2:
+                    data_pool:
+                    ec-pool-k-m: 2,1
+                    ec_profile:
+                    pg_num:
+                    pgp_num:
+                    ec_pg_num:
+                    ec_pgp_num:
+                    image_1:
+                        size:
+                        io_total:
+                    image_2:
+                        size:
+                        io_total:
+    """
+    # This method uses the mutable property of dictionaries to update kw with required values'
+    pool_types = []
+    config = kw.get("config", {})
+    if not config or not config.get("ec-pool-only"):
+        pool_types.append("rep_pool_config")
+        if not config or not config.get("rep_pool_config"):
+            log.info(
+                "No configuration provided, so creating one replicated pool and one image with default parameters"
+            )
+            pool = "rep_pool_" + random_string(len=5)
+            image = "rep_image_" + random_string(len=5)
+            rep_pool_config = {pool: {image: {"size": "1G", "io_total": "1G"}}}
+            kw["config"] = rep_pool_config
+        elif config.get("rep_pool_config"):
+            rep_pool_config = config.get("rep_pool_config")
+
+            # If all values of rep_pool_config are dictionaries it means
+            # it is already in required format, so return it as it is
+            # Only iterate over required number of pools if config is
+            # already not in required format and num_pools parameter is specified
+            is_pool_config_updated = [
+                k for k in getdict(rep_pool_config).keys() if k not in ["test_config"]
+            ]
+
+            if not is_pool_config_updated and rep_pool_config.get("num_pools"):
+                for i in range(rep_pool_config.get("num_pools")):
+                    pool = rep_pool_config.get(
+                        "pool_prefix", "rep_pool_" + random_string(len=5)
+                    ) + str(i)
+                    if rep_pool_config.get("pg_num"):
+                        kw["config"]["rep_pool_config"] = {
+                            pool: {
+                                "pg_num": rep_pool_config.get("pg_num"),
+                                "pgp_num": rep_pool_config.get("pgp_num"),
+                            }
+                        }
+                    image_config = {}
+                    # if rep_pool_config.get("num_images") != 0:
+                    num_images = rep_pool_config.get("num_images", 1)
+                    num_secondary_images = rep_pool_config.get(
+                        "num_secondary_images", 0
+                    )
+                    is_secondary = kw.get("is_secondary")
+                    if is_secondary:
+                        num_images_to_be_created = num_secondary_images
+                    else:
+                        num_images_to_be_created = num_images - num_secondary_images
+                    # for j in range(rep_pool_config.get("num_images", 1)):
+                    for j in range(num_images_to_be_created):
+                        image = rep_pool_config.get(
+                            "image_prefix", "rep_image_" + random_string(len=5)
+                        ) + str(j)
+                        image_config.update(
+                            {
+                                image: {
+                                    "size": rep_pool_config.get("size", "1G"),
+                                }
+                            }
+                        )
+                        if not config.get("do_not_run_io"):
+                            image_config[image].update(
+                                {"io_total": rep_pool_config.get("io_total", "1G")}
+                            )
+
+                        if rep_pool_config.get("mirrormode") != "snapshot":
+                            image_config[image].update({"image-feature": "journaling"})
+
+                        if is_secondary:
+                            image_config[image].update({"is_secondary": True})
+
+                    if rep_pool_config.get(pool):
+                        rep_pool_config[pool].update(image_config)
+                    else:
+                        rep_pool_config[pool] = image_config
+
+                    if rep_pool_config.get("mode"):
+                        rep_pool_config[pool].update({"mode": rep_pool_config["mode"]})
+
+                    if rep_pool_config.get("mirrormode"):
+                        rep_pool_config[pool].update(
+                            {"mirrormode": rep_pool_config["mirrormode"]}
+                        )
+
+    if not kw.get("config").get("rep-pool-only"):
+        pool_types.append("ec_pool_config")
+        if not config.get("ec_pool_config"):
+            log.info(
+                "No configuration provided, so creating one EC pool and one image with default parameters"
+            )
+            pool = "ec_pool_" + random_string(len=5)
+            image = "ec_image_" + random_string(len=5)
+            ec_pool_config = {pool: {image: {"size": "1G", "io_total": "1G"}}}
+            kw["config"] = ec_pool_config
+        elif config.get("ec_pool_config"):
+            ec_pool_config = config.get("ec_pool_config")
+
+            # If all values of rep_pool_config are dictionaries it means
+            # it is already in required format, so return it as it is
+            # Only iterate over required number of pools if config is
+            # already not in required format and num_pools parameter is specified
+            is_pool_config_updated = [
+                k for k in getdict(ec_pool_config).keys() if k not in ["test_config"]
+            ]
+            if not is_pool_config_updated and ec_pool_config.get("num_pools"):
+                for i in range(ec_pool_config.get("num_pools")):
+                    pool = ec_pool_config.get(
+                        "pool_prefix", "ec_pool_" + random_string(len=5)
+                    ) + str(i)
+                    data_pool = ec_pool_config.get(
+                        "data_pool_prefix", "data_pool_" + random_string(len=5)
+                    ) + str(i)
+                    if ec_pool_config.get("pg_num"):
+                        kw["config"]["ec_pool_config"] = {
+                            pool: {
+                                "pg_num": ec_pool_config.get("pg_num"),
+                                "pgp_num": ec_pool_config.get("pgp_num"),
+                                "ec_pg_num": ec_pool_config.get("ec_pg_num"),
+                                "ec_pgp_num": ec_pool_config.get("ec_pgp_num"),
+                            }
+                        }
+                    image_config = {}
+                    # if ec_pool_config.get("num_images") != 0:
+                    num_images = ec_pool_config.get("num_images", 1)
+                    num_secondary_images = ec_pool_config.get("num_secondary_images", 0)
+                    is_secondary = kw.get("is_secondary")
+                    if is_secondary:
+                        num_images_to_be_created = num_secondary_images
+                    else:
+                        num_images_to_be_created = num_images - num_secondary_images
+                    # for j in range(ec_pool_config.get("num_images", 1)):
+                    for j in range(num_images_to_be_created):
+                        image = ec_pool_config.get(
+                            "image_prefix", "ec_image_" + random_string(len=5)
+                        ) + str(j)
+                        image_config.update(
+                            {
+                                image: {
+                                    "size": ec_pool_config.get("size", "1G"),
+                                }
+                            }
+                        )
+                        if not config.get("do_not_run_io"):
+                            image_config[image].update(
+                                {"io_total": ec_pool_config.get("io_total", "1G")}
+                            )
+
+                        if ec_pool_config.get("mirrormode") != "snapshot":
+                            image_config[image].update({"image-feature": "journaling"})
+
+                        if is_secondary:
+                            image_config[image].update({"is_secondary": True})
+
+                    if ec_pool_config.get(pool):
+                        ec_pool_config[pool].update(image_config)
+                    else:
+                        ec_pool_config[pool] = image_config
+                    ec_pool_config[pool].update({"data_pool": data_pool})
+
+                    if ec_pool_config.get("mode"):
+                        ec_pool_config[pool].update({"mode": ec_pool_config["mode"]})
+
+                    if ec_pool_config.get("mirrormode"):
+                        ec_pool_config[pool].update(
+                            {"mirrormode": ec_pool_config["mirrormode"]}
+                        )
+    return pool_types
+
+
+def initial_rbd_config(ceph_cluster, **kw):  # ,
+    """
+    Create replicated pools, ecpools or both and corresponding images based on arguments specified
+    Args:
+        **kw:
+
+    Examples: In default configuration, pool and image names will be taken as random values.
+        Default configuration for ecpools only :
+            config:
+                ec-pool-only: True
+        Default configuration for replicated pools only :
+            config:
+                rep-pool-only: True
+        Advanced configuration <specifying only number of pools and images>:
+            config:
+                do_not_create_image: True     # if not set then images will be created by default
+                ec-pool-only: False
+                rep-pool-only: False
+                rep_pool_config:
+                    num_pools:
+                    num_images:
+                    num_secondary_images: # num of images out of num_images to be secondary
+                    # in given cluster, (num_images - num_secondary_images) number of
+                    # images will be created as primary in given cluster in same pool
+                    pool_prefix:
+                    image_prefix:
+                    size:
+                    io_total:
+                    pg_num:
+                    pgp_num:
+                    ec_pg_num:
+                    ec_pgp_num:
+                ec_pool_config:
+                    ec-pool-k-m: 2,1
+                    num_pools:
+                    num_images:
+                    num_secondary_images: # num of images out of num_images to be secondary
+                    # in given cluster, (num_images - num_secondary_images) number of
+                    # images will be created as primary in given cluster in same pool
+                    pool_prefix:
+                    image_prefix:
+                    data_pool_prefix:
+                    size:
+                    io_total:
+                    pg_num:
+                    pgp_num:
+                    ec_pg_num:
+                    ec_pgp_num:
+        Advanced configuration <specifying only detailed pool and image configuration>:
+            config:
+                do_not_create_image: True  # if not set then images will be created by default
+                ec-pool-only: False
+                rep-pool-only: False
+                rep_pool_config:
+                    pool_1:
+                        pg_num:
+                        pgp_num:
+                        image_1:
+                            size:
+                            io_total:
+                            is_secondary: # if true the image in this cluster will
+                            # become secondary, else by default it will be primary
+                        image_2:
+                            size:
+                            io_total:
+                    pool_2:
+                        pg_num:
+                        pgp_num:
+                        image_1:
+                            size:
+                            io_total:
+                        image_2:
+                            size:
+                            io_total:
+                ec_pool_config:
+                    pool_1:
+                        data_pool:
+                        ec-pool-k-m: 2,1
+                        ec_profile:
+                        pg_num:
+                        pgp_num:
+                        ec_pg_num:
+                        ec_pgp_num:
+                        image_1:
+                            size:
+                            io_total:
+                            is_secondary: # if true the image in this cluster will
+                            # become secondary, else by default it will be primary
+                        image_2:
+                            size:
+                            io_total:
+                    pool_2:
+                        data_pool:
+                        ec-pool-k-m: 2,1
+                        ec_profile:
+                        pg_num:
+                        pgp_num:
+                        ec_pg_num:
+                        ec_pgp_num:
+                        image_1:
+                            size:
+                            io_total:
+                        image_2:
+                            size:
+                            io_total:
+    """
+    log.debug(
+        f'config received for rbd_config: {kw.get("config", "Config not received, assuming default values")}'
+    )
+    pool_types = update_config(**kw)
+    config = kw.get("config", {})
+    ceph_version = int(config.get("rhbuild")[0])
+
+    if kw.get("client_node"):
+        client = get_node_by_id(ceph_cluster, kw.get("client_node"))
+    else:
+        client = ceph_cluster.get_nodes(role="client")[0]
+    rbd = Rbd(client)
+
+    for pool_type in pool_types:
+        pool_config = getdict(config.get(pool_type))
+        is_ec_pool = True if "ec" in pool_type else False
+        if config_rbd_multi_pool(
+            rbd=rbd,
+            multi_pool_config=pool_config,
+            is_ec_pool=is_ec_pool,
+            ceph_version=ceph_version,
+            config=config,
+            client=client,
+            is_secondary=kw.get("is_secondary"),
+        ):
+            log.error(f"RBD configuration failed for {pool_type}")
+            return None
+
+    return {"rbd": rbd, "client": client, "pool_types": pool_types}
+
+
+def initial_mirror_config(**kw):
+    """
+    Create replicated pools, ecpools or both and corresponding images based on arguments specified
+    Configure mirroring and enable required type of mirroring on the given pools and images
+    For all the images mentioned in the config, primary_cluster will be the primary cluster
+    and secondary_cluster will be the secondary cluster.
+
+    Note: If in any test case there is a requirement to create few images as primary from primary_cluster
+    and few other images as primary from secondary_cluster, then please call initial_mirror_config twice
+    by specifying only the required images to be primary on the given primary_cluster cluster
+    Args:
+        **kw:
+            "clusters":
+                "<cluster_1_name>":
+                    "config": <config_as_shown_in_example_below>"
+                "<cluster_2_name>":
+                    "config": <config_as_shown_in_example_below>"
+    Note: For configuration Advanced configuration <specifying only number of pools and images>,
+    num_pools number of pools will be created as specified in both cluster configurations,
+    num_images number of images will be created as primary in that pool, unless num_secondary_images
+    is exclusively specified, if it is specified then the rest of the images will be primary.
+
+    Examples: In default configuration, pool and image names will be taken as random values.
+    Journal mirroring, at pool level will be applied to all pools by default
+        Default configuration for ecpools only :
+            config:
+                ec-pool-only: True
+        Default configuration for replicated pools only :
+            config:
+                rep-pool-only: True
+        Advanced configuration <specifying only number of pools and images>:
+            config:
+                do_not_create_image: True  # if not set then images will be created by default
+                do_not_run_io: True
+                ec-pool-only: False
+                rep-pool-only: False
+                rep_pool_config:
+                    num_pools:
+                    num_images:
+                    num_secondary_images: # num of images out of num_images to be secondary
+                    # in given cluster, (num_images - num_secondary_images) number of
+                    # images will be created as primary in given cluster in same pool
+                    pool_prefix:
+                    image_prefix:
+                    size:
+                    io_total:
+                    pg_num:
+                    pgp_num:
+                    ec_pg_num:
+                    ec_pgp_num:
+                    mode: <pool/image>
+                    mirrormode: <journal/snapshot>
+                ec_pool_config:
+                    ec-pool-k-m: 2,1
+                    num_pools:
+                    num_images:
+                    num_secondary_images: # num of images out of num_images to be secondary
+                    # in given cluster, (num_images - num_secondary_images) number of
+                    # images will be created as primary in given cluster in same pool
+                    pool_prefix:
+                    image_prefix:
+                    data_pool_prefix:
+                    size:
+                    io_total:
+                    pg_num:
+                    pgp_num:
+                    ec_pg_num:
+                    ec_pgp_num:
+                    mode: <pool/image>
+                    mirrormode: <journal/snapshot>
+        Advanced configuration <specifying only detailed pool and image configuration>:
+            config:
+                do_not_create_image: True  # if not set then images will be created by default
+                do_not_run_io: True # if not set then IO will be run on images by default
+                ec-pool-only: False
+                rep-pool-only: False
+                rep_pool_config:
+                    pool_1:
+                        pg_num:
+                        pgp_num:
+                        mode: <pool/image>
+                        mirrormode: <journal/snapshot>
+                        peer_mode: <bootstrap>
+                        rbd_client: <client.admin>
+                        image_1:
+                            size:
+                            io_total:
+                            is_secondary: # if true the image in this cluster will
+                            # become secondary, else by default it will be primary
+                        image_2:
+                            size:
+                            io_total:
+                    pool_2:
+                        pg_num:
+                        pgp_num:
+                        mode: <pool/image>
+                        mirrormode: <journal/snapshot>
+                        peer_mode: <bootstrap>
+                        rbd_client: <client.admin>
+                        image_1:
+                            size:
+                            io_total:
+                        image_2:
+                            size:
+                            io_total:
+                ec_pool_config:
+                    pool_1:
+                        data_pool:
+                        ec-pool-k-m: 2,1
+                        ec_profile:
+                        pg_num:
+                        pgp_num:
+                        ec_pg_num:
+                        ec_pgp_num:
+                        mode: <pool/image>
+                        mirrormode: <journal/snapshot>
+                        peer_mode: <bootstrap>
+                        rbd_client: <client.admin>
+                        image_1:
+                            size:
+                            io_total:
+                        image_2:
+                            size:
+                            io_total:
+                    pool_2:
+                        data_pool:
+                        ec-pool-k-m: 2,1
+                        ec_profile:
+                        pg_num:
+                        pgp_num:
+                        ec_pg_num:
+                        ec_pgp_num:
+                        mode: <pool/image>
+                        mirrormode: <journal/snapshot>
+                        peer_mode: <bootstrap>
+                        rbd_client: <client.admin>
+                        image_1:
+                            size:
+                            io_total:
+                        image_2:
+                            size:
+                            io_total:
+    """
+    log.info("Creating pools and images as specified in configuration")
+    ret_config = dict()
+    # fetch the current value of ceph_cluster key and store it elsewhere
+    # update it with primary cluster since initial_rbd_config is for primary cluster
+    # Once initial config is done, the change can be reverted
+    ceph_cluster = kw["ceph_cluster"]
+    primary_config = dict()
+    secondary_config = dict()
+    for cluster_name, cluster in kw.get("ceph_cluster_dict").items():
+        kw["ceph_cluster"] = cluster
+        if cluster_name == ceph_cluster.name:
+            primary_config = ret_config[cluster_name] = initial_rbd_config(
+                is_secondary=False, **kw
+            )
+            ret_config[cluster_name]["is_secondary"] = False
+            primary_config["cluster"] = cluster
+        else:
+            secondary_config = ret_config[cluster_name] = initial_rbd_config(
+                is_secondary=True, **kw
+            )
+            ret_config[cluster_name]["is_secondary"] = True
+            secondary_config["cluster"] = cluster
+
+        # Revert kw["ceph_cluster"] to its original value
+    kw["ceph_cluster"] = ceph_cluster
+    config = kw.get("config")
+
+    for pool_type in primary_config.get("pool_types"):
+        pool_config = getdict(config.get(pool_type))
+        kw["do_not_enable_mirror_on_image"] = config.get(pool_type).get(
+            "do_not_enable_mirror_on_image"
+        )
+        config_mirror_multi_pool(primary_config, secondary_config, pool_config, **kw)
+        config_mirror_multi_pool(
+            secondary_config, primary_config, pool_config, is_secondary=True, **kw
+        )
+
+    return ret_config

--- a/ceph/rbd/utils.py
+++ b/ceph/rbd/utils.py
@@ -1,0 +1,186 @@
+import random
+import string
+
+from ceph.ceph import CommandFailed
+from utility.log import Log
+
+log = Log(__name__)
+
+
+getdict = lambda x: {k: v for (k, v) in x.items() if isinstance(v, dict)}
+
+isdict = lambda x: [isinstance(i, dict) for i in x]
+
+
+def find(key, dictionary):
+    """Find list of values for a particular key from a nested dictionary."""
+    for k, v in dictionary.items():
+        if k == key:
+            yield v
+        elif isinstance(v, dict):
+            for result in find(key, v):
+                yield result
+        elif isinstance(v, list):
+            for d in v:
+                if isinstance(d, dict):
+                    for result in find(key, d):
+                        yield result
+                else:
+                    yield d
+
+
+def value(key, dictionary):
+    """Retrieve first value of a particular key from a nested dictionary."""
+    return str(list(find(key, dictionary))[0])
+
+
+def copy_file(file_name, src, dest):
+    """Copies the given file from src node to dest node
+
+    Args:
+        file_name: Full path of the file to be copied
+        src: Source CephNode object
+        dest: Destination CephNode object
+    """
+    contents, err = src.exec_command(sudo=True, cmd="cat {}".format(file_name))
+    key_file = dest.remote_file(sudo=True, file_name=file_name, file_mode="w")
+    key_file.write(contents)
+    key_file.flush()
+
+
+def get_md5sum_rbd_image(**kw):
+    """
+    Get md5sum of an RBD image.
+    kw: {
+        "image_spec": <pool/image> for which md5sum needs to be fetched,
+        "file_path": <path/filename> to which image is exported/mounted to fetch md5sum,
+        "rbd": <rbd_object>,
+        "client": <client_node>
+    }
+    """
+    if kw.get("image_spec"):
+        export_spec = {
+            "source-image-or-snap-spec": kw.get("image_spec"),
+            "path-name": kw.get("file_path"),
+        }
+        if kw.get("rbd").export(**export_spec):
+            log.error(f"Export failed for image {kw.get('image_spec')}")
+            return None
+    return exec_cmd(
+        output=True, cmd="md5sum {}".format(kw.get("file_path")), node=kw.get("client")
+    ).split()[0]
+
+
+def check_data_integrity(**kw):
+    """
+    kw: {
+        "first":{
+            "image_spec": <>,
+            "file_path": <>,
+            "rbd":<rbd_object>,
+            "client":<client_node>
+        },
+        "second":{
+            "image_spec": <>,
+            "file_path":<>,
+            "rbd":<rbd_object>,
+            "client":<client_node>
+        }
+    }
+    """
+    md5_sum_first = get_md5sum_rbd_image(**kw.get("first"))
+    if not md5_sum_first:
+        log.error("Error while fetching md5sum")
+        return 1
+    md5_sum_second = get_md5sum_rbd_image(**kw.get("second"))
+    if not md5_sum_second:
+        log.error("Error while fetching md5sum")
+        return 1
+
+    log.info(
+        f"md5sum values of given images are {md5_sum_first} and {md5_sum_second} respectively"
+    )
+    if md5_sum_first != md5_sum_second:
+        log.error("md5sum values don't match")
+        return 1
+    return 0
+
+
+def exec_cmd(node, cmd, **kw):
+    """
+    exec_command wrapper with additional functionality
+
+    Args:
+        node: Ceph Node in which command needs to be executed
+        cmd: the command to be executed
+        kw: {
+            output: True if command output needs to be returned
+            all: Both out and err outputs returned if this is set to True
+                    In case command execution gives an exception, then
+                    out,err will be 1,<exception message>
+            long_running: True if you want long_running functionality of exec_command
+            check_ec: False will run the command and not wait for exit code
+        }
+
+    Returns:  0 -> pass, 1 -> fail, by default and output if output arg is set to true
+                out,err if all arg is set to true
+    """
+    try:
+        if kw.get("long_running"):
+            out = node.exec_command(
+                sudo=True,
+                cmd=cmd,
+                long_running=True,
+                check_ec=kw.get("check_ec", True),
+            )
+            return out
+
+        out, err = node.exec_command(
+            sudo=True,
+            cmd=cmd,
+            long_running=False,
+            check_ec=kw.get("check_ec", True),
+        )
+
+        if kw.get("output", False):
+            return out
+
+        if kw.get("all", False):
+            return out, err
+
+        log.info("Command execution complete")
+        return 0
+
+    except CommandFailed as e:
+        log.error(f"Command {cmd} execution failed")
+        if kw.get("all", False):
+            return 1, e
+        return 1
+
+
+def random_string(**kw):
+    """
+    Generates a random string and returns it
+
+    Args:
+        kw: {
+            "len": 20
+        }
+
+    Returns:
+        The generated string
+    """
+    length = kw.get("len", 10)
+    temp_str = "".join([random.choice(string.ascii_letters) for _ in range(length)])
+    return temp_str
+
+
+def create_map_options(encryption_config):
+    """ """
+    options = ""
+    for encryption in encryption_config:
+        for k, v in encryption.items():
+            options += f"{k}={v},"
+    options = options[:-1]  # remove trailing comma
+
+    return options

--- a/ceph/rbd/workflows/cleanup.py
+++ b/ceph/rbd/workflows/cleanup.py
@@ -1,0 +1,127 @@
+import json
+from time import sleep
+
+from ceph.rbd.utils import exec_cmd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def pool_cleanup(client, pools, **kw):
+    """Remove all the specified pools from the cluster
+
+    Args:
+        client: client node for cluster from which pools to be removed
+        pools: list of pools to be removed
+        kw:
+            dir_name: if any folders to be deleted.
+    """
+    if kw.get("dir_name"):
+        exec_cmd(node=client, cmd="rm -rf {}".format(kw.get("dir_name")))
+
+    ceph_version = kw.get("ceph_version")
+
+    if ceph_version and ceph_version >= 5:
+        exec_cmd(node=client, cmd="ceph config set mon mon_allow_pool_delete true")
+        sleep(20)
+
+    for pool in pools:
+        exec_cmd(
+            cmd=f"ceph osd pool delete {pool} {pool} " "--yes-i-really-really-mean-it",
+            node=client,
+        )
+
+
+def unmount(client, mount_point):
+    """ """
+    flag = 0
+    umount_cmd = f"umount -f {mount_point}"
+    # if kw.get("read_only"):
+    #     umount_cmd += " -o ro,noload"
+    if exec_cmd(cmd=umount_cmd, sudo=True, node=client):
+        log.error(f"Umount failed for {mount_point}")
+        flag = 1
+
+    if exec_cmd(cmd=f"rm -rf {mount_point}", sudo=True, node=client):
+        log.error(f"Remove dir failed for {mount_point}")
+        flag = 1
+
+    return flag
+
+
+def device_cleanup(rbd, client, **kw):
+    """
+    Unmout the given file_name, unmap the given device_name encrypted using encryption_config
+    Args:
+        rbd: rbd object
+        kw:
+            "file_name": <path>/<file> to be unmounted
+            "passphrase_file": <path>/<passphrase_file> to be removed
+            "image_spec": image which was encrypted
+            "device_type": default "nbd"
+            "device_name": device created for image map without encryption
+            "all": if True will unmount and unmap all devices to type specified in device_type
+                    (only nbd is supported as of now)
+    """
+    flag = 0
+
+    if kw.get("all"):
+        device_type = kw.get("device_type", "nbd")
+
+        if device_type == "nbd":
+            cmd = "lsblk --include 43 --json"
+            out = exec_cmd(cmd=cmd, sudo=True, node=client, output=True)
+            if out:
+                nbd_devices = json.loads(out)
+
+                for devices in nbd_devices.get("blockdevices"):
+                    device_name = f"/dev/{devices.get('name')}"
+                    mount_point = devices.get("mountpoints")
+                    for mnt_pnt in mount_point:
+                        if mnt_pnt is not None:
+                            unmount(mount_point=mnt_pnt, client=client)
+                    map_config = {
+                        "image-snap-or-device-spec": device_name,
+                        "device-type": kw.get("device_type", "nbd"),
+                    }
+                    _, err = rbd.device.unmap(**map_config)
+                    if err:
+                        log.error(f"Device unmap failed for {device_name} ")
+                        flag = 1
+
+    if kw.get("file_name"):
+        file_name = kw.get("file_name")
+        unmount(mount_point=file_name, client=client)
+
+    if kw.get("passphrase_file") and exec_cmd(
+        cmd=f"rm -rf {kw.get('passphrase_file')}", sudo=True, node=client
+    ):
+        log.error(f"Remove passphrase file failed for {kw.get('passphrase_file')}")
+        flag = 1
+
+    if kw.get("image_spec"):
+        pool_name = kw["image_spec"].split("/")[0]
+        image_name = kw["image_spec"].split("/")[1]
+        map_config = {
+            "pool": pool_name,
+            "image": image_name,
+            "device-type": kw.get("device_type", "nbd"),
+        }
+
+        _, err = rbd.device.unmap(**map_config)
+        if err:
+            log.error(f"Device unmap failed for {pool_name}/{image_name} ")
+            flag = 1
+
+    if kw.get("device_name"):
+        map_config = {
+            "image-snap-or-device-spec": kw["device_name"],
+            "device-type": kw.get("device_type", "nbd"),
+        }
+
+        _, err = rbd.device.unmap(**map_config)
+        if err:
+            log.error(f"Device unmap failed for {kw['device_name']} ")
+            flag = 1
+
+    return flag

--- a/ceph/rbd/workflows/encryption.py
+++ b/ceph/rbd/workflows/encryption.py
@@ -1,0 +1,1043 @@
+import random
+from copy import deepcopy
+from time import sleep
+
+from ceph.rbd.utils import check_data_integrity, copy_file, random_string
+from ceph.rbd.workflows.krbd_io_handler import krbd_io_handler
+from ceph.rbd.workflows.rbd import create_snap_and_clone
+from utility.log import Log
+
+log = Log(__name__)
+
+IO_CONFIG = {
+    "rbd": None,
+    "client": None,
+    "read_only": False,
+    "size": "",
+    "do_not_create_image": True,
+    "config": {
+        "file_size": "100M",
+        "file_path": [],
+        "image_spec": [],
+        "operations": {
+            "fs": "ext4",
+            "io": True,
+            "mount": True,
+            "nounmap": True,
+            "device_map": True,
+        },
+        "skip_mkfs": False,
+        "runtime": 30,
+        "encryption_config": [],
+    },
+}
+
+
+def create_passphrase_file(client, file):
+    """Creates a file in the given path and adds a random passphrase in the file
+    The passphrase generated and saved in the file will be used for luks encryption
+
+    Args:
+        file (str): file_path/file_name in which the passphrase needs to be saved
+    """
+    passphrase = random_string()
+
+    passphrase_file = client.remote_file(sudo=True, file_name=file, file_mode="w")
+    passphrase_file.write(passphrase)
+    passphrase_file.flush()
+
+
+def encrypt_image_and_run_io(**kw):
+    """Apply encryption to an image or its clone based on the args specified
+    Run IOs on the encrypted image by mapping the image onto a device
+    and mounting it to a filepath
+
+    Args:
+        kw: <Should contain all parameters in IO_CONFIG variable and the configs below>
+            config:
+                image_spec: <pool>/<image> for which encryption needs to be applied
+                encryption_config: encryption config details for image and its parent
+                        <[{encryption-type: <>, encryption-passphrase-file: <>}]>
+            size: current size of the image (needed to perform resize post encryption)
+            is_clone: True if image is clone
+            is_parent_encrypted: True, if image is clone and its parent is encrypted
+            is_clone_encrypted: True, if image is clone and it is encrypted
+            rbd: RBD object
+            client: client CephNode object
+            do_not_map_and_mount: True if image need not be mounted and IO not run.
+    """
+    config = kw.get("config", {})
+    size = kw.get("size")
+    if config.get("encryption_config"):
+        if kw.get("is_clone"):
+            if kw.get("is_parent_encrypted"):
+                if kw.get("is_clone_encrypted"):
+                    parent_clone_spec = {
+                        "parent_encryption_type": config.get("encryption_config")[
+                            1
+                        ].get("encryption-format"),
+                        "parent_spec": kw.get("parent_spec"),
+                        "parent_passphrase": config.get("encryption_config")[1].get(
+                            "encryption-passphrase-file"
+                        ),
+                        "clone_encryption_type": config.get("encryption_config")[0].get(
+                            "encryption-format"
+                        ),
+                        "clone_spec": config.get("image_spec")[0],
+                        "clone_passphrase": config.get("encryption_config")[0].get(
+                            "encryption-passphrase-file"
+                        ),
+                        "size": size,
+                    }
+                else:
+                    parent_clone_spec = {
+                        "parent_encryption_type": config.get("encryption_config")[
+                            0
+                        ].get("encryption-format"),
+                        "parent_spec": kw.get("parent_spec"),
+                        "parent_passphrase": config.get("encryption_config")[0].get(
+                            "encryption-passphrase-file"
+                        ),
+                        "clone_spec": config.get("image_spec")[0],
+                        "size": size,
+                    }
+            else:
+                parent_clone_spec = {
+                    "clone_encryption_type": config.get("encryption_config")[0].get(
+                        "encryption-format"
+                    ),
+                    "clone_spec": config.get("image_spec")[0],
+                    "parent_spec": kw.get("parent_spec"),
+                    "clone_passphrase": config.get("encryption_config")[0].get(
+                        "encryption-passphrase-file"
+                    ),
+                    "size": size,
+                }
+            resize_sequence = "after_clone"
+        else:
+            parent_clone_spec = {
+                "parent_encryption_type": config.get("encryption_config")[0].get(
+                    "encryption-format"
+                ),
+                "parent_spec": config.get("image_spec")[0],
+                "parent_passphrase": config.get("encryption_config")[0].get(
+                    "encryption-passphrase-file"
+                ),
+                "size": size,
+            }
+            resize_sequence = "before_clone"
+        rbd = kw.get("rbd")
+        client = kw.get("client")
+        image_spec = config.get("image_spec")[0]
+        passphrase = config.get("encryption_config")[0].get(
+            "encryption-passphrase-file"
+        )
+        encryption_type = config.get("encryption_config")[0].get("encryption-format")
+        if not kw.get("is_clone") or (
+            kw.get("is_clone") and kw.get("is_clone_encrypted")
+        ):
+            create_passphrase_file(client, passphrase)
+        encrypt_config = {
+            "image-spec": image_spec,
+            "format": encryption_type,
+            "passphrase-file": passphrase,
+        }
+
+        out, _ = rbd.encryption_format(**encrypt_config)
+        if out:
+            log.error(f"Apply RBD encryption {encryption_type} failed on {image_spec}")
+            return 1
+
+        resize_parent_and_clone(
+            rbd=rbd,
+            resize_sequence=resize_sequence,
+            parent_clone_spec=parent_clone_spec,
+        )
+
+    if kw.get("do_not_map_and_mount"):
+        return 0
+
+    out, _ = krbd_io_handler(**kw)
+    if out != 0:
+        log.error(f"Map, and mount failed for {image_spec}")
+        return 1
+
+    return 0
+
+
+def resize_parent_and_clone(rbd, resize_sequence, parent_clone_spec):
+    """
+    Resize parent and clone images to compensate overhead due to the header size.
+    Headers required for luks encryption take up some space in the image, so we perform
+    resize to compensate for the same.
+    Note: Please refer official documentation for more info.
+
+    Scenarios and corresponding steps
+    1) Parent and clone are luks1 encrypted
+        Resize parent at beginning to compensate for header size,
+        clone resize not required
+    2) Parent luks1/luks2 and clone is not encrypted
+        Resize parent at beginning to compensate for header size,
+        clone resize not required since it has no header
+    3) Parent luks2 and clone luks1
+        Resize parent at beginning to compensate for header size,
+        resize clone with --allow-shrink since luks2 header is bigger than luks1
+    4) Parent not encrypted and clone is luks1/luks2
+        Resize not required before clone since parent is not encrypted, resize
+        clone with --allow-shrink post cloning to compensate for header
+    5) Parent luks1 and clone luks2
+        Resize parent before clone, resize both parent and
+        clone with --allow-shrink post cloning
+
+    Justification:
+    Since LUKS2 header is usually bigger than LUKS1 header, the rbd resize command at
+    the beginning temporarily grows the parent image to reserve some extra space in the
+    parent snapshot and consequently the cloned image. This is necessary to make all parent
+    data accessible in the cloned image. The rbd resize command at the end shrinks the
+    parent image back to its original size and does not impact the parent snapshot and
+    the cloned image to get rid of the unused reserved space
+
+    The same applies to creating a formatted clone of an unformatted image,
+    since an unformatted image does not have a header at all.
+    Args:
+        rbd: rbd object
+        resize_sequence: before_clone if resize is being performed before cloning, else after_clone
+        parent_clone_spec:
+            Example: {
+                "parent_encryption_type": "luks1",
+                "parent_spec": "pool/image",
+                "parent_passphrase": "passphrase.bin",
+                "clone_encryption_type": "luks2",
+                "clone_spec": "pool/clone",
+                "clone_passphrase": "clone_passphrase.bin",
+                "size": <image_size>
+            }
+    """
+    log.info(
+        "Performing resize operation on encrypted image to "
+        f"compensate for the overhead of luks header: {resize_sequence}"
+    )
+
+    parent_encryption_type = parent_clone_spec.get("parent_encryption_type", "NA")
+    clone_encryption_type = parent_clone_spec.get("clone_encryption_type", "NA")
+    parent_spec = parent_clone_spec.get("parent_spec")
+    [pool, image] = parent_spec.split("/")
+    clone_spec = parent_clone_spec.get("clone_spec")
+    if clone_spec:
+        clone = clone_spec.split("/")[1]
+    size = parent_clone_spec.get("size")
+
+    if resize_sequence == "before_clone":
+        if parent_encryption_type.startswith("luks"):
+            parent_encryption_passphrase = {
+                "encryption_config": [
+                    {
+                        "encryption-passphrase-file": parent_clone_spec.get(
+                            "parent_passphrase"
+                        )
+                    }
+                ]
+            }
+            out = rbd.resize(
+                pool=pool, image=image, size=size, **parent_encryption_passphrase
+            )
+            log.info(f"Output of rbd resize for parent {resize_sequence}: {out}")
+            if out[0]:
+                log.error(
+                    "Image resize to compensate overhead due to "
+                    f"{parent_encryption_type} header failed for {parent_spec}"
+                )
+                return 1
+        else:
+            log.info("Parent image resize not required since it is not encrypted")
+        return 0
+
+    if resize_sequence == "after_clone":
+        if parent_encryption_type == "luks1" and clone_encryption_type == "luks2":
+            parent_encryption_passphrase = {
+                "encryption_config": [
+                    {
+                        "encryption-passphrase-file": parent_clone_spec.get(
+                            "parent_passphrase"
+                        )
+                    }
+                ]
+            }
+            resize_config = {
+                "pool": pool,
+                "image": image,
+                "size": size,
+                "allow-shrink": True,
+                "encryption_config": parent_encryption_passphrase["encryption_config"],
+            }
+            out = rbd.resize(**resize_config)
+            log.info(f"Output of rbd resize for parent {resize_sequence}: {out}")
+            if "new size is equal to original size" not in str(out[1]):
+                log.error(
+                    "Image resize to compensate overhead due to "
+                    f"{parent_encryption_type} header failed for {parent_spec}"
+                )
+                return 1
+
+        if (
+            clone_encryption_type.startswith("luks")
+            and parent_encryption_type != clone_encryption_type
+        ):
+            if parent_encryption_type.startswith("luks"):
+                clone_encryption_passphrase = {
+                    "encryption_config": [
+                        {
+                            "encryption-passphrase-file": parent_clone_spec.get(
+                                "clone_passphrase"
+                            )
+                        },
+                        {
+                            "encryption-passphrase-file": parent_clone_spec.get(
+                                "parent_passphrase"
+                            )
+                        },
+                    ]
+                }
+            else:
+                clone_encryption_passphrase = {
+                    "encryption_config": [
+                        {
+                            "encryption-passphrase-file": parent_clone_spec.get(
+                                "clone_passphrase"
+                            )
+                        }
+                    ]
+                }
+            resize_config = {
+                "pool": pool,
+                "image": clone,
+                "size": size,
+                "allow-shrink": True,
+                "encryption_config": clone_encryption_passphrase["encryption_config"],
+            }
+            out = rbd.resize(**resize_config)
+            log.info(f"Output of rbd resize for clone {resize_sequence}: {out}")
+            if out[0]:
+                log.error(
+                    "Clone resize to compensate overhead due to "
+                    f"{clone_encryption_type} header failed for {clone_spec}"
+                )
+                return 1
+        else:
+            log.info(
+                "Clone resize not required since clone is either not encrypted or encrypted with same format as parent"
+            )
+        return 0
+
+
+def create_and_encrypt_clone(**kw):
+    """Create a snap and clone for the given image
+    Also apply specified encryption on the clone and mount clone to a file
+
+    Args:
+        kw: {
+            "rbd": rbd,
+            "client": client,
+            "format": format,
+            "size": size,
+            "image_spec": image_spec,
+            "clone_spec": clone_spec,
+            "snap_spec": snap_spec,
+            "parent_passphrase": passphrase,
+            "clone_file_path": kw["clone_file_path"],
+            "clone_passphrase": None,
+            "do_not_map_and_mount": True,
+        }
+    """
+    rbd = kw.get("rbd")
+    client = kw.get("client")
+    [parent_encryption_type, clone_encryption_type] = kw.get("format").split(",")
+    is_parent_encrypted = parent_encryption_type.startswith("luks")
+    is_clone_encrypted = clone_encryption_type.startswith("luks")
+    size = kw.get("size")
+    image_spec = kw.get("image_spec")
+    clone_spec = kw.get("clone_spec")
+    snap_spec = kw.get("snap_spec")
+    passphrase = kw.get("parent_passphrase")
+    ret_config = list()
+
+    encrypt_and_io_config = deepcopy(IO_CONFIG)
+    encrypt_and_io_config.update(
+        {
+            "rbd": rbd,
+            "client": client,
+            "size": size,
+            "is_clone": True,
+            "is_parent_encrypted": is_parent_encrypted,
+            "is_clone_encrypted": is_clone_encrypted,
+            "parent_spec": image_spec,
+            "do_not_map_and_mount": kw.get("do_not_map_and_mount"),
+        }
+    )
+
+    encrypt_and_io_config["config"].update(
+        {
+            "file_path": [kw["clone_file_path"]],
+            "image_spec": [clone_spec],
+            "skip_mkfs": True,
+        }
+    )
+
+    encrypt_and_io_config["config"]["operations"].update({"io": False})
+
+    if create_snap_and_clone(rbd=rbd, snap_spec=snap_spec, clone_spec=clone_spec):
+        log.error(f"Snapshot and/or clone creation failed for {image_spec}")
+        return None
+
+    if is_clone_encrypted:
+        log.info(
+            f"Applying encryption of type {clone_encryption_type} on the clone {clone_spec}"
+        )
+        clone_passphrase = (
+            kw.get("clone_passphrase")
+            or f"clone_{clone_encryption_type}_passphrase.bin"
+        )
+        if is_parent_encrypted:
+            ret_config = encrypt_and_io_config["config"]["encryption_config"] = [
+                {
+                    "encryption-format": clone_encryption_type,
+                    "encryption-passphrase-file": clone_passphrase,
+                },
+                {
+                    "encryption-format": parent_encryption_type,
+                    "encryption-passphrase-file": passphrase,
+                },
+            ]
+        else:
+            encrypt_and_io_config["config"]["encryption_config"] = ret_config = [
+                {
+                    "encryption-format": clone_encryption_type,
+                    "encryption-passphrase-file": clone_passphrase,
+                }
+            ]
+    elif is_parent_encrypted:
+        encrypt_and_io_config["config"]["encryption_config"] = ret_config = [
+            {
+                "encryption-format": parent_encryption_type,
+                "encryption-passphrase-file": passphrase,
+            }
+        ]
+
+    out = encrypt_image_and_run_io(**encrypt_and_io_config)
+    if out:
+        log.error(f"Encryption and/or IO execution failed on image {clone_spec}")
+        return None
+
+    return ret_config
+
+
+def test_encryption_between_image_and_clone(**kw):
+    """Apply specified encryption to parent, run IOs
+    Create a snap and clone for this parent,
+    Apply specified encryption to clone, mount the clone to a file
+    Verify data integrity between image and its clone.
+
+    Args:
+        kw:
+            {
+                "rbd": RBD object,
+                "client": client node,
+                "image_spec": <pool>/<parent_image>,
+                "snap_spec": <pool>/<parent_image>@<snap>,
+                "clone_spec": <pool>/<clone_image>,
+                "parent_file_path": <path/file> where parent should be mounted,
+                "clone_file_path": <path/file> where clone should be mounted,
+                "size": image size,
+                "format": encryption format Ex: luks1,luks2 (parent,clone),
+            }
+    """
+    rbd = kw.get("rbd")
+    client = kw.get("client")
+    [parent_encryption_type, clone_encryption_type] = kw.get("format").split(",")
+    size = kw.get("size")
+    image_spec = kw.get("image_spec")
+    clone_spec = kw.get("clone_spec")
+    snap_spec = kw.get("snap_spec")
+    ret_config = dict()
+
+    encrypt_and_io_config = deepcopy(IO_CONFIG)
+    encrypt_and_io_config.update(
+        {
+            "rbd": rbd,
+            "client": client,
+            "size": size,
+        }
+    )
+    encrypt_and_io_config["config"].update(
+        {
+            "file_path": [kw["parent_file_path"]],
+            "image_spec": [image_spec],
+        }
+    )
+
+    passphrase = ""
+    if parent_encryption_type.startswith("luks"):
+        log.info(
+            f"Applying luks encryption of type {parent_encryption_type} on {image_spec}"
+        )
+        passphrase = f"{parent_encryption_type}_passphrase.bin"
+        encrypt_and_io_config["config"]["encryption_config"] = ret_config[
+            "parent_encryption_config"
+        ] = [
+            {
+                "encryption-format": parent_encryption_type,
+                "encryption-passphrase-file": passphrase,
+            }
+        ]
+    if encrypt_image_and_run_io(**encrypt_and_io_config):
+        log.error(f"Encryption and/or IO execution failed on image {image_spec}")
+        return None
+
+    # Sleep for sometime after running IOs before creating snap
+    sleep(60)
+
+    clone_config = {
+        "rbd": rbd,
+        "client": client,
+        "format": kw.get("format"),
+        "size": size,
+        "image_spec": image_spec,
+        "clone_spec": clone_spec,
+        "snap_spec": snap_spec,
+        "parent_passphrase": passphrase,
+        "clone_file_path": kw["clone_file_path"],
+    }
+    ret_config["clone_encryption_config"] = create_and_encrypt_clone(**clone_config)
+
+    if not ret_config["clone_encryption_config"]:
+        return None
+
+    data_check_config = {
+        "first": {"file_path": kw["parent_file_path"], "rbd": rbd, "client": client},
+        "second": {"file_path": kw["clone_file_path"], "rbd": rbd, "client": client},
+    }
+    if check_data_integrity(**data_check_config):
+        log.error(f"Data inconsistency found between {image_spec} and {clone_spec}")
+        return None
+    else:
+        log.info(f"Data is consistent between {image_spec} and {clone_spec}")
+
+    return ret_config
+
+
+def map_and_mount_image(**kw):
+    """Map the given image to a device
+    and Mount it to a file specified
+
+    Args:
+        kw:
+            All parameters required by IO_CONFIG variable and
+            return_output: True, if stdout for commands executed is to be returned
+    """
+
+    io_config = deepcopy(IO_CONFIG)
+    io_config.update(
+        {
+            "rbd": kw.get("rbd"),
+            "client": kw.get("client"),
+            "size": kw.get("size"),
+            "read_only": kw.get("read_only"),
+        }
+    )
+    io_config["config"].update(
+        {
+            "file_path": [kw.get("file_path")],
+            "image_spec": [kw.get("image_spec")],
+            "skip_mkfs": kw.get("skip_mkfs"),
+            "encryption_config": kw.get("encryption_config"),
+        }
+    )
+    io_config["config"]["operations"].update(
+        {
+            "io": kw.get("io"),
+            "nounmap": kw.get("nounmap", True),
+        }
+    )
+
+    out, err = krbd_io_handler(**io_config)
+
+    if err and not kw.get("return_output"):
+        log.error(f"Map, and mount failed for {kw.get('image_spec')}")
+        return 1
+
+    if kw.get("return_output"):
+        return out, err
+
+    return 0
+
+
+def mount_image_and_mirror_and_check_data(**kw):
+    """Check data integrity between an image and its mirror
+    Prerequisites:
+        An image which is mapped to a device and mounted to a file
+        A mirror image to the above original image
+    Steps:
+        Map the mirrored image and mount it to specified file path
+        Verify that the data in original image and mirrored image match
+
+    Args:
+        kw:
+            "rbd": RBD object pointing to the original image
+            "client": Client node for primary cluster
+            "mirror_rbd": RBD object pointing to mirrored image
+            "mirror_client": Client node for mirrored cluster
+            "size": image size
+            "encryption_config": encryption applied to the given image
+                    <[{encryption-type: <>, encryption-passphrase-file: <>}]>
+            "file_path": File where image is mounted in primary cluster
+                    and mirrored image to be mounted in mirrored cluster
+    """
+    rbd = kw.get("rbd")
+    client = kw.get("client")
+    mirror_rbd = kw.get("mirror_rbd")
+    mirror_client = kw.get("mirror_client")
+    image_spec = kw.get("image_spec")
+    size = kw.get("size")
+
+    if kw.get("encryption_config"):
+        passphrase = kw.get("encryption_config")[0].get("encryption-passphrase-file")
+        copy_file(passphrase, client, mirror_client)
+
+    mount_config = {
+        "rbd": mirror_rbd,
+        "client": mirror_client,
+        "size": size,
+        "file_path": kw.get("file_path"),
+        "image_spec": image_spec,
+        "encryption_config": kw.get("encryption_config"),
+        "io": False,
+        "skip_mkfs": True,
+        "return_output": False,
+        "read_only": True,
+    }
+
+    if map_and_mount_image(**mount_config):
+        log.error(f"Map and mount failed for {image_spec}")
+        return 1
+
+    data_check_config = {
+        "first": {"file_path": kw["file_path"], "rbd": rbd, "client": client},
+        "second": {
+            "file_path": kw["file_path"],
+            "rbd": mirror_rbd,
+            "client": mirror_client,
+        },
+    }
+    if check_data_integrity(**data_check_config):
+        log.error(f"Data inconsistency found between {image_spec} and its mirror")
+        return 1
+    else:
+        log.info(f"Data is consistent between {image_spec} and its mirror")
+    return 0
+
+
+def get_wrong_format(**kw):
+    """Fetch the encryption format other than the
+    format specified in input
+
+    Args:
+        kw:
+            input_: Input format
+    Returns:
+        luks2 if luks1 is input and viceversa
+        returns a random choice luks1/luks2 if input is not specified
+    """
+    format = kw.get("input_")
+    encryption_format = ["luks1", "luks2"]
+
+    if format not in encryption_format:
+        return random.choice(encryption_format)
+
+    return "luks1" if "luks1" != format else "luks2"
+
+
+def get_wrong_passphrase(**kw):
+    """Create a dummy passphrase file and return it
+
+    Args:
+        kw:
+            client: Client node where passphrase file needs to be created
+    """
+    client = kw.get("client")
+    dummy_passphrase_file = "dummy_passphrase.bin"
+    create_passphrase_file(client, dummy_passphrase_file)
+    return dummy_passphrase_file
+
+
+def return_input(**kw):
+    """Returns the value specified in kw["input_"]"""
+    return kw.get("input_")
+
+
+def return_empty(**kw):
+    """Method to return None"""
+    return None
+
+
+def validate_neg_scenario(
+    description, expected_error, actual_output, actual_error, alternate_error=[]
+):
+    """Compare the actual error to expected and alternate errors specified
+
+    Args:
+        description: Negative scenario being tested
+        expected_error: List of strings defining the error message required for the scenario
+        actual_output: actual output code, 0 if neg scenario command passed, 1 if command failed
+        actual_error: Error message received by executing command for given negative scenario
+        alternate_error: If any alternate error message is also acceptable for a scenario
+
+    Returns:
+        0 if validation is successful, 1 otherwise
+    """
+    if not actual_output:
+        log.error(f"Negative scenario {description} did not throw any error")
+        return 1
+    else:
+        is_error_expected = False
+        if all(error in actual_error for error in expected_error):
+            is_error_expected = True
+        elif alternate_error and all(
+            error in actual_error for error in alternate_error
+        ):
+            is_error_expected = True
+        if is_error_expected:
+            log.info(
+                f"Negative scenario {description} failed appropriately with error {actual_error}"
+            )
+            return 0
+        else:
+            log.error(
+                f"Error message {actual_error} is not appropriate for scenario {description}"
+            )
+            return 1
+
+
+class NegativeScenario:
+    def __init__(
+        self,
+        desc="",
+        format_methods=None,
+        passphrase_methods=None,
+        error_message=[],
+        alternate_error=[],
+    ):
+        self.desc = desc
+        self.format_methods = format_methods or []
+        self.passphrase_methods = passphrase_methods or []
+        self.error_message = error_message
+        self.alternate_error = alternate_error
+        assert len(self.format_methods) == len(self.passphrase_methods)
+
+
+def execute_neg_encryption_scenarios(**kw):
+    """Execute all the negative scenarios specified in kw["scenarios"]
+    and validate the same for the given image
+
+    Args:
+        kw:
+            scenarios: list of scenarios to be executed, Ex: [1,4,10]
+            encryption_config: current encryption config
+                                <[{encryption-type: <>, encryption-passphrase-file: <>}]>
+            rbd: RBD object
+            client: client node
+            size: image size
+            image_spec: <pool>/<image> for which scenarios to be tested
+
+    Scenarios:
+        1. wrong image format (when image has no parent)
+        2. wrong image passphrase (when image has no parent)
+        3. no image config (when image has no parent)
+        4. wrong image config (both format and passphrase are wrong)(when image has no parent)
+        5. wrong parent format
+        6. wrong parent passphrase
+        7. no parent config
+        8. wrong parent config (both format and passphrase are wrong)
+        9. wrong image format and parent format
+        10. wrong image passphrase and parent passphrase
+        11. wrong image config (both format and passphrase are wrong)(when parent in present)
+        12. wrong image config and parent config (both format and passphrase are wrong)
+        13. no image config(when parent in present and encrypted)
+        14. no image config(when parent in present and not encrypted)
+        15. no image config(when parent is present and clone not encrypted)
+        16. mount read-only image as read-write
+    """
+    # scenario metadata is a dictionary for each scenario as given below
+    scenario_metadata = {
+        1: NegativeScenario(
+            desc="wrong image format (when image has no parent)",
+            format_methods=[get_wrong_format],
+            passphrase_methods=[return_input],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        2: NegativeScenario(
+            desc="wrong image passphrase (when image has no parent)",
+            format_methods=[return_input],
+            passphrase_methods=[get_wrong_passphrase],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(1)",
+                "Operation not permitted",
+            ],
+        ),
+        3: NegativeScenario(
+            desc="no image config (when image has no parent)",
+            format_methods=[return_empty],
+            passphrase_methods=[return_empty],
+            error_message=["unknown filesystem type 'crypto_LUKS'"],
+        ),
+        4: NegativeScenario(
+            desc="wrong image config (both format and passphrase are wrong)(when image has no parent)",
+            format_methods=[get_wrong_format],
+            passphrase_methods=[get_wrong_passphrase],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        5: NegativeScenario(
+            desc="wrong parent format",
+            format_methods=[return_input, get_wrong_format],
+            passphrase_methods=[return_input, return_input],
+            error_message=[
+                "image name: parent_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        6: NegativeScenario(
+            desc="wrong parent passphrase",
+            format_methods=[return_input, return_input],
+            passphrase_methods=[return_input, get_wrong_passphrase],
+            error_message=[
+                "image name: parent_name",
+                "failed to load encryption",
+                "(1)",
+                "Operation not permitted",
+            ],
+        ),
+        7: NegativeScenario(
+            desc="no parent config",
+            format_methods=[return_input, return_empty],
+            passphrase_methods=[return_input, return_empty],
+            error_message=[
+                "image name: parent_name",
+                "failed to load encryption",
+                "(1)",
+                "Operation not permitted",
+            ],
+            alternate_error=[
+                "image name: parent_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+            # alternate error occurs when encryption is luks2,luks1
+            # or luks1,luks2 since by default luks1 is taken
+            # as encryption format when nothing is specified
+        ),
+        8: NegativeScenario(
+            desc="wrong parent config (both format and passphrase are wrong)",
+            format_methods=[return_input, get_wrong_format],
+            passphrase_methods=[return_input, get_wrong_passphrase],
+            error_message=[
+                "image name: parent_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        9: NegativeScenario(
+            desc="wrong image format and parent format",
+            format_methods=[get_wrong_format, get_wrong_format],
+            passphrase_methods=[return_input, return_input],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        10: NegativeScenario(
+            desc="wrong image passphrase and parent passphrase",
+            format_methods=[return_input, return_input],
+            passphrase_methods=[get_wrong_passphrase, get_wrong_passphrase],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(1)",
+                "Operation not permitted",
+            ],
+        ),
+        11: NegativeScenario(
+            desc="wrong image config (both format and passphrase are wrong)(when parent in present)",
+            format_methods=[get_wrong_format, return_input],
+            passphrase_methods=[get_wrong_passphrase, return_input],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        12: NegativeScenario(
+            desc="wrong image config and parent config (both format and passphrase are wrong)",
+            format_methods=[get_wrong_format, get_wrong_format],
+            passphrase_methods=[get_wrong_passphrase, get_wrong_passphrase],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+        ),
+        13: NegativeScenario(
+            desc="no image config(when parent in present and encrypted)",
+            format_methods=[return_empty, return_input],
+            passphrase_methods=[return_empty, return_input],
+            error_message=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(1)",
+                "Operation not permitted",
+            ],
+            alternate_error=[
+                "image name: image_name",
+                "failed to load encryption",
+                "(22)",
+                "Invalid argument",
+            ],
+            # alternate error occurs when encryption is luks2,luks1
+            # or luks1,luks2 since by default luks1 is taken
+            # as encryption format when nothing is specified
+        ),
+        14: NegativeScenario(
+            desc="no image config(when parent in present and not encrypted)",
+            format_methods=[return_empty, return_input],
+            passphrase_methods=[return_empty, return_input],
+            error_message=[
+                "wrong fs type, bad option, bad superblock",
+                "missing codepage or helper program, or other error",
+            ],
+        ),
+        15: NegativeScenario(
+            desc="no image config(when parent is present and clone not encrypted)",
+            format_methods=[return_empty],
+            passphrase_methods=[return_empty],
+            error_message=[
+                "wrong fs type, bad option, bad superblock",
+                "missing codepage or helper program, or other error",
+            ],
+        ),
+    }
+
+    encryption_config = kw.get("encryption_config")
+    scenarios = kw.get("scenarios")
+
+    if len(encryption_config) == 1 and any(
+        s > 4 and s not in [15, 16] for s in scenarios
+    ):
+        log.error("Parent clone scenario requested for an image with no parent")
+        return 1
+
+    mount_config = {
+        "rbd": kw.get("rbd"),
+        "client": kw.get("client"),
+        "size": kw.get("size"),
+        "file_path": "",
+        "image_spec": kw.get("image_spec"),
+        "encryption_config": encryption_config,
+        "io": False,
+        "skip_mkfs": True,
+        "return_output": True,
+        "read_only": kw.get("read_only"),
+        "nounmap": False,
+    }
+
+    if 16 in scenarios:
+        desc = "mount read-only image as read-write"
+        error_message = ["can't read superblock"]
+        scenarios.remove(16)
+        file_path = f"/tmp/{random_string(len=5)}_dir/{random_string(len=5)}_file"
+
+        dummy_encryption_config = list()
+        for enc_config in mount_config["encryption_config"]:
+            if enc_config.get("encryption-format") != "NA":
+                dummy_encryption_config.append(enc_config)
+
+        mount_config.update(
+            {
+                "file_path": file_path,
+                "read_only": False,
+                "encryption_config": dummy_encryption_config,
+            }
+        )
+        out, err = map_and_mount_image(**mount_config)
+        if not isinstance(err, str):
+            err = str(err)
+        if validate_neg_scenario(desc, error_message, out, err):
+            return 1
+        mount_config.update({"read_only": kw.get("read_only")})
+
+    for s_id in scenarios:
+        dummy_encryption_config = list()
+        scenario_obj = scenario_metadata.get(s_id)
+
+        for format_method, passphrase_method, config in zip(
+            scenario_obj.format_methods,
+            scenario_obj.passphrase_methods,
+            encryption_config,
+        ):
+            new_format = format_method(input_=config.get("encryption-format"))
+            new_passphrase = passphrase_method(
+                client=kw.get("client"), input_=config.get("encryption-passphrase-file")
+            )
+            if new_passphrase:
+                encrypt_config = {
+                    "encryption-passphrase-file": new_passphrase,
+                }
+                if new_format != "NA":
+                    encrypt_config.update({"encryption-format": new_format})
+                dummy_encryption_config.append(encrypt_config)
+
+        file_path = f"/tmp/{random_string(len=5)}_dir/{random_string(len=5)}_file"
+        mount_config.update(
+            {"file_path": file_path, "encryption_config": dummy_encryption_config}
+        )
+
+        out, err = map_and_mount_image(**mount_config)
+
+        if not isinstance(err, str):
+            err = str(err)
+
+        image = kw.get("image_spec").split("/")[1] if kw.get("image_spec") else ""
+        parent = kw.get("parent_spec").split("/")[1] if kw.get("parent_spec") else ""
+        expected_err = [
+            err.replace("image_name", image).replace("parent_name", parent)
+            for err in scenario_obj.error_message
+        ]
+        alternate_error = []
+        if scenario_obj.alternate_error:
+            alternate_error = [
+                err.replace("image_name", image).replace("parent_name", parent)
+                for err in scenario_obj.alternate_error
+            ]
+        if validate_neg_scenario(
+            scenario_obj.desc, expected_err, out, err, alternate_error
+        ):
+            return 1
+
+    return 0

--- a/ceph/rbd/workflows/krbd_io_handler.py
+++ b/ceph/rbd/workflows/krbd_io_handler.py
@@ -1,0 +1,174 @@
+from ceph.rbd.utils import create_map_options, exec_cmd
+from ceph.rbd.workflows.cleanup import device_cleanup
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+from utility.utils import run_fio, run_mkfs
+
+log = Log(__name__)
+
+
+def run(**kw):
+    return krbd_io_handler(**kw)
+
+
+def krbd_io_handler(**kw):
+    """krbd io handler.
+    Usage:
+        config:
+          operations:
+            map: true
+            mount: true
+            fs: ext4/xfs
+            io: true
+            fsck: true
+            nounmap: false
+            device_map: true
+          image_spec:
+            - pool_name/image_name
+          runtime: 30
+          file_size: 100M
+          device_names:
+            - /dev/<>  # newly created devices will be returned in this parameter
+          file_path:
+            - /<path>/<name> # Pass the file path with file name where image needs to be mounted to run IOs
+          encryption_config:
+            - <encryption_type>: <passphrase> # List of encryptions and passphrases to be passed for device map
+          skip_mkfs: true # Will skip creating new filesystem while mounting a device.
+        rbd: The RBD object to be used for testing, if not passed a new RBD object will be created.
+        do_not_create_image: Default False, Set True if image on which operations need to be executed already exists
+        client: client node to be used
+        read_only: True if map and mount needs to happen with read only configuration
+        Note:
+        1) if mount is set to true, a mount point will be created and fs will be created on the device by default
+        2) Required pool needs to be created.
+        3) Run time is per image
+    """
+    client = kw.get("client")
+    if kw.get("rbd_obj"):
+        rbd = kw.get("rbd")
+    else:
+        rbd = Rbd(client)
+    config = kw.get("config")
+    log.debug(f"Config received for execution: {config}")
+
+    operations = config["operations"]
+    device_names = []
+    mount_points = []
+    return_flag = 0
+
+    for image_spec in config["image_spec"]:
+        pool_name = image_spec.split("/")[0]
+        image_name = image_spec.split("/")[1]
+        try:
+            if not kw.get("do_not_create_image"):
+                create_config = {
+                    "pool": pool_name,
+                    "image": image_name,
+                    "size": config.get("size", "1G"),
+                }
+                if config.get("is_ec_pool"):
+                    create_config.update({"data-pool": config.get("data_pool")})
+                if config.get("thick_provision"):
+                    create_config.update(
+                        {"thick_provision": config.get("thick_provision")}
+                    )
+                if rbd.create(**create_config)[0]:
+                    log.error(f"Image {image_name} creation failed")
+                    return 1, "Image creation failed"
+
+            if operations.get("map"):
+                device_names.append(rbd.map(pool=pool_name, image=image_name)[:-1])
+
+            if operations.get("device_map"):
+                map_config = {
+                    "pool": pool_name,
+                    "image": image_name,
+                    "device-type": config.get("device_type", "nbd"),
+                }
+                if config.get("encryption_config"):
+                    options = create_map_options(config.get("encryption_config"))
+                    map_config.update(
+                        {
+                            "options": options,
+                        }
+                    )
+                if kw.get("read_only"):
+                    map_config.update({"read-only": True})
+
+                out, err = rbd.device.map(**map_config)
+                if err:
+                    log.error(
+                        f"RBD device map failed for {image_spec} and "
+                        f"encryption_config: {config.get('encryption_config')}"
+                    )
+                    return 1, err
+                device_names.append(out.strip())
+
+            image_index = config["image_spec"].index(image_spec)
+
+            if operations.get("mount"):
+                if not config.get("skip_mkfs"):
+                    run_mkfs(
+                        client_node=client,
+                        device_name=device_names[-1],
+                        type=operations.get("fs"),
+                    )
+                # Creating mount directory and mouting device
+                mount_point = (
+                    config.get("file_path")[image_index].rsplit("/", 1)[0]
+                    if config.get("file_path")
+                    else f"/tmp/mp_{device_names[-1].split('/')[-1]}"
+                )
+                mount_points.append(mount_point)
+                mount_cmd = (
+                    f"mkdir {mount_point}; mount {device_names[-1]} {mount_point}"
+                )
+                if kw.get("read_only"):
+                    mount_cmd += " -o ro,noload"
+                out, err = exec_cmd(cmd=mount_cmd, node=client, all=True)
+                if err:
+                    log.error(f"Mount failed for device: {device_names[-1]}")
+                    return 1, err
+
+            if operations.get("io"):
+                if operations.get("mount"):
+                    file_name = (
+                        config.get("file_path")[image_index]
+                        if config.get("file_path")
+                        else f"{mount_point}/{image_name}"
+                    )
+                    run_fio(
+                        client_node=client,
+                        filename=file_name,
+                        runtime=config.get("runtime", 30),
+                        size=config.get("file_size", "100M"),
+                    )
+                else:
+                    run_fio(
+                        client_node=client,
+                        device_name=device_names[-1],
+                        runtime=config.get("runtime", 30),
+                    )
+
+            if operations.get("fsck"):
+                if exec_cmd(node=client, cmd=f"fsck -n {device_names[-1]}"):
+                    log.debug("fsck failed")
+                    return_flag = 1
+
+        finally:
+            if not operations.get("nounmap"):
+                for mount_point, device_name in zip(mount_points, device_names):
+                    cleanup_config = {
+                        "rbd": rbd,
+                        "client": client,
+                        "file_name": mount_point,
+                        # "image_spec": image_spec,
+                        # "encryption_config": config.get("encryption_config"),
+                        "device_type": config.get("device_type", "nbd"),
+                        "device_name": device_name,
+                        # "read_only": kw.get("read_only"),
+                    }
+                    # Note: Implement cleanup for map
+                    return_flag = device_cleanup(**cleanup_config)
+    kw["config"]["device_names"] = device_names
+    return return_flag, ""

--- a/ceph/rbd/workflows/pool.py
+++ b/ceph/rbd/workflows/pool.py
@@ -1,0 +1,136 @@
+import json
+
+from ceph.rbd.utils import exec_cmd
+from ceph.waiter import WaitUntil
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def check_pool_exists(pool_name, client, timeout=10, interval=10):
+    """
+    recursively checks if the specified pool exists in the cluster
+    Args:
+        pool_name: Name of the pool to be checked
+        timeout: number in seconds to wait until pool exists
+                  default will be 10
+        interval: number in seconds to check for pool existence until timeout
+                  default will be 10
+
+    Returns:
+        0 if pool created successfully,
+        1 if pool creation failed.
+
+    """
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        out = exec_cmd(node=client, cmd="ceph df -f json", output=True)
+        if pool_name in [ele["name"] for ele in json.loads(out)["pools"]]:
+            log.info(f"Pool '{pool_name}' present in the cluster")
+            return 0
+        elif timeout == 0:
+            log.error(f"Pool '{pool_name}' not present in the cluster")
+            return 1
+        log.info(
+            f"Pool '{pool_name}' not populated yet.\n"
+            f"Waiting for {interval} seconds and retrying"
+        )
+
+    if w.expired:
+        log.info(
+            f"Failed to wait {timeout} seconds to pool '{pool_name}'"
+            f" present on cluster"
+        )
+        return 1
+
+
+def set_ec_profile(k_m, profile, failure_domain, client):
+    """
+    Sets erasure code profile for the given k_m and profile values
+
+    Args:
+        k_m: Comma separated values of k and m. Ex: 2,1
+        profile: EC profile name to be created
+        failure_domain: osd
+
+    Returns:
+        0 if ec profile creation is successful
+        1 if ec profile creation fails
+    """
+    exec_cmd(node=client, cmd=f"ceph osd erasure-code-profile rm {profile}")
+
+    cmd = f"ceph osd erasure-code-profile set {profile} k={k_m[0]} m={k_m[2]}"
+    if failure_domain:
+        cmd += f" crush-failure-domain={failure_domain}"
+    return exec_cmd(node=client, cmd=cmd)
+
+
+def create_ecpool(
+    pool,
+    client,
+    k_m="",
+    profile="use_default",
+    pg_num=16,
+    pgp_num=16,
+    failure_domain="",
+    cluster="ceph",
+):
+    """
+    Creates an ec pool with the given parameters
+
+    Args:
+        pool: Pool name to be created
+        client: client node to be used to execute commands
+        pg_num: pg_num value for the pool, default 16
+        pgp_num: pgp_num value for the pool, default 16
+        k_m: Comma separated values of k and m. Ex: 2,1, default ""
+        profile: EC profile name to be created default "use_default"
+        failure_domain: osd default ""
+
+    Returns:
+        0 if ec pool creation is successful
+        1 if ec pool creation fails
+    """
+    cmd = f"ceph osd pool create {pool} {pg_num} {pgp_num} erasure --cluster {cluster}"
+    if profile != "use_default":
+        cmd += profile
+        if set_ec_profile(
+            client=client, k_m=k_m, profile=profile, failure_domain=failure_domain
+        ):
+            log.error("EC profile creation failed")
+            return 1
+    if exec_cmd(node=client, cmd=cmd):
+        log.error("Pool creation failed")
+        return 1
+    if check_pool_exists(pool_name=pool, client=client, timeout=200, interval=2):
+        log.error("Pool not created")
+        return 1
+    if exec_cmd(node=client, cmd=f"ceph osd pool set {pool} allow_ec_overwrites true"):
+        log.error("Set allow_ec_overwrites failed")
+        return 1
+    return 0
+
+
+def create_pool(pool, client, pg_num=64, pgp_num=64, cluster="ceph"):
+    """
+    Creates a pool with the given name
+
+    Args:
+        pool: name of the pool to be created
+        client: client node to be used to execute commands
+        pg_num: pg_num value for the pool, default 64
+        pgp_num: pgp_num value for the pool, default 64
+
+    Returns:
+        0 if pool creation is successful
+        1 if pool creation fails
+    """
+    if exec_cmd(
+        node=client,
+        cmd=f"ceph osd pool create {pool} {pg_num} {pgp_num} --cluster {cluster}",
+    ):
+        log.error("Pool creation failed")
+        return 1
+    if check_pool_exists(client=client, pool_name=pool):
+        log.error("Pool not created")
+        return 1
+    return 0

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -1,0 +1,115 @@
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.pool import create_ecpool, create_pool
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def create_snap_and_clone(rbd, snap_spec, clone_spec):
+    """_summary_
+
+    Args:
+        snap_spec (_type_): _description_
+        clone_spec (_type_): _description_
+    """
+    snap_config = {"snap-spec": snap_spec}
+
+    out, _ = rbd.snap.create(**snap_config)
+    if out:
+        log.error(f"Snapshot creation failed for {snap_spec}")
+        return 1
+
+    out, _ = rbd.snap.protect(**snap_config)
+    if out:
+        log.error(f"Snapshot protect failed for {snap_spec}")
+        return 1
+
+    clone_config = {"source-snap-spec": snap_spec, "dest-image-spec": clone_spec}
+
+    out, _ = rbd.clone(**clone_config)
+    if out:
+        log.error(f"Clone creation failed for {clone_spec}")
+        return 1
+
+    return 0
+
+
+def config_rbd_multi_pool(
+    rbd,
+    multi_pool_config,
+    is_ec_pool,
+    ceph_version,
+    config,
+    client,
+    is_secondary=False,
+    cluster="ceph",
+):
+    """ """
+    # If any pool level test config is present, pop it out
+    # so that it does not get mistaken as another image configuration
+    pool_test_config = multi_pool_config.pop("test_config", None)
+
+    for pool, pool_config in multi_pool_config.items():
+        if create_pool(
+            pool=pool,
+            pg_num=pool_config.get("pg_num", 64),
+            pgp_num=pool_config.get("pgp_num", 64),
+            client=client,
+            cluster=cluster,
+        ):
+            log.error(f"Pool creation failed for pool {pool}")
+            return 1
+
+        if ceph_version >= 3:
+            pool_init_conf = {"pool-name": pool, "cluster": cluster}
+            rbd.pool.init(**pool_init_conf)
+
+        if is_ec_pool and create_ecpool(
+            pool=pool_config.get("data_pool"),
+            k_m=pool_config.get("ec-pool-k-m"),
+            profile=pool_config.get("ec_profile", "use_default"),
+            pg_num=pool_config.get("ec_pg_num", 16),
+            pgp_num=pool_config.get("ec_pgp_num", 16),
+            failure_domain=pool_config.get("failure_domain", ""),
+            client=client,
+            cluster=cluster,
+        ):
+            log.error(f"EC Pool creation failed for {pool_config.get('data_pool')}")
+            return 1
+
+        if is_ec_pool and ceph_version >= 3:
+            pool_init_conf = {
+                "pool-name": pool_config.get("data_pool"),
+                "cluster": cluster,
+            }
+            rbd.pool.init(**pool_init_conf)
+
+        multi_image_config = getdict(pool_config)
+        image_config = {
+            k: v
+            for k, v in multi_image_config.items()
+            if v.get("is_secondary", False) == is_secondary
+        }
+
+        for image, image_config_val in image_config.items():
+            if not config.get("do_not_create_image"):
+                create_config = {"pool": pool, "image": image}
+                if is_ec_pool:
+                    create_config.update({"data-pool": pool_config.get("data_pool")})
+                # Update any other specific arguments that rbd create command takes if passed in config
+                create_config.update(
+                    {
+                        k: v
+                        for k, v in image_config_val.items()
+                        if k not in ["io_total", "test_config", "is_secondary"]
+                    }
+                )
+                create_config.update({"cluster": cluster})
+                if rbd.create(**create_config)[0]:
+                    log.error(f"Image {image} creation failed")
+                    return 1
+
+    # Add back the popped pool test config once configuration is complete
+    if pool_test_config:
+        multi_pool_config["test_config"] = pool_test_config
+    return 0

--- a/ceph/rbd/workflows/rbd_mirror.py
+++ b/ceph/rbd/workflows/rbd_mirror.py
@@ -1,0 +1,488 @@
+import ast
+import datetime
+import json
+import time
+
+from ceph.parallel import parallel
+from ceph.rbd.utils import copy_file, exec_cmd, getdict, value
+from utility.log import Log
+
+log = Log(__name__)
+
+
+# Get Position
+def get_position(rbd, imagespec, pattern=None):
+    status_config = {"image-spec": imagespec, "format": "json"}
+    image_status = rbd.mirror.image.status(**status_config)
+    out = value(
+        "description",
+        json.loads(image_status),
+    )
+    if out == "local image is primary":
+        raise Exception("Position cannot be determined ")
+    if pattern is not None:
+        primary_pos = out.find("primary_position")
+        mirror_pos = out.find("mirror_position")
+        entries_behind = out.find("entries")
+        pos = [
+            out[primary_pos : mirror_pos - 2],
+            out[mirror_pos : entries_behind - 2],
+            out[entries_behind:],
+        ]
+        if "primary" in pattern:
+            return pos[0]
+        elif "mirror" in pattern:
+            return pos[1]
+        else:
+            return pos[2]
+    else:
+        return out
+
+
+def wait_for_status(rbd, cluster_name, **kw):
+    """Wait for required mirror status of pool or image.
+
+    Args:
+        kw:
+        poolname: Name of the pool
+        imagespec: Image specification of the image of which status needs to be checked
+        state_pattern: Required mirror image state
+        description_pattern: Required mirror image description
+        retry_interval: sleep duration in between retries.
+        ignore_command_failure: true if command failure is to be ignored.
+    """
+    starttime = datetime.datetime.now()
+    if kw.get("tout"):
+        tout = kw.get("tout")
+    else:
+        tout = datetime.timedelta(seconds=1200)
+    time.sleep(kw.get("retry_interval", 20))
+    while True:
+        if kw.get("poolname", False):
+            if kw.get("health_pattern"):
+                out = value(
+                    "health",
+                    json.loads(
+                        rbd.mirror.pool.status(pool=kw.get("poolname"), format="json")[
+                            0
+                        ]
+                    ),
+                )
+                log.info(
+                    "Health of {} pool in {} cluster: {}".format(
+                        kw.get("poolname"), cluster_name, out
+                    )
+                )
+                if kw.get("health_pattern") in out:
+                    return 0
+            if kw.get("images_pattern"):
+                out = value(
+                    "states",
+                    json.loads(
+                        rbd.mirror.pool.status(pool=kw.get("poolname"), format="json")[
+                            0
+                        ]
+                    ),
+                )
+                out = ast.literal_eval(out)
+                state_pattern = kw.get("state", "total")
+                num_image = 0
+                if "total" in state_pattern:
+                    for k, v in out.items():
+                        num_image = num_image + v
+                else:
+                    num_image = out[state_pattern]
+                log.info(
+                    "Images in {} pool in {} cluster {}: {}, expected is :{}".format(
+                        kw.get("poolname"),
+                        cluster_name,
+                        state_pattern,
+                        num_image,
+                        kw.get("images_pattern"),
+                    )
+                )
+                if kw.get("images_pattern") == num_image:
+                    return 0
+        else:
+            try:
+                if kw.get("state_pattern"):
+                    status_config = {
+                        "image-spec": kw.get("imagespec"),
+                        "format": "json",
+                    }
+                    image_status = rbd.mirror.image.status(**status_config)
+                    out = value(
+                        "state",
+                        json.loads(image_status[0]),
+                    )
+                    log.info(
+                        f"State of image {kw['imagespec']} : {out}, \
+                        waiting for {kw['state_pattern']}"
+                    )
+                    if kw["state_pattern"] in out:
+                        return 0
+                if kw.get("description_pattern"):
+                    out = get_position(
+                        rbd=rbd,
+                        imagespec=kw.get("imagespec"),
+                        pattern=kw.get("description_pattern"),
+                    )
+                    log.info(
+                        "Description of {} image in {} cluster: {}".format(
+                            kw.get("imagespec"), cluster_name, out
+                        )
+                    )
+                    return out
+                if kw.get("description"):
+                    status_config = {
+                        "image-spec": kw.get("imagespec"),
+                        "format": "json",
+                    }
+                    image_status = rbd.mirror.image.status(**status_config)
+                    image_description = value(
+                        "description",
+                        json.loads(image_status[0]),
+                    )
+                    log.debug(
+                        f"Image description: {image_description}, expected {kw['description']}"
+                    )
+                    if kw["description"] == image_description:
+                        return 0
+            except Exception:
+                if kw.get("state_pattern") == "down+unknown" or kw.get(
+                    "ignore_command_failure"
+                ):
+                    continue
+                else:
+                    raise
+        if datetime.datetime.now() - starttime <= tout:
+            time.sleep(kw.get("retry_interval", 20))
+        else:
+            raise Exception("Required status can not be attained")
+
+
+def bootstrap_and_add_peers(rbd_primary, rbd_secondary, **kw):
+    """ """
+    primary_client = kw.get("primary_client")
+    secondary_client = kw.get("secondary_client")
+
+    poolname = kw.get("pool_name")
+
+    primary_cluster = kw.get("primary_cluster")
+    primary_cluster_name = primary_cluster.name
+    secondary_cluster = kw.get("secondary_cluster")
+    secondary_cluster_name = secondary_cluster.name
+
+    ceph_cluster_primary = kw.get("ceph_cluster_primary", "ceph")
+    ceph_cluster_secondary = kw.get("ceph_cluster_secondary", "ceph")
+
+    peer_mode = kw.get("peer_mode")
+    rbd_client = kw.get("rbd_client")
+    build = kw.get("build")
+    ceph_version = kw.get("ceph_version")
+    direction = "rx-only" if kw.get("way") == "one-way" else ""
+    if ceph_version >= 4:
+        if peer_mode == "bootstrap":
+            file_name = "/root/bootstrap_token_primary"
+            bootstrap_config = {
+                "pool": poolname,
+                "site-name": primary_cluster_name,
+                "cluster": ceph_cluster_primary,
+            }
+            out = rbd_primary.mirror.pool.peer.bootstrap.create(**bootstrap_config)
+            token = out[0].strip()
+            cmd = f"echo {token} > {file_name}"
+            rbd_primary.execute_as_sudo(cmd=cmd)
+
+            copy_file(file_name, primary_client, secondary_client)
+
+            import_config = {
+                "pool": poolname,
+                "site-name": secondary_cluster_name,
+                "token-path": file_name,
+                "cluster": ceph_cluster_secondary,
+            }
+
+            if direction:
+                import_config.update({"direction": direction})
+            rbd_secondary.mirror.pool.peer.bootstrap.import_(**import_config)
+
+        else:
+            primary_mon = ",".join(
+                [
+                    obj.node.ip_address
+                    for obj in primary_cluster.get_ceph_objects(role="mon")
+                ]
+            )
+            secondary_mon = ",".join(
+                [
+                    obj.node.ip_address
+                    for obj in secondary_cluster.get_ceph_objects(role="mon")
+                ]
+            )
+            primary_fsid = secondary_cluster.get_cluster_fsid(build)
+            secondary_fsid = primary_cluster.get_cluster_fsid(build)
+            secret = exec_cmd(
+                node=primary_client,
+                cmd=f"ceph auth get-or-create {rbd_client}",
+                output=True,
+            )
+            secret = secret.split(" ")[-1].strip()
+            key_file_path = "/etc/ceph/secret_key"
+            exec_cmd(node=primary_client, cmd=f"echo {secret} > {key_file_path}")
+            exec_cmd(node=secondary_client, cmd=f"echo {secret} > {key_file_path}")
+
+            if "one-way" in kw.get("way", ""):
+                peer_config = {
+                    "pool": poolname,
+                    "remote-cluster-spec": f"{rbd_client}@{primary_fsid}",
+                    "remote-client-name": rbd_client,
+                    "remote-cluster": primary_cluster_name,
+                    "remote-mon-host": primary_mon,
+                    "remote-key-file": key_file_path,
+                    "direction": direction,
+                }
+                rbd_secondary.mirror.pool.peer.add_(**peer_config)
+            else:
+                peer_config = {
+                    "pool": poolname,
+                    "remote-cluster-spec": f"{rbd_client}@{secondary_fsid}",
+                    "remote-client-name": rbd_client,
+                    "remote-cluster": secondary_cluster_name,
+                    "remote-mon-host": secondary_mon,
+                    "remote-key-file": key_file_path,
+                    "direction": direction,
+                }
+                rbd_primary.mirror.pool.peer.add_(**peer_config)
+                peer_config = {
+                    "pool": poolname,
+                    "remote-cluster-spec": f"{rbd_client}@{primary_fsid}",
+                    "remote-client-name": rbd_client,
+                    "remote-cluster": primary_cluster_name,
+                    "remote-mon-host": primary_mon,
+                    "remote-key-file": key_file_path,
+                    "direction": direction,
+                }
+                rbd_secondary.mirror.pool.peer.add_(**peer_config)
+    else:
+        if "one-way" in kw.get("way", ""):
+            peer_config = {
+                "pool": poolname,
+                "remote-cluster-spec": f"{rbd_client}@{primary_cluster_name}",
+            }
+            rbd_secondary.mirror.pool.peer.add_(**peer_config)
+        else:
+            peer_config = {
+                "pool": poolname,
+                "remote-cluster-spec": f"{rbd_client}@{secondary_cluster_name}",
+            }
+            rbd_primary.mirror.pool.peer.add_(**peer_config)
+            peer_config = {
+                "pool": poolname,
+                "remote-cluster-spec": f"{rbd_client}@{primary_cluster_name}",
+            }
+
+    primary_peer_info = value(
+        key="peers",
+        dictionary=json.loads(
+            rbd_primary.mirror.pool.info(
+                pool=poolname, format="json", cluster=ceph_cluster_primary
+            )[0]
+        ),
+    )
+    secondary_peer_info = value(
+        key="peers",
+        dictionary=json.loads(
+            rbd_secondary.mirror.pool.info(
+                pool=poolname, format="json", cluster=ceph_cluster_secondary
+            )[0]
+        ),
+    )
+    if primary_peer_info.lower() not in [
+        "none",
+        "",
+        None,
+    ] and secondary_peer_info.lower() not in ["none", "", None]:
+        log.info("Peers were successfully added")
+
+    else:
+        log.error("Peers were not added")
+
+
+def config_mirror(rbd_primary, rbd_secondary, **kw):
+    """
+    Configure mirroring on RBD clusters based on the parameters provided
+    Args:
+        peer_cluster: peer_cluster object for the secondary RBD cluster
+        **kw:
+            pool_name: poolname to be used for creating pool
+            mode: mirroring mode, pool or image to be used
+            way: one-way or two-way mirroring
+    """
+    poolname = kw.get("pool_name")
+
+    primary_cluster = kw.get("primary_cluster")
+    primary_cluster_name = primary_cluster.name
+    secondary_cluster = kw.get("secondary_cluster")
+    secondary_cluster_name = secondary_cluster.name
+    mode = kw.get("mode")
+
+    is_wait_for_status = kw.get("wait_for_status", True)
+
+    ceph_cluster_primary = kw.get("ceph_cluster_primary", "ceph")
+    ceph_cluster_secondary = kw.get("ceph_cluster_secondary", "ceph")
+
+    enable_config = {
+        "pool": poolname,
+        "mode": mode,
+        "cluster": ceph_cluster_primary,
+    }
+    out = rbd_primary.mirror.pool.enable(**enable_config)
+    log.info(f"Output of RBD mirror pool enable: {out}")
+
+    if "rbd: mirroring is already configured" not in out[0].strip():
+        enable_config.update({"cluster": ceph_cluster_secondary})
+        out = rbd_secondary.mirror.pool.enable(**enable_config)
+        bootstrap_and_add_peers(rbd_primary, rbd_secondary, **kw)
+    else:
+        log.info(f"RBD Mirroring has already been configured for pool {poolname}")
+
+    # Waiting for OK pool mirror status to be okay based on user input as in image based
+    # mirorring status wouldn't reach OK without enabling mirroing on individual images
+    if is_wait_for_status:
+        wait_for_status(
+            rbd=rbd_primary,
+            cluster_name=primary_cluster_name,
+            poolname=poolname,
+            health_pattern="OK",
+        )
+        wait_for_status(
+            rbd=rbd_secondary,
+            cluster_name=secondary_cluster_name,
+            poolname=poolname,
+            health_pattern="OK",
+        )
+
+
+def enable_image_mirroring(primary_config, secondary_config, **kw):
+    """ """
+    rbd_primary = primary_config.get("rbd")
+
+    rbd_secondary = secondary_config.get("rbd")
+
+    primary_cluster = primary_config.get("cluster")
+    secondary_cluster = secondary_config.get("cluster")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    mirrormode = kw.get("mirrormode")
+    io_total = kw.get("io_total")
+
+    rbd_primary.mirror.image.enable(pool=pool, image=image, mode=mirrormode)
+    wait_for_status(
+        rbd=rbd_primary,
+        cluster_name=primary_cluster.name,
+        poolname=pool,
+        health_pattern="OK",
+    )
+    wait_for_status(
+        rbd=rbd_secondary,
+        cluster_name=secondary_cluster.name,
+        poolname=pool,
+        health_pattern="OK",
+    )
+
+    # TBD: We need to override wait_for_status to match images in cluster1==cluster2
+    # ITs failing here when the pool contains more than 1 image
+    # Using same image pool for replicated and ec pool
+    # mirror2.wait_for_status(poolname=poolname, images_pattern=1)
+
+    if io_total:
+        bench_config = {
+            "io-type": "write",
+            "io-threads": "16",
+            "io-total": io_total,
+            "pool_name": pool,
+            "image_name": image,
+        }
+        rbd_primary.bench(**bench_config)
+        time.sleep(60)
+    with parallel() as p:
+        p.spawn(
+            wait_for_status,
+            rbd=rbd_primary,
+            cluster_name=primary_cluster.name,
+            imagespec=f"{pool}/{image}",
+            state_pattern="up+stopped",
+        )
+        p.spawn(
+            wait_for_status,
+            rbd=rbd_secondary,
+            cluster_name=secondary_cluster.name,
+            imagespec=f"{pool}/{image}",
+            state_pattern="up+replaying",
+        )
+
+
+def config_mirror_multi_pool(
+    primary_config, secondary_config, multi_pool_config, is_secondary=False, **kw
+):
+    """ """
+    rbd_primary = primary_config.get("rbd")
+    primary_client = primary_config.get("client")
+
+    rbd_secondary = secondary_config.get("rbd")
+    secondary_client = secondary_config.get("client")
+
+    primary_cluster = primary_config.get("cluster")
+    secondary_cluster = secondary_config.get("cluster")
+
+    config = kw.get("config")
+    pool_test_config = multi_pool_config.pop("test_config", None)
+    for pool, pool_config in multi_pool_config.items():
+        # If any pool level test config is present, pop it out
+        # so that it does not get mistaken as another image configuration
+        if pool_config.get("mode"):
+            pool_config["peer_mode"] = pool_config.get("peer_mode", "bootstrap")
+            pool_config["rbd_client"] = pool_config.get("rbd_client", "client.admin")
+            if pool_config.get("mode") == "image":
+                kw["wait_for_status"] = False
+            config_mirror(
+                rbd_primary,
+                rbd_secondary,
+                primary_client=primary_client,
+                secondary_client=secondary_client,
+                pool_name=pool,
+                primary_cluster=primary_cluster,
+                secondary_cluster=secondary_cluster,
+                build=kw.get("build"),
+                ceph_version=int(config.get("rhbuild")[0]),
+                **pool_config,
+            )
+
+            # Enable image level mirroring only when mode is image type
+            if (
+                not kw.get("do_not_enable_mirror_on_image")
+                and pool_config.get("mode") == "image"
+            ):
+                mirrormode = pool_config.get("mirrormode", "")
+                multi_image_config = getdict(pool_config)
+                image_config = {
+                    k: v
+                    for k, v in multi_image_config.items()
+                    if v.get("is_secondary", False) == is_secondary
+                }
+                # for image, image_config in multi_image_config.items():
+                for image, image_config_val in image_config.items():
+                    image_enable_config = {
+                        "pool": pool,
+                        "image": image,
+                        "mirrormode": mirrormode,
+                        "io_total": image_config_val.get("io_total", None),
+                    }
+                    enable_image_mirroring(
+                        primary_config, secondary_config, **image_enable_config
+                    )
+
+    # Add back the popped pool test config once configuration is complete
+    if pool_test_config:
+        pool_config["test_config"] = pool_test_config

--- a/suites/quincy/rbd/tier-3_rbd_mirror_encrypted_image.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_mirror_encrypted_image.yaml
@@ -1,0 +1,175 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-3_rbd_mirror_encrypted_image.yaml
+# Suite contains rbd-mirror tier-3 testcases with encrypted image
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/5-node-2-clusters.yaml
+#       this can be changed to a baremetal configuration
+#       once baremetal config for RBD Miror is decided
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - rbd-nbd
+              - fio
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - rbd-nbd
+              - fio
+            copy_admin_keyring: true
+      desc: Configure the client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: True
+      desc: Run encryption tests on images with mirroring enabled
+      name: Verify the luks encryption functionality for a mirrored image
+      module: test_encryption_on_mirrored_image.py
+      polarion-id: CEPH-83575408
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 8 # one each of below encryptions will be applied on each image
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              do_not_enable_mirror_on_image: True
+              test_config:
+                encryption_type: #parent,clone
+                  - luks1,luks1
+                  - luks1,NA
+                  - luks2,luks1
+                  - luks2,luks2
+                  - luks2,NA
+                  - NA,luks1
+                  - NA,luks2
+                  - luks1,luks2
+            ec_pool_config:
+              num_pools: 1
+              num_images: 8 # one each of below encryptions will be applied on each image
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              do_not_enable_mirror_on_image: True
+              test_config:
+                encryption_type: #parent,clone
+                  - luks1,luks1
+                  - luks1,NA
+                  - luks2,luks1
+                  - luks2,luks2
+                  - luks2,NA
+                  - NA,luks1
+                  - NA,luks2
+                  - luks1,luks2

--- a/tests/rbd_mirror/test_encryption_on_mirrored_image.py
+++ b/tests/rbd_mirror/test_encryption_on_mirrored_image.py
@@ -1,0 +1,483 @@
+from copy import deepcopy
+from time import sleep
+
+from ceph.rbd.initial_config import initial_mirror_config, random_string
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.cleanup import device_cleanup, pool_cleanup
+from ceph.rbd.workflows.encryption import (
+    create_and_encrypt_clone,
+    execute_neg_encryption_scenarios,
+    mount_image_and_mirror_and_check_data,
+    test_encryption_between_image_and_clone,
+)
+from ceph.rbd.workflows.rbd_mirror import enable_image_mirroring
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_negative_scenarios(**kw):
+    """_summary_
+    kw: {
+        "rbd": rbd,
+        "client": client,
+        "mirror_rbd": mirror_rbd,
+        "mirror_client": mirror_client,
+        "size": size,
+        "parent_spec": image_spec,
+        "clone_spec": clone_spec,
+        "parent_encryption_config": parent_encryption_config,
+        "clone_encryption_config": clone_encryption_config,
+        "format": format,
+    }
+    """
+    # 1) Execute negative scenarios on parent image
+    scenarios = [4]
+    encryption_config = [{"encryption-format": "NA", "encryption-passphrase-file": ""}]
+    if kw.get("parent_encryption_config"):
+        scenarios.extend([1, 2, 3])
+        encryption_config = kw.get("parent_encryption_config")
+
+    neg_config = {
+        "scenarios": scenarios,
+        "encryption_config": encryption_config,
+        "rbd": kw.get("rbd"),
+        "client": kw.get("client"),
+        "size": kw.get("size"),
+        "image_spec": kw.get("parent_spec"),
+    }
+    if execute_neg_encryption_scenarios(**neg_config):
+        log.error(
+            f"Testing of negative scenarios failed on parent image {kw.get('parent_spec')}"
+        )
+        return 1
+
+    # 2) Execute negative scenarios on clone image (after flatten)
+    scenarios = [4]
+    if kw.get("clone_encryption_config") and 3 not in scenarios:
+        scenarios.extend([1, 2, 3])
+
+    neg_config = {
+        "scenarios": scenarios,
+        "encryption_config": [kw.get("clone_encryption_config")[0]],
+        "rbd": kw.get("rbd"),
+        "client": kw.get("client"),
+        "size": kw.get("size"),
+        "image_spec": kw.get("clone_spec"),
+    }
+    if execute_neg_encryption_scenarios(**neg_config):
+        log.error(
+            f"Testing of negative scenarios failed on clone image {kw.get('clone_spec')}"
+        )
+        return 1
+
+    # 3) Execute negative scenarios on mirrored parent image
+    scenarios = [4]
+    if kw.get("parent_encryption_config") and 3 not in scenarios:
+        scenarios.extend([1, 2, 3])
+        encryption_config = kw.get("parent_encryption_config")
+
+    scenarios.append(16)
+    neg_config = {
+        "scenarios": scenarios,
+        "encryption_config": encryption_config,
+        "rbd": kw.get("mirror_rbd"),
+        "client": kw.get("mirror_client"),
+        "size": kw.get("size"),
+        "image_spec": kw.get("parent_spec"),
+        "read_only": True,
+    }
+    if execute_neg_encryption_scenarios(**neg_config):
+        log.error(
+            f"Testing of negative scenarios failed on mirrored parent image {kw.get('parent_spec')}"
+        )
+        return 1
+
+    # 4) Execute negative scenarios on mirrored clone image (after flatten)
+    scenarios = [4]
+    if kw.get("clone_encryption_config") and 3 not in scenarios:
+        scenarios.extend([1, 2, 3])
+
+    scenarios.append(16)
+    neg_config = {
+        "scenarios": scenarios,
+        "encryption_config": [kw.get("clone_encryption_config")[0]],
+        "rbd": kw.get("mirror_rbd"),
+        "client": kw.get("mirror_client"),
+        "size": kw.get("size"),
+        "image_spec": kw.get("clone_spec"),
+        "read_only": True,
+    }
+    if execute_neg_encryption_scenarios(**neg_config):
+        log.error(
+            f"Testing of negative scenarios failed on mirrored clone image {kw.get('clone_spec')}"
+        )
+        return 1
+
+    # 5) Execute negative scenario on clone image (before flatten)
+    [pool, image] = kw.get("parent_spec").split("/")
+    snap = f"snap_{random_string(len=5)}"
+    clone = f"clone_{random_string(len=5)}"
+    clone_spec = f"{pool}/{clone}"
+    snap_spec = f"{pool}/{image}@{snap}"
+    passphrase = (
+        ""
+        if not kw.get("parent_encryption_config")
+        else kw.get("parent_encryption_config")[0].get("encryption-passphrase-file")
+    )
+    clone_file_path = f"/tmp/{clone}_dir/{clone}_file"
+    clone_passphrase = f"clone_{clone}_passphrase.bin"
+    clone_config = {
+        "rbd": kw.get("rbd"),
+        "client": kw.get("client"),
+        "format": kw.get("format"),
+        "size": kw.get("size"),
+        "image_spec": kw.get("parent_spec"),
+        "clone_spec": clone_spec,
+        "snap_spec": snap_spec,
+        "parent_passphrase": passphrase,
+        "clone_file_path": clone_file_path,
+        "clone_passphrase": clone_passphrase,
+        "do_not_map_and_mount": True,
+    }
+
+    clone_encryption_config = create_and_encrypt_clone(**clone_config)
+    if not passphrase:
+        clone_encryption_config.append(
+            {"encryption-format": "NA", "encryption-passphrase-file": ""}
+        )
+
+    clone_not_encrypted = len(kw.get("parent_encryption_config", [])) == len(
+        clone_encryption_config
+    )
+    scenarios = list(range(5, 14))
+
+    # temp luks2,luks1
+    # luks1,luks2
+    # scenarios.remove(7)
+    # scenarios.remove(13)
+
+    if not kw.get("parent_encryption_config"):
+        scenarios = [8, 11, 12, 14]
+
+    if clone_not_encrypted:
+        scenarios = [1, 2, 4, 15]
+
+    neg_config = {
+        "scenarios": scenarios,
+        "encryption_config": clone_encryption_config,
+        "rbd": kw.get("rbd"),
+        "client": kw.get("client"),
+        "size": kw.get("size"),
+        "image_spec": clone_spec,
+        "parent_spec": kw.get("parent_spec"),
+    }
+    if execute_neg_encryption_scenarios(**neg_config):
+        log.error(
+            f"Testing of negative scenarios before flatten failed on clone image {clone_spec}"
+        )
+        return 1
+
+    return 0
+
+
+def test_rbd_encryption(mirror_obj, pool, image, format, **kw):
+    """ """
+    size = kw.get("size")
+    snap = f"snap_{random_string(len=5)}"
+    clone = f"clone_{random_string(len=5)}"
+    image_spec = f"{pool}/{image}"
+    clone_spec = f"{pool}/{clone}"
+    snap_spec = f"{pool}/{image}@{snap}"
+    parent_encryption_config = list()
+    clone_encryption_config = list()
+    parent_file_path = f"/tmp/{image}_dir/{image}_file"
+    clone_file_path = f"/tmp/{clone}_dir/{image}_file"
+    mirrormode = kw.get("mirrormode", "")
+
+    for val in mirror_obj.values():
+        if val.get("is_secondary", False) == kw.get("is_secondary"):
+            rbd = val.get("rbd")
+            client = val.get("client")
+            cluster = val.get("cluster")
+        else:
+            mirror_rbd = val.get("rbd")
+            mirror_client = val.get("client")
+            mirror_cluster = val.get("cluster")
+
+    try:
+        log.info(f"Testing encryption between {image=} and its {clone=}")
+        test_config = {
+            "rbd": rbd,
+            "client": client,
+            "image_spec": image_spec,
+            "snap_spec": snap_spec,
+            "clone_spec": clone_spec,
+            "parent_file_path": parent_file_path,
+            "clone_file_path": clone_file_path,
+            "size": size,
+            "format": format,
+        }
+
+        encryption_config = test_encryption_between_image_and_clone(**test_config)
+        if not encryption_config:
+            log.error(
+                f"Testing encryption between {image=} and its {clone=} failed for encryption format: {format}"
+            )
+            return 1
+
+        parent_encryption_config = encryption_config.get("parent_encryption_config", [])
+        clone_encryption_config = encryption_config.get("clone_encryption_config", [])
+
+        flatten_config = {
+            "image-spec": clone_spec,
+            "encryption_config": clone_encryption_config,
+        }
+
+        out, _ = rbd.flatten(**flatten_config)
+        if out:
+            log.error(
+                f"Flatten clone with encryption failed for {clone_spec} for encryption format: {format}"
+            )
+            return None
+
+        # Sleep after flatten clone for flattening to complete
+        sleep(60)
+
+        log.info(f"Applying mirroring on parent image: {image_spec}")
+        primary_config = {
+            "rbd": rbd,
+            "cluster": cluster,
+        }
+        secondary_config = {"rbd": mirror_rbd, "cluster": mirror_cluster}
+        mirror_enable_config = {"pool": pool, "image": image, "mirrormode": mirrormode}
+
+        enable_image_mirroring(primary_config, secondary_config, **mirror_enable_config)
+
+        log.info(f"Applying mirroring on cloned image: {clone_spec}")
+        primary_config = {
+            "rbd": rbd,
+            "cluster": cluster,
+        }
+        secondary_config = {"rbd": mirror_rbd, "cluster": mirror_cluster}
+        mirror_enable_config = {"pool": pool, "image": clone, "mirrormode": mirrormode}
+
+        enable_image_mirroring(primary_config, secondary_config, **mirror_enable_config)
+
+        # Sleep for image mirroring to copy all data to mirror cluster
+        # Maybe check if there is a way to verify data is copied to mirror
+        # instead of random wait
+        sleep(60)
+
+        log.info(f"Checking data integrity between {image} and its mirror")
+
+        mirror_config = {
+            "rbd": rbd,
+            "client": client,
+            "mirror_rbd": mirror_rbd,
+            "mirror_client": mirror_client,
+            "image_spec": image_spec,
+            "size": size,
+            "file_path": parent_file_path,
+            "encryption_config": parent_encryption_config,
+        }
+
+        if mount_image_and_mirror_and_check_data(**mirror_config):
+            log.error(
+                f"Checking data integrity between {image} and its mirror failed for encryption format: {format}"
+            )
+            return 1
+
+        log.info(f"Checking data integrity between {clone=} and its mirror")
+
+        mirror_config.update(
+            {
+                "image_spec": clone_spec,
+                "file_path": clone_file_path,
+                "encryption_config": [clone_encryption_config[0]],
+            }
+        )
+
+        if mount_image_and_mirror_and_check_data(**mirror_config):
+            log.error(
+                f"Checking data integrity between {clone=} and its mirror failed for encryption format: {format}"
+            )
+            return 1
+
+        encryption_config = deepcopy(clone_encryption_config)
+
+        negative_config = {
+            "rbd": rbd,
+            "client": client,
+            "mirror_rbd": mirror_rbd,
+            "mirror_client": mirror_client,
+            "size": size,
+            "parent_spec": image_spec,
+            "clone_spec": clone_spec,
+            "parent_encryption_config": parent_encryption_config,
+            "clone_encryption_config": clone_encryption_config,
+            "format": format,
+        }
+        if test_negative_scenarios(**negative_config):
+            log.error(
+                f"Testing negative scenarios failed for encryption format: {format}"
+            )
+            return 1
+
+    except Exception as error:
+        log.error(str(error))
+        return 1
+
+    finally:
+        log.info("Executing cleanup")
+        cleanup_config = {
+            "rbd": rbd,
+            "client": client,
+            "all": True,
+            "passphrase_file": "*.bin",
+        }
+        device_cleanup(**cleanup_config)
+        cleanup_config.update(
+            {
+                "rbd": mirror_rbd,
+                "client": mirror_client,
+            }
+        )
+        device_cleanup(**cleanup_config)
+
+    return 0
+
+
+def test_encryption_on_mirrored_cluster(mirror_obj, pool_type, **kw):
+    """ """
+    config = deepcopy(kw.get("config").get(pool_type))
+    test_config = config.pop("test_config", {})
+    encryption_types = test_config.get("encryption_type")
+
+    for pool, pool_config in getdict(config).items():
+        image_index = 0
+        multi_image_config = getdict(pool_config)
+        multi_image_config.pop("test_config")
+        for image, image_config in multi_image_config.items():
+            format = encryption_types[image_index]
+            image_index += 1
+            log.info(
+                f"Testing encryption for pool type : {pool_type} and encryption format : {format}"
+            )
+            if test_rbd_encryption(
+                mirror_obj,
+                pool,
+                image,
+                format,
+                size=image_config.get("size"),
+                is_secondary=image_config.get("is_secondary", False),
+                mirrormode=config.get("mirrormode"),
+            ):
+                log.error(
+                    f"RBD encryption test failed for image_spec: {pool}/{image} and encryption format: {format}"
+                )
+                return 1
+    return 0
+
+
+def run(**kw):
+    """Verify the luks encryption functionality for a mirrored image
+    Pre-requisites :
+    We need atleast one client node with ceph-common, fio and rbd-nbd packages,
+    conf and keyring files in both clusters with snapshot based RBD mirroring
+    enabled between the clusters.
+    Test cases covered -
+    1) CEPH-83575408 - RBD mirroring operations on encrypted images
+    kw:
+        config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 6 # one each of below encryptions will be applied on each image
+              mode: image
+              mirrormode: snapshot
+              test_config:
+                encryption_type: #parent,clone number of formats defined should correspond to num_images
+                  - luks1,luks1
+                  - luks1,NA
+                  - luks2,luks1
+                  - luks2,luks2
+                  - luks2,NA
+                  - NA,luks1
+                  - NA,luks2
+                  - luks1,luks2
+            ec_pool_config:
+              num_pools: 1
+              num_images: 6 # one each of below encryptions will be applied on each image
+              mode: image
+              mirrormode: snapshot
+              test_config:
+                encryption_type: #parent,clone number of formats defined should correspond to num_images
+                  - luks1,luks1
+                  - luks1,NA
+                  - luks2,luks1
+                  - luks2,luks2
+                  - luks2,NA
+                  - NA,luks1
+                  - NA,luks2
+                  - luks1,luks2
+    Test Case Flow
+    1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
+    2. Create a pool and given number of Images, enable snapshot based mirroring for all these images
+    3. Apply Encryption to each of the images as per the formats mentioned in test_config above
+    4. Create a clone for each image and apply encryption as per formats mentioned in test_config
+    5. Verify the data integrity between encrypted image and its clone
+    6. On the secondary site, map the encrypted image using its encryption passphrase as read-only
+      and verify data integrity
+    7. On the secondary site, map the encrypted image as read-write, it should error out appropriately
+    8. On the secondary site, map the encrypted image using wrong encryption type and/or passphrase,
+      it should error out appropriately
+    9. Apply mirroring on the cloned images in Step 4 and perform steps 6 to 8 on these images
+    10. Repeat the above steps for replicated and ec pool
+    """
+    pool_types = ["rep_pool_config", "ec_pool_config"]
+    log.info(
+        "Running luks encryption tests on images mirrored using snapshot based mirroring"
+    )
+    try:
+        kw.get("config", {})["do_not_run_io"] = True
+        mirror_obj = initial_mirror_config(**kw)
+        log.info("Initial configuration complete")
+
+        pool_types = list(mirror_obj.values())[0].get("pool_types")
+        for pool_type in pool_types:
+            ret_val = test_encryption_on_mirrored_cluster(
+                mirror_obj=mirror_obj,
+                pool_type=pool_type,
+                **kw,
+            )
+            if ret_val:
+                log.error(f"RBD encryption test failed for pool_type {pool_type}")
+                break
+    except Exception as e:
+        log.error(f"Testing mirrored encryption failed with error {str(e)}")
+        ret_val = 1
+    finally:
+        pools = list()
+        for pool_type in pool_types:
+            multi_pool_config = kw.get("config").get(pool_type)
+            pools.extend(
+                [
+                    key
+                    for key in getdict(multi_pool_config).keys()
+                    if key != "test_config"
+                ]
+            )
+            pools.extend(
+                [
+                    val["data_pool"]
+                    for val in getdict(multi_pool_config).values()
+                    if val.get("data_pool")
+                ]
+            )
+        for cluster_config in mirror_obj.values():
+            pool_cleanup(
+                cluster_config.get("client"),
+                pools,
+                ceph_version=int(kw["config"].get("rhbuild")[0]),
+            )
+    return ret_val


### PR DESCRIPTION
Adding RBD and RBD Mirror related workflows as wrappers into CLI module. Also automating the encryption scenario mentioned in polarion test case - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575408 

The scenario consists of the following major steps which are automated as part of this PR

1. Setup different combinations of encryptions between an image and its clone as given below and verify that the data integrity between image and clone is preserved.
```
Parent, Clone
Not encrypted, luks1
Not encrypted, luks2
luks1, luks1
luks1, luks2
luks2, luks1
luks2, luks2
```
2. Also verify data integrity between an encrypted image and its mirror, encrypted clone and its mirror as well
3. Also verify that passing any wrong encryption type or encryption passphrase or both to either the image or its clone, will result in appropriate error messages and the device mapping doesn't work

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-77F2PM/ 
