### PR TITLE
Adding monitoring of 6.1 and 7.0

### DIFF
--- a/pipeline/psi-post-umb.groovy
+++ b/pipeline/psi-post-umb.groovy
@@ -5,7 +5,12 @@
     modified releases are then compared against a the list of feature complete releases.
     A message is posted for the filtered list.
 */
-def featureCompleteReleases = ['RHCEPH-4.3.yaml', 'RHCEPH-5.3.yaml', 'RHCEPH-6.0.yaml']
+def featureCompleteReleases = [
+    'RHCEPH-5.3.yaml',
+    'RHCEPH-6.0.yaml',
+    'RHCEPH-6.1.yaml',
+    'RHCEPH-7.0.yaml'
+]
 
 node('rhel-9-medium || ceph-qe-ci') {
     stage('prepareNode') {


### PR DESCRIPTION
# Description

In this patch set, we add support for RH Ceph 6.1 and RH Ceph 7.0 recipe file monitoring so that a message can be posted on periodic bases.

<summary>click to expand checklist</summary>

- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
</details>
