### PR TITLE
removing known issue comments for BZ-2149259 and BZ-2187982 from bucket notifications suites

### DIFF
--- a/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
@@ -160,7 +160,6 @@ tests:
       desc: notify on lifecycle expiration non current objects with prefix rule
       polarion-id: CEPH-83575583
       module: sanity_rgw.py
-      comments: Known issue BZ-2187982
       config:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
@@ -81,7 +81,6 @@ tests:
       name: notify on multipart upload events with SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -106,7 +105,6 @@ tests:
       desc: notify on multipart upload events with SASL_PLAINTEXT SCRAM-SHA-256
       module: sanity_rgw.py
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -129,7 +127,6 @@ tests:
       name: notify on multipart upload events with SASL_SSL PLAIN
       desc: notify on multipart upload events with SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -153,7 +150,6 @@ tests:
       name: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
@@ -83,7 +83,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -107,7 +106,6 @@ tests:
       desc: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
       module: sanity_rgw.py
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -130,7 +128,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
       desc: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -153,7 +150,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -179,7 +175,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -202,7 +197,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -225,7 +219,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -248,7 +241,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -272,7 +264,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
       desc: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -295,7 +286,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
       desc: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -318,7 +308,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -341,7 +330,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
@@ -81,7 +81,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SSL security
       desc: notify on multipart upload events with kafka_broker and SSL security
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -105,7 +104,6 @@ tests:
       desc: notify on multipart upload events with kafka_broker_persistent and SSL security
       module: sanity_rgw.py
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -129,7 +127,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SSL security
       desc: notify on multipart upload events with kafka_none and SSL security
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -152,7 +149,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
       desc: notify on multipart upload events with kafka_none_persistent and SSL security
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -114,7 +114,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent
       desc: notify on multipart upload events with kafka_none_persistent
       polarion-id: CEPH-83574070
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -150,7 +149,6 @@ tests:
       name: notify on multipart upload events with kafka_none and verify timestamp of event record
       desc: notify on multipart upload events with kafka_none and verify timestamp of event record
       polarion-id: CEPH-83574693
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -92,6 +92,7 @@ tests:
       name: notify put,delete events with kafka_none_persistent and delete kafka topic
       desc: notify put,delete events with kafka_none_persistent and delete kafka topic
       module: sanity_rgw.py
+      comments: Known issue BZ-2239173
       polarion-id: CEPH-83574076
       config:
         run-on-rgw: true
@@ -114,7 +115,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent
       desc: notify on multipart upload events with kafka_none_persistent
       polarion-id: CEPH-83574070
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -150,7 +150,6 @@ tests:
       name: notify on multipart upload events with kafka_none and verify timestamp of event record
       desc: notify on multipart upload events with kafka_none and verify timestamp of event record
       polarion-id: CEPH-83574693
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -164,6 +163,7 @@ tests:
       name: notify put,delete events with kafka_broker
       desc: notify put,delete events with kafka_broker
       module: sanity_rgw.py
+      comments: Known issue BZ-2239173
       polarion-id: CEPH-83574073
       config:
         run-on-rgw: true
@@ -219,6 +219,7 @@ tests:
       name: put empty bucket notifications
       desc: put empty bucket notifications
       module: sanity_rgw.py
+      comments: Known issue BZ-2239173
       polarion-id: CEPH-83575036
       config:
         run-on-rgw: true
@@ -328,7 +329,6 @@ tests:
       desc: notify on lifecycle expiration non current objects with prefix rule
       polarion-id: CEPH-83575583
       module: sanity_rgw.py
-      comments: Known issue BZ-2187982
       config:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
@@ -82,7 +82,6 @@ tests:
       name: notify on multipart upload events with SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -107,7 +106,6 @@ tests:
       desc: notify on multipart upload events with SASL_PLAINTEXT SCRAM-SHA-256
       module: sanity_rgw.py
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -130,7 +128,6 @@ tests:
       name: notify on multipart upload events with SASL_SSL PLAIN
       desc: notify on multipart upload events with SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -154,7 +151,6 @@ tests:
       name: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -180,7 +176,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -204,7 +199,6 @@ tests:
       desc: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
       module: sanity_rgw.py
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -227,7 +221,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
       desc: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -250,7 +243,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -276,7 +268,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -299,7 +290,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
       desc: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -322,7 +312,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -345,7 +334,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -369,7 +357,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
       desc: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -392,7 +379,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
       desc: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -415,7 +401,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -438,7 +423,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
       polarion-id: CEPH-83575407
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
@@ -82,7 +82,6 @@ tests:
       name: notify on multipart upload events with kafka_broker and SSL security
       desc: notify on multipart upload events with kafka_broker and SSL security
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -106,7 +105,6 @@ tests:
       desc: notify on multipart upload events with kafka_broker_persistent and SSL security
       module: sanity_rgw.py
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
@@ -130,7 +128,6 @@ tests:
       name: notify on multipart upload events with kafka_none and SSL security
       desc: notify on multipart upload events with kafka_none and SSL security
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true
@@ -153,7 +150,6 @@ tests:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
       desc: notify on multipart upload events with kafka_none_persistent and SSL security
       polarion-id: CEPH-83575471
-      comments: known issue (bz-2149259)
       module: sanity_rgw.py
       config:
         run-on-rgw: true

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -198,7 +198,7 @@ def run(**kw):
         install_start_kafka(secondary_rgw_node, cloud_type)
     if configure_kafka_broker_security:
         configure_kafka_security(primary_rgw_node, cloud_type)
-        install_start_kafka(secondary_rgw_node, cloud_type)
+        configure_kafka_security(secondary_rgw_node, cloud_type)
 
     if test_config["config"]:
         log.info("creating custom config")

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1729,7 +1729,7 @@ def configure_kafka_security(rgw_node, cloud_type):
         cmd=f"yes | cp /tmp/kafka_server.properties {KAFKA_HOME}/config/server.properties",
     )
 
-    # download kafka_security.sh script, create certs and and store them in keystore and truststore
+    # download kafka_security.sh script, create certs and store them in keystore and truststore
     if cloud_type == "ibmc":
         curl_security_sh = (
             "curl -o /tmp/kafka-security.sh https://10.245.4.89/kafka-security.sh"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2149259 is fixed and closed. no issue now in multipart upload for notifications in event record

https://bugzilla.redhat.com/show_bug.cgi?id=2187982 is closed as not a bug. dev decided to have the event type capitalization based on aws doc i.e., ObjectLifecycle:Expiration:Noncurrent

https://bugzilla.redhat.com/show_bug.cgi?id=2239173 filed for all objects deletion failed using boto3 resource. added comment for bucket delete notifications testcases in reef rgw bucket notification suite.
recent failure logs: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-20/Weekly/rgw/6/tier-2_rgw_test_bucket_notifications/

also in sanity_rgw_multisite test for configuring kafka security replaced it with correct method for secondary site. previously it was install_kafka by mistake

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
