### PR TITLE
[Rados] Enhancement of recovery modules to account for mClock Scheduler

### DIFF
--- a/tests/rados/pool_tests.py
+++ b/tests/rados/pool_tests.py
@@ -71,7 +71,7 @@ def run(ceph_cluster, **kw):
                 return 1
 
         log.info("Stopped 'm' number of OSD's from, starting to wait for recovery")
-        rados_obj.change_recover_threads(config=ec_config, action="set")
+        rados_obj.change_recovery_threads(config=ec_config, action="set")
 
         # Sleeping for 25 seconds ( "osd_heartbeat_grace": "20" ) for osd's to be marked down
         time.sleep(25)
@@ -116,7 +116,7 @@ def run(ceph_cluster, **kw):
             return 1
         log.info(f" Acting set of the pool consists of OSD's : {acting_pg_set}")
         # Changing recovery threads back to default
-        rados_obj.change_recover_threads(config=ec_config, action="rm")
+        rados_obj.change_recovery_threads(config=ec_config, action="rm")
 
         log.debug("Starting the stopped OSD's")
         for osd_id in stop_osds:
@@ -319,7 +319,7 @@ def run(ceph_cluster, **kw):
                 return 1
             log.debug("Set the ratio. getting the projected pg's")
 
-            rados_obj.change_recover_threads(config=config, action="set")
+            rados_obj.change_recovery_threads(config=config, action="set")
             log.debug(
                 "Waiting for the rebalancing to complete on the cluster after the change"
             )
@@ -367,7 +367,7 @@ def run(ceph_cluster, **kw):
                     f" after removing the target ratios"
                 )
                 return 1
