### PR TITLE
Removing nfs ha sanity TC

### DIFF
--- a/suites/pacific/cephfs/tier-0_fs.yaml
+++ b/suites/pacific/cephfs/tier-0_fs.yaml
@@ -125,12 +125,6 @@ tests:
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false
-  - test:
-      name: nfs-ha-sanity
-      module: nfs_ha_sanity.py
-      desc: Deploy NFS HA and validate the services are UP.
-      polarion-id: CEPH-83575092
-      abort-on-fail: false
   -
     test:
       desc: "generate sosreport"

--- a/suites/quincy/baremetal_pipeline/tier-0_fs.yaml
+++ b/suites/quincy/baremetal_pipeline/tier-0_fs.yaml
@@ -138,12 +138,6 @@ tests:
       desc: Deploy mds using cephadm and increase & decrease number of mds.
       polarion-id: CEPH-83574286
       abort-on-fail: false
-  - test:
-      name: nfs-ha-sanity
-      module: nfs_ha_sanity.py
-      desc: Deploy NFS HA and validate the services are UP.
-      polarion-id: CEPH-83575092
-      abort-on-fail: false
   -
     test:
       desc: "generate sosreport"


### PR DESCRIPTION
# Description
Removing nfs ha sanity TC

TC is unstable on OpenStack due to IP assignment.

Same TC is covered as part of baremetal suite tier-2_cephfs_test-nfs_ha.yaml
https://github.com/red-hat-storage/cephci/blob/5e0cad0c4a988419656230ad2d78ad840ddd6d48/suites/pacific/cephfs/tier-2_cephfs_test-nfs_ha.yaml#L126 


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
