### PR TITLE
Automation of the inconsistent pg test case(CEPH-9924)

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -104,7 +104,23 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
-
+  - test:
+      name: Inconsistent object pg check
+      desc: Inconsistent object pg check
+      module: test_osd_inconsistency_pg.py
+      polarion-id: CEPH-9924
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
   - test:
       name: OMAP feature
       desc: Testing omap features

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -104,7 +104,23 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
-
+  - test:
+      name: Inconsistent object pg check
+      desc: Inconsistent object pg check
+      module: test_osd_inconsistency_pg.py
+      polarion-id: CEPH-9924
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
   - test:
       name: OMAP feature
       desc: Testing omap features

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -104,7 +104,23 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
-
+  - test:
+      name: Inconsistent object pg check
+      desc: Inconsistent object pg check
+      module: test_osd_inconsistency_pg.py
+      polarion-id: CEPH-9924
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
   - test:
       name: OMAP feature
       desc: Testing omap features

--- a/tests/rados/test_osd_inconsistency_pg.py
+++ b/tests/rados/test_osd_inconsistency_pg.py
@@ -1,0 +1,82 @@
+"""
+This file contains the  methods to verify the  inconsistent objects.
+AS part of verification the script  perform the following tasks-
+   1. Creating omaps
+   2. Convert the object in to inconsistent object
+"""
+
+
+import random
+import traceback
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from utility.log import Log
+from utility.utils import method_should_succeed
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test to create an inconsistent object and verify that objects details can  retrieve with various command.
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    pool_target_configs = config["verify_osd_omap_entries"]["configurations"]
+    omap_target_configs = config["verify_osd_omap_entries"]["omap_config"]
+    try:
+        # Creating pools and starting the test
+        for entry in pool_target_configs.values():
+            log.debug(
+                f"Creating {entry['pool_type']} pool on the cluster with name {entry['pool_name']}"
+            )
+            method_should_succeed(
+                rados_obj.create_pool,
+                **entry,
+            )
+            pool_name = entry["pool_name"]
+            log.info(
+                f"Created the pool {entry['pool_name']}. beginning to create large number of omap entries on the pool"
+            )
+        # Creating omaps
+        if not pool_obj.fill_omap_entries(pool_name=pool_name, **omap_target_configs):
+            log.error(f"Omap entries not generated on pool {pool_name}")
+            return 1
+        obj_list = rados_obj.get_object_list(pool_name)
+        oname = random.choice(obj_list)
+        # Create inconsistency objects
+        pg_id = rados_obj.create_inconsistent_object(pool_name, oname)
+        inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
+        if any(pg_id in search for search in inconsistent_pg_list):
+            log.info(f"Inconsistent PG is{pg_id}  ")
+        else:
+            log.error("Inconsistent PG is not generated")
+            return 1
+        # checking the  inconsistent objects
+        object_list = rados_obj.get_inconsistent_object_details(pg_id)
+        no_objects = len(object_list["inconsistents"])
+        for obj_count in range(no_objects):
+            obj_id = object_list["inconsistents"][obj_count]["object"]["name"]
+            if obj_id == oname:
+                log.info(f"Inconsistent object {obj_id} is exists in the objects list.")
+            else:
+                log.error("Inconsistent object is not exists in the objects list")
+                return 1
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Execution of finally block")
+        if config.get("delete_pool"):
+            method_should_succeed(rados_obj.detete_pool, pool_name)
+            log.info("deleted the pool successfully")
+    return 0


### PR DESCRIPTION
#  Alter an existing entry(key or value) of a replica using ceph-objectstore-tool and check list-inconsistent-obj
The manual steps are updated at - 
https://docs.google.com/document/d/1dbK1inAWCuOc31021EPIp8M-dWDriPIqP_sZnmxeda0/edit?usp=sharing

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
