### PR TITLE
CEPH-83576087 Reboot the client

### DIFF
--- a/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -337,3 +337,20 @@ tests:
       module: test_ceph_nvmeof_neg_tests.py
       name: Map-Unmap NVMe namespaces continuously
       polarion-id: CEPH-83576085
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node7
+        operation: CEPH-83576087
+      desc: Perform reboot on initiator node and validate the namespaces.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Reboot client node and check NVMe namespaces
+      polarion-id: CEPH-83576087


### PR DESCRIPTION
CEPH-83576087 Reboot the clients and verify that they are able to get back the LUNs that were mapped earlier

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9HW8LT

```All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9HW8LT

All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9HW8LT

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Reboot client node and check N   Perform reboot on initiator node and validate the namespaces   0:06:38.491618                   Pass```