### PR TITLE
[Lib] Add FIPS support

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1232,7 +1232,7 @@ class SSHConnectionManager(object):
         if look_for_keys:
             self.pkey = paramiko.RSAKey.from_private_key_file(private_key_file_path)
         self.__client = paramiko.SSHClient()
-        self.__client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.__client.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy())
         self.__transport = None
         self.__outage_start_time = None
         self.outage_timeout = datetime.timedelta(seconds=outage_timeout)

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -380,6 +380,49 @@ def set_selinux_mode(nodes, enforcing_mode):
     return True
 
 
+def enable_fips_mode(node):
+    """Enable FIPS mode on node
+
+    Args:
+        node (CephNode): Ceph Node Object
+    """
+    # Set FIPS commands
+    enable_fips = "fips-mode-setup --enable"
+    finish_fips_setup = "fips-finish-install --complete"
+
+    # Enable FIPS mode
+    out, err = node.exec_command(cmd=enable_fips, sudo=True)
+    if "FIPS mode will be enabled." not in out:
+        log.error(f"Failed to setup FIPS mode config. Error -\n{err}")
+        return False
+
+    # Finish FIPS mode
+    _, err = node.exec_command(cmd=finish_fips_setup, sudo=True)
+    if err:
+        log.error(f"Failed to setup enable mode. Error -\n{err}")
+        return False
+
+    return True
+
+
+def is_fips_mode_enabled(node):
+    """Check for FIPS mode on node
+
+    Args:
+        node (CephNode): Ceph Node Object
+    """
+    # Check FIPS command
+    check_fips_setup = "fips-mode-setup --check"
+
+    # Check for FIPS status
+    out, _ = node.exec_command(cmd=check_fips_setup, sudo=True)
+    if "FIPS mode is enabled" not in out:
+        log.error(f"FIPS mode is disabled on node '{node.hostname}'")
+        return False
+
+    return True
+
+
 def reboot_node(node):
     """
     Reboots a given node and waits till the reboot complete

--- a/run.py
+++ b/run.py
@@ -742,9 +742,12 @@ def run(args):
             )
 
             if custom_config:
-                ibm_build = [c for c in custom_config if "ibm-build=" in c]
-                if ibm_build:
-                    config["ibm_build"] = bool(ibm_build[0].split("=")[1])
+                for _config in custom_config:
+                    if "ibm-build=" in _config:
+                        config["ibm_build"] = bool(_config.split("=")[1])
+
+                    elif "enable-fips-mode=" in _config:
+                        config["enable_fips_mode"] = bool(_config.split("=")[1])
 
             config["ceph_docker_registry"] = docker_registry
             config["ceph_docker_image"] = docker_image


### PR DESCRIPTION
Add support to enable FIPS mode. Use `--custom-config enable-fips-mode=True` to enable the FIPS mode. Below is example - 
```
python run.py \
    --osp-cred ~/osp-creds.yaml \
    --instances-name fips \
    --rhbuild 7.0 \
    --platform rhel-9 \
    --global-conf conf/reef/smoke/1admin-4node-1client-bvt.yaml \
    --suite suites/reef/smoke/bvt.yaml \
    --inventory conf/inventory/rhel-9.2-server-x86_64-large.yaml \
    --build latest \
    --custom-config enable-fips-mode=True \
    --log-level DEBUG \
    --log-dir ~/cephci-logs/fips-tests.log
```