### PR TITLE
Incorporate tox to run s3tests from Reef 7.0 onwards

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -177,7 +177,7 @@ def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> in
         extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!encryption'"
         tests = "s3tests"
 
-        if not build.startswith("4"):
+        if not build.startswith("7"):
             extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616"
 
             if not encryption:
@@ -185,6 +185,15 @@ def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> in
 
             extra_args += ",!test_of_sts,!s3select,!user-policy,!webidentity_test'"
             tests = "s3tests_boto3"
+
+        else:
+            base_cmd = "cd s3-tests; S3TEST_CONF=config.yaml virtualenv/bin/tox"
+            extra_args = "-- -v -m 'not fails_on_rgw and not fails_strict_rfc2616"
+            tests = "s3tests_boto3"
+
+            if not encryption:
+                extra_args += " and not encryption"
+            extra_args += " and not user-policy and not webidentity_test'"
 
         cmd = f"{base_cmd} {extra_args} {tests}"
         return node.exec_command(cmd=cmd, long_running=True)


### PR DESCRIPTION
Changes:
- Add tox for s3tests runs from 7.0 
- Retain older nose tests framework for backward compatibility <7.0

PS: This is only the cephci change to use tox, it does not fix the s3tests failures . They will be addressed in a further PR.

Pass logs : 
7.0 s3tests : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-j05zz/execute_s3tests_0.log
6.1 s3tests : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4q5h3/execute_s3tests_0.log
