### PR TITLE
Added fips test case

### DIFF
--- a/suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml
@@ -225,3 +225,36 @@ tests:
       module: test_ceph_nvmeof_gateway.py
       name: Basic E2ETest Ceph NVMEoF GW sanity test
       polarion-id: CEPH-83575441
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - intiators
+          - pool
+          - gateway
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5001
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 5001
+            node: node7
+      desc: E2E-Test NVMEoF Gateway collocated and Run IOs on targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Basic E2ETest Ceph NVMEoF GW sanity test
+      polarion-id: CEPH-83577610


### PR DESCRIPTION
Enable FIPS mode on nvme sanity test suite

```
$ for i in 10.0.210.68 10.0.211.27 10.0.210.217 10.0.211.169 10.0.210.253 10.0.211.23 10.0.209.107 ; do echo --------$i-------------; ssh $i "fips-mode-setup --check; sudo  cat /proc/sys/crypto/fips_enabled"; done
--------10.0.210.68-------------
Warning: Permanently added '10.0.210.68' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1
--------10.0.211.27-------------
Warning: Permanently added '10.0.211.27' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1
--------10.0.210.217-------------
Warning: Permanently added '10.0.210.217' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1
--------10.0.211.169-------------
Warning: Permanently added '10.0.211.169' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1
--------10.0.210.253-------------
Warning: Permanently added '10.0.210.253' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1
--------10.0.211.23-------------
Warning: Permanently added '10.0.211.23' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1
--------10.0.209.107-------------
Warning: Permanently added '10.0.209.107' (ECDSA) to the list of known hosts.
FIPS mode is enabled.
1


All test logs located here: /tmp/cephci-run-BXYRJL

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:07:12.793455                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm                          0:15:24.723970                   Pass                             
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:01:03.277150                   Pass                             
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:03:08.478915                   Pass                             
Manage nvmeof gateway entities   Manage NVMeoF Subsystem entities                               0:01:06.752142                   Pass                             
Delete nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:48.378123                   Pass                             
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:53.662604                   Pass                             
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway collocated and Run IOs on targets      0:24:30.179026                   Pass   
```
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BXYRJL/
