### PR TITLE
remove abort-on-fail flag to allow rest of the tests to run

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -212,9 +212,8 @@ tests:
 
 # Bucket generation verify
   - test:
-      name: Bucket generaion verification
-      desc: Bucket generaion verification
-      abort-on-fail: true
+      name: Bucket generation verification
+      desc: Bucket generation verification
       module: sanity_rgw_multisite.py
       polarion-id: CEPH-83574423
       clusters:
@@ -228,7 +227,6 @@ tests:
   - test:
       name: Disable DBR feature on zonegroup
       desc: Disable DBR feature on zonegroup
-      abort-on-fail: true
       module: sanity_rgw_multisite.py
       polarion-id: CEPH-83574626
       clusters:
@@ -241,7 +239,6 @@ tests:
   - test:
       name: Re-enable DBR feature on cluster and Verify
       desc: Re-enable DBR feature on cluster an verify
-      abort-on-fail: true
       module: sanity_rgw_multisite.py
       polarion-id: CEPH-83573596
       clusters:


### PR DESCRIPTION
# Description
Removing the  flag abort-on-fail = true, to allow all the tests in the suite to execute 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
