### PR TITLE
Updating relaese for 5.3 deployment for archive cluster

### DIFF
--- a/suites/quincy/rgw/tier-1_rgw_ms_archive_test-upgrade-5-to-latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_ms_archive_test-upgrade-5-to-latest.yaml
@@ -113,7 +113,7 @@ tests:
                   service: cephadm
                   args:
                     rhcs-version: 5.3
-                    release: ga
+                    release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true


### PR DESCRIPTION
# Description
In http://magna002.ceph.redhat.com/cephci-jenkins/latest-rhceph-container-info/RHCEPH-5.3.yaml, we dont have ga key, so tc failed with error: utility.utils.TestSetupFailure: Could not fetch build details of : 'ga'

failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-147/Weekly/rgw/12/tier-1_rgw_ms_archive_test-upgrade-5-to-latest/deploy_cluster_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
