### PR TITLE
modify sanity suite to remove known failures

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -435,3 +435,27 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
             timeout: 300
+  - test:
+      name: listing flat ordered buckets on secondary
+      desc: test_bucket_listing_flat_ordered on secondary
+      polarion-id: CEPH-83574826
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_flat_ordered.yaml
+            monitor-consistency-bucket-stats: true
+            timeout: 300
+  - test:
+      name: listing pseudo ordered dir only buckets on secondary
+      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
+      polarion-id: CEPH-83573651
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_listing.py
+            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            monitor-consistency-bucket-stats: true
+            timeout: 300

--- a/suites/reef/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/reef/rgw/tier-1_rgw_multisite.yaml
@@ -313,42 +313,6 @@ tests:
       name: Manual Resharding tests on Primary cluster
       polarion-id: CEPH-83574734
   - test:
-      name: listing flat ordered buckets on secondary
-      desc: test_bucket_listing_flat_ordered on secondary
-      polarion-id: CEPH-83574826
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered.yaml
-            monitor-consistency-bucket-stats: true
-            timeout: 300
-  - test:
-      name: listing pseudo ordered dir only buckets on secondary
-      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
-      polarion-id: CEPH-83573651
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            monitor-consistency-bucket-stats: true
-            timeout: 300
-  - test:
-      name: ordered listing of bucket with pseudo directories and objects
-      desc: measure execution time for ordered listing of bucket with pseudo directories and objects
-      polarion-id: CEPH-83573545
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered.yaml
-            monitor-consistency-bucket-stats: true
-            timeout: 300
-  - test:
       name: setting acls to versioned objects on secondary
       desc: test_versioning_objects_acls on secondary
       polarion-id: CEPH-9190
@@ -432,15 +396,3 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
             timeout: 300
 
-  - test:
-      name: Delete object version with id null
-      desc: test_delete_object_version_id_null
-      polarion-id: CEPH-83576431
-      comments: Known issue BZ-1967576
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: ../aws/test_delete_version_id_null.py
-            config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
-            timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -340,6 +340,20 @@ tests:
       module: sanity_rgw_multisite.py
       name: Perform zone deletion in master
       polarion-id: CEPH-10753
+
+  - test:
+      name: Delete object version with id null
+      desc: test_delete_object_version_id_null
+      polarion-id: CEPH-83576431
+      comments: Known issue BZ-1967576
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../aws/test_delete_version_id_null.py
+            config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
+            timeout: 300
+
   # Inlcude before this tc
   - test:
       clusters:


### PR DESCRIPTION
# Description
Modify sanity suite to remove the known failures.
1.  listing tests are already part of suite - [reef/rgw/tier-1_rgw_ms_ecpool_regression_test]( https://github.com/red-hat-storage/cephci/blob/master/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml#L404) 
2. Version-id test is added to tier-2_rgw_ms_regression_test.yaml
 
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
