### PR TITLE
Use exception object instead of ex.message while logging

### DIFF
--- a/tests/rbd/rbd_clone_delete_parent_image.py
+++ b/tests/rbd/rbd_clone_delete_parent_image.py
@@ -75,7 +75,7 @@ def rbd_clone_delete_parent_image(rbd, pool_type, **kw):
             return 0
 
     except RbdBaseException as error:
-        log.error(error.message)
+        log.error(error)
         return 1
 
     finally:

--- a/tests/rbd/rbd_exclusive_lock_rm_image.py
+++ b/tests/rbd/rbd_exclusive_lock_rm_image.py
@@ -28,7 +28,7 @@ def rbd_exclusive_verify(rbd, pool_type, **kw):
         return 0
 
     except RbdBaseException as error:
-        log.error(error.message)
+        log.error(error)
         return 1
 
     finally:


### PR DESCRIPTION
**Pipeline Failure Fix**

Use exception object instead of ex.message while logging to avoid errors when exception object does not have message attribute.

Error Log from pipeline - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/baremetal/18.2.0-44/rados/2/tier-2_rbd_regression/Verify_exclusive_lock_feature_0.log and http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/baremetal/18.2.0-44/rados/2/tier-2_rbd_regression/Test_for_parent_image_deletion_after_flattening_the_clone_and_removing_snap_0.log 

Success Log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IZZFIH/