### PR TITLE
[TFA] Removed upstream luks encryption as it covered in downstream test suites

### DIFF
--- a/suites/pacific/rbd/tier-0_rbd.yaml
+++ b/suites/pacific/rbd/tier-0_rbd.yaml
@@ -120,15 +120,6 @@ tests:
   -
     test:
       config:
-        script: luks-encryption.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD LUKS Encryption scenarios"
-      module: test_rbd.py
-      name: 4_rbd_luks_encryption
-      polarion-id: CEPH-83574242
-  -
-    test:
-      config:
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"

--- a/suites/quincy/e2e/poc/test-rbd-core-features.yaml
+++ b/suites/quincy/e2e/poc/test-rbd-core-features.yaml
@@ -31,15 +31,6 @@ tests:
   -
     test:
       config:
-        script: luks-encryption.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD LUKS Encryption scenarios"
-      module: test_rbd.py
-      name: "Evaluate LUKS encryption"
-      polarion-id: CEPH-83574242
-  -
-    test:
-      config:
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"

--- a/suites/quincy/rbd/basic-operations-unit-testing.yaml
+++ b/suites/quincy/rbd/basic-operations-unit-testing.yaml
@@ -130,15 +130,6 @@ tests:
   -
     test:
       config:
-        script: luks-encryption.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD LUKS Encryption scenarios"
-      module: test_rbd.py
-      name: 4_rbd_luks_encryption
-      polarion-id: CEPH-83574242
-  -
-    test:
-      config:
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"

--- a/suites/quincy/rbd/tier-1_rbd.yaml
+++ b/suites/quincy/rbd/tier-1_rbd.yaml
@@ -116,15 +116,6 @@ tests:
   -
     test:
       config:
-        script: luks-encryption.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD LUKS Encryption scenarios"
-      module: test_rbd.py
-      name: 3_rbd_luks_encryption
-      polarion-id: CEPH-83574242
-  -
-    test:
-      config:
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"

--- a/suites/reef/rbd/tier-1_rbd.yaml
+++ b/suites/reef/rbd/tier-1_rbd.yaml
@@ -116,15 +116,6 @@ tests:
   -
     test:
       config:
-        script: luks-encryption.sh
-        script_path: qa/workunits/rbd
-      desc: "Executing upstream RBD LUKS Encryption scenarios"
-      module: test_rbd.py
-      name: 3_rbd_luks_encryption
-      polarion-id: CEPH-83574242
-  -
-    test:
-      config:
         script: cli_migration.sh
         script_path: qa/workunits/rbd
       desc: "Executing upstream RBD CLI Migration scenarios"


### PR DESCRIPTION
# Description

Fixes TFA https://issues.redhat.com/browse/RHCEPHQE-11057

As discussed with team having another downstream test case which is testing luks encryption hence removed this upstream test from our test suite.

also it's related test case is marked as Inactive 
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574242

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
