### PR TITLE
Adding skipped in xunit files

### DIFF
--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -1,7 +1,15 @@
 """Create xUnit result files."""
 from datetime import timedelta
 
-from junitparser import Failure, JUnitXml, Properties, Property, TestCase, TestSuite
+from junitparser import (
+    Failure,
+    JUnitXml,
+    Properties,
+    Property,
+    Skipped,
+    TestCase,
+    TestSuite,
+)
 
 from utility.log import Log
 
@@ -29,7 +37,11 @@ def generate_test_case(
     else:
         test_case.time = 0.0
 
-    if status != "Pass":
+    if status == "Pass":
+        pass  # Test passed, no need to add Failure or Skipped
+    elif status == "Skipped":
+        test_case.result = [Skipped()]
+    else:
         _result = Failure(err_msg, err_type)
         _result.text = err_text
         test_case.result = [_result]


### PR DESCRIPTION
# Description
Adding skipped in xunit files

This is to support skipped and add those as skipped count while generating the xunit files

Logs : http://10.70.46.85:8080/job/qe-reef-rbd-baremetal/8/ 

Xunit files : http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/baremetal/18.2.0-44/rbd/8/tier-2_rbd_regression/xunit.xml

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
