### PR TITLE
Adding tests to verify deep flatten feature in RBD

### DIFF
--- a/ceph/rbd/initial_config.py
+++ b/ceph/rbd/initial_config.py
@@ -138,7 +138,10 @@ def update_config(**kw):
                                 {"io_total": rep_pool_config.get("io_total", "1G")}
                             )
 
-                        if rep_pool_config.get("mirrormode") != "snapshot":
+                        if (
+                            kw.get("is_mirror")
+                            and rep_pool_config.get("mirrormode") != "snapshot"
+                        ):
                             image_config[image].update({"image-feature": "journaling"})
 
                         if is_secondary:
@@ -220,7 +223,10 @@ def update_config(**kw):
                                 {"io_total": ec_pool_config.get("io_total", "1G")}
                             )
 
-                        if ec_pool_config.get("mirrormode") != "snapshot":
+                        if (
+                            kw.get("is_mirror")
+                            and ec_pool_config.get("mirrormode") != "snapshot"
+                        ):
                             image_config[image].update({"image-feature": "journaling"})
 
                         if is_secondary:
@@ -371,7 +377,7 @@ def initial_rbd_config(ceph_cluster, **kw):  # ,
             ceph_version=ceph_version,
             config=config,
             client=client,
-            is_secondary=kw.get("is_secondary"),
+            is_secondary=kw.get("is_secondary", False),
         ):
             log.error(f"RBD configuration failed for {pool_type}")
             return None
@@ -534,13 +540,13 @@ def initial_mirror_config(**kw):
         kw["ceph_cluster"] = cluster
         if cluster_name == ceph_cluster.name:
             primary_config = ret_config[cluster_name] = initial_rbd_config(
-                is_secondary=False, **kw
+                is_secondary=False, is_mirror=True, **kw
             )
             ret_config[cluster_name]["is_secondary"] = False
             primary_config["cluster"] = cluster
         else:
             secondary_config = ret_config[cluster_name] = initial_rbd_config(
-                is_secondary=True, **kw
+                is_secondary=True, is_mirror=True, **kw
             )
             ret_config[cluster_name]["is_secondary"] = True
             secondary_config["cluster"] = cluster

--- a/ceph/rbd/workflows/cleanup.py
+++ b/ceph/rbd/workflows/cleanup.py
@@ -7,7 +7,7 @@ from utility.log import Log
 log = Log(__name__)
 
 
-def cleanup(pool_types, mirror_obj, **kw):
+def cleanup(pool_types, multi_cluster_obj, **kw):
     """ """
     pools = list()
     for pool_type in pool_types:
@@ -22,8 +22,8 @@ def cleanup(pool_types, mirror_obj, **kw):
                 if val.get("data_pool")
             ]
         )
-    mirror_obj.pop("output", {})
-    for cluster_config in mirror_obj.values():
+    multi_cluster_obj.pop("output", {})
+    for cluster_config in multi_cluster_obj.values():
         pool_cleanup(
             cluster_config.get("client"),
             pools,

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -14,20 +14,20 @@ def create_snap_and_clone(rbd, snap_spec, clone_spec):
     """
     snap_config = {"snap-spec": snap_spec}
 
-    out, _ = rbd.snap.create(**snap_config)
-    if out:
+    out, err = rbd.snap.create(**snap_config)
+    if out or err and "100% complete" not in err:
         log.error(f"Snapshot creation failed for {snap_spec}")
         return 1
 
-    out, _ = rbd.snap.protect(**snap_config)
-    if out:
+    out, err = rbd.snap.protect(**snap_config)
+    if out or err:
         log.error(f"Snapshot protect failed for {snap_spec}")
         return 1
 
     clone_config = {"source-snap-spec": snap_spec, "dest-image-spec": clone_spec}
 
-    out, _ = rbd.clone(**clone_config)
-    if out:
+    out, err = rbd.clone(**clone_config)
+    if out or err:
         log.error(f"Clone creation failed for {clone_spec}")
         return 1
 

--- a/cli/rbd/feature.py
+++ b/cli/rbd/feature.py
@@ -1,0 +1,56 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Feature(Cli):
+    """
+    This module provides CLI interface to manage snapshots from images in pool.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Feature, self).__init__(nodes)
+        self.base_cmd = base_cmd + " feature"
+
+    def enable(self, **kw):
+        """
+        Enable an RBD feature on an image.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    features(str): <space separated list of features to be enabled>
+                    See rbd help feature enable for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        features = kw_copy.pop("features", "")
+        cmd = f"{self.base_cmd} enable {image_spec} {features} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def disable(self, **kw):
+        """
+        Disable an RBD feature on an image.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    features(str): <space separated list of features to be disabled>
+                    See rbd help feature enable for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        features = kw_copy.pop("features", "")
+        cmd = f"{self.base_cmd} disable {image_spec} {features} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -4,6 +4,7 @@ from cli import Cli
 from cli.utilities.utils import build_cmd_from_args
 
 from .device import Device
