### PR TITLE
Fix for tfa failure tier-2-osd-scenarios.yaml

### DIFF
--- a/suites/quincy/cephadm/tier-2-osd-scenarios.yaml
+++ b/suites/quincy/cephadm/tier-2-osd-scenarios.yaml
@@ -141,7 +141,7 @@ tests:
       module: test_osd_memory_target.py
       config:
         hosts:
-            - node2
+            - node3
         value: 8888888888
       polarion-id: CEPH-83575349
       abort-on-fail: true

--- a/tests/cephadm/test_osd_memory_target.py
+++ b/tests/cephadm/test_osd_memory_target.py
@@ -33,7 +33,7 @@ def run(ceph_cluster, **kw):
     hostname = node[0].shortname
     log.info("Setting the memory target on host")
     cephadm.ceph.config.set(
-        key="osd_memory_target", value=value, daemon="osd/host:{hostname}"
+        key="osd_memory_target", value=value, daemon=f"osd/host:{hostname}"
     )
     log.info(f"Memory target is set on host '{hostname}' : '{value}'")
 

--- a/tests/cephadm/test_replace_osd.py
+++ b/tests/cephadm/test_replace_osd.py
@@ -27,7 +27,7 @@ def verify_osd_state(cephadm, osd_id, state):
         log.info(f"OSD '{osd_id}' is not in '{state}' state. Retrying")
     if w.expired:
         raise OsdOperationError(
-            f"Failed to get OSD osd '{osd_id}' in '{state}' state within '{interval}' sec"
+            f"Failed to get OSD osd '{osd_id}' in '{state}' state within '{timeout}' sec"
         )
 
 
@@ -39,7 +39,7 @@ def run(ceph_cluster, **kw):
 
     # Replace OSD
     osd_id_list = replace_config.get("pos_args", [])
-    kw = {"--replace": True}
+    kw = {"replace": True}
     node_name_list = replace_config.get("nodes", [])
     if not node_name_list or not osd_id_list or not osd_id_list[0]:
         raise OsdOperationError("Missing node or OSD ID for replace OSD test")


### PR DESCRIPTION
# Description

Fix for tfa failure tier-2-osd-scenarios.yaml
![image](https://github.com/red-hat-storage/cephci/assets/83664366/ec952399-615f-4d98-bfd7-2c40d045e8ef)

http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-146/Weekly/dmfg/9/tier-2-osd-scenarios/

pass log - http://magna002.ceph.redhat.com/ceph-qe-logs/cephci-run-O5NFVV/