### PR TITLE
Added rados tests to check for inconsistency after OSD epcoh changes.

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -104,6 +104,7 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
   - test:
       name: Inconsistent object pg check
       desc: Inconsistent object pg check
@@ -121,6 +122,7 @@ tests:
             obj_end: 5
             num_keys_obj: 10
         delete_pool: true
+
   - test:
       name: OMAP feature
       desc: Testing omap features
@@ -150,3 +152,19 @@ tests:
           - 23
           - 107
       polarion-id: CEPH-83571710
+
+  - test:
+      name: Inconsistent OSD epoch
+      desc: list-inconsistent requires the correct epoch
+      module: test_inconsistency_osd_epoch.py
+      polarion-id: CEPH-9947
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool_name: test_pool_4
+            pool_type: replicated
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -104,6 +104,7 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
   - test:
       name: Inconsistent object pg check
       desc: Inconsistent object pg check
@@ -121,6 +122,7 @@ tests:
             obj_end: 5
             num_keys_obj: 10
         delete_pool: true
+
   - test:
       name: OMAP feature
       desc: Testing omap features
@@ -150,3 +152,19 @@ tests:
           - 23
           - 107
       polarion-id: CEPH-83571710
+
+  - test:
+      name: Inconsistent OSD epoch
+      desc: list-inconsistent requires the correct epoch
+      module: test_inconsistency_osd_epoch.py
+      polarion-id: CEPH-9947
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool_name: test_pool_4
+            pool_type: replicated
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -104,6 +104,7 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
   - test:
       name: Inconsistent object pg check
       desc: Inconsistent object pg check
@@ -121,6 +122,7 @@ tests:
             obj_end: 5
             num_keys_obj: 10
         delete_pool: true
+
   - test:
       name: OMAP feature
       desc: Testing omap features
@@ -150,3 +152,19 @@ tests:
           - 23
           - 107
       polarion-id: CEPH-83571710
+
+  - test:
+      name: Inconsistent OSD epoch
+      desc: list-inconsistent requires the correct epoch
+      module: test_inconsistency_osd_epoch.py
+      polarion-id: CEPH-9947
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool_name: test_pool_4
+            pool_type: replicated
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true

