### PR TITLE
Test to check "require-osd-release" warning generated on cluster 

### DIFF
--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -63,7 +63,7 @@ globals:
         disk-size: 25
       node8:
         image-name:
-          openstack: RHEL-9.2.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
+          openstack: RHEL-8.8.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
         role:
           - client

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -19,10 +19,13 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-          custom_repo: "cdn"
+          rhcs-version: 5.3
+          release: rc
           mon-ip: node1
           orphan-initial-daemons: true
+          registry-url: registry.redhat.io
           skip-monitoring-stack: true
+          registry-json: registry.redhat.io
           skip-dashboard: true
           ssh-user: cephuser
           apply-spec:
@@ -135,7 +138,7 @@ tests:
         id: client.1                      # client Id (<type>.<Id>)
         nodes:
           - node8:
-              release: 6
+              release: 5
         install_packages:
           - ceph-common
           - ceph-base
@@ -214,22 +217,10 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
-      name: Upgrade ceph
-      desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83574982
-      config:
-        command: start
-        service: upgrade
-        base_cmd_args:
-          verbose: true
-        benchmark:
-          type: rados                      # future-use
-          pool_per_client: true
-          pg_num: 128
-          duration: 10
-        verify_cluster_health: true
-      destroy-cluster: false
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       abort-on-fail: true
 
   # Running basic rbd and rgw tests after upgrade

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -19,7 +19,7 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-          rhcs-version: 6.1
+          rhcs-version: 5.3
           release: rc
           mon-ip: node1
           orphan-initial-daemons: true
@@ -138,7 +138,7 @@ tests:
         id: client.1                      # client Id (<type>.<Id>)
         nodes:
           - node8:
-              release: 6
+              release: 5
         install_packages:
           - ceph-common
           - ceph-base
@@ -167,7 +167,6 @@ tests:
         tiebreaker_mon_site_name: arbiter
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
-
 
   - test:
       name: rbd-io
@@ -217,22 +216,10 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
-      name: Upgrade ceph
-      desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83574982
-      config:
-        command: start
-        service: upgrade
-        base_cmd_args:
-          verbose: true
-        benchmark:
-          type: rados                      # future-use
-          pool_per_client: true
-          pg_num: 128
-          duration: 10
-        verify_cluster_health: true
-      destroy-cluster: false
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       abort-on-fail: true
 
   # Running basic rbd and rgw tests after upgrade

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -1,0 +1,105 @@
+"""
+Module to check for the warning "OSD_UPGRADE_FINISHED" during upgrades
+
+"""
+
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.ceph_admin.orch import Orch
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test to check if the warning "OSD_UPGRADE_FINISHED" is generated when "require_osd_release" does ot match
+    the current release during upgrades.
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm_obj = CephAdmin(cluster=ceph_cluster, **config)
+    cluster_obj = Orch(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm_obj)
+
+    log.debug("Starting upgrade")
+    try:
+        cluster_obj.set_tool_repo()
+        time.sleep(5)
+        cluster_obj.install()
+        time.sleep(5)
+
+        # Check service versions vs available and target containers
+        cluster_obj.upgrade_check(image=config.get("container_image"))
+
+        ceph_version = rados_obj.run_ceph_command(cmd="ceph version")
+        log.info(f"Current version on the cluster : {ceph_version}")
+
+        # Start Upgrade
+        config.update({"args": {"image": "latest"}})
+        cluster_obj.start_upgrade(config)
+        time.sleep(5)
+
+        warn_flag = False
+        upgrade_complete = False
+        # Monitor upgrade status, till completion, checking for the warning to be generated
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=14400)
+        while end_time > datetime.datetime.now():
+            cmd = "ceph orch upgrade status"
+            out = rados_obj.run_ceph_command(cmd=cmd, client_exec=True)
+
+            if not out["in_progress"]:
+                log.info("Upgrade Complete...")
+                upgrade_complete = True
+                break
+
+            log.debug(f"upgrade in progress. Status : {out}")
+            if not warn_flag:
+                status_report = rados_obj.run_ceph_command(
+                    cmd="ceph report", client_exec=True
+                )
+                ceph_health_status = list(status_report["health"]["checks"].keys())
+                expected_health_warns = "OSD_UPGRADE_FINISHED"
+                if expected_health_warns in ceph_health_status:
+                    warn_flag = True
+                    log.info(
+                        f"We have the expected health warning generated on the cluster.\n "
+                        f"Warnings on cluster: {ceph_health_status}"
+                    )
+                    out = rados_obj.run_ceph_command(cmd="ceph health detail")
+                    log.info(f"\n\nHealth detail on the cluster :\n {out}\n\n")
+                else:
+                    log.debug(
+                        "expected health warning not yet generated on the cluster."
+                        f" health_warns on cluster : {ceph_health_status}"
+                    )
+        if not warn_flag:
+            log.error("expected warning not generated on the cluster. Fail")
+            raise Exception("Warning not raised")
+
+        if not upgrade_complete:
+            log.error("Upgrade was not completed on the cluster. Fail")
+            raise Exception("Upgrade not complete")
+
+        status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)
+        ceph_health_status = list(status_report["health"]["checks"].keys())
+        expected_health_warns = "OSD_UPGRADE_FINISHED"
+        if expected_health_warns in ceph_health_status:
+            log.error(
+                "Warning about the mismatched release present on the cluster. Fail. "
+            )
+            out = rados_obj.run_ceph_command(cmd="ceph health detail")
+            log.error(f"\n\nHealth detail on the cluster :\n {out}\n\n")
+            raise Exception("Warning present post upgrade")
+
+        log.info("Warning about the mismatched release found on cluster. Pass. ")
+        log.info("Completed upgrade on the cluster")
+        return 0
+    except Exception as e:
+        log.error(f"Could not upgrade the cluster. error : {e}")
+        return 1


### PR DESCRIPTION
Test added to check the health warning generated when the "require-osd-release" does not match the current release during upgrades.

