### PR TITLE
Install rbd-nbd before running device map in krbd

### DIFF
--- a/ceph/rbd/workflows/krbd_io_handler.py
+++ b/ceph/rbd/workflows/krbd_io_handler.py
@@ -80,6 +80,12 @@ def krbd_io_handler(**kw):
                 device_names.append(rbd.map(pool=pool_name, image=image_name)[:-1])
 
             if operations.get("device_map"):
+                out = exec_cmd(
+                    cmd="rpm -qa|grep rbd-nbd", node=client, sudo=True, output=True
+                )
+                if not out or out == 1:
+                    exec_cmd(cmd="dnf install rbd-nbd -y", node=client, sudo=True)
+
                 map_config = {
                     "pool": pool_name,
                     "image": image_name,

--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -67,6 +67,10 @@ def krbd_io_handler(**kw):
                 device_names.append(rbd.image_map(pool_name, image_name)[:-1])
 
             if operations.get("device_map"):
+                out = rbd.exec_cmd(cmd="rpm -qa|grep rbd-nbd", sudo=True, output=True)
+                if not out or out == 1:
+                    rbd.exec_cmd(cmd="dnf install rbd-nbd -y", sudo=True)
+
                 out, err = rbd.device_map(
                     "map",
                     f"{pool_name}/{image_name}",


### PR DESCRIPTION
Baremetal pipeline fix - 

http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/baremetal/18.2.0-44/rados/2/tier-2_rbd_encryption/ - 
Since we create cluster and configure client only once, we would not have installed rbd-nbd in the previous tests. We need to make sure it is installed before running any of the encryption tests. 

Success Log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WYVBE4/
