### PR TITLE
Switching to latest key instead of tier-0

### DIFF
--- a/pipeline/vars/umb.groovy
+++ b/pipeline/vars/umb.groovy
@@ -12,7 +12,7 @@ def postUMBTestQueue(def version, Map recipeMap, def scratch) {
     def payload = [
         "artifact": [
             "nvr": version,
-            "latest": recipeMap['tier-0'],
+            "latest": recipeMap['latest'],
             "stable": stableBuild,
             "scratch": scratch
         ],


### PR DESCRIPTION
# Description

The `tier-0` key is currently unavailable in the recipe files. Switching to `latest` key instead of `tier-0` till things start falling into place.

<details>

<summary>click to expand checklist</summary>

- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] https://jenkins.ceph.redhat.com/view/RHCS%20QE/job/rhceph-post-umb/189/console
</details>
