### PR TITLE
Fix for test cases related to OSD full scenarios

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1365,13 +1365,17 @@ class RadosOrchestrator:
         current_qos, _ = self.node.shell(["ceph config get osd osd_op_queue"])
         return True if qos.lower() in str(current_qos).lower() else False
 
-    def set_mclock_parameter(self, param: str, value, restart_osd: bool = False):
+    def set_mclock_parameter(
+        self, param: str, value, restart_osd: bool = False
+    ) -> bool:
         """Set value for any of the valid mClock config parameters
         Args:
             param (str): mClock config parameter to be modified
             value: value to be set for the input parameter
             restart_osd (boolean): flag to control restart of all OSDs;
                 necessary only for few parameters, hence added as a tunable setting.
+        Returns:
+            boolean: True if mClock parameter was set, False otherwise
         """
         if self.rhbuild and self.rhbuild.split(".")[0] < "6":
             log.info(


### PR DESCRIPTION
[RHCEPHQE-9100](https://issues.redhat.com/browse/RHCEPHQE-9100): RADOS - tier-2_rados_test-osd-rebalance - suite failed in regression

Test case: [CEPH-83571715](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571715)

Pacific
Test suite: suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
Pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EUYKT8/

Quincy
Test suite: suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
Pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M7WLTL/

Reef
Test suite: suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
Pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TB3EUN

Test case: [CEPH-9232](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9232)

Reef
Test suite: suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
Pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L4CR1J

Test modules modified:
- tests/rados/test_osd_full.py

Signed-off-by: Harsh Kumar <hakumar@redhat.com>