### PR TITLE
updating cephadm_ansible.py to take str for matching rhcs version

### DIFF
--- a/ceph/ceph_admin/cephadm_ansible.py
+++ b/ceph/ceph_admin/cephadm_ansible.py
@@ -41,7 +41,9 @@ class CephadmAnsible:
 
     def install_cephadm_ansible(self):
         """Enable ansible rpm repos and install cephadm-ansible."""
-        rhcs_version = re.match(r"(\d)\.(.?)(.*)", self.cluster._Ceph__rhcs_version)
+        rhcs_version = re.match(
+            r"(\d)\.(.?)(.*)", str(self.cluster._Ceph__rhcs_version)
+        )
         if not rhcs_version:
             raise CephadmAnsibleError(
                 f"Invalid string for RHCS version - '{self.cluster.__Ceph_rhcs_version}'"
@@ -122,4 +124,4 @@ class CephadmAnsible:
         )
 
         if rc != 0:
-            raise CephadmAnsibleError("Playbook {playbook} failed....")
+            raise CephadmAnsibleError(f"Playbook {playbook} failed....")


### PR DESCRIPTION
# Description
fixing issue seen in 
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-81/Weekly/rgw/9/tier-1_rgw_ms_upgrade_multirealm_61GA_to_7x_latest/deploy_cluster_0.log
and
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-147/Weekly/rgw/12/tier-1_rgw_multisite_multirealm_upgrade-5-to-latest/deploy_cluster_0.log

return _compile(pattern, flags).match(string) TypeError: expected string or bytes-like object

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
