### PR TITLE
CEPH-83574780: Negative test to verify addition of OSD on an unavailable disk

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -577,9 +577,8 @@ class Ceph(object):
             )
 
         out, err = client.exec_command(
-            "sudo ceph {role} metadata -f json-pretty".format(role=role)
+            cmd=f"ceph {role} metadata -f json-pretty", sudo=True
         )
-
         return json.loads(out)
 
     def get_osd_metadata(self, osd_id, client=None):

--- a/suites/pacific/rados/tier-4_rados_tests.yaml
+++ b/suites/pacific/rados/tier-4_rados_tests.yaml
@@ -149,6 +149,12 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: OSD addition on an unavailable disk
+      desc: Add new OSD on an pre-occupied OSD disk
+      module: test_add_new_osd.py
+      polarion-id: CEPH-83574780
+
+  - test:
       name: mon replacement test
       polarion-id: CEPH-9407
       module: test_mon_addition_removal.py

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -149,6 +149,12 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: OSD addition on an unavailable disk
+      desc: Add new OSD on an pre-occupied OSD disk
+      module: test_add_new_osd.py
+      polarion-id: CEPH-83574780
+
+  - test:
       name: mon replacement test
       polarion-id: CEPH-9407
       module: test_mon_addition_removal.py

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -149,6 +149,12 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: OSD addition on an unavailable disk
+      desc: Add new OSD on an pre-occupied OSD disk
+      module: test_add_new_osd.py
+      polarion-id: CEPH-83574780
+
+  - test:
       name: Test ceph osd command arguments
       desc: Provide invalid values as argument to different ceph osd commands
       module: test_osd_args.py

--- a/tests/rados/test_add_new_osd.py
+++ b/tests/rados/test_add_new_osd.py
@@ -1,0 +1,46 @@
+import random
+
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83574780
+    Verify addition of a new OSD on existing OSD device, expected to fail
+    1. Create a cluster with few OSDs
+    2. Choose on OSD from the existing OSD list
+    3. Fetch OSD metadata to get the disk and hostname
+    4. Use ceph orch command to add new OSD on same disk
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    log.info("Running test case to verify addition of new OSD on existing OSD disk")
+
+    try:
+        out, _ = cephadm.shell(args=["ceph osd ls"])
+        osd_list = out.strip().split("\n")
+        osd_id = random.choice(osd_list)
+        osd_metadata = ceph_cluster.get_osd_metadata(osd_id=int(osd_id), client=client)
+        log.debug(osd_metadata)
+        osd_device = f"/dev/{osd_metadata['devices']}"
+        osd_hostname = osd_metadata["hostname"]
+        # try to add OSD on the same device
+        out, err = cephadm.shell(
+            [f"ceph orch daemon add osd {osd_hostname}:{osd_device}"]
+        )
+        log.info(out)
+        assert "Created no osd(s) on host" in out and "already created" in out
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    log.info(
+        "Verification complete, addition of new OSD on existing OSD disk, failed as expected"
+    )
+    return 0


### PR DESCRIPTION
[CEPH-83574780](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574780): Tier-4 test to verify expected failure during addition of new OSD on a pre occupied OSD disk

Jira: [RHCEPHQE-11698](https://issues.redhat.com/browse/RHCEPHQE-11698)

Test modules added/modified:
ceph/ceph.py
tests/rados/test_add_new_osd.py

Test suites modified: 
- suites/pacific/rados/tier-4_rados_tests.yaml
- suites/quincy/rados/tier-4_rados_tests.yaml
- suites/reef/rados/tier-4_rados_tests.yaml

Steps:
    1. Create a cluster with few OSDs
    2. Choose on OSD from the existing OSD list
    3. Fetch OSD metadata to get the disk and hostname
    4. Use ceph orch command to add new OSD on same disk

Logs:
Quincy - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KTBTEZ/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
