### PR TITLE
Addition of test suite for EC2+2@4

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1628,17 +1628,13 @@ class RadosOrchestrator:
                 "PG_AVAILABILITY",
                 "PG_DEGRADED",
                 "PG_RECOVERY_FULL",
-                "TOO_FEW_OSDS",
                 "PG_BACKFILL_FULL",
                 "PG_DAMAGED",
                 "OSD_SCRUB_ERRORS",
                 "OSD_TOO_MANY_REPAIRS",
                 "CACHE_POOL_NEAR_FULL",
-                "SMALLER_PGP_NUM",
-                "MANY_OBJECTS_PER_PG",
                 "OBJECT_MISPLACED",
                 "OBJECT_UNFOUND",
-                "SLOW_OPS",
                 "RECENT_CRASH",
             )
 
@@ -1665,6 +1661,28 @@ class RadosOrchestrator:
             return False
 
         log.info("Completed check on the cluster. Pass!")
+        return True
+
+    def check_inactive_pgs_on_pool(self, pool_name) -> bool:
+        """
+        Method to check if the provided pool has any PGs in inactive state
+
+        Args:
+            pool_name: Name of the pool, on which inactive PGs should be checked
+
+        Returns: True-> Pass,  false -> Fail
+        """
+        log.debug(f"Checking for inactive PGs on pool : {pool_name}")
+        pool_pgids = self.get_pgid(pool_name=pool_name)
+        for pgid in pool_pgids:
+            # Checking the PG state. There Should not be inactive state
+            pg_state = self.get_pg_state(pg_id=pgid)
+            if any("inactive" in key for key in pg_state.split("+")):
+                log.error(f"PG: {pgid} in inactive state)")
+                return False
+        log.info(
+            f"Completed checking for inactive PGs on Pool : {pool_name}. No inactive PGs found"
+        )
         return True
 
     def get_osd_hosts(self):

--- a/suites/pacific/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -158,6 +158,9 @@ tests:
       desc: Perform rgw tests
 
   - test:
+      name: Compression test - EC pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
       config:
         Compression_tests:
           pool_type: erasure
@@ -174,7 +177,7 @@ tests:
           compression_config:
             compression_mode: aggressive
             compression_algorithm: snappy
-            compression_required_ratio: 0.3
+            compression_required_ratio: 0.7
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on erasure coded pools

--- a/suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -159,6 +159,9 @@ tests:
       desc: Perform rgw tests
 
   - test:
+      name: Compression test - EC pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
       config:
         Compression_tests:
           pool_type: erasure
@@ -175,7 +178,7 @@ tests:
           compression_config:
             compression_mode: aggressive
             compression_algorithm: snappy
-            compression_required_ratio: 0.3
+            compression_required_ratio: 0.7
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on erasure coded pools

--- a/suites/reef/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/reef/rados/deploy-stretch-cluster-mode.yaml
@@ -24,6 +24,7 @@
 #       - site3:
 #              name: "DC3"                           # Name of the Arbiter location to be added in crush map
 #              hosts: ["<host5-shortname>"]          # List of hostname present in Arbiter
+# Added to BM pipeline
 
 tests:
   - test:
@@ -45,7 +46,7 @@ tests:
               base_cmd_args:
                 verbose: true
               args:
-                mon-ip: <bootstrap-mon-shortname>
+                mon-ip: mero001
                 orphan-initial-daemons: true
                 allow-fqdn-hostname: true
           - config:
@@ -86,12 +87,28 @@ tests:
                   encrypted: "true"                     # boolean as string
                   placement:
                     nodes:
-                      - <host3-shortname>
-                      - <host4-shortname>
+                      - mero005
+                      - mero007
+                      - mero009
+                      - mero011
+                      - mero013
+                      - mero014
+                      - mero017
+                      - mero018
+                      - mero019
+                      - mero020
                   spec:
                     data_devices:
