### PR TITLE
Eklavya multisite environment for baremetal and scale tests

### DIFF
--- a/suites/reef/baremetal/eklavya_conf.yaml
+++ b/suites/reef/baremetal/eklavya_conf.yaml
@@ -1,0 +1,180 @@
+globals:
+  -
+    ceph-cluster:
+      name: ceph-pri
+      networks:
+        public: ['10.0.0.0/12']
+      nodes:
+        -
+          hostname: depressa013.ceph.redhat.com
+          ip: 10.1.172.213
+          root_password: r
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: depressa014.ceph.redhat.com
+          ip: 10.1.172.214
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: depressa015.ceph.redhat.com
+          ip: 10.1.172.215
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+
+        -
+          hostname: extensa024.ceph.redhat.com
+          ip: 10.1.172.124
+          root_password: r
+          role:
+            - rgw
+
+        -
+          hostname: extensa025.ceph.redhat.com
+          ip: 10.1.172.125
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa026.ceph.redhat.com
+          ip: 10.1.172.126
+          root_password: r
+          role:
+            - rgw
+
+        -
+          hostname: extensa027.ceph.redhat.com
+          ip: 10.1.172.127
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa028.ceph.redhat.com
+          ip: 10.1.172.128
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa029.ceph.redhat.com
+          ip: 10.1.172.129
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa022.ceph.redhat.com
+          ip: 10.1.172.122
+          root_password: r
+          role:
+            - client
+
+  -
+    ceph-cluster:
+      name: ceph-sec
+      networks:
+        public: ['10.0.0.0/12']
+      nodes:
+        -
+          hostname: depressa016.ceph.redhat.com
+          ip: 10.1.172.216
+          root_password: r
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: depressa017.ceph.redhat.com
+          ip: 10.1.172.217
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: depressa018.ceph.redhat.com
+          ip: 10.1.172.218
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+
+        -
+          hostname: extensa031.ceph.redhat.com
+          ip: 10.1.172.131
+          root_password: r
+          role:
+            - rgw
+
+        -
+          hostname: extensa032.ceph.redhat.com
+          ip: 10.1.172.132
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa033.ceph.redhat.com
+          ip: 10.1.172.133
+          root_password: r
+          role:
+            - rgw
+
+        -
+          hostname: extensa034.ceph.redhat.com
+          ip: 10.1.172.134
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa035.ceph.redhat.com
+          ip: 10.1.172.135
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa036.ceph.redhat.com
+          ip: 10.1.172.136
+          root_password: r
+          role:
+            - rgw
+        -
+          hostname: extensa030.ceph.redhat.com
+          ip: 10.1.172.130
+          root_password: r
+          role:
+            - client

