### PR TITLE
Fixing nfs_ha sanity suite

### DIFF
--- a/tests/cephfs/nfs_ha_sanity.py
+++ b/tests/cephfs/nfs_ha_sanity.py
@@ -77,7 +77,7 @@ def run(ceph_cluster, **kw):
         fs_util.remove_floating_ip(floating_ip, **params)
 
 
-@retry(CommandFailed, tries=3, delay=60)
+@retry(CommandFailed, tries=10, delay=60)
 def validate_services(client, service_name):
     out, rc = client.exec_command(
         sudo=True, cmd=f"ceph orch ls --service_name={service_name} --format json"


### PR DESCRIPTION
# Description
Fixing nfs_ha sanity suite
Problem:
NFS services are taking a longer time to bring up the service.
Solution:
Increased the time to 10 min

Failed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NTYECZ

Passed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YQG2PL

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
