### PR TITLE
[tfa-fix]: Remove Rate limits test from suite tier-1-extn_rgw

### DIFF
--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -271,17 +271,6 @@ tests:
         timeout: 300
 
   - test:
-      name: Test Rate limits on a User and Bucket level using s3cmd
-      desc: Test Rate limits on a User and Bucket level using s3cmd
-      polarion-id: CEPH-83574910
-      module: sanity_rgw.py
-      config:
-        run-on-rgw: true
-        script-name: ../s3cmd/test_rate_limit.py
-        config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300
-
-  - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create
       polarion-id: CEPH-83574597


### PR DESCRIPTION
# Description
Removing this test from the suite  tier-1-extn_rgw, which is configured with rgw-ssl. s3cmd looking for non ssl rgw endpoint. hence the failure.
Also the same test - test Ratelimit for regular buckets(config yaml - test_rate_limit.yaml) is already a part of s3cmd suite execution 
Failure Logs - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-115/Regression/rgw/9/tier-1-extn_rgw/Test_Rate_limits_on_a_User_and_Bucket_level_using_s3cmd_0.log 

Pass Logs - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-138/Regression/rgw/11/tier-2_rgw_test-using-s3cmd/Test_Ratelimit_for_regular_buckets_0.log  

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