--- a/suites/reef/baremetal/eklavya_suite.yaml
+++ b/suites/reef/baremetal/eklavya_suite.yaml
@@ -1,0 +1,729 @@
+# The deployment is evaluated by running IOs across the environments.
+
+################- primary site ###############
+#mons : depressa013, 14, 15
+#osds : depressa013, 14, 15
+#mgrs: depressa013, 14, 15
+#sync- rgws : extensa024,25,26
+#IO-rgws: extensa027,28,29
+
+#haproxy-sync: extensa022
+#haproxy-IO : extensa027,28
+
+#################  secondary site ###################
+
+#mons : depressa016, 17, 18
+#osds : depressa016, 17, 18
+#mgrs: depressa016, 17, 18
+#sync- rgws : extensa031,32,33
+#IO-rgws: extensa034,35,36
+#haproxy-sync: extensa030
+#haproxy-IO : extensa034,35
+
+
+# run pre-requisites
+tests:
+#   - test:
+#       abort-on-fail: true
+#       desc: Install software pre-requisites for cluster deployment.
+#       module: install_prereq.py
+#       name: setup pre-requisites
+
+# #perform bootstrap
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: bootstrap
+#                   service: cephadm
+#                   args:
+#                     registry-url: registry.redhat.io
+#                     mon-ip: depressa013
+#                     allow-fqdn-hostname: true
+#                     orphan-initial-daemons: true
+#                     initial-dashboard-password: admin@123
+#                     dashboard-password-noupdate: true
+#         ceph-sec:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: bootstrap
+#                   service: cephadm
+#                   args:
+#                     registry-url: registry.redhat.io
+#                     mon-ip: depressa016
+#                     allow-fqdn-hostname: true
+#                     orphan-initial-daemons: true
+#                     initial-dashboard-password: admin@123
+#                     dashboard-password-noupdate: true
+
+#       desc: Bootstrap clusters using cephadm.
+#       polarion-id: CEPH-83573386
+#       destroy-cluster: false
+#       module: test_cephadm.py
+#       name: Bootstrap clusters
+
+
+# #enable ptrace and set log to file
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph config set mgr mgr/cephadm/allow_ptrace true"
+#               - "ceph config set global log_to_file true"
+#               - "ceph config set mgr mgr/cephadm/container_image_grafana registry-proxy.engineering.redhat.com/rh-osbs/grafana:9.4.7-1"
+#         ceph-sec:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph config set mgr mgr/cephadm/allow_ptrace true"
+#               - "ceph config set global log_to_file true"
+#               - "ceph config set mgr mgr/cephadm/container_image_grafana registry-proxy.engineering.redhat.com/rh-osbs/grafana:9.4.7-1"
+#       desc: setup debugging(ptrace) for containers
+#       module: exec.py
+#       name: setup debugging for containers
+#       polarion-id: CEPH-10362
+
+
+# #deploy more mons and mgrs
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: add_hosts
+#                   service: host
+#                   args:
+#                     attach_ip_address: true
+#                     labels: apply-all-labels
+#               - config:
+#                   command: apply
+#                   service: mgr
+#                   args:
+#                     placement:
+#                       label: mgr
+#               - config:
+#                   command: apply
+#                   service: mon
+#                   args:
+#                     placement:
+#                       label: mon
+
+#         ceph-sec:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: add_hosts
+#                   service: host
+#                   args:
+#                     attach_ip_address: true
+#                     labels: apply-all-labels
+#               - config:
+#                   command: apply
+#                   service: mgr
+#                   args:
+#                     placement:
+#                       label: mgr
+#               - config:
+#                   command: apply
+#                   service: mon
+#                   args:
+#                     placement:
+#                       label: mon
+
+
+#       desc: RHCS deploy more mons and mgrs.
+#       polarion-id: CEPH-83575222
+#       destroy-cluster: false
+#       module: test_cephadm.py
+#       name: deploy more mons and mgrs.
+
+
+# # deploy osds
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa013
+#                     - "/dev/sdb"
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa013
+#                     - "/dev/sdc"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa013
+#                     - "/dev/sdd"
+
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa014
+#                     - "/dev/sdb"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa014
+#                     - "/dev/sdc"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa014
+#                     - "/dev/sdd"
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa015
+#                     - "/dev/sdb"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa015
+#                     - "/dev/sdc"
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa015
+#                     - "/dev/sdd"
+
+
+#         ceph-sec:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa016
+#                     - "/dev/sdb"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa016
+#                     - "/dev/sda"
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa016
+#                     - "/dev/sdd"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa017
+#                     - "/dev/sdb"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa017
+#                     - "/dev/sdc"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa017
+#                     - "/dev/sdd"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa018
+#                     - "/dev/sdb"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa018
+#                     - "/dev/sdc"
+
+#               - config:
+#                   command: add
+#                   service: osd
+#                   pos_args:
+#                     - depressa018
+#                     - "/dev/sdd"
+#       desc: RHCS OSD deployment on single SSD
+#       polarion-id: CEPH-83575222
+#       destroy-cluster: false
+#       module: test_daemon.py
+#       name: Add OSD services on single SSD.
+
+
+# # deploy only sync rgws
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: apply
+#                   service: rgw
+#                   pos_args:
+#                     - shared.sync.80
+#                   args:
+#                     port: 80
+#                     placement:
+#                       nodes:
+#                         - extensa024
+#                         - extensa025
+#                         - extensa026
+
+#         ceph-sec:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: apply
+#                   service: rgw
+#                   pos_args:
+#                     - shared.sync.80
+#                   args:
+#                     port: 80
+#                     placement:
+#                       nodes:
+#                         - extensa031
+#                         - extensa032
+#                         - extensa033
+
+#       desc: RHCS sync rgws deploy using cephadm.
+#       polarion-id: CEPH-83575222
+#       destroy-cluster: false
+#       module: test_cephadm.py
+#       name: sync rgws deploy using cephadm
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: apply_spec
+#                   service: orch
+#                   validate-spec-services: true
+#                   specs:
+#                     - service_type: prometheus
+#                       placement:
+#                         count: 1
+#                         nodes:
+#                           - depressa013
+#                     - service_type: grafana
+#                       placement:
+#                         nodes:
+#                           - depressa013
+#                     - service_type: alertmanager
+#                       placement:
+#                         count: 1
+#                     - service_type: node-exporter
+#                       placement:
+#                         host_pattern: "*"
+#                     - service_type: crash
+#                       placement:
+#                         host_pattern: "*"
+#         ceph-sec:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: apply_spec
+#                   service: orch
+#                   validate-spec-services: true
+#                   specs:
+#                     - service_type: prometheus
+#                       placement:
+#                         count: 1
+#                         nodes:
+#                           - depressa016
+#                     - service_type: grafana
+#                       placement:
+#                         nodes:
+#                           - depressa016
+#                     - service_type: alertmanager
+#                       placement:
+#                         count: 1
+#                     - service_type: node-exporter
+#                       placement:
+#                         host_pattern: "*"
+#                     - service_type: crash
+#                       placement:
+#                         host_pattern: "*"
+
+#       name: Monitoring Services deployment
+#       desc: Add monitoring services using spec file.
+#       module: test_cephadm.py
+#       polarion-id: CEPH-83574727
+
+
+# #configure clients
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             command: add
+#             id: client.pri
+#             node: extensa022
+#             install_packages:
+#               - ceph-common
+#             copy_admin_keyring: true
+#         ceph-sec:
+#           config:
+#             command: add
+#             id: client.sec
+#             node: extensa030
+#             install_packages:
+#               - ceph-common
+#             copy_admin_keyring: true
+
+#       desc: Configure the sync RGW client system
+#       polarion-id: CEPH-83573758
+#       destroy-cluster: false
+#       module: test_client.py
+#       name: configure client
+
+# # Setting up primary site in a multisite
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "radosgw-admin realm create --rgw-realm india --default"
+#               - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://extensa024:80,http://extensa025:80,http://extensa026:80 --master --default"
+#               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://extensa024:80,http://extensa025:80,http://extensa026:80 --master --default"
+#               - "radosgw-admin period update --rgw-realm india --commit"
+#               - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key a123 --secret s123 --rgw-realm india --system"
+#               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key a123 --secret s123"
+#               - "radosgw-admin period update --rgw-realm india --commit"
+#               - "ceph config set client.rgw.shared.sync.80 rgw_realm india"
+#               - "ceph config set client.rgw.shared.sync.80 rgw_zonegroup shared"
+#               - "ceph config set client.rgw.shared.sync.80 rgw_zone primary"
+#               - "ceph orch restart rgw.shared.sync.80"
+#               - "radosgw-admin zonegroup modify --rgw-realm india --rgw-zonegroup shared --endpoints http://extensa022:5000"
+#               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --endpoints http://extensa022:5000"
+#               - "radosgw-admin period update --rgw-realm india --commit"
+#       desc: Setting up primary site in a multisite.
+#       module: exec.py
+#       name: Setting up primary site in a multisite
+#       polarion-id: CEPH-10362
+
+
+# # configuring HAproxy on the port '5000'
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             haproxy_clients:
+#               - extensa022
+#             rgw_endpoints:
+#               - "extensa024:80"
+#               - "extensa025:80"
+#               - "extensa026:80"
+
+#         ceph-sec:
+#           config:
+#             haproxy_clients:
+#               - extensa030
+#             rgw_endpoints:
+#               - "extensa031:80"
+#               - "extensa032:80"
+#               - "extensa033:80"
+
+#       desc: "Configure HAproxy fpr sync rgws"
+#       module: haproxy.py
+#       name: "Configure HAproxy"
+#       polarion-id: CEPH-83572703
+
+
+# # configuring HAproxy on the client node 'node6' and port '5000'
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             haproxy_clients:
+#               - extensa027
+#               - extensa028
+#             rgw_endpoints:
+#               - "extensa027:80"
+#               - "extensa028:80"
+#               - "extensa029:80"
+
+#         ceph-sec:
+#           config:
+#             haproxy_clients:
+#               - extensa034
+#               - extensa035
+#             rgw_endpoints:
+#               - "extensa034:80"
+#               - "extensa035:80"
+#               - "extensa036:80"
+
+
+#       desc: "Configure HAproxy for client IO rgws"
+#       module: haproxy.py
+#       name: "Configure HAproxy"
+#       polarion-id: CEPH-83572703
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             controllers:
+#               - extensa027
+#             drivers:
+#               count: 4
+#               hosts:
+#                 - extensa027
+#                 - extensa028
+#         ceph-sec:
+#           config:
+#             controllers:
+#               - extensa034
+#             drivers:
+#               count: 4
+#               hosts:
+#                 - extensa034
+#                 - extensa035
+
+#       desc: Start COS Bench controller and driver
+#       module: cosbench.py
+#       name: deploy cosbench
+# #configuring the secondary zone and archive zone from the Primary's Haproxy.
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph orch restart rgw.shared.sync.80"
+
+
+#         ceph-sec:
+#           config:
+#             commands:
+#               - "sleep 120"
+#               - "radosgw-admin realm pull --rgw-realm india --url http://extensa022:5000  --access-key a123 --secret s123 --default"
+#               - "radosgw-admin period pull --url http://extensa022:5000 --access-key a123 --secret s123"
+#               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://extensa032:80,http://extensa031:80,http://extensa033;80 --access-key a123 --secret s123"
+#               - "radosgw-admin period update --rgw-realm india --commit"
+#               - "ceph config set client.rgw.shared.sync.80 rgw_realm india"
+#               - "ceph config set client.rgw.shared.sync.80 rgw_zonegroup shared"
+#               - "ceph config set client.rgw.shared.sync.80 rgw_zone secondary"
+#               - "ceph orch restart rgw.shared.sync.80"
+#               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://extensa030:5000"
+#               - "radosgw-admin period update --rgw-realm india --commit"
+
+#       desc: Setting up RGW multisite replication environment
+#       module: exec.py
+#       name: setup multisite
+#       polarion-id: CEPH-10362
+
+# # deploy client IO rgws
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: apply
+#                   service: rgw
+#                   pos_args:
+#                     - shared.IO.80
+#                   args:
+#                     port: 80
+#                     placement:
+#                       nodes:
+#                         - extensa027
+#                         - extensa028
+#                         - extensa029
+
+#         ceph-sec:
+#           config:
+#             verify_cluster_health: true
+#             steps:
+#               - config:
+#                   command: apply
+#                   service: rgw
+#                   pos_args:
+#                     - shared.IO.80
+#                   args:
+#                     port: 80
+#                     placement:
+#                       nodes:
+#                         - extensa034
+#                         - extensa035
+#                         - extensa036
+
+#       desc: RHCS client IO rgws deploy using cephadm.
+#       polarion-id: CEPH-83575222
+#       destroy-cluster: false
+#       module: test_cephadm.py
+#       name: client IO rgws deploy using cephadm
+# #enable rgw_run_sync_thread=false on IO rgws
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-pri:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph config set client.rgw.shared.IO.80 rgw_run_sync_thread false"
+
+
+#         ceph-sec:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph config set client.rgw.shared.IO.80 rgw_run_sync_thread false"
+
+
+#       desc: enable rgw_run_sync_thread=false on IO rgws
+#       module: exec.py
+#       name: enable rgw_run_sync_thread=false on IO rgws
+#       polarion-id: CEPH-10362
+
+# # configure vault agent on IO rgws
+
+#   - test:
+#       clusters:
+#         ceph-pri:
+#           config:
+#             install:
+#               - agent
+#             run-on-rgw: true
+#         ceph-sec:
+#           config:
+#             install:
+#               - agent
+#             run-on-rgw: true
+
+#       desc: Setup and configure vault agent
+#       destroy-cluster: false
+#       module: install_vault.py
+#       name: configure vault agent
+#       polarion-id: CEPH-83575226
+
+#   - test:
+#       abort-on-fail: true
+#       clusters:
+#         ceph-sec:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_require_ssl false"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_backend vault"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_auth agent"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_prefix /v1/transit "
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_secret_engine transit"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_default_encryption_key 4YSmvJtBv0aZ7geVgAsdpRnLBEwWSWlMIGnRS8a9TSA="
+#               - "ceph orch restart rgw.shared.IO.80"
+#             timeout: 120
+#         ceph-pri:
+#           config:
+#             cephadm: true
+#             commands:
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_require_ssl false"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_backend vault"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_auth agent"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_prefix /v1/transit "
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_sse_s3_vault_secret_engine transit"
+#               - "ceph config set client.rgw.shared.IO.80 rgw_crypt_default_encryption_key 4YSmvJtBv0aZ7geVgAsdpRnLBEwWSWlMIGnRS8a9TSA="
+#               - "ceph orch restart rgw.shared.IO.80"
+#             timeout: 120
+
+#       desc: Setting vault configs for sse-s3 on multisite archive
+#       module: exec.py
+#       name: set sse-s3 vault configs on multisite
+
+   - test:
+       clusters:
+         ceph-pri:
+           config:
+             cephadm: true
+             commands:
+               - "ceph versions"
+               - "radosgw-admin sync status"
+               - "ceph -s"
+               - "radosgw-admin realm list"
+               - "radosgw-admin zonegroup list"
+               - "radosgw-admin zone list"
+               - "radosgw-admin user list"
+         ceph-sec:
+           config:
+             cephadm: true
+             commands:
+               - "ceph versions"
+               - "radosgw-admin sync status"
+               - "ceph -s"
+               - "radosgw-admin realm list"
+               - "radosgw-admin zonegroup list"
+               - "radosgw-admin zone list"
+               - "radosgw-admin user list"
+       desc: Retrieve the configured environment details
+       polarion-id: CEPH-83575227
+       module: exec.py
+       name: get shared realm info


### PR DESCRIPTION
# Description

Eklavya multisite environment for baremetal and scale tests

It comprises 6 depressa, and 14 extensa nodes.

- primary site
====================
mons : depressa013, 14, 15
osds : depressa013, 14, 15
mgrs: depressa013, 14, 15
sync- rgws : extensa024,25,26 
IO-rgws: extensa027,28,29
haproxy-sync: extensa022
haproxy-IO/cosbench controler and driver : extensa027,28

- secondary site
=========================
mons : depressa016, 17, 18
osds : depressa016, 17, 18
mgrs: depressa016, 17, 18
sync- rgws : extensa031,32,33 
IO-rgws: extensa034,35,36
haproxy-sync: extensa030
haproxy-IO/cosbench controler and driver  : extensa034,35


pass logs 
---------------
- pre-requisites, bootstrap, and setting debugging --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3I2A41/
-  osd deploy --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Z3SPOE
-  deploy sync rgws --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- monitoring services and grafana  --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- configure clients --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- Setting up primary site --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- Configuring sync HAproxy on the port '5000' --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- Configuring HAproxy for the client node --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- Configuring the secondary zone  --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4TICMK
- vault setup --> http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0J8DPB


