### PR TITLE
Add polarion id to rbd upgrade, merge CEPH-9231 with CEPH-9230

### DIFF
--- a/suites/reef/rbd/tier-2_rbd_upgrade_6x_to_7x.yaml
+++ b/suites/reef/rbd/tier-2_rbd_upgrade_6x_to_7x.yaml
@@ -153,6 +153,7 @@ tests:
       desc: Multicluster upgrade with rbd mirror daemon
       module: test_cephadm_upgrade.py
       name: multi-cluster ceph upgrade
+      polarion-id: CEPH-83574829
       clusters:
         ceph-rbd1:
           config:

--- a/tests/rbd/rbd_snap_clone_imported_image.py
+++ b/tests/rbd/rbd_snap_clone_imported_image.py
@@ -48,6 +48,7 @@ def test_snap_clone(rbd, pool_type, **kw):
         snap_name = f"{pool}/{image}@{snap}"
         rbd.protect_snapshot(snap_name)
         rbd.create_clone(snap_name, pool, clone)
+        rbd.export_image(imagespec=f"{pool}/{image}", path=f"dummy_file_{image}")
         return 0
 
     except RbdBaseException as error:


### PR DESCRIPTION
Added polarion id - CEPH-83574829 to RBD mirror upgrade test case

Merged rbd export functionality in CEPH-9231 with import in CEPH-9230 by adding command for export in the same test module and updating polarion test steps as well.
Success logs for the same - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BYKKSZ/ 
