### PR TITLE
CEPH-9408: System Test: Replace a failed OSD Host

### DIFF
--- a/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -38,7 +38,7 @@ tests:
             - node4
             - node5
             - node6
-            - node7
+            - node8
             - node9
             - node10
             - node11

--- a/suites/pacific/rados/tier-4_rados_tests.yaml
+++ b/suites/pacific/rados/tier-4_rados_tests.yaml
@@ -1,5 +1,5 @@
 # Suite contains basic tier-4 rados tests
-# conf - conf/pacific/rados/11-node-cluster.yaml
+# conf - conf/pacific/rados/13-node-cluster.yaml
 tests:
   - test:
       name: setup install pre-requisistes
@@ -21,13 +21,39 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
-                orphan-initial-daemons: true
-          - config:
-              command: add_hosts
-              service: host
-              args:
-                attach_ip_address: true
-                labels: apply-all-labels
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+            - node5
+            - node6
+            - node8
+            - node9
+            - node10
+            - node11
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
               service: mgr
@@ -40,35 +66,69 @@ tests:
               args:
                 placement:
                   label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args: # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
           - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
               command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
+              service: rgw
               pos_args:
-                - cephfs              # name of the filesystem
+                - rgw.1
               args:
                 placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
+                  label: rgw
 
   - test:
       name: Configure client admin
@@ -188,3 +248,11 @@ tests:
       polarion-id: CEPH-83573854
       module: mute_alerts.py
       desc: Mute health alerts
+
+  - test:
+      name: Replacement of a failed OSD host
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-9408
+      config:
+        osd_host_fail: True
+      desc: Replacement of a failed OSD host with a healthy host

--- a/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -38,7 +38,7 @@ tests:
             - node4
             - node5
             - node6
-            - node7
+            - node8
             - node9
             - node10
             - node11

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -1,5 +1,5 @@
 # Suite contains basic tier-4 rados tests
-# conf - conf/quincy/rados/11-node-cluster.yaml
+# conf - conf/quincy/rados/13-node-cluster.yaml
 tests:
   - test:
       name: setup install pre-requisistes
@@ -21,13 +21,39 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
-                orphan-initial-daemons: true
-          - config:
-              command: add_hosts
-              service: host
-              args:
-                attach_ip_address: true
-                labels: apply-all-labels
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+            - node5
+            - node6
+            - node8
+            - node9
+            - node10
+            - node11
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
               service: mgr
@@ -40,35 +66,69 @@ tests:
               args:
                 placement:
                   label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args: # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
           - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
               command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
+              service: rgw
               pos_args:
-                - cephfs              # name of the filesystem
+                - rgw.1
               args:
                 placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
+                  label: rgw
 
   - test:
       name: Configure client admin
@@ -188,3 +248,11 @@ tests:
       polarion-id: CEPH-83573854
       module: mute_alerts.py
       desc: Mute health alerts
+
+  - test:
+      name: Replacement of a failed OSD host
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-9408
+      config:
+        osd_host_fail: True
+      desc: Replacement of a failed OSD host with a healthy host

--- a/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -38,7 +38,7 @@ tests:
             - node4
             - node5
             - node6
-            - node7
+            - node8
             - node9
             - node10
             - node11

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -1,5 +1,5 @@
 # Suite contains basic tier-4 rados tests
-# conf - conf/reef/rados/11-node-cluster.yaml
+# conf - conf/reef/rados/13-node-cluster.yaml
 tests:
   - test:
       name: setup install pre-requisistes
@@ -21,13 +21,39 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
-                orphan-initial-daemons: true
-          - config:
-              command: add_hosts
-              service: host
-              args:
-                attach_ip_address: true
-                labels: apply-all-labels
+
+  - test:
+      name: Add host
+      desc: Add new host node with IP address
+      module: test_host.py
+      config:
+        command: add_hosts
+        service: host
+        args:
+          nodes:
+            - node1
+            - node2
+            - node3
+            - node4
+            - node5
+            - node6
+            - node8
+            - node9
+            - node10
+            - node11
+          attach_ip_address: true
+          labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
               service: mgr
@@ -40,35 +66,69 @@ tests:
               args:
                 placement:
                   label: mon
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args: # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
           - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
               command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
+              service: rgw
               pos_args:
-                - cephfs              # name of the filesystem
+                - rgw.1
               args:
                 placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
+                  label: rgw
 
   - test:
       name: Configure client admin
@@ -188,3 +248,11 @@ tests:
       polarion-id: CEPH-83573854
       module: mute_alerts.py
       desc: Mute health alerts
