### PR TITLE
removing & adding the v1 acls test from ssl_env to non_ssl_env

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -446,6 +446,18 @@ tests:
         config-file-name: test_acls_reset.yaml
         timeout: 300
 
+  - test:
+      name: test acls on all users
+      desc: Test acls on all users
+      polarion-id: CEPH-14240 # also applies to CEPH-14241
+      module: sanity_rgw.py
+      config:
+        test-version: v1
+        run-on-rgw: true
+        script-name: test_acls_all_usrs.py
+        config-file-name: test_acls_all_usrs.yaml
+        timeout: 300
+
   # multipart test
   - test:
       name: multipart upload cancel reupload

--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -256,18 +256,6 @@ tests:
         timeout: 300
 
   - test:
-      name: test acls on all users
-      desc: Test acls on all users
-      polarion-id: CEPH-14240 # also applies to CEPH-14241
-      module: sanity_rgw.py
-      config:
-        test-version: v1
-        run-on-rgw: true
-        script-name: test_acls_all_usrs.py
-        config-file-name: test_acls_all_usrs.yaml
-        timeout: 300
-
-  - test:
       name: Test single delete marker for versioned object using LC
       desc: Test single delete marker for versioned object using LC
       polarion-id: CEPH-83574806


### PR DESCRIPTION
# Description

Removing & adding the V1 acls tests from ssl env to non ssl env. 
Pass log from non_ssl_env - http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/test_acls_all_usrs_console.log 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
