### PR TITLE
fixing rados test issues identified in CI runs ( TFA fixes )

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -108,7 +108,7 @@ tests:
         create_pools:
           - create_pool:
               pool_name: pool1
-              pg_num: 64
+              pg_num: 32
               rados_put: true
               num_objs: 200
               byte_size: 1024
@@ -125,14 +125,14 @@ tests:
         create_pools:
           - create_pool:
               restart_osd: true
-              pool_name: pool1
-              pg_num: 64
+              pool_name: pool2
+              pg_num: 32
               rados_put: true
               num_objs: 200
               byte_size: 1024
               pool_type: replicated
         delete_pools:
-          - pool1
+          - pool2
 
   - test:
       name: Verify delete object during PG split
@@ -143,12 +143,12 @@ tests:
         create_pools:
           - create_pool:
               del_obj: true
-              pool_name: pool1
-              pg_num: 64
+              pool_name: pool3
+              pg_num: 32
               rados_put: true
               num_objs: 200
               objs_to_del: 20
               byte_size: 1024
               pool_type: replicated
         delete_pools:
-          - pool1
+          - pool3

--- a/suites/quincy/rados/tier-2_rados_test-clay-ecpool.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-clay-ecpool.yaml
@@ -58,7 +58,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node8                       # client node
+        node: node7                       # client node
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/quincy/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -108,7 +108,7 @@ tests:
         create_pools:
           - create_pool:
               pool_name: pool1
-              pg_num: 64
+              pg_num: 32
               rados_put: true
               num_objs: 200
               byte_size: 1024
@@ -125,14 +125,14 @@ tests:
         create_pools:
           - create_pool:
               restart_osd: true
-              pool_name: pool1
-              pg_num: 64
+              pool_name: pool2
+              pg_num: 32
               rados_put: true
               num_objs: 200
               byte_size: 1024
               pool_type: replicated
         delete_pools:
-          - pool1
+          - pool2
 
   - test:
       name: Verify delete object during PG split
@@ -143,12 +143,12 @@ tests:
         create_pools:
           - create_pool:
               del_obj: true
-              pool_name: pool1
-              pg_num: 64
+              pool_name: pool3
+              pg_num: 32
               rados_put: true
               num_objs: 200
               objs_to_del: 20
               byte_size: 1024
               pool_type: replicated
         delete_pools:
-          - pool1
+          - pool3

--- a/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -108,7 +108,7 @@ tests:
         create_pools:
           - create_pool:
               pool_name: pool1
-              pg_num: 64
+              pg_num: 32
               rados_put: true
               num_objs: 200
               byte_size: 1024
@@ -125,14 +125,14 @@ tests:
         create_pools:
           - create_pool:
               restart_osd: true
-              pool_name: pool1
-              pg_num: 64
+              pool_name: pool2
+              pg_num: 32
               rados_put: true
               num_objs: 200
               byte_size: 1024
               pool_type: replicated
         delete_pools:
-          - pool1
+          - pool2
 
   - test:
       name: Verify delete object during PG split
@@ -143,12 +143,12 @@ tests:
         create_pools:
           - create_pool:
               del_obj: true
-              pool_name: pool1
-              pg_num: 64
+              pool_name: pool3
+              pg_num: 32
               rados_put: true
               num_objs: 200
               objs_to_del: 20
               byte_size: 1024
               pool_type: replicated
         delete_pools:
-          - pool1
+          - pool3


### PR DESCRIPTION
1. Corrected the client node in clay profile tests. there was mismatch for client node for reef on suite & conf files.
2. Increasing the timeout for identifying the OSD state.
3. There was a issue with the way we were fetching PG count after the bulk flag application.
We fetched the currecnt PG count on the pool, instaed of the target PG count on the pool.
Corrected the discrepancy and updated the code to collect projected PG count for pool.