### PR TITLE
[tfa] reduce the latency variance to avoid read timeouts

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -31,7 +31,7 @@ tests:
           config:
             roles:
               - rgw
-            rule: root netem delay 30ms 6ms distribution normal
+            rule: root netem delay 30ms 1ms distribution normal
         ceph-sec:
           config:
             roles:


### PR DESCRIPTION
# Description
Reduce latency variance to avoid read timeouts.
Pass log:  http://magna002.ceph.redhat.com/ceph-qe-logs/madhavi/PRs/latency/sharding.log 

Failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-81/Weekly/rgw/9/tier-1_rgw_ms_ecpool_regression_test/test_sharding_on_primary_0.log 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
