### PR TITLE
[TestFix] Fix rm failure in nfs cleanup

### DIFF
--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -48,7 +48,7 @@ def run(ceph_cluster, **kw):
         )
 
         # Linux untar on client 1
-        _ = linux_untar(clients[0], nfs_mount)
+        io = linux_untar(clients[0], nfs_mount)
 
         # Test 1: Perform Linux untar from 1 client and do readir operation from other client (ls -lart)
         cmd = f"ls -lart {nfs_mount}"
@@ -62,6 +62,22 @@ def run(ceph_cluster, **kw):
         cmd = f"find {nfs_mount} -name *.txt"
         clients[3].exec_command(cmd=cmd, sudo=True)
 
+        # Wait for io to complete on all clients
+        for th in io:
+            th.join()
+
+        # Repeat the tests post untar completes
+        # Test 1: Perform Linux untar from 1 client and do readir operation from other client (ls -lart)
+        cmd = f"ls -lart {nfs_mount}"
+        clients[1].exec_command(cmd=cmd, sudo=True)
+
+        # Test 2: Perform Linux untar from 1 client and do readir operation from other client (du -sh)
+        cmd = f"du -sh {nfs_mount}"
+        clients[2].exec_command(cmd=cmd, sudo=True)
+
+        # Perform Linux untar from 1 client and do readir operation from other client (finds)
+        cmd = f"find {nfs_mount} -name *.txt"
+        clients[3].exec_command(cmd=cmd, sudo=True)
     except Exception as e:
         log.error(f"Failed to validate read dir operations : {e}")
         return 1


### PR DESCRIPTION
# Description

Problem:
The rm operations were failing in cleanup because of directory not empty error for linux untar tests causing the mount dirs to be present even after cleanup, failing the test and the consecutive tests. The issue is because the linux untar thread was not joined post the readdir operations and also a known behaviour of nfs where the cleanup might fail once. 

Solution:
Add a join to the untar thread and keep a waiter to perform the rm operation recursively till it completes. This has resolved the issue. The run log of failed tests are attached below showcasing the fix is working as expected and tests are passing.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
