### PR TITLE
Reads Balancer: adding automation for offline tool

### DIFF
--- a/conf/pacific/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/pacific/rados/stretch-mode-host-location-attrs.yaml
@@ -12,13 +12,13 @@ globals:
           - _admin
           - installer
           - mon
-          - mgr
           - alertmanager
           - grafana
           - prometheus
       node2:
         role:
           - mon
+          - mgr
           - _admin
           - mds
           - osd
@@ -49,6 +49,7 @@ globals:
       node6:
         role:
           - mon
+          - mgr
           - osd
           - rgw
         no-of-volumes: 4

--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -12,13 +12,13 @@ globals:
           - _admin
           - installer
           - mon
-          - mgr
           - alertmanager
           - grafana
           - prometheus
       node2:
         role:
           - mon
+          - mgr
           - _admin
           - mds
           - osd
@@ -49,6 +49,7 @@ globals:
       node6:
         role:
           - mon
+          - mgr
           - osd
           - rgw
         no-of-volumes: 4

--- a/conf/reef/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/reef/rados/stretch-mode-host-location-attrs.yaml
@@ -12,13 +12,13 @@ globals:
           - _admin
           - installer
           - mon
-          - mgr
           - alertmanager
           - grafana
           - prometheus
       node2:
         role:
           - mon
+          - mgr
           - _admin
           - mds
           - osd
@@ -49,6 +49,7 @@ globals:
       node6:
         role:
           - mon
+          - mgr
           - osd
           - rgw
         no-of-volumes: 4

--- a/suites/reef/rados/tier-2_rados_test-clay-ecpool.yaml
+++ b/suites/reef/rados/tier-2_rados_test-clay-ecpool.yaml
@@ -58,7 +58,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        node: node8                       # client node
+        node: node7                       # client node
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -79,6 +79,7 @@ tests:
         node: node7                       # client node
         install_packages:
           - ceph-common
+          - ceph-base
         copy_admin_keyring: true          # Copy admin keyring to node
         caps: # authorize client capabilities
           mon: "allow *"
@@ -96,10 +97,55 @@ tests:
   - test:
       name: Test Reads Balancer
       module: test_reads_balancer.py
-      desc: Testing reads balancer functionality in RHCS
+      desc: Testing reads balancer online tool functionality in RHCS
       polarion-id: CEPH-83576078
       config:
         online_command_verification: true
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              rados_write_duration: 50
+              rados_read_duration: 30
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              rados_write_duration: 50
+              rados_read_duration: 30
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              rados_write_duration: 50
+              rados_read_duration: 30
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              rados_write_duration: 50
+              rados_read_duration: 30
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_2
+
+  - test:
+      name: Test Reads Balancer
+      module: test_reads_balancer.py
+      desc: Testing reads balancer offline tool functionality in RHCS
+      polarion-id: CEPH-83576079
+      config:
+        offline_command_verification: true
         create_pools:
           - create_pool:
               pool_name: rpool_1


### PR DESCRIPTION
1. Added methods and classes for verification of offline tool
2. Corrected Clay EC pool, reef suite to correct client node. - TFA
3. Increased timeouts for the stretch cluster, recovery tests. - TFA
4.  Updated the stretch cluster conf to include 4 mgr's, and removed mgr instance from arbiter node.