-                      all: "true"                         # boolean as string
-
+                      paths:
+                        - /dev/sdc
+                        - /dev/sdd
+                        - /dev/sde
+                        - /dev/sdf
+                        - /dev/sdg
+                        - /dev/sdh
+                    db_devices:
+                      paths:
+                        - /dev/nvme0n1
   - test:
       name: MDS Service deployment with spec
       desc: Add MDS services using spec file
@@ -134,23 +151,31 @@ tests:
                   label: rgw
 
   - test:
-      name: Configure client admin
-      desc: Configures client admin node on cluster
-      module: test_client.py
-      polarion-id:
-      config:
-        command: add
-        id: client.1                      # client Id (<type>.<Id>)
-        node: <client-host-shortname>                     # client node
-        install_packages:
-          - ceph-common
-          - ceph-base
-        copy_admin_keyring: true          # Copy admin keyring to node
-        caps:                             # authorize client capabilities
-          mon: "allow *"
-          osd: "allow *"
-          mds: "allow *"
-          mgr: "allow *"
+      name: Configure clients
+      desc: Configures multiple client nodes on cluster
+      module: test_parallel.py
+      parallel:
+        - test:
+            name: Configure client 1
+            desc: Configures client.1 admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.1                      # client Id (<type>.<Id>)
+              nodes:
+                  - node10:
+                      release: 6
+                  - node11:
+                      release: 6
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
 
   - test:
       name: Deploy stretch Cluster
@@ -160,12 +185,12 @@ tests:
         stretch_rule_name: "stretch_rule"
         site1:
           name: "DC1"
-          hosts: ["<host1-shortname>", "<host2-shortname>", ... ]
+          hosts: ["mero001"]
         site2:
           name: "DC2"
-          hosts: ["<host3-shortname>", "<host4-shortname>", ... ]
+          hosts: ["mero003", "mero004", "mero013", "mero011", "mero009", "mero007", "mero005" ]
         site3:
           name: "DC3"
-          hosts: ["<host5-shortname>"]
+          hosts: ["mero017", "mero018", "mero014", "mero019", "mero020"]
       desc: Enables connectivity mode, deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -149,6 +149,8 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
   - test:
       name: Verify osd heartbeat no reply
       desc: heartbeat_check log entries should contain hostname:port

--- a/suites/reef/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/reef/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -159,6 +159,9 @@ tests:
       desc: Perform rgw tests
 
   - test:
+      name: Compression test - EC pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
       config:
         Compression_tests:
           pool_type: erasure
@@ -175,7 +178,7 @@ tests:
           compression_config:
             compression_mode: aggressive
             compression_algorithm: snappy
-            compression_required_ratio: 0.3
+            compression_required_ratio: 0.7
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on erasure coded pools

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -135,6 +135,8 @@ tests:
 #        write_iteration: 3
 #        delete_pool: true
 
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
   - test:
       name: Cluster behaviour when OSDs are full
       desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full

--- a/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -125,7 +125,7 @@ tests:
               pool_type: replicated
           - create_pool:
               create: true
-              pool_name: ecpool_2
+              pool_name: ecpool_test_1
               pool_type: erasure
               pg_num: 32
               k: 2
@@ -137,7 +137,7 @@ tests:
           - rpool_1
           - rpool_2
           - rpool_3
-          - ecpool_2
+          - ecpool_test_1
 
   - test:
       name: Test Reads Balancer
@@ -170,7 +170,7 @@ tests:
               pool_type: replicated
           - create_pool:
               create: true
-              pool_name: ecpool_2
+              pool_name: ecpool_test_2
               pool_type: erasure
               pg_num: 32
               k: 2
@@ -182,8 +182,10 @@ tests:
           - rpool_1
           - rpool_2
           - rpool_3
-          - ecpool_2
+          - ecpool_test_2
 
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
   - test:
       name: verify mon parameter 'mon_pg_warn_max_object_skew'
       polarion-id: CEPH-83575440