+from .feature import Feature
 from .mirror.mirror import Mirror
 from .pool import Pool
 from .snap import Snap
@@ -17,6 +18,7 @@ class Rbd(Cli):
         self.mirror = Mirror(nodes, self.base_cmd)
         self.device = Device(nodes, self.base_cmd)
         self.snap = Snap(nodes, self.base_cmd)
+        self.feature = Feature(nodes, self.base_cmd)
 
     def create(self, **kw):
         """

--- a/suites/pacific/rbd/tier-4_rbd_negative_scenario_regression.yaml
+++ b/suites/pacific/rbd/tier-4_rbd_negative_scenario_regression.yaml
@@ -1,0 +1,96 @@
+# Tier4: RBD negative scenario testing
+#
+# This test suite runs test scripts to evaluate negative scenarios of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/pacific/rbd/tier-0_rbd.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-9831 - Test parent snapshot deletion on an image where deep-flatten is disabled
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+# Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Test parent snapshot deletion on an image where deep-flatten is disabled
+      destroy-cluster: false
+      module: test_rbd_deep_flatten_negative.py
+      name: Test deep-flatten feature negative
+      polarion-id: CEPH-9831
+      config:
+        rep_pool_config:
+          num_pools: 1
+          num_images: 1
+        ec_pool_config:
+          num_pools: 1
+          num_images: 1

--- a/suites/quincy/rbd/tier-4_rbd_negative_scenario_regression.yaml
+++ b/suites/quincy/rbd/tier-4_rbd_negative_scenario_regression.yaml
@@ -1,0 +1,96 @@
+# Tier4: RBD negative scenario testing
+#
+# This test suite runs test scripts to evaluate negative scenarios of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-9831 - Test parent snapshot deletion on an image where deep-flatten is disabled
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+# Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Test parent snapshot deletion on an image where deep-flatten is disabled
+      destroy-cluster: false
+      module: test_rbd_deep_flatten_negative.py
+      name: Test deep-flatten feature negative
+      polarion-id: CEPH-9831
+      config:
+        rep_pool_config:
+          num_pools: 1
+          num_images: 1
+        ec_pool_config:
+          num_pools: 1
+          num_images: 1

--- a/suites/reef/rbd/tier-4_rbd_negative_scenario_regression.yaml
+++ b/suites/reef/rbd/tier-4_rbd_negative_scenario_regression.yaml
@@ -1,0 +1,96 @@
+# Tier4: RBD negative scenario testing
+#
+# This test suite runs test scripts to evaluate negative scenarios of
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/reef/rbd/4-node-cluster-with-1-client.yaml
+#    Node 2 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-9831 - Test parent snapshot deletion on an image where deep-flatten is disabled
+
+tests:
+
+   #Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+# Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Test parent snapshot deletion on an image where deep-flatten is disabled
+      destroy-cluster: false
+      module: test_rbd_deep_flatten_negative.py
+      name: Test deep-flatten feature negative
+      polarion-id: CEPH-9831
+      config:
+        rep_pool_config:
+          num_pools: 1
+          num_images: 1
+        ec_pool_config:
+          num_pools: 1
+          num_images: 1

--- a/tests/rbd/test_rbd_deep_flatten_negative.py
+++ b/tests/rbd/test_rbd_deep_flatten_negative.py
@@ -1,0 +1,109 @@
+import json
+
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.rbd import create_snap_and_clone
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_deep_flatten_negative_scenario(rbd_obj, **kw):
+    """ """
+    for pool_type in rbd_obj.get("pool_types"):
+        rbd_config = kw.get("config", {}).get(pool_type, {})
+        multi_pool_config = getdict(rbd_config)
+        for pool, pool_config in multi_pool_config.items():
+            multi_image_config = getdict(pool_config)
+            for image in multi_image_config.keys():
+                log.info(f"Creating snapshot and clone for image {pool}/{image}")
+                rbd = rbd_obj.get("rbd")
+                # Start by creating cli for rbd feature commands
+                feature_spec = {
+                    "image-spec": f"{pool}/{image}",
+                    "features": "deep-flatten",
+                }
+                out, err = rbd.feature.disable(**feature_spec)
+                if out or err:
+                    log.error(f"Feature deep-flatten was not disabled for {image}")
+                    return 1
+                info_spec = {"image-or-snap-spec": f"{pool}/{image}", "format": "json"}
+                out, err = rbd.info(**info_spec)
+                if err:
+                    log.info(f"Error while fetching info for image {image}")
+                    return 1
+                log.info(f"Image info: {out}")
+
+                out_json = json.loads(out)
+                if "deep-flatten" in out_json["features"]:
+                    log.error(f"Feature deep-flatten was not disabled for {image}")
+                    return 1
+
+                snap_spec = f"{pool}/{image}@snap_{image}"
+                clone_spec = f"{pool}/clone_{image}"
+                create_snap_and_clone(rbd, snap_spec, clone_spec)
+                # Create snapshot for the clone
+                clone_snap_spec = {
+                    "snap-spec": f"{pool}/clone_{image}@snap_clone_{image}"
+                }
+                out, err = rbd.snap.create(**clone_snap_spec)
+                if out or err and "100% complete" not in err:
+                    log.error(f"Snapshot creation failed for {clone_snap_spec}")
+                    return 1
+
+                flatten_config = {"image-spec": clone_spec}
+                out, err = rbd.flatten(**flatten_config)
+                if out or err and "100% complete" not in err:
+                    log.error(f"Flatten clone failed for {clone_spec}")
+                    return 1
+
+                snap_conf = {"snap-spec": snap_spec}
+                out, err = rbd.snap.unprotect(**snap_conf)
+                if out or err:
+                    err_msg = f"Snapshot unprotect failed as expected for {snap_spec} since deep-flatten"
+                    err_msg += f" is not enabled on the image {image} and clone contains snapshots"
+                    log.info(err_msg)
+                    log.info(f"Error message for snapshot unprotect: {out} {err}")
+                else:
+                    log.error(
+                        "Snapshot unprotect succeeded even though clone had snapshots"
+                    )
+                    return 1
+    return 0
+
+
+def run(**kw):
+    """Test parent snapshot deletion on an image where deep-flatten is disabled
+     (Negative scenario)
+
+    Pre-requisites :
+    We need atleast one client node with ceph-common and fio packages,
+    conf and keyring files
+
+    Test cases covered -
+    1) CEPH-9831 - Test parent snapshot deletion on an image where deep-flatten
+     is disabled (Negative scenario)
+
+    Test Case Flow
+    1. Create image and disable deep-flatten feature on that image
+    2. Create a snapshot on this image, protect the snapshot and create a clone on that image
+    3. Create a snapshot for the clone
+    4. Flatten the clone
+    5. Unprotect the parent snapshot
+
+    """
+    log.info("Running deep-flatten negative scenario test CEPH-9831")
+
+    try:
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_deep_flatten_negative_scenario(rbd_obj=rbd_obj, **kw)
+    except Exception as e:
+        log.error(f"deep-flatten negative scenario tests failed with error {str(e)}")
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val

--- a/tests/rbd_mirror/test_encryption_on_mirrored_image.py
+++ b/tests/rbd_mirror/test_encryption_on_mirrored_image.py
@@ -457,5 +457,5 @@ def run(**kw):
         log.error(f"Testing mirrored encryption failed with error {str(e)}")
         ret_val = 1
     finally:
-        cleanup(pool_types=pool_types, mirror_obj=mirror_obj, **kw)
+        cleanup(pool_types=pool_types, multi_cluster_obj=mirror_obj, **kw)
     return ret_val

--- a/tests/rbd_mirror/test_snapshot_mirroring_on_pool_negative.py
+++ b/tests/rbd_mirror/test_snapshot_mirroring_on_pool_negative.py
@@ -54,5 +54,5 @@ def run(**kw):
         )
         ret_val = 1
     finally:
-        cleanup(pool_types=pool_types, mirror_obj=mirror_obj, **kw)
+        cleanup(pool_types=pool_types, multi_cluster_obj=mirror_obj, **kw)
     return ret_val


### PR DESCRIPTION
This PR is created to automate the test case - CEPH-9831 - Test parent snapshot deletion on an image where deep-flatten is disabled (Negative scenario)

Test Steps:
1. Create image and disable deep-flatten feature on that image
2. Create a snapshot on this image, protect the snapshot and create a clone on that image
3. Create a snapshot for the clone
4. Flatten the clone
5. Unprotect the parent snapshot

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F08IO0/
