### PR TITLE
snap schedule service restart test automation

### DIFF
--- a/suites/pacific/cephfs/tier-4_cephfs_recovery.yaml
+++ b/suites/pacific/cephfs/tier-4_cephfs_recovery.yaml
@@ -195,3 +195,12 @@ tests:
       module: cephfs_recovery.fs_scrub.py
       polarion-id: CEPH-11267
       name: "Cephfs Scrubing"
+  - test:
+      name: snap_retention_service_restart
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83575627
+      desc: Verify Snapshot retention works even after service restarts
+      abort-on-fail: false
+      config:
+        test_name : snap_retention_service_restart
+

--- a/suites/reef/cephfs/tier-4_cephfs_recovery.yaml
+++ b/suites/reef/cephfs/tier-4_cephfs_recovery.yaml
@@ -195,3 +195,12 @@ tests:
       module: cephfs_recovery.fs_scrub.py
       polarion-id: CEPH-11267
       name: "Cephfs Scrubing"
+  - test:
+      name: snap_retention_service_restart
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83575627
+      desc: Verify Snapshot retention works even after service restarts
+      abort-on-fail: false
+      config:
+        test_name : snap_retention_service_restart
+

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -245,7 +245,7 @@ class FsUtils(object):
             sudo=True,
             cmd=f"systemctl list-units --type=service | grep {service} | awk {{'print $1'}}",
         )
-        service_deamon = out.strip()
+        service_deamon = out.strip().split()[0]
         return service_deamon
 
     @staticmethod


### PR DESCRIPTION
# Description
Added -ve test to Snap Schedule and Retention Automation module,

snap_retention_service_restart:
1. Schedule a snapshot with snap_schedule on dir
2. Add Retention to the dir
3. Check status of the schedule. Verify schedule is active and note Retention fields before mgr restart.
4. Restart mgrs
5. Check again status of the schedule. Verify Retention fields are the same and schedule is active and working.

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SLO89G

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
