### PR TITLE
Automation of CEPH-9925-[RADOS]: remove an omap entry of a replica using ceph-objectstore-tool and list-inconsistent-obj

### DIFF
--- a/tests/rados/test_osd_inconsistency_pg.py
+++ b/tests/rados/test_osd_inconsistency_pg.py
@@ -5,7 +5,6 @@ AS part of verification the script  perform the following tasks-
    2. Convert the object in to inconsistent object
 """
 
-
 import random
 import traceback
 
@@ -77,9 +76,22 @@ def run(ceph_cluster, **kw):
             obj_id = object_list["inconsistents"][obj_count]["object"]["name"]
             if obj_id == oname:
                 log.info(f"Inconsistent object {obj_id} is exists in the objects list.")
+                errors_list = object_list["inconsistents"][obj_count]["errors"]
+                log.info(
+                    f"Checking the error messages of the inconsistent object {obj_id} "
+                )
+                if "omap_digest_mismatch" not in errors_list:
+                    log.error(
+                        f"The inconsistent object {obj_id} is not reported with the omap_digest_mismatch error"
+                    )
+                    return 1
+                log.info(
+                    f"The inconsistent object {obj_id} is reported with the omap_digest_mismatch error"
+                )
             else:
                 log.error("Inconsistent object is not exists in the objects list")
                 return 1
+
         osd_map_output = rados_obj.get_osd_map(pool=pool_name, obj=oname)
         primary_osd = osd_map_output["acting_primary"]
         # Executing the fsck on the OSD


### PR DESCRIPTION
# Automation of the testcase - [RADOS]: remove an omap entry of a replica using ceph-objectstore-tool and list-inconsistent-obj 

Polarion Id- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9925

The major steps in the CEPH-9925 are included in the CEPH-9924. I am adding the additional verification step into CEPH-9924 and making the CEPH-9925 inactive.

**The manual step which is automated in the test case -**

 Step[13] - Checking the "omap_digest_mismatch" error message in the "rados list-inconsistent-obj <pg>" output.
 

 

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