+
+  - test:
+      name: Replacement of a failed OSD host
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-9408
+      config:
+        osd_host_fail: True
+      desc: Replacement of a failed OSD host with a healthy host

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -7,6 +7,7 @@ Module to perform tier-4 tests on pools WRT OSD daemons.
 4. restart all OSD daemons belonging to single pg
 5. Removal and addition of OSD daemons
 6. Removal and addition of OSD Hosts
+7. Replacement of a failed OSD host
 
 """
 import datetime
@@ -40,312 +41,483 @@ def run(ceph_cluster, **kw) -> int:
     config = kw["config"]
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
-    pool_configs = config["pool_configs"]
-    pool_configs_path = config["pool_configs_path"]
+    pool_configs = config.get("pool_configs")
+    pool_configs_path = config.get("pool_configs_path")
     osd_nodes = ceph_cluster.get_nodes(role="osd")
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
 
-    with open(pool_configs_path, "r") as fd:
-        pool_conf_file = yaml.safe_load(fd)
+    if config.get("pool_configs_path"):
+        with open(pool_configs_path, "r") as fd:
+            pool_conf_file = yaml.safe_load(fd)
 
-    pools = []
-    for i in pool_configs:
-        pool = pool_conf_file[i["type"]][i["conf"]]
-        create_given_pool(rados_obj, pool)
-        pools.append(pool["pool_name"])
+    if config.get("pool_configs"):
+        pools = []
+        for i in pool_configs:
+            pool = pool_conf_file[i["type"]][i["conf"]]
+            create_given_pool(rados_obj, pool)
+            pools.append(pool["pool_name"])
+        log.info(f"Created {len(pools)} pools for testing. pools : {pools}")
 
-    log.info(f"Created {len(pools)} pools for testing. pools : {pools}")
+        # Checking cluster health before starting the tests
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info(
+            "Completed health check of the cluster after test pool creation. Cluster health good!!"
+        )
 
-    # Checking cluster health before starting the tests
-    method_should_succeed(rados_obj.run_pool_sanity_check)
-    log.info(
-        "Completed health check of the cluster after test pool creation. Cluster health good!!"
-    )
+    def add_new_hosts(add_nodes: list = None):
+        try:
+            if add_nodes is None:
+                add_nodes = ["node12", "node13"]
+            # Adding new hosts to the cluster
+            add_args = {
+                "command": "add_hosts",
+                "service": "host",
+                "args": {
+                    "nodes": add_nodes,
+                    "attach_address": True,
+                    "labels": "apply-all-labels",
+                },
+            }
+            add_args.update(config)
+
+            ncount_pre = len(rados_obj.run_ceph_command(cmd="ceph orch host ls"))
+            deploy_host(ceph_cluster=ceph_cluster, config=add_args)
+
+            if not ncount_pre < len(
+                rados_obj.run_ceph_command(cmd="ceph orch host ls")
+            ):
+                log.error("New hosts are not added into the cluster")
+                raise Exception("Execution error")
+
+            log.info(
+                "New hosts added to the cluster successfully, Proceeding to deploy OSDs on the same."
+            )
+            # Deploying OSDs on the new nodes.
+            osd_args = {
+                "steps": [
+                    {
+                        "config": {
+                            "command": "apply_spec",
+                            "service": "orch",
+                            "validate-spec-services": True,
+                            "specs": [
+                                {
+                                    "service_type": "osd",
+                                    "service_id": "new_osds",
+                                    "encrypted": "true",
+                                    "placement": {"label": "osd-bak"},
+                                    "spec": {"data_devices": {"all": "true"}},
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+            osd_args.update(config)
+            ocount_pre = len(get_osd_details(node=cephadm))
+            add_osd(ceph_cluster=ceph_cluster, config=osd_args)
+            if not ocount_pre < len(get_osd_details(node=cephadm)):
+                log.error("New OSDs were not added into the cluster")
+                raise Exception("Execution error")
+
+            log.info("Deployed new hosts and deployed OSDs on them")
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            raise
+
+    def remove_offline_host(host_node_name: str):
+        # get initial count of hosts in the cluster
+        host_count_pre = len(rados_obj.run_ceph_command(cmd="ceph orch host ls"))
+        # Removing an OSD host and checking status
+        rm_host = get_node_by_id(ceph_cluster, host_node_name)
+        log.info(f"Identified host : {rm_host.hostname} to be removed from the cluster")
+
+        # get list of osd_id on the host to be removed
+        rm_osd_list = rados_obj.collect_osd_daemon_ids(osd_node=rm_host)
+        log.info(f"list of osds on {rm_host.hostname}: {rm_osd_list}")
+        # Starting to drain an offline host.
+        log.info("Starting to drain an offline host")
+        cephadm.shell([f"ceph orch host drain {rm_host.hostname} --force"])
+        # Sleeping for 2 seconds for removal to have started
+        time.sleep(2)
+        log.debug(f"Started drain operation on node : {rm_host.hostname}")
+
+        status_cmd = "ceph orch osd rm status -f json"
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=7200)
+        flag = False
+        while end_time > datetime.datetime.now():
+            out, err = cephadm.shell([status_cmd])
+            try:
+                drain_ops = json.loads(out)
+                for entry in drain_ops:
+                    if entry["drain_done_at"] is None or entry["draining"]:
+                        log.debug(
+                            f"Drain operations are going on host {rm_host.hostname} \nOperations: {entry}"
+                        )
+                        raise Exception(
+                            f"drain process for OSD {entry['osd_id']} is still going on"
+                        )
+                    log.info(f"Drain operation completed for OSD {entry['osd_id']}")
+                log.info(f"Drain operations completed on host : {rm_host.hostname}")
+                flag = True
+                break
+            except json.JSONDecodeError:
+                log.info(f"Drain operations completed on host : {rm_host.hostname}")
+                flag = True
+                break
+            except Exception as error:
+                if end_time < datetime.datetime.now():
+                    log.error(f"Hit issue during drain operations: {error}")
+                    raise Exception(error)
+                log.info("Sleeping for 120 seconds and checking again....")
+                time.sleep(120)
+
+        if not flag:
+            log.error(
+                "Drain operation not completed on the cluster even after 7200 seconds"
+            )
+            raise
+        # remove the offline host so that drain operation gets completed
+        log.info(f"Removing host {rm_host.hostname} from the cluster")
+        cephadm.shell([f"ceph orch host rm {rm_host.hostname} --force --offline"])
+        time.sleep(10)
+        if not host_count_pre > len(
+            rados_obj.run_ceph_command(cmd="ceph orch host ls")
+        ):
+            log.error("Host count in the cluster has not reduced")
+            out, err = cephadm.shell(
+                [f"ceph orch host ls --host_pattern {rm_host.hostname}"]
+            )
+            if "0 hosts in cluster" not in out or rm_host.hostname in out:
+                log.error(f"{rm_host.hostname} is still part of the cluster")
+            raise Exception("Host count in the cluster has not reduced")
+        log.info(
+            f"Completed drain and removal operation on the host. {rm_host.hostname}"
+        )
+
+    def remove_custom_host(host_node_name: str):
+        try:
+            # Removing an OSD host and checking status
+            rm_host = get_node_by_id(ceph_cluster, host_node_name)
+            log.info(
+                f"Identified host : {rm_host.hostname} to be removed from the cluster"
+            )
+
+            # get list of osd_id on the host to be removed
+            rm_osd_list = rados_obj.collect_osd_daemon_ids(osd_node=rm_host)
+            dev_path_list = []
+            for osd_id in rm_osd_list:
+                dev_path_list.append(get_device_path(host=rm_host, osd_id=osd_id))
+                utils.set_osd_out(ceph_cluster, osd_id=osd_id)
+                utils.osd_remove(ceph_cluster, osd_id=osd_id)
+            time.sleep(30)
+            # Starting to drain the host
+            drain_cmd = f"ceph orch host drain {rm_host.hostname} --force"
+            cephadm.shell([drain_cmd])
+            # Sleeping for 2 seconds for removal to have started
+            time.sleep(2)
+            log.debug(f"Started drain operation on node : {rm_host.hostname}")
+
+            status_cmd = "ceph orch osd rm status -f json"
+            end_time = datetime.datetime.now() + datetime.timedelta(seconds=600)
+            flag = False
+            while end_time > datetime.datetime.now():
+                out, err = cephadm.shell([status_cmd])
+                try:
+                    drain_ops = json.loads(out)
+                    for entry in drain_ops:
+                        log.debug(
+                            f"Drain operations are going on host {rm_host.hostname} \nOperations: {entry}"
+                        )
+                except json.JSONDecodeError:
+                    log.info(f"Drain operations completed on host : {rm_host.hostname}")
+                    flag = True
+                    break
+                except Exception as error:
+                    log.error(f"Hit issue during drain operations: {error}")
+                    raise Exception(error)
+                log.debug("Sleeping for 10 seconds and checking again....")
+                time.sleep(10)
+
+            if not flag:
+                log.error(
+                    "Drain operation not completed on the cluster even after 600 seconds"
+                )
+                raise Exception("Execution Error")
+            log.info(
+                f"Completed drain operation on the host. {rm_host.hostname}\n Removing host from the cluster"
+            )
+
+            for dev_path in dev_path_list:
+                assert utils.zap_device(
+                    ceph_cluster, host=rm_host.hostname, device_path=dev_path
+                )
+
+            time.sleep(5)
+            rm_cmd = f"ceph orch host rm {rm_host.hostname} --force"
+            cephadm.shell([rm_cmd])
+            time.sleep(5)
+
+            # Checking if the host still exists on the cluster
+            ls_cmd = "ceph orch host ls"
+            hosts = rados_obj.run_ceph_command(cmd=ls_cmd)
+            for host in hosts:
+                if host["hostname"] == rm_host.hostname:
+                    log.error(f"Host : {rm_host.hostname} still present on the cluster")
+                    raise Exception("Host not removed error")
+            log.info(
+                f"Successfully removed host : {rm_host.hostname} from the cluster. Checking status after removal"
+            )
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            raise
 
     log.info("\n\n---- Starting All workflows ----\n\n")
-    # rebooting one OSD and checking cluster health
-    log.info(
-        "---- Starting workflow ----\n---- 1. Reboot of single osd and health check ----"
-    )
-    for pool in pools:
-        target_osd = rados_obj.get_pg_acting_set(pool_name=pool)[0]
-        log.debug(f"Rebooting OSD : {target_osd} and checking health status")
-        if not rados_obj.change_osd_state(action="restart", target=target_osd):
-            log.error(f"Unable to restart the OSD : {target_osd}")
-            raise Exception("Execution error")
-
-        # Waiting for recovery to post OSD reboot
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        log.debug(
-            "PG's are active + clean post OSD reboot, proceeding to restart next OSD"
+    if not config.get("osd_host_fail", False):
+        # rebooting one OSD and checking cluster health
+        log.info(
+            "---- Starting workflow ----\n---- 1. Reboot of single osd and health check ----"
         )
-
-    log.info("All the planned primary OSD reboots have completed")
-    # Checking cluster health after the tests
-    method_should_succeed(rados_obj.run_pool_sanity_check)
-    log.info("----Completed workflows 1. Reboot of single osd and health check----")
-
-    log.info("---- Starting workflow ----\n---- 2. Rolling Reboot OSD hosts ----")
-    for nodes in osd_nodes:
-        log.info(f"Rebooting node : {nodes.hostname}")
-        nodes.exec_command(sudo=True, cmd="reboot", long_running=True)
-
-        # Sleeping for 10 seconds and starting verification.
-        time.sleep(10)
-
-        # Waiting for recovery to post OSD host reboot
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        log.info(f"PG's are active + clean post reboot of host {nodes.hostname}")
-
-    log.info("Completed reboot of all the OSD hosts, Checking cluster health status")
-    # Checking cluster health after the test
-    method_should_succeed(rados_obj.run_pool_sanity_check)
-
-    log.info("Wait for rebooted hosts to come online")
-    timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=900)
-    while datetime.datetime.now() < timeout_time:
-        try:
-            for node in osd_nodes:
-                assert rados_obj.check_host_status(hostname=node.hostname)
-            log.info("Rebooted hosts are up")
-            break
-        except AssertionError:
-            time.sleep(25)
-            if datetime.datetime.now() >= timeout_time:
-                log.error(f"{node.hostname} status is still offline after 15 mins")
-                return 1
-    log.info(
-        "---- Completed workflows 2. Rolling Reboot OSD hosts and health check ----"
-    )
-
-    log.info(
-        "---- Starting workflow ----\n---- 3. Stopping and starting OSD daemons ----"
-    )
-    for pool in pools:
-        target_osd = rados_obj.get_pg_acting_set(pool_name=pool)[0]
-        log.debug(f"Stopping OSD : {target_osd} and checking health status")
-        if not rados_obj.change_osd_state(action="stop", target=target_osd):
-            log.error(f"Unable to stop the OSD : {target_osd}")
-            raise Exception("Execution error")
-
-        # Waiting for recovery to post OSD stop
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        log.debug(
-            f"PG's are active + clean post OSD stop of {target_osd}, proceeding to start OSD"
-        )
-
-        log.debug(f"Starting OSD : {target_osd} and checking health status")
-        if not rados_obj.change_osd_state(action="start", target=target_osd):
-            log.error(f"Unable to start the OSD : {target_osd}")
-            raise Exception("Execution error")
-
-        # Waiting for recovery to post OSD start
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        log.debug(
-            f"PG's are active + clean post OSD start of {target_osd}, proceeding to restart next OSD"
-        )
-
-    log.info("Completed start and stop for all targeted OSDs. Checking cluster health")
-    # Checking cluster health after the tests
-    method_should_succeed(rados_obj.run_pool_sanity_check)
-    log.info("--- Completed workflows 3. Stopping and starting OSD daemons ---")
-
-    log.info(
-        "---- Starting workflow ----\n---- 4. restart all OSD daemons belonging to single pg----"
-    )
-    for pool in pools:
-        pg_set = rados_obj.get_pg_acting_set(pool_name=pool)
-        log.debug(f"Acting set of OSDs for testing reboot are : {pg_set}")
-        for target_osd in pg_set:
-            log.debug(f"Restarting OSD : {target_osd} and checking health status")
+        for pool in pools:
+            target_osd = rados_obj.get_pg_acting_set(pool_name=pool)[0]
+            log.debug(f"Rebooting OSD : {target_osd} and checking health status")
             if not rados_obj.change_osd_state(action="restart", target=target_osd):
                 log.error(f"Unable to restart the OSD : {target_osd}")
                 raise Exception("Execution error")
 
-            # Waiting for recovery to post OSD restart
+            # Waiting for recovery to post OSD reboot
             method_should_succeed(wait_for_clean_pg_sets, rados_obj)
             log.debug(
-                f"PG's are active + clean post OSD restart of {target_osd}, proceeding to restart next OSD"
+                "PG's are active + clean post OSD reboot, proceeding to restart next OSD"
             )
 
-    # Checking cluster health after the tests
-    method_should_succeed(rados_obj.run_pool_sanity_check)
-    log.info(
-        "--- Completed workflows 4. restart OSD daemons belonging to single pg ---"
-    )
-
-    log.info("---- Starting workflow ----\n---- 5. Removal and addition of OSD daemons")
-    for pool in pools:
-        pg_set = rados_obj.get_pg_acting_set(pool_name=pool)
-        log.debug(f"Acting set for removal and addition of OSDs {pg_set}")
-        target_osd = pg_set[0]
-        host = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=target_osd)
-
-        dev_path = get_device_path(host, target_osd)
-        log.debug(
-            f"osd device path  : {dev_path}, osd_id : {target_osd}, host.hostname : {host.hostname}"
-        )
-
-        utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=True)
-        method_should_succeed(utils.set_osd_out, ceph_cluster, target_osd)
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        utils.osd_remove(ceph_cluster, target_osd)
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        method_should_succeed(utils.zap_device, ceph_cluster, host.hostname, dev_path)
-        method_should_succeed(wait_for_device, host, target_osd, action="remove")
-
-        # Checking cluster health after OSD removal
+        log.info("All the planned primary OSD reboots have completed")
+        # Checking cluster health after the tests
         method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info("----Completed workflows 1. Reboot of single osd and health check----")
+
+        log.info("---- Starting workflow ----\n---- 2. Rolling Reboot OSD hosts ----")
+        for nodes in osd_nodes:
+            log.info(f"Rebooting node : {nodes.hostname}")
+            nodes.exec_command(sudo=True, cmd="reboot", long_running=True)
+
+            # Sleeping for 10 seconds and starting verification.
+            time.sleep(10)
+
+            # Waiting for recovery to post OSD host reboot
+            method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+            log.info(f"PG's are active + clean post reboot of host {nodes.hostname}")
+
         log.info(
-            f"Removal of OSD : {target_osd} is successful. Proceeding to add back the OSD daemon."
+            "Completed reboot of all the OSD hosts, Checking cluster health status"
         )
-
-        # Adding the removed OSD back and checking the cluster status
-        utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
-        method_should_succeed(wait_for_device, host, target_osd, action="add")
-        time.sleep(10)
-
-        # Checking cluster health after OSD removal
+        # Checking cluster health after the test
         method_should_succeed(rados_obj.run_pool_sanity_check)
+
+        log.info("Wait for rebooted hosts to come online")
+        timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=900)
+        while datetime.datetime.now() < timeout_time:
+            try:
+                for node in osd_nodes:
+                    assert rados_obj.check_host_status(hostname=node.hostname)
+                log.info("Rebooted hosts are up")
+                break
+            except AssertionError:
+                time.sleep(25)
+                if datetime.datetime.now() >= timeout_time:
+                    log.error(f"{node.hostname} status is still offline after 15 mins")
+                    return 1
         log.info(
-            f"Addition of OSD : {target_osd} back into the cluster was successful, and the health is good!"
+            "---- Completed workflows 2. Rolling Reboot OSD hosts and health check ----"
         )
 
-        utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=False)
+        log.info(
+            "---- Starting workflow ----\n---- 3. Stopping and starting OSD daemons ----"
+        )
+        for pool in pools:
+            target_osd = rados_obj.get_pg_acting_set(pool_name=pool)[0]
+            log.debug(f"Stopping OSD : {target_osd} and checking health status")
+            if not rados_obj.change_osd_state(action="stop", target=target_osd):
+                log.error(f"Unable to stop the OSD : {target_osd}")
+                raise Exception("Execution error")
 
-    log.info("---- Completed workflows 5. Removal and addition of OSD daemons ----")
+            # Waiting for recovery to post OSD stop
+            method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+            log.debug(
+                f"PG's are active + clean post OSD stop of {target_osd}, proceeding to start OSD"
+            )
 
-    log.info(
-        "---- Starting workflow ----\n---- 6. Removal and addition of OSD Hosts ----"
-    )
-    # Adding new hosts to the cluster
-    add_args = {
-        "command": "add_hosts",
-        "service": "host",
-        "args": {
-            "nodes": ["node12", "node13"],
-            "attach_address": True,
-            "labels": "apply-all-labels",
-        },
-    }
-    add_args.update(config)
+            log.debug(f"Starting OSD : {target_osd} and checking health status")
+            if not rados_obj.change_osd_state(action="start", target=target_osd):
+                log.error(f"Unable to start the OSD : {target_osd}")
+                raise Exception("Execution error")
 
-    ncount_pre = len(rados_obj.run_ceph_command(cmd="ceph orch host ls"))
-    deploy_host(ceph_cluster=ceph_cluster, config=add_args)
+            # Waiting for recovery to post OSD start
+            method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+            log.debug(
+                f"PG's are active + clean post OSD start of {target_osd}, proceeding to restart next OSD"
+            )
 
-    if not ncount_pre <= len(rados_obj.run_ceph_command(cmd="ceph orch host ls")):
-        log.error("New hosts are not added into the cluster")
-        raise Exception("Execution error")
+        log.info(
+            "Completed start and stop for all targeted OSDs. Checking cluster health"
+        )
+        # Checking cluster health after the tests
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info("--- Completed workflows 3. Stopping and starting OSD daemons ---")
 
-    log.info(
-        "New hosts added to the cluster successfully, Proceeding to deploy OSDs on the same."
-    )
-    # Deploying OSDs on the new nodes.
-    osd_args = {
-        "steps": [
-            {
-                "config": {
-                    "command": "apply_spec",
-                    "service": "orch",
-                    "validate-spec-services": True,
-                    "specs": [
-                        {
-                            "service_type": "osd",
-                            "service_id": "new_osds",
-                            "encrypted": "true",
-                            "placement": {"label": "osd-bak"},
-                            "spec": {"data_devices": {"all": "true"}},
-                        }
-                    ],
-                }
-            }
-        ]
-    }
-    osd_args.update(config)
-    ocount_pre = len(get_osd_details(node=cephadm))
-    add_osd(ceph_cluster=ceph_cluster, config=osd_args)
-    if not ocount_pre <= len(get_osd_details(node=cephadm)):
-        log.error("New OSDs were not added into the cluster")
-        raise Exception("Execution error")
+        log.info(
+            "---- Starting workflow ----\n---- 4. restart all OSD daemons belonging to single pg----"
+        )
+        for pool in pools:
+            pg_set = rados_obj.get_pg_acting_set(pool_name=pool)
+            log.debug(f"Acting set of OSDs for testing reboot are : {pg_set}")
+            for target_osd in pg_set:
+                log.debug(f"Restarting OSD : {target_osd} and checking health status")
+                if not rados_obj.change_osd_state(action="restart", target=target_osd):
+                    log.error(f"Unable to restart the OSD : {target_osd}")
+                    raise Exception("Execution error")
 
-    log.info("Deployed new hosts and deployed OSDs on them")
-    # Waiting for recovery to post OSD addition into cluster
-    method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-    log.debug("PG's are active + clean post OSD addition")
-
-    # Checking cluster health after the tests
-    method_should_succeed(rados_obj.run_pool_sanity_check)
-
-    log.info(
-        "Cluster is healthy post addition of New hosts and osds."
-        " Proceeding to remove one of the added host and it's OSDs"
-    )
-
-    # Removing newly added OSD host and checking status
-    rm_host_id = config.get("remove_host", "node13")
-    rm_host = get_node_by_id(ceph_cluster, rm_host_id)
-    log.info(f"Identified host : {rm_host.hostname} to be removed from the cluster")
-
-    # Starting to drain the host
-    drain_cmd = f"ceph orch host drain {rm_host.hostname}"
-    cephadm.shell([drain_cmd])
-    # Sleeping for 2 seconds for removal to have started
-    time.sleep(2)
-    log.debug(f"Started drain operation on node : {rm_host.hostname}")
-
-    status_cmd = "ceph orch osd rm status -f json"
-    end_time = datetime.datetime.now() + datetime.timedelta(seconds=3000)
-    flag = False
-    while end_time > datetime.datetime.now():
-        out, err = cephadm.shell([status_cmd])
-        try:
-            drain_ops = json.loads(out)
-            for entry in drain_ops:
+                # Waiting for recovery to post OSD restart
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj)
                 log.debug(
-                    f"Drain operations are going on host {rm_host.hostname} \nOperations: {entry}"
+                    f"PG's are active + clean post OSD restart of {target_osd}, proceeding to restart next OSD"
                 )
-        except json.JSONDecodeError:
-            log.info(f"Drain operations completed on host : {rm_host.hostname}")
-            flag = True
-            break
-        except Exception as error:
-            log.error(f"Hit issue during drain operations: {error}")
-            raise Exception(error)
-        log.debug("Sleeping for 10 seconds and checking again....")
-        time.sleep(10)
 
-    if not flag:
-        log.error(
-            "Drain operation not completed on the cluster even after 3000 seconds"
+        # Checking cluster health after the tests
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info(
+            "--- Completed workflows 4. restart OSD daemons belonging to single pg ---"
         )
-        raise Exception("Execution Error")
 
-    log.info(
-        f"Completed drain operation on the host. {rm_host.hostname}\n Removing host from the cluster"
-    )
-    time.sleep(5)
-    rm_cmd = f"ceph orch host rm {rm_host.hostname} --force"
-    cephadm.shell([rm_cmd])
-    time.sleep(5)
+        log.info(
+            "---- Starting workflow ----\n---- 5. Removal and addition of OSD daemons"
+        )
+        for pool in pools:
+            pg_set = rados_obj.get_pg_acting_set(pool_name=pool)
+            log.debug(f"Acting set for removal and addition of OSDs {pg_set}")
+            target_osd = pg_set[0]
+            host = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=target_osd)
 
-    # Checking if the host still exists on the cluster
-    ls_cmd = "ceph orch host ls"
-    hosts = rados_obj.run_ceph_command(cmd=ls_cmd)
-    for host in hosts:
-        if host["hostname"] == rm_host.hostname:
-            log.error(f"Host : {rm_host.hostname} still present on the cluster")
-            raise Exception("Host not removed error")
-    log.info(
-        f"Successfully removed host : {rm_host.hostname} from the cluster. Checking status after removal"
-    )
+            dev_path = get_device_path(host, target_osd)
+            log.debug(
+                f"osd device path  : {dev_path}, osd_id : {target_osd}, host.hostname : {host.hostname}"
+            )
 
-    # Waiting for recovery to post OSD host remove
-    method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-    log.debug("PG's are active + clean post OSD removal")
+            utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=True)
+            method_should_succeed(utils.set_osd_out, ceph_cluster, target_osd)
+            method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+            utils.osd_remove(ceph_cluster, target_osd)
+            method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+            method_should_succeed(
+                utils.zap_device, ceph_cluster, host.hostname, dev_path
+            )
+            method_should_succeed(wait_for_device, host, target_osd, action="remove")
 
-    # Checking cluster health after the tests
-    method_should_succeed(rados_obj.run_pool_sanity_check)
+            # Checking cluster health after OSD removal
+            method_should_succeed(rados_obj.run_pool_sanity_check)
+            log.info(
+                f"Removal of OSD : {target_osd} is successful. Proceeding to add back the OSD daemon."
+            )
 
-    log.info("---- Completed workflows 6. Removal and addition of OSD Hosts ----")
+            # Adding the removed OSD back and checking the cluster status
+            utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
+            method_should_succeed(wait_for_device, host, target_osd, action="add")
+            time.sleep(10)
 
-    log.info("Completed All the workflows")
-    return 0
+            # Checking cluster health after OSD removal
+            method_should_succeed(rados_obj.run_pool_sanity_check)
+            log.info(
+                f"Addition of OSD : {target_osd} back into the cluster was successful, and the health is good!"
+            )
+
+            utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=False)
+
+        log.info("---- Completed workflows 5. Removal and addition of OSD daemons ----")
+
+        log.info(
+            "---- Starting workflow ----\n---- 6. Removal and addition of OSD Hosts ----"
+        )
+        add_new_hosts()
+        # Waiting for recovery to post OSD addition into cluster
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        log.debug("PG's are active + clean post OSD addition")
+        # Checking cluster health after the tests
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info(
+            "Cluster is healthy post addition of New hosts and osds."
+            " Proceeding to remove one of the added host and it's OSDs"
+        )
+
+        # Removing newly added OSD host and checking status
+        remove_custom_host(host_node_name=config.get("remove_host", "node13"))
+        # Waiting for recovery to post OSD host remove
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        log.debug("PG's are active + clean post OSD removal")
+
+        # Checking cluster health after the tests
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info("---- Completed workflows 6. Removal and addition of OSD Hosts ----")
+
+        log.info("Completed All the workflows")
+        return 0
+    if config.get("osd_host_fail"):
+        log.info(
+            "---- Starting workflow ----\n---- 7. Replacement of a failed OSD host"
+        )
+        try:
+            osd_hosts = rados_obj.get_osd_hosts()
+            fail_host = get_node_by_id(ceph_cluster, osd_hosts[0])
+
+            # workflow to fail the host and make it offline
+            # Blocks all incoming traffic on selected OSD node, except for SSH
+            out, _ = installer_node.exec_command(
+                sudo=True, cmd=f"iptables -A INPUT -d {fail_host.ip_address} -j REJECT"
+            )
+            out, _ = installer_node.exec_command(
+                sudo=True, cmd=f"iptables -A OUTPUT -d {fail_host.ip_address} -j REJECT"
+            )
+
+            # smart wait to check the status of osd host
+            end_time = datetime.datetime.now() + datetime.timedelta(seconds=400)
+            while datetime.datetime.now() < end_time:
+                if rados_obj.check_host_status(hostname=osd_hosts[0], status="offline"):
+                    break
+                else:
+                    log.info(
+                        f"{osd_hosts[0]} is yet to become offline. Sleeping for 60 secs"
+                    )
+                    time.sleep(60)
+            else:
+                log.error(f"{osd_hosts[0]} is still Online after 8 mins.")
+                raise Exception(
+                    f"{osd_hosts[0]} should have been Offline, still Online after 8 mins."
+                )
+            log.info(f"{osd_hosts[0]} is offline as expected.")
+
+            # proceeding to remove the offline host
+            remove_offline_host(host_node_name=osd_hosts[0])
+
+            # adding new OSD host which will serve as replacement to the offline host
+            add_new_hosts(add_nodes=["node13"])
+
+            # Waiting for recovery to post OSD host addition
+            method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+            log.info("PG's are active + clean post OSD removal")
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            return 1
+        finally:
+            log.info("*********** Execution of finally block starts ***********")
+            # Flush iptables to reset the rules
+            out, _ = installer_node.exec_command(sudo=True, cmd="iptables -F")
+            # log.info(
+            #     f"----- Adding the failed OSD host {osd_hosts[0]} which was removed -------"
+            # )
+            # add_new_hosts(add_nodes=[osd_hosts[0]])
+            # # proceeding to remove the newly added OSD host
+            # log.info("----- Removing the newly added OSD host -------")
+            # remove_custom_host(host_node_name="node13")
+        return 0


### PR DESCRIPTION
Jira tracker: [RHCEPHQE-11384](https://issues.redhat.com/browse/RHCEPHQE-11384)
[CEPH-9408](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9408): Tier 4 test to replace a unhealthy / failed OSD host with a new one.

Test modules changed:
- tests/rados/test_pool_osd_recovery.py

Test suites modified:
- suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
- suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
- suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
- suites/pacific/tier-4_rados_tests.yaml
- suites/quincy/tier-4_rados_tests.yaml
- suites/reef/tier-4_rados_tests.yaml
- suites/reef/tier-2_rados_test-clay-ecpool.yaml

Steps:
1. Fetch all the OSD hosts part of the cluster
2. Choose any of the OSD host at random and add iptables rules to inhibit all traffic except ssh
3. Drain and remove the concerned host once it is reported as offline in the cluster status
4. Add a standby host as the new OSD host for the cluster
5. Wait for active+clean PGs
6. Flush the iptables rules on the removed OSD host and add it back

Include a TFA fix to change the list of nodes added as a host for tier-4 tests, previously node7 was being as host and client and node8 was not being part of the cluster, this was causing failures in basic RGW and CephFS tests.

Pass Logs:
Pacific:
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HAU5RB
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XJ6VL3
**tier-4_rados_tests.yaml**:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IHT9EL
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6SZR4X
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-D94X84
          http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VJ0PVQ
**tier-4_rados_test-pool-osd-recovery.yaml**:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NZFY4J
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5EY9AO
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4Y7JY0
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZCNNVH

Signed-off-by: Harsh Kumar <hakumar@redhat.com>