### PR TITLE
[Nfs-Ganesha][Failover][Automation]Add new sceanrio

### DIFF
--- a/suites/reef/nfs/tier1-nfs-ganesha-ha.yaml
+++ b/suites/reef/nfs/tier1-nfs-ganesha-ha.yaml
@@ -313,3 +313,30 @@ tests:
         servers: 3
         ha: true
         vip: 10.8.130.255/21
+
+  - test:
+      name: Nfs-Ganesha perform failover when linux untar is running
+      module: nfs_ha_failover_with_untar.py
+      desc:  Nfs-Ganesha perform failover when linux untar is running
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 1
+        servers: 3
+        ha: true
+        vip: 10.8.129.133/21
+
+  - test:
+      name: Nfs-Ganesha perform failover and delete the export, check the export list
+      module: nfs_ha_failover_delete_export.py
+      desc:  Nfs-Ganesha perform failover and delete the export and when failback happens check the export list
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 1
+        no_export_per_client: 10
+        servers: 3
+        ha: true
+        vip: 10.8.129.133/21

--- a/tests/nfs/nfs_ha_failover_delete_export.py
+++ b/tests/nfs/nfs_ha_failover_delete_export.py
@@ -1,0 +1,101 @@
+from threading import Thread
+from time import sleep
+
+from nfs_operations import perform_failover
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def delete_export(client, nfs_name, nfs_export, total_export):
+    for i in range(0, total_export):
+        try:
+            Ceph(client).nfs.export.delete(nfs_name, f"{nfs_export}_{i}")
+            sleep(1)
+        except Exception:
+            raise OperationFailedError(f"Fail to delete {nfs_export}_{i}")
+
+
+def run(ceph_cluster, **kw):
+    """Perform failover when linux untar is running
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+    no_clients = int(config.get("clients", "1"))
+    no_servers = int(config.get("servers", "3"))
+    no_export_per_client = int(config.get("no_export_per_client", "10"))
+    ha = bool(config.get("ha", False))
+    vip = config.get("vip", None)
+    total_export = no_clients * no_export_per_client
+
+    # If the setup doesn't have required number of clients, exit.
+    if no_clients > len(clients):
+        raise ConfigError("The test requires more clients than available")
+
+    # If the setup doesn't have required number of nfs server, exit.
+    if no_servers > len(nfs_nodes):
+        raise ConfigError("The test requires more servers than available")
+
+    clients = clients[:no_clients]
+    servers = nfs_nodes[:no_servers]
+    fs_name = "cephfs"
+    nfs_name = "cephfs-nfs"
+    nfs_export = "/export"
+    fs = "cephfs"
+    nfs_server_name = [nfs_node.hostname for nfs_node in servers]
+
+    try:
+        # Setup nfs cluster
+        Ceph(clients[0]).mgr.module(action="enable", module="nfs", force=True)
+        Ceph(clients[0]).nfs.cluster.create(
+            name=nfs_name, nfs_server=nfs_server_name, ha=ha, vip=vip
+        )
+        for i in range(0, total_export):
+            Ceph(clients[0]).nfs.export.create(
+                fs_name=fs_name,
+                nfs_name=nfs_name,
+                nfs_export=f"{nfs_export}_{i}",
+                fs=fs,
+            )
+            log.info(f"Export: {nfs_export}_{i} successfuly created")
+            sleep(3)
+
+        # Delete all exports
+        th = Thread(
+            target=delete_export,
+            args=(
+                clients[0],
+                nfs_name,
+                nfs_export,
+                total_export,
+            ),
+        )
+        th.start()
+
+        # Perfrom and verify failover
+        failover_node = nfs_nodes[0]
+        perform_failover(nfs_nodes, failover_node, vip)
+
+        # Wait to complete delete export
+        th.join()
+
+        # Check export
+        out = (
+            clients[0]
+            .exec_command(cmd=f"ceph nfs export ls {nfs_name}", sudo=True)[0]
+            .strip()
+        )
+        if out != "[]":
+            raise OperationFailedError("All export not deleted")
+            return 1
+
+    except Exception as e:
+        log.error(f"Error : {e}")
+        return 1
+    return 0

--- a/tests/nfs/nfs_ha_failover_with_untar.py
+++ b/tests/nfs/nfs_ha_failover_with_untar.py
@@ -1,0 +1,88 @@
+from threading import Thread
+from time import sleep
+
+from nfs_operations import cleanup_cluster, perform_failover, setup_nfs_cluster
+
+from cli.exceptions import ConfigError
+from cli.io.io import linux_untar
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Perform failover when linux untar is running
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+    port = config.get("port", "2049")
+    version = config.get("nfs_version", "4.1")
+    no_clients = int(config.get("clients", "1"))
+    no_servers = int(config.get("servers", "3"))
+    ha = bool(config.get("ha", False))
+    vip = config.get("vip", None)
+
+    # If the setup doesn't have required number of clients, exit.
+    if no_clients > len(clients):
+        raise ConfigError("The test requires more clients than available")
+
+    # If the setup doesn't have required number of nfs server, exit.
+    if no_servers > len(nfs_nodes):
+        raise ConfigError("The test requires more servers than available")
+
+    clients = clients[:no_clients]
+    servers = nfs_nodes[:no_servers]
+    fs_name = "cephfs"
+    nfs_name = "cephfs-nfs"
+    nfs_export = "/export"
+    nfs_mount = "/mnt/nfs"
+    fs = "cephfs"
+    nfs_server_name = [nfs_node.hostname for nfs_node in servers]
+
+    try:
+        # Setup nfs cluster
+        setup_nfs_cluster(
+            clients,
+            nfs_server_name,
+            port,
+            version,
+            nfs_name,
+            nfs_mount,
+            fs_name,
+            nfs_export,
+            fs,
+            ha,
+            vip,
+        )
+
+        sleep(3)
+
+        # Linux untar on client 1
+        th = Thread(
+            target=linux_untar,
+            args=(
+                clients[0],
+                nfs_mount,
+            ),
+        )
+        th.start()
+
+        # Perfrom and verify failover
+        failover_node = nfs_nodes[0]
+        perform_failover(nfs_nodes, failover_node, vip)
+
+        # Wait to complete linux untar
+        th.join()
+
+    except Exception as e:
+        log.error(f"Error : {e}")
+        return 1
+    finally:
+        log.info("Cleaning up")
+        sleep(100)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        log.info("Cleaning up successfull")
+    return 0


### PR DESCRIPTION
[Nfs-Ganesha][Failover][Automation]Add new sceanrio
Scenarios:
1. Nfs-Ganesha perform failover when linux untar is running
2. Nfs-Ganesha perform failover and delete the export and when failback happens check the export list