-            rados_obj.change_recover_threads(config=config, action="rm")
+            rados_obj.change_recovery_threads(config=config, action="rm")
             if entry.get("delete_pool", False):
                 rados_obj.detete_pool(pool=entry["pool_name"])
             log.info(

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -94,7 +94,7 @@ def run(ceph_cluster, **kw):
         time.sleep(25)
 
         log.info("Stopped 2 OSD's from acting set, starting to wait for recovery")
-        rados_obj.change_recover_threads(config=config, action="set")
+        rados_obj.change_recovery_threads(config=config, action="set")
 
         if not rados_obj.bench_write(pool_name=pool_name, **config):
             log.error("Failed to write objects into the Pool")
@@ -230,7 +230,7 @@ def run(ceph_cluster, **kw):
         return 1
 
     # Increasing backfill/rebalance threads so that cluster will re-balance it faster
-    rados_obj.change_recover_threads(config=config, action="set")
+    rados_obj.change_recovery_threads(config=config, action="set")
 
     # wait for active + clean after deployment of stretch mode
     # checking the state after deployment coz of BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2025800
@@ -290,7 +290,7 @@ def run(ceph_cluster, **kw):
                 log.info(res)
         log.info("Successfully completed Add Capacity scenario")
 
-    rados_obj.change_recover_threads(config=config, action="rm")
+    rados_obj.change_recovery_threads(config=config, action="rm")
 
     # Checking if the pools have been updated with the new crush rules
     acting_set = rados_obj.get_pg_acting_set(pool_name=pool_name)

--- a/tests/rados/test_omap_entries.py
+++ b/tests/rados/test_omap_entries.py
@@ -69,7 +69,7 @@ def run(ceph_cluster, **kw):
             if omap_config["large_warn"]:
                 # Fetching the current acting set for the pool
                 acting_set = rados_obj.get_pg_acting_set(pool_name=pool_name)
-                rados_obj.change_recover_threads(config={}, action="set")
+                rados_obj.change_recovery_threads(config={}, action="set")
                 log.debug(
                     f"Proceeding to restart OSDs from the acting set {acting_set}"
                 )
@@ -97,7 +97,7 @@ def run(ceph_cluster, **kw):
             log.exception(e)
             return 1
         finally:
-            rados_obj.change_recover_threads(config={}, action="rm")
+            rados_obj.change_recovery_threads(config={}, action="rm")
             # deleting the pool created after the test
             rados_obj.detete_pool(pool=pool_name)
 

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -44,7 +44,7 @@ def run(ceph_cluster, **kw):
         pool = create_pools(config, rados_obj, client_node)
         should_not_be_empty(pool, "Failed to retrieve pool details")
         write_to_pools(config, rados_obj, client_node)
-        rados_obj.change_recover_threads(config=pool, action="set")
+        rados_obj.change_recovery_threads(config=pool, action="set")
         acting_pg_set = rados_obj.get_pg_acting_set(pool_name=pool["pool_name"])
         log.info(f"Acting set {acting_pg_set}")
         should_not_be_empty(acting_pg_set, "Failed to retrieve acting pg set")
@@ -84,7 +84,7 @@ def run(ceph_cluster, **kw):
         if pool.get("rados_put", False):
             do_rados_get(client_node, pool["pool_name"], 1)
         utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
-        rados_obj.change_recover_threads(config=pool, action="rm")
+        rados_obj.change_recovery_threads(config=pool, action="rm")
         if config.get("delete_pools"):
             for name in config["delete_pools"]:
                 method_should_succeed(rados_obj.detete_pool, name)

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -55,8 +55,7 @@ def run(ceph_cluster, **kw):
         return 1
 
     # Set recover threads configurations
-    if not rhbuild.startswith("6"):
-        rados_obj.change_recover_threads(config=pool, action="set")
+    rados_obj.change_recovery_threads(config=pool, action="set")
 
     # Set mclock_profile
     if rhbuild.startswith("6") and config.get("mclock_profile"):
@@ -116,7 +115,7 @@ def run(ceph_cluster, **kw):
     if cr_pool.get("rados_put", False):
         do_rados_get(client_node, pool["pool_name"], 1)
     utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
-    rados_obj.change_recover_threads(config=pool, action="rm")
+    rados_obj.change_recovery_threads(config=pool, action="rm")
 
     if config.get("delete_pools"):
         for name in config["delete_pools"]:

--- a/tests/rados/test_osd_rebalance_snap.py
+++ b/tests/rados/test_osd_rebalance_snap.py
@@ -49,7 +49,7 @@ def run(ceph_cluster, **kw):
 
         # Set recover threads configurations
         if not rhbuild.startswith("6"):
-            rados_obj.change_recover_threads(config=pool, action="set")
+            rados_obj.change_recovery_threads(config=pool, action="set")
 
         # Set mclock_profile
         if rhbuild.startswith("6") and config.get("mclock_profile"):
@@ -105,7 +105,7 @@ def run(ceph_cluster, **kw):
                 do_rados_snap_get(client_node, pool["pool_name"], 1, snap_name)
 
         utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
-        rados_obj.change_recover_threads(config=pool, action="rm")
+        rados_obj.change_recovery_threads(config=pool, action="rm")
 
         if config.get("delete_pools"):
             for name in config["delete_pools"]:

--- a/tests/rados/test_slow_op_requests.py
+++ b/tests/rados/test_slow_op_requests.py
@@ -39,7 +39,7 @@ def run(ceph_cluster, **kw):
         pool = create_pools(config, rados_obj, client_node)
         should_not_be_empty(pool, "Failed to retrieve pool details")
         write_to_pools(config, rados_obj, client_node)
-        rados_obj.change_recover_threads(config=pool, action="set")
+        rados_obj.change_recovery_threads(config=pool, action="set")
 
         end_time, err = installer.exec_command(cmd="sudo date -u '+%Y-%m-%d %H:%M:%S'")
         logs = get_slow_requests_log(installer, start_time.strip(), end_time.strip())


### PR DESCRIPTION
[RHCEPHQE-9493](https://issues.redhat.com/browse/RHCEPHQE-9493): Modification made in `change_recovery_threads` module to account for the new OSD QoS mClock Scheduler introduced with RHCS 6.1

Test modules modified - 
-  _change_recovery_threads_ in _ceph/rados/core_workflows.py_

Test cases modified - 
- tests/rados/pool_tests.py
- tests/rados/stretch_cluster.py
- tests/rados/test_omap_entries.py
- tests/rados/test_osd_inprogress_rebalance.py
- tests/rados/test_osd_rebalance.py
- tests/rados/test_osd_rebalance_snap.py
- tests/rados/test_slow_op_requests.py
- tests/rados/test_slow_op_requests.py

Pass logs:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OAAD9K

Reef:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>