### PR TITLE
Core_workflows.py: Added method to simulate network delay and packet loss

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -117,6 +117,24 @@ tests:
           - pool1
 
   - test:
+      name: Verify PG split and merge with network delay
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool5
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        add_network_delay: true
+        delete_pools:
+          - pool5
+
+  - test:
       name: Verify restart osd during PG split
       module: test_pg_split.py
       desc: Verify restart osd when PG split in progress

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -211,6 +211,19 @@ tests:
       abort-on-fail: true
 
   - test:
+      name: test stretch Cluster site down with delay - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83571705
+      config:
+        pool_name: test_stretch_pool9
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+        add_network_delay: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+      abort-on-fail: true
+
+  - test:
       name: test stretch Cluster site down - Arbiter site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974

--- a/suites/quincy/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -117,6 +117,24 @@ tests:
           - pool1
 
   - test:
+      name: Verify PG split and merge with network delay
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool5
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        add_network_delay: true
+        delete_pools:
+          - pool5
+
+  - test:
       name: Verify restart osd during PG split
       module: test_pg_split.py
       desc: Verify restart osd when PG split in progress

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -212,6 +212,19 @@ tests:
       abort-on-fail: true
 
   - test:
+      name: test stretch Cluster site down with delay - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83571705
+      config:
+        pool_name: test_stretch_pool9
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+        add_network_delay: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+      abort-on-fail: true
+
+  - test:
       name: test stretch Cluster site down - Arbiter site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974

--- a/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -228,6 +228,24 @@ tests:
           - pool2
 
   - test:
+      name: Verify PG split and merge with network delay
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool5
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        add_network_delay: true
+        delete_pools:
+          - pool5
+
+  - test:
       name: Verify delete object during PG split
       module: test_pg_split.py
       desc: Verify delete object when PG split in progress

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -215,6 +215,19 @@ tests:
       abort-on-fail: true
 
   - test:
+      name: test stretch Cluster site down with delay - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83571705
+      config:
+        pool_name: test_stretch_pool9
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+        add_network_delay: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+      abort-on-fail: true
+
+  - test:
       name: test stretch Cluster site down - Arbiter site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974


### PR DESCRIPTION
…loss

Added new method to simulate network delays and packet loss on the ceph nodes & clients. Added the delays during rebalance scenarios for:
1. Regular RHCS cluster during PG split-merge -> recovery
2. Stretch Mode RHCS cluster during site down -> recovery

CEPH-83571705 - Network failures and Delays during rebalance on RHCS cluster

Polarion test : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571705 
