### PR TITLE
Remove client evict test flag from pacific

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml
@@ -115,15 +115,6 @@ tests:
                 - max_mds
                 - "2"
               command: shell
-          - config:
-              args:
-                - ceph
-                - config
-                - set
-                - mds
-                - defer_client_eviction_on_laggy_osds
-                - "false"
-              command: shell
       destroy-cluster: false
       abort-on-fail: true
   -

--- a/suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-nfs.yaml
@@ -102,15 +102,6 @@ tests:
                 - max_mds
                 - "2"
               command: shell
-          - config:
-              args:
-                - ceph
-                - config
-                - set
-                - mds
-                - defer_client_eviction_on_laggy_osds
-                - "false"
-              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false


### PR DESCRIPTION
# Description

Removed client evict test flag from pacific suites path for nfs and test-clients suites as now we have copy of test suites in reef path and this flag is applicable to reef only.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