--- a/tests/rados/test_inconsistency_osd_epoch.py
+++ b/tests/rados/test_inconsistency_osd_epoch.py
@@ -1,0 +1,138 @@
+"""
+This file contains the  methods to generate inconsistent objects, collect the OSD epoch,
+ and then change the epoch to check if the inconsistency persists.
+"""
+
+
+import random
+import traceback
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from utility.log import Log
+from utility.utils import method_should_succeed
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    This file contains the  methods to generate inconsistent objects, collect the OSD epoch,
+    and then change the epoch to check if the inconsistency persists.
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+    pool_target_configs = config["verify_osd_omap_entries"]["configurations"]
+    omap_target_configs = config["verify_osd_omap_entries"]["omap_config"]
+    try:
+        method_should_succeed(
+            rados_obj.create_pool,
+            **pool_target_configs,
+        )
+        pool_name = pool_target_configs["pool_name"]
+        log.info(f"Created the pool {pool_name} to generate inconsistent objects")
+
+        # Creating omaps
+        if not pool_obj.fill_omap_entries(pool_name=pool_name, **omap_target_configs):
+            log.error(f"Omap entries not generated on pool {pool_name}")
+            return 1
+        log.debug("Completed writing omap entries onto the pool")
+
+        # Fetching all objects and selecting one object to generate inconsistency
+        obj_list = rados_obj.get_object_list(pool_name)
+        log.debug(f"All the objects added onto the pool are : {obj_list}")
+
+        oname = random.choice(obj_list)
+        log.debug(
+            f"Selected object {oname} at random to generate inconsistent objects."
+        )
+
+        primary_osd = rados_obj.get_osd_map(pool=pool_name, obj=oname)["acting_primary"]
+        log.debug(f"The object stored in the primary osd number-{primary_osd}")
+
+        # getting the OSD epoch before generating inconsistent objects
+        epoch_cmd = "ceph osd dump"
+        init_epoch = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+        log.info(f"Initial epoch before generating inconsistency is {init_epoch}")
+
+        # Create inconsistency objects
+        pg_id = rados_obj.create_inconsistent_object(pool_name, oname)
+        log.debug(f"PG ID {pg_id} has inconsistent object generated on it.")
+
+        # Checking for inconsistency in the PG list
+        inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
+        if any(pg_id in search for search in inconsistent_pg_list):
+            log.info(f"Inconsistent PG is{pg_id}  ")
+        else:
+            log.error("Inconsistent PG is not generated")
+            raise Exception("Inconsistent object not generated error")
+
+        epoch_incon = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+        log.info(f"OSD epoch when Inconsistent object is generated : {epoch_incon}")
+
+        log.debug(
+            f"Marking the primary OSD with inconsistency, OSD.{primary_osd} down and out"
+        )
+        rados_obj.change_osd_state(action="stop", target=primary_osd)
+        rados_obj.run_ceph_command(cmd=f"ceph osd out {primary_osd}")
+
+        # Checking for the inconsistent pg's
+        inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)
+        if any(pg_id in search for search in inconsistent_pg_list):
+            log.error(
+                "Inconsistent pg exists in the cluster even after the OSD epoch was changed with OSD down"
+            )
+            raise Exception("Inconsistent PG on cluster Error")
+        log.info("Inconsistent pg does not exist on the cluster post epoch change.")
+
+        epoch_osd = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+        log.info(f"OSD epoch when affected OSD is marked out & down: {epoch_osd}")
+
+        if epoch_incon == epoch_osd:
+            log.error(
+                "The osd epoch has not changed post bringing down the affected OSD"
+            )
+            raise Exception("OSD epoch not changed error")
+
+        # Marking the OSD in the cluster and bringing it up.
+        log.debug(
+            f"Marking the primary OSD with inconsistency, OSD.{primary_osd} Up and In"
+        )
+        rados_obj.change_osd_state(action="start", target=primary_osd)
+        rados_obj.run_ceph_command(cmd=f"ceph osd in {primary_osd}")
+
+        # Repairing the OSD using CBT
+        log.info(f"Performing the repair on the osd.{primary_osd}")
+        op = bluestore_obj.repair(primary_osd)
+        log.info(f"CBT repair status :{op}")
+
+        epoch_final = rados_obj.run_ceph_command(cmd=epoch_cmd)["epoch"]
+        log.info(
+            f"OSD epoch when Inconsistent object is repaiered + affected OSD is brought up : {epoch_final}"
+        )
+
+        if epoch_final == epoch_osd:
+            log.error(
+                "The osd epoch has not changed post PG repair of the affected OSD"
+            )
+            raise Exception("OSD epoch not changed error")
+        log.info("Completed the test. Pass")
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        log.info("------------Execution of finally block-----------------")
+        if config.get("delete_pool"):
+            method_should_succeed(rados_obj.detete_pool, pool_name)
+            log.info("deleted the pool successfully")
+    return 0

--- a/tests/rados/test_stretch_site_maintenance_modes.py
+++ b/tests/rados/test_stretch_site_maintenance_modes.py
@@ -181,7 +181,9 @@ def run(ceph_cluster, **kw):
             if not rados_obj.host_maintenance_enter(hostname=host, retry=10):
                 log.error(f"Failed to add host : {host} into maintenance mode")
                 raise Exception("Test execution Failed")
-        time.sleep(120)
+
+        # Sleeping for 4 minutes. Observed that sometimes warning gets generated post 2 minutes.
+        time.sleep(240)
 
         # Installer node will be in maintenance mode this point. all operations need to be done at client nodes
         status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)


### PR DESCRIPTION
# Description
Polarion link : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-9947 

CEPH-9947 - [RADOS]: make sure that list-inconsistent-* requires the correct epoch

Test Steps :
1. Create pool, write OMAP entries.
2. Corrupt the object by deleting omap entries and generating inconsistent object. Check the epoch.
3. Bring down and mark out the corrupted OSD. The inconsistency should be gone. Check the epoch. Should be new.
4. Bring up the OSD and repair using CBT. New epoch should be generated.

