### PR TITLE
Adding image mode mirroring to journal to snapshot test case

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_image_operations.yaml
@@ -169,7 +169,12 @@ tests:
       clusters:
         ceph-rbd1:
           config:
-            imagesize: 2G
+            rep_pool_config:
+              mode: "image"
+              size: "2G"
+            ec_pool_config:
+              mode: "image"
+              size: "2G"
       polarion-id: CEPH-83573618
       desc: Testing journal mirroring to snapshot mirroring
 


### PR DESCRIPTION
Fix for pipeline failure for pacific test case - convert journal based mirroring to snapshot.
https://issues.redhat.com/browse/RHCEPHQE-11567 

Failure Logs - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/16.2.10-208/Regression/rbd/13/tier-2_rbd_mirror_image_operations/Mirroring_from_journal_to_snapshot_0.log

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L21VVN/
