### PR TITLE
fixing a TFA failure due to very less sync lease period

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -458,33 +458,6 @@ tests:
       name: test LC from primary to secondary
       polarion-id: CEPH-11194
       comments: bug-1991808, test LC rules from primary to secondary
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.sec rgw_sync_lease_period 10"
-              - "ceph orch restart rgw.shared.sec"
-            timeout: 120
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.pri rgw_sync_lease_period 10"
-              - "ceph orch restart rgw.shared.pri"
-            timeout: 120
-        ceph-arc:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.arc rgw_sync_lease_period 10"
-              - "ceph orch restart rgw.shared.arc"
-            timeout: 120
-      desc: Setting rgw_sync_lease_period to 10 on multisite archive
-      module: exec.py
-      name: Setting rgw_sync_lease_period to 10 on multisite archive
 
   - test:
       clusters:


### PR DESCRIPTION
# Description


pass logs 1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8K924Y/
pass log1 for LC primary to secondary : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Q34HHC
pass log2 for LC 2 primary to secondary: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-H3FO02

