### PR TITLE
workaround for inducing nvmeof image in test run

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -326,7 +326,6 @@ class BootstrapMixin:
 
         logger.info("Bootstrap output : %s", out)
         logger.error("Bootstrap error: %s", err)
-
         # The path to ssh public key mentioned in either output-pub-ssh-key or
         # ssh-public-key options will be considered for distributing the ssh public key,
         # if these are not specified, then the default ssh key path /etc/ceph/ceph.pub
@@ -356,6 +355,7 @@ class BootstrapMixin:
                 "promtail",
                 "snmp_gateway",
                 "loki",
+                "nvmeof",
             ]
 
             for image in supported_overrides:

--- a/ceph/nvmeof/nvmeof_gwcli.py
+++ b/ceph/nvmeof/nvmeof_gwcli.py
@@ -11,8 +11,6 @@ from utility.log import Log
 
 LOG = Log(__name__)
 
-CEPH_NVMECLI_IMAGE = "quay.io/ceph/nvmeof-cli:0.0.3"
-
 
 def find_client_daemon_id(cluster, pool_name):
     """Find client daemon Id."""
@@ -27,6 +25,8 @@ def find_client_daemon_id(cluster, pool_name):
 
 class NVMeCLI:
     """NVMeCLI class for managing NVMeoF Gateway entities."""
+
+    CEPH_NVMECLI_IMAGE = "quay.io/ceph/nvmeof-cli:0.0.3"
 
     def __init__(self, node, port=5500):
         self.node = node
@@ -43,7 +43,7 @@ class NVMeCLI:
 
     def run_control_cli(self, action, **cmd_args):
         """Run CLI via control daemon."""
-        base_cmd = f"podman run {CEPH_NVMECLI_IMAGE}"
+        base_cmd = f"podman run {self.CEPH_NVMECLI_IMAGE}"
         base_cmd += (
             f" --server-address {self.node.ip_address} --server-port {self.port}"
         )

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -186,6 +186,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     rbd_pool = config["rbd_pool"]
     rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
     rbd_obj.ceph_client = get_node_by_id(ceph_cluster, config["initiator"]["node"])
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
 
     if config.get("cleanup-only"):
         teardown(ceph_cluster, rbd_obj, config)

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -237,10 +237,15 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                         - gateway
     """
     LOG.info("Starting Ceph Ceph NVMEoF deployment.")
-
     config = kwargs["config"]
     rbd_pool = config["rbd_pool"]
     rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
 
     if config.get("cleanup-only"):
         teardown(ceph_cluster, rbd_obj, config)

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
@@ -158,6 +158,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     )
     rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
 
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
     nvme_cli = NVMeCLI(node, config.get("port", 5500))
     try:
         steps = config.get("steps", [])

--- a/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
@@ -124,6 +124,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     )
     rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
 
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
     nvme_cli = NVMeCLI(node, config.get("port", 5500))
     try:
         steps = config.get("steps", [])

--- a/tests/nvmeof/test_io_perf.py
+++ b/tests/nvmeof/test_io_perf.py
@@ -589,6 +589,11 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         }
     )
     rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
 
     io_profiles = config["io_profiles"]
     iterations = config.get("iterations", 1)

--- a/tests/nvmeof/test_nvme_cli.py
+++ b/tests/nvmeof/test_nvme_cli.py
@@ -70,7 +70,13 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
     config = deepcopy(kwargs["config"])
     node = get_node_by_id(ceph_cluster, config["node"])
 
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
     nvme_cli = NVMeCLI(node, config.get("port", 5500))
+
     try:
         steps = config.get("steps", [])
         for step in steps:


### PR DESCRIPTION
- Workaround for nvmeof image to induce in the CephCI test run

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SVYUVF/

`/home/sunilkumar/workspace/venv/bin/python3 run.py --log-level debug --osp-cred /home/sunilkumar/osp-sys-test.yaml --instances-name 3sunilkumar --rhbuild 7.0 --build latest --platform rhel-9 --global-conf conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml --suite suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml --inventory conf/inventory/rhel-9.1-server-x86_64.yaml --custom-config nvmeof_image=registry-proxy.engineering.redhat.com/rh-osbs/ceph-nvmeof:0.0.3-1 nvmeof_cli_image=registry-proxy.engineering.redhat.com/rh-osbs/ceph-nvmeof-cli:0.0.3-1 --reuse rerun/3sunilkumar-YSAHWK`
