### PR TITLE
NVMeoTCP needs VM instance with 4CPU cores

### DIFF
--- a/conf/reef/nvmeof/ceph_nvmeof_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_cluster.yaml
@@ -1,6 +1,7 @@
 globals:
   - ceph-cluster:
       name: ceph
+      vm-size: ci.standard.large
       node1:
         role:
           - _admin

--- a/conf/reef/nvmeof/ceph_nvmeof_functional.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_functional.yaml
@@ -1,6 +1,7 @@
 globals:
   - ceph-cluster:
       name: ceph
+      vm-size: ci.standard.large
       node1:
         role:
           - _admin

--- a/conf/reef/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
@@ -1,6 +1,7 @@
 globals:
   - ceph-cluster:
       name: ceph
+      vm-size: ci.standard.large
       node1:
         role:
           - _admin

--- a/conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
@@ -1,6 +1,7 @@
 globals:
   - ceph-cluster:
       name: ceph
+      vm-size: ci.standard.large
       node1:
         role:
           - _admin

--- a/conf/reef/nvmeof/ceph_nvmeof_scale_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_scale_cluster.yaml
@@ -1,6 +1,7 @@
 globals:
   - ceph-cluster:
       name: ceph
+      vm-size: ci.standard.large
       node1:
         role:
           - _admin

--- a/conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml
@@ -1,6 +1,7 @@
 globals:
   - ceph-cluster:
       name: ceph
+      vm-size: ci.standard.large
       node1:
         role:
           - _admin


### PR DESCRIPTION
NVMeoTCP gateway needs VM instance with 4CPU cores, hence using `ci.standard.large` for all NVMeoTCP test suites.