### PR TITLE
Bare metal fix- Reduced the OSDs to 10

### DIFF
--- a/tests/rados/test_config_parameter_chk.py
+++ b/tests/rados/test_config_parameter_chk.py
@@ -7,6 +7,7 @@ This method contains the scenarios to check the-
 5. Mclock reservation,weight and limit parameters are not modifiable
 """
 
+import random
 import time
 from configparser import ConfigParser
 
@@ -33,7 +34,14 @@ def run(ceph_cluster, **kw):
     for node in ceph_nodes:
         if node.role == "osd":
             node_osds = rados_object.collect_osd_daemon_ids(node)
+            # Pick a single OSD from the host OSDs list
+            node_osds = random.sample(node_osds, 1)
             osd_list = osd_list + node_osds
+    log.info(f"The number of OSDs in the cluster are-{len(osd_list)}")
+    # If OSD list is more than 10 then randomly picking the 10 OSDs to check the parameters.
+    if len(osd_list) > 10:
+        osd_list = random.sample(osd_list, 10)
+    log.info(f"The parameters are checking on {osd_list} osds")
     if config.get("scenario") == "msgrv2_5x":
         ini_file = config.get("ini-file")
         config_info.read(ini_file)


### PR DESCRIPTION
#  Parameter verification of OSD list to 10.
 Parameters are verified on all OSDs. In some cases on bare metal, the OSD count is more. It is more than 100, so executing the test case takes more than a day. As a fix, I am picking a random 10 OSDs from the cluster.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of the Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