--- a/suites/reef/rados/tier-2_rados_test-slow-op-requests.yaml
+++ b/suites/reef/rados/tier-2_rados_test-slow-op-requests.yaml
@@ -1,4 +1,6 @@
 # Suite contains tests related to verify slow op requests
+# Keeping this suite Openstack only as generating slow-ops in BM env is difficult
+
 tests:
   - test:
       name: setup install pre-requisistes

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -2,6 +2,9 @@
 # Use cluster-conf file: conf/quincy/rados/stretch-mode-host-location-attrs.yaml
 # Stretch mode tests performing upgrade
 
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/reef/rados/deploy-stretch-cluster-mode.yaml
+
 tests:
   - test:
       name: Install ceph pre-requisites

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -1,0 +1,141 @@
+# Suite is to be used to verify the EC 2+2 config on 4 nodes
+
+tests:
+
+  - test:
+      name: Configure email alerts
+      module: rados_prep.py
+      polarion-id: CEPH-83574472
+      config:
+        email_alerts:
+          smtp_host: smtp.corp.redhat.com
+          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
+          smtp_port: 25
+          interval: 10
+          smtp_destination:
+            - pdhiran@redhat.com
+          smtp_from_name: Rados Sanity Cluster Alerts
+      desc: Configure email alerts on ceph cluster
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - osd
+                - osd_async_recovery_min_cost
+                - "1099511627776"
+
+  - test:
+      name: EC pool LC
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        delete_pools:
+          - test_ec_pool
+      desc: Create, modily & delete EC pools and run IO
+
+  - test:
+      name: EC Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          crush-failure-domain: host
+          rados_write_duration: 100
+          rados_read_duration: 50
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          disable_pg_autoscale: true
+          rados_write_duration: 50
+          rados_read_duration: 30
+        set_pool_configs:
+          pool_name: test_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_ec_pool
+      desc: Create, modily & delete EC pools and run IO
+
+  - test:
+      name: EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          rados_write_duration: 50
+          rados_read_duration: 30
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -1,6 +1,9 @@
 # Use cluster-conf file: conf/reef/rados/stretch-mode-host-location-attrs.yaml
 # Stretch mode tests performing site down scenarios
 
+# This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
+# Stretch mode deployment in BM is run by suite : suites/reef/rados/deploy-stretch-cluster-mode.yaml
+
 tests:
   - test:
       name: Install ceph pre-requisites

