### PR TITLE
[Nfs-Ganesha][Automation]Add hard and symbolic link scenario

### DIFF
--- a/suites/reef/nfs/tier1-nfs-ganesha.yaml
+++ b/suites/reef/nfs/tier1-nfs-ganesha.yaml
@@ -216,3 +216,33 @@ tests:
         nfs_version: 4.1
         clients: 1
         operation: default_permissions
+
+  - test:
+      name: Verify that hard links remain valid after an NFS server reboot.
+      module: nfs_hard_links_server_reboot.py
+      desc: Verify that hard links remain valid after an NFS server reboot.
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 1
+
+  - test:
+      name: Verify renaming a file that has one or more hard or symbolic links associated with it.
+      module: nfs_hard_symbolic_links_rename.py
+      desc: Test NFS behavior when renaming a file that has one or more hard or symbolic links associated with it.
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 1
+
+  - test:
+      name: Verify when deleting a file with one or more hard links and verify that the remaining hard links are still valid.
+      module: nfs_hard_links_delete_file.py
+      desc: Test NFS behavior when deleting a file with one or more hard links and verify that the remaining hard links are still valid.
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 4.1
+        clients: 1

--- a/tests/nfs/nfs_hard_links_delete_file.py
+++ b/tests/nfs/nfs_hard_links_delete_file.py
@@ -1,0 +1,94 @@
+from time import sleep
+
+from nfs_operations import cleanup_cluster, setup_nfs_cluster
+
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Verify symbolic links scenarios
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+
+    port = config.get("port", "2049")
+    version = config.get("nfs_version", "4.0")
+    no_clients = int(config.get("clients", "2"))
+
+    # If the setup doesn't have required number of clients, exit.
+    if no_clients > len(clients):
+        raise ConfigError("The test requires more clients than available")
+
+    clients = clients[:no_clients]  # Select only the required number of clients
+    nfs_node = nfs_nodes[0]
+    fs_name = "cephfs"
+    nfs_name = "cephfs-nfs"
+    nfs_export = "/export"
+    nfs_mount = "/mnt/nfs"
+    fs = "cephfs"
+    nfs_server_name = nfs_node.hostname
+
+    try:
+        # Setup nfs cluster
+        setup_nfs_cluster(
+            clients,
+            nfs_server_name,
+            port,
+            version,
+            nfs_name,
+            nfs_mount,
+            fs_name,
+            nfs_export,
+            fs,
+        )
+
+        # Create file in local file system
+        cmd = f"touch {nfs_mount}/test_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Create hard links
+        cmd = f"ln {nfs_mount}/test_file {nfs_mount}/hard_link_file1"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+        cmd = f"ln {nfs_mount}/test_file {nfs_mount}/hard_link_file2"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Delete file with multiple hard links
+        cmd = f"rm -rf {nfs_mount}/test_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Verify hardlink remaning hardlinks files
+        hardlink_file1_inode = (
+            clients[0]
+            .exec_command(
+                cmd="ls -i /mnt/nfs/hard_link_file1 | awk '{print $1}'", sudo=True
+            )[0]
+            .strip()
+        )
+        hardlink_file2_inode = (
+            clients[0]
+            .exec_command(
+                cmd="ls -i /mnt/nfs/hard_link_file2 | awk '{print $1}'", sudo=True
+            )[0]
+            .strip()
+        )
+        if hardlink_file1_inode != hardlink_file2_inode:
+            raise OperationFailedError(
+                "hard link file not have same inode as original file"
+            )
+            return 1
+        else:
+            log.info("iNode match for original and hard link file")
+    except Exception as e:
+        log.error(f"Error : {e}")
+    finally:
+        log.info("Cleaning up")
+        sleep(3)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        log.info("Cleaning up successfull")
+    return 0

