### PR TITLE
[tfa]: change to sanity_multisite test in suite tier-2_rgw_ms_async_data_notification.yaml

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -371,7 +371,7 @@ tests:
         config-file-name: test_sse_s3_per_object.yaml
         timeout: 300
       desc: test_sse_s3_per_object
-      module: sanity_rgw.py
+      module: sanity_rgw_multisite.py
       name: sse-s3 per object encryption test
       polarion-id: CEPH-83575153
 
@@ -394,7 +394,7 @@ tests:
         config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
         timeout: 300
       desc: sse_s3_per_bucket_enc_multipart_upload
-      module: sanity_rgw.py
+      module: sanity_rgw_multisite.py
       name: sse_s3_per_bucket_enc_multipart_upload
       polarion-id: CEPH-83575155
       comments: known issue (bz-2153452)
@@ -456,7 +456,7 @@ tests:
         config-file-name: test_sse_kms_per_object.yaml
         timeout: 300
       desc: test_sse_kms_per_object
-      module: sanity_rgw.py
+      module: sanity_rgw_multisite.py
       name: test_sse_kms_per_object
       polarion-id: CEPH-83574040
 


### PR DESCRIPTION
# Description
Change to sanity_multisite test in suite https://github.com/red-hat-storage/cephci/blob/master/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml  

The tests have failed looking for user_details.json file. 
Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-81/Weekly/rgw/9/tier-2_rgw_ms_async_data_notification/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