--- a/tests/rados/test_four_node_ecpool.py
+++ b/tests/rados/test_four_node_ecpool.py
@@ -1,0 +1,203 @@
+"""
+test Module to :
+1. Create a 2+2 ec pool
+2. fill the pool
+3. Test the effects of bulk flag and no IO stoppage
+4. rolling reboot of OSDs of a host
+5. OSD start and stop for failure domain level
+6. Serviceability tests
+"""
+
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from tests.rados.monitor_configurations import MonConfigMethods
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.log import Log
+from utility.utils import method_should_succeed
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test to Verify the ec 2+2 pool
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    pool_obj = PoolFunctions(node=cephadm)
+
+    if not mon_obj.verify_set_config(
+        section="mon", name="mon_osd_down_out_subtree_limit", value="host"
+    ):
+        log.error(
+            "mon_osd_down_out_subtree_limit not set on the cluster. setting the same now"
+        )
+        mon_obj.set_config(
+            section="mon", name="mon_osd_down_out_subtree_limit", value="host"
+        )
+
+    if not mon_obj.verify_set_config(
+        section="osd", name="osd_async_recovery_min_cost", value="1099511627776"
+    ):
+        log.error(
+            "osd_async_recovery_min_cost not set on the cluster. setting the same now"
+        )
+        mon_obj.set_config(
+            section="osd", name="osd_async_recovery_min_cost", value="1099511627776"
+        )
+
+    # Creating the EC pool
+    ec_config = config.get("ec_pool")
+    pool_name = ec_config["pool_name"]
+    if not rados_obj.create_erasure_pool(name=ec_config["profile_name"], **ec_config):
+        log.error("Failed to create the EC Pool")
+        return 1
+
+    cmd = "ceph osd pool autoscale-status"
+    pool_status = rados_obj.run_ceph_command(cmd=cmd)
+
+    for entry in pool_status:
+        if entry["pool_name"] == pool_name:
+            if entry["pg_autoscale_mode"] == "off":
+                log.error(
+                    f"Pg autoscaler turned off for the new pool : {entry['pool_name']} "
+                )
+                return 1
+
+    init_pg_count = rados_obj.get_pool_property(pool=pool_name, props="pg_num")[
+        "pg_num"
+    ]
+    log.debug(f"init PG count on the pool : {init_pg_count}")
+
+    bulk = pool_obj.get_bulk_details(pool_name=pool_name)
+    if bulk:
+        log.error("Expected bulk flag should be False.")
+        raise Exception("Expected bulk flag should be False.")
+
+    log.debug(f"Bulk flag not enabled on pool {pool_name}, Proceeding to enable bulk")
+
+    new_bulk = pool_obj.set_bulk_flag(pool_name=pool_name)
+    if not new_bulk:
+        log.error("Expected bulk flag should be True.")
+        raise Exception("Expected bulk flag should be True.")
+    # Sleeping for 60 seconds for bulk flag application and PG count to be increased.
+    time.sleep(60)
+
+    pg_count_bulk_true = rados_obj.get_pool_details(pool=pool_name)["pg_num_target"]
+    log.debug(
+        f"PG count on pool {pool_name} post addition of bulk flag : {pg_count_bulk_true}"
+        f"Starting to wait for PG count on the pool to go from {init_pg_count} to"
+        f" {pg_count_bulk_true} while checking for PG inactivity"
+    )
+
+    endtime = datetime.datetime.now() + datetime.timedelta(seconds=10000)
+    while datetime.datetime.now() < endtime:
+        pool_pg_num = rados_obj.get_pool_property(pool=pool_name, props="pg_num")[
+            "pg_num"
+        ]
+        if pool_pg_num == pg_count_bulk_true:
+            log.info(f"PG count on pool {pool_name} is achieved")
+            break
+        log.info(
+            f"PG count on pool {pool_name} has not reached desired levels."
+            f"Expected : {pg_count_bulk_true}, Current : {pool_pg_num}"
+        )
+        if not rados_obj.check_inactive_pgs_on_pool(pool_name=pool_name):
+            log.error(f"Inactive PGs found on pool : {pool_name}")
+            raise Exception("Inactive PGs upon OSD stop error")
+
+        log.info("Sleeping for 20 secs and checking the PG states and PG count")
+        time.sleep(20)
+    else:
+        raise Exception(
+            f"pg_num on pool {pool_name} did not reach the desired levels of PG count "
+            f"with bulk flag enabled"
+            f"Expected : {pg_count_bulk_true}"
+        )
+    log.info(
+        "PGs increased to desired levels after application of bulk flag on the pool with no inactive PGs"
+    )
+
+    # Restarting OSDs belonging to a particular host
+    osd_node = ceph_cluster.get_nodes(role="osd")[0]
+    osd_list = rados_obj.collect_osd_daemon_ids(osd_node=osd_node)
+
+    for osd_id in osd_list:
+        log.debug(f"Rebooting OSD : {osd_id} and checking health status")
+        if not rados_obj.change_osd_state(action="restart", target=osd_id):
+            log.error(f"Unable to restart the OSD : {osd_id}")
+            raise Exception("Execution error")
+
+        time.sleep(5)
+        # Waiting for recovery to post OSD reboot
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        log.debug(
+            "PG's are active + clean post OSD reboot, proceeding to restart next OSD"
+        )
+
+    log.info(
+        f"All the planned  OSD reboots have completed for host {osd_node.hostname}"
+    )
+
+    # Beginning with OSD stop operations
+    log.debug("Stopping 1 OSD from each host. No inactive PGs")
+    osd_nodes = ceph_cluster.get_nodes(role="osd")
+    for node in osd_nodes:
+        osd_list = rados_obj.collect_osd_daemon_ids(osd_node=node)
+        if not rados_obj.change_osd_state(action="stop", target=osd_list[0]):
+            log.error(f"Unable to stop the OSD : {osd_list[0]}")
+            raise Exception("Execution error")
+        time.sleep(5)
+
+        if not rados_obj.check_inactive_pgs_on_pool(pool_name=pool_name):
+            log.error(f"Inactive PGs found on pool : {pool_name}")
+            raise Exception("Inactive PGs upon OSD stop error")
+
+        time.sleep(5)
+        # Waiting for recovery to post OSD reboot
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        log.debug(
+            "PG's are active + clean post OSD reboot, proceeding to restart next OSD"
+        )
+        if not rados_obj.change_osd_state(action="start", target=osd_list[0]):
+            log.error(f"Unable to stop the OSD : {osd_list[0]}")
+            raise Exception("Execution error")
+        time.sleep(5)
+
+    # Stopping all OSDs of 1 host and check for inactive PGs
+    stop_host = osd_nodes[0]
+    osd_list = rados_obj.collect_osd_daemon_ids(osd_node=stop_host)
+    for osd in osd_list:
+        if not rados_obj.change_osd_state(action="stop", target=osd):
+            log.error(f"Unable to stop the OSD : {osd_list[0]}")
+            raise Exception("Unable to stop OSDs error")
+        time.sleep(5)
+
+    if not rados_obj.check_inactive_pgs_on_pool(pool_name=pool_name):
+        log.error(f"Inactive PGs found on pool : {pool_name}")
+        raise Exception("Inactive PGs upon OSD stop error")
+
+    for osd in osd_list:
+        if not rados_obj.change_osd_state(action="start", target=osd):
+            log.error(f"Unable to start the OSD : {osd_list[0]}")
+            raise Exception("Unable to start OSDs error")
+        time.sleep(5)
+
+    # tbd: Serviceability scenarios remaining.
+
+    if ec_config.get("delete_pool"):
+        # Deleting the pool created earlier
+        if not rados_obj.detete_pool(pool=pool_name):
+            log.error(f"the pool {pool_name} could not be deleted")
+
+    log.info("EC 2+2 pool is working as expected.")
+    return 0