--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -1,0 +1,92 @@
+from time import sleep
+
+from nfs_operations import cleanup_cluster, setup_nfs_cluster
+
+from cli.exceptions import ConfigError, OperationFailedError
+from cli.utilities.utils import reboot_node
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Verify symbolic links scenarios
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+
+    port = config.get("port", "2049")
+    version = config.get("nfs_version", "4.0")
+    no_clients = int(config.get("clients", "2"))
+
+    # If the setup doesn't have required number of clients, exit.
+    if no_clients > len(clients):
+        raise ConfigError("The test requires more clients than available")
+
+    clients = clients[:no_clients]  # Select only the required number of clients
+    nfs_node = nfs_nodes[0]
+    fs_name = "cephfs"
+    nfs_name = "cephfs-nfs"
+    nfs_export = "/export"
+    nfs_mount = "/mnt/nfs"
+    fs = "cephfs"
+    nfs_server_name = nfs_node.hostname
+
+    try:
+        # Setup nfs cluster
+        setup_nfs_cluster(
+            clients,
+            nfs_server_name,
+            port,
+            version,
+            nfs_name,
+            nfs_mount,
+            fs_name,
+            nfs_export,
+            fs,
+        )
+
+        # Create file in local file system
+        cmd = f"touch {nfs_mount}/test_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Create hard links
+        cmd = f"ln {nfs_mount}/test_file {nfs_mount}/link_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Reboot NFS server
+        reboot_node(nfs_node)
+
+        # After reboot, Verify hardlink
+        original_file_inode = (
+            clients[0]
+            .exec_command(cmd="ls -i /mnt/nfs/test_file | awk '{print $1}'", sudo=True)[
+                0
+            ]
+            .strip()
+        )
+        hard_link_file_inode = (
+            clients[0]
+            .exec_command(cmd="ls -i /mnt/nfs/link_file | awk '{print $1}'", sudo=True)[
+                0
+            ]
+            .strip()
+        )
+        if original_file_inode != hard_link_file_inode:
+            raise OperationFailedError(
+                "hard link file not have same inode as original file"
+            )
+            return 1
+        else:
+            log.info("iNode match for original and hard link file")
+    except Exception as e:
+        log.error(f"Error : {e}")
+    finally:
+        log.info("Cleaning up")
+        sleep(3)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        log.info("Cleaning up successfull")
+    return 0

--- a/tests/nfs/nfs_hard_symbolic_links_rename.py
+++ b/tests/nfs/nfs_hard_symbolic_links_rename.py
@@ -1,0 +1,109 @@
+from time import sleep
+
+from nfs_operations import cleanup_cluster, setup_nfs_cluster
+
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Verify symbolic links scenarios
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+
+    port = config.get("port", "2049")
+    version = config.get("nfs_version", "4.0")
+    no_clients = int(config.get("clients", "2"))
+
+    # If the setup doesn't have required number of clients, exit.
+    if no_clients > len(clients):
+        raise ConfigError("The test requires more clients than available")
+
+    clients = clients[:no_clients]  # Select only the required number of clients
+    nfs_node = nfs_nodes[0]
+    fs_name = "cephfs"
+    nfs_name = "cephfs-nfs"
+    nfs_export = "/export"
+    nfs_mount = "/mnt/nfs"
+    fs = "cephfs"
+    nfs_server_name = nfs_node.hostname
+
+    try:
+        # Setup nfs cluster
+        setup_nfs_cluster(
+            clients,
+            nfs_server_name,
+            port,
+            version,
+            nfs_name,
+            nfs_mount,
+            fs_name,
+            nfs_export,
+            fs,
+        )
+
+        # Create file in local file system
+        cmd = f"touch {nfs_mount}/test_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Create hard and symbolic links
+        cmd = f"ln {nfs_mount}/test_file {nfs_mount}/hard_link_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+        cmd = f"ln -s {nfs_mount}/test_file {nfs_mount}/symbolic_link_file"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Rename file having hard and symbolic links
+        cmd = f"mv {nfs_mount}/test_file {nfs_mount}/test_file_rename"
+        clients[0].exec_command(cmd=cmd, sudo=True)
+
+        # Verify hard link after rename
+        original_file_inode = (
+            clients[0]
+            .exec_command(
+                cmd="ls -i /mnt/nfs/test_file_rename | awk '{print $1}'", sudo=True
+            )[0]
+            .strip()
+        )
+        hard_link_file_inode = (
+            clients[0]
+            .exec_command(
+                cmd="ls -i /mnt/nfs/hard_link_file | awk '{print $1}'", sudo=True
+            )[0]
+            .strip()
+        )
+        if original_file_inode != hard_link_file_inode:
+            raise OperationFailedError(
+                "hard link file not have same inode as original file"
+            )
+            return 1
+        else:
+            log.info("iNode match for original and hard link file")
+
+        # Verify symbolic link after rename
+        out = (
+            clients[0]
+            .exec_command(
+                cmd="ls -l /mnt/nfs/symbolic_link_file | awk '{print $10}'", sudo=True
+            )[0]
+            .strip()
+        )
+        if "->" not in out:
+            raise OperationFailedError("Failed to created symbolic links to files")
+            return 1
+        else:
+            log.info("Successfully created symbolic links to file")
+
+    except Exception as e:
+        log.error(f"Error : {e}")
+    finally:
+        log.info("Cleaning up")
+        sleep(3)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        log.info("Cleaning up successfull")
+    return 0


### PR DESCRIPTION
[Nfs-Ganesha][Automation]Add hard and symbolic link scenario
Scenario:
Verify that hard links remain valid after an NFS server reboot.
Test NFS behavior when renaming a file that has one or more hard or symbolic links associated with it.
Test NFS behavior when deleting a file with one or more hard links and verify that the remaining hard links are still valid.