### PR TITLE
[Rados] Increasing wait timeout for OSD host reboot and OSD removal

### DIFF
--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -193,7 +193,7 @@ def run(ceph_cluster, **kw):
                 ceph_cluster, host=osd_host.hostname, device_path=dev_path
             )
             assert wait_for_device(
-                host=osd_host, osd_id=osd_id, action="remove", timeout=600
+                host=osd_host, osd_id=osd_id, action="remove", timeout=1000
             )
 
             out, _ = cephadm.shell(["ceph config set osd osd_crush_initial_weight 0"])
@@ -253,6 +253,7 @@ def run(ceph_cluster, **kw):
             log.exception(AE)
             return 1
         finally:
+            log.info("\n ************* Executing finally block **********\n")
             assert rados_obj.reweight_crush_items(
                 name=f"osd.{osd_id}", weight=org_weight
             )

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -58,7 +58,7 @@ def run(ceph_cluster, **kw) -> int:
     # Checking cluster health before starting the tests
     method_should_succeed(rados_obj.run_pool_sanity_check)
     log.info(
-        "Completed health cehck of the cluster after test pool creation. Cluster health good!!"
+        "Completed health check of the cluster after test pool creation. Cluster health good!!"
     )
 
     log.info("\n\n---- Starting All workflows ----\n\n")
@@ -101,7 +101,7 @@ def run(ceph_cluster, **kw) -> int:
     method_should_succeed(rados_obj.run_pool_sanity_check)
 
     log.info("Wait for rebooted hosts to come online")
-    timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=300)
+    timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=900)
     while datetime.datetime.now() < timeout_time:
         try:
             for node in osd_nodes:
@@ -111,7 +111,7 @@ def run(ceph_cluster, **kw) -> int:
         except AssertionError:
             time.sleep(25)
             if datetime.datetime.now() >= timeout_time:
-                log.error(f"{node.hostname} status is still offline after 5 mins")
+                log.error(f"{node.hostname} status is still offline after 15 mins")
                 return 1
     log.info(
         "---- Completed workflows 2. Rolling Reboot OSD hosts and health check ----"


### PR DESCRIPTION
Address two TFA issues:
Test - Failure recovery on Replicated & EC
Polarion ID : [CEPH-11032](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11032)
- [RHCEPHQE-9832](https://issues.redhat.com/browse/RHCEPHQE-9832): RADOS - tier-4_rados_test-pool-osd-recovery failed in regression
- [RHCEPHQE-11173](https://issues.redhat.com/browse/RHCEPHQE-11173): [TFA][RADOS][tier-4_rados_test-pool-osd-recovery][Failure recovery on Replicated & EC] Message: ceph-weekly-fzaeru-4z9r46-node10 status is still offline after 5 mins Type: error

Pass logs:
RHCS 6.1:: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JWXT0Q

Test - Verify Ceph df MAX_AVAIL
Polarion ID : [CEPH-10312](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10312)
- [RHCEPHQE-11163](https://issues.redhat.com/browse/RHCEPHQE-11163): [TFA][RADOS][tier-4_rados_tests][Verify Ceph df MAX_AVAIL] Failed with exception: Assertion failed.

Pass logs:
RHCS 6.1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XPTGEP

Test modules modified:
- tests/rados/test_pool_osd_recovery.py
- tests/rados/test_cephdf.py

Signed-off-by: Harsh Kumar <hakumar@redhat.com>