--- a/tests/rados/test_osd_heartbeat.py
+++ b/tests/rados/test_osd_heartbeat.py
@@ -25,7 +25,7 @@ def run(ceph_cluster, **kw):
     config = kw["config"]
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
-    timeout = config.get("timeout", 150)
+    timeout = config.get("timeout", 350)
     recovery_timeout = config.get("recovery_timeout", 2400)
     installer_node = ceph_cluster.get_nodes(role="installer")[0]
 

--- a/tests/rados/test_pg_split.py
+++ b/tests/rados/test_pg_split.py
@@ -153,7 +153,7 @@ def run(ceph_cluster, **kw):
         )
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout)
 
-        endtime = datetime.datetime.now() + datetime.timedelta(seconds=5000)
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=10000)
         while datetime.datetime.now() < endtime:
             pool_pg_num = rados_obj.get_pool_property(
                 pool=pool["pool_name"], props="pg_num"
@@ -202,7 +202,7 @@ def run(ceph_cluster, **kw):
                 f"pg_num {pg_count_bulk_true} is expected to be greater than {pg_count_bulk_false} after bulk removal"
             )
 
-        endtime = datetime.datetime.now() + datetime.timedelta(seconds=5000)
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=10000)
         while datetime.datetime.now() < endtime:
             pool_pg_num = rados_obj.get_pool_property(
                 pool=pool["pool_name"], props="pg_num"


### PR DESCRIPTION
1. Added new module to test EC pool for 2+2 config on a 4 node cluster.
2. Modified other test suites for BM pipeline

Pass logs for EC 2+2 suite on 4 node BM cluster: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QRQF69 
