### PR TITLE
Fixing MDS pinning TCs

### DIFF
--- a/suites/reef/cephfs/tier-2_cephfs_test_mds_pinning.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test_mds_pinning.yaml
@@ -195,10 +195,10 @@ tests:
       desc: Directory pinning on two MDS with node reboots
       abort-on-fail: false
   - test:
-      name: Subtree Split and Subtree merging by pinning Subtrees/directories to MDS.
+      name: Subtree Split and Subtree merging by pinning Subtrees directories to MDS.
       module: cephfs_mds_pinning.mds_pinning_split_merge.py
       polarion-id: CEPH-11233
-      desc: Subtree Split and Subtree merging by pinning Subtrees/directories to MDS.
+      desc: Subtree Split and Subtree merging by pinning Subtrees directories to MDS.
       abort-on-fail: false
   - test:
       name: map and unmap directory trees to a mds rank

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_equal_dir_on_two_mdss.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_equal_dir_on_two_mdss.py
@@ -165,7 +165,7 @@ def run(ceph_cluster, **kw):
                     25,
                     10,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
                 for op in p:
                     return_counts, rc = op
@@ -179,7 +179,7 @@ def run(ceph_cluster, **kw):
                     50,
                     20,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
                 for op in p:
                     return_counts, rc = op

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_max_min_dir_on_two_mdss.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_max_min_dir_on_two_mdss.py
@@ -223,7 +223,7 @@ def run(ceph_cluster, **kw):
                     num_of_dirs * 5,
                     10,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
                 for op in p:
                     return_counts, rc = op
@@ -238,7 +238,7 @@ def run(ceph_cluster, **kw):
                     num_of_dirs * 8,
                     20,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
                 for op in p:
                     return_counts, rc = op

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_node_reboots.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_node_reboots.py
@@ -264,7 +264,7 @@ def run(ceph_cluster, **kw):
                     iotype="touch",
                 )
                 for node in client_info["mon_node"]:
-                    fs_util.pid_kill(node, "mon")
+                    fs_util_v1.pid_kill(node, "mon")
             with parallel() as p:
                 p.spawn(
                     fs_util.stress_io,
@@ -354,7 +354,7 @@ def run(ceph_cluster, **kw):
                     iotype="touch",
                 )
                 for node in client_info["osd_nodes"]:
-                    fs_util.pid_kill(node, "osd")
+                    fs_util_v1.pid_kill(node, "osd")
             with parallel() as p:
                 p.spawn(
                     fs_util.stress_io,
@@ -414,7 +414,7 @@ def run(ceph_cluster, **kw):
                     iotype="touch",
                 )
                 for mon in fs_util_v1.mons:
-                    FsUtilsV1.deamon_op(mon, "mon", "restart")
+                    FsUtilsV1.deamon_op(mon, "mon.ceph", "restart")
             log.info("Execution of Test case CEPH-%s ended:" % (tc))
             log.info("Cleaning up!-----")
             if client3[0].pkg_type != "deb" and client4[0].pkg_type != "deb":

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_split_merge.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_split_merge.py
@@ -111,7 +111,7 @@ def run(ceph_cluster, **kw):
             print("Data validation success")
             tc = "11233"
             log.info("Execution of Test cases %s started:" % (tc))
-            fs_util_v1.allow_dir_fragmentation(client_info["clients"][0:])
+            fs_util.allow_dir_fragmentation(client_info["clients"][0:])
             log.info("Creating directory:")
             for node in client_info["fuse_clients"]:
                 out, rc = node.exec_command(

--- a/tests/cephfs/cephfs_mds_pinning/mds_pinning_unequal_dir_on_two_mdss.py
+++ b/tests/cephfs/cephfs_mds_pinning/mds_pinning_unequal_dir_on_two_mdss.py
@@ -212,7 +212,7 @@ def run(ceph_cluster, **kw):
                     num_of_dirs / 2,
                     1,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
             with parallel() as p:
                 p.spawn(
@@ -224,7 +224,7 @@ def run(ceph_cluster, **kw):
                     num_of_dirs,
                     2,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
             with parallel() as p:
                 p.spawn(
@@ -236,7 +236,7 @@ def run(ceph_cluster, **kw):
                     num_of_dirs * 5,
                     1,
                     fs_util.mds_fail_over,
-                    client_info["mds_nodes"],
+                    client_info["clients"][0:],
                 )
                 for op in p:
                     return_counts, rc = op


### PR DESCRIPTION
# Description
Fixing MDS pinning TCs

MDS pinning test cases are failing and not getting reported in reportportal as there was no xunit file generated

Failed Logs : http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/cephfs/14/tier-2_cephfs_test_mds_pinning/

The reason for xunit files not getting generated is 
https://github.com/red-hat-storage/cephci/blob/7333aa1ab363fac594a9015b78e3dd6d261458af/suites/reef/cephfs/tier-2_cephfs_test_mds_pinning.yaml#L198
this line as `/` and which is making log file creation failure

We are observing few other failures which got fixed as part of this PR

**Pass Logs :** http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U6KKU7/
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
