### PR TITLE
[Nfs][TestFix] Fix pynfs test

### DIFF
--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -50,7 +50,7 @@ def run(ceph_cluster, **kw):
         cmd = (
             f"python3 -m pip install ply;cd {nfs_mount};git clone git://linux-nfs.org/~bfields/pynfs.git;cd pynfs;-- "
             f"yes |"
-            f"python setup.py build;cd nfs{version};./testserver.py {nfs_server_name}:{nfs_export} -v --outfile "
+            f"python setup.py build;cd nfs{version};./testserver.py {nfs_server_name}:{nfs_export}_0 -v --outfile "
             f"~/pynfs.run --maketree --showomit --rundep all"
         )
 


### PR DESCRIPTION
Issue:
The pynfs requires the export path to be specified, since with the recent changes, there has been a change in the nfs export path and this caused the pynfs tests to fail

Solution:
Update the export path as per the new format

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
