### PR TITLE
CEPH-83572702: Replacement of an OSD with retention of its ID

### DIFF
--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -205,15 +205,16 @@ class OSD(ApplyMixin, Orch):
             except json.decoder.JSONDecodeError:
                 break
 
-        # validate OSD removal
-        out, verify = self.shell(
-            args=["ceph", "osd", "tree", "-f", "json"],
-        )
-        out = json.loads(out)
-        for id_ in out["nodes"]:
-            if id_["id"] == osd_id:
-                LOG.error("OSD Removed ID found")
-                raise AssertionError("fail, OSD is present still after removing")
+        if config.get("validate", True):
+            # validate OSD removal
+            out, verify = self.shell(
+                args=["ceph", "osd", "tree", "-f", "json"],
+            )
+            out = json.loads(out)
+            for id_ in out["nodes"]:
+                if int(id_["id"]) == int(osd_id):
+                    LOG.error("OSD Removed ID found")
+                    raise AssertionError("fail, OSD is present still after removing")
         LOG.info(f" OSD {osd_id} Removal is successful")
 
     def out(self, config: Dict):

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -201,6 +201,26 @@ def osd_remove(ceph_cluster, osd_id):
     osd.rm(config)
 
 
+def osd_replace(ceph_cluster, osd_id):
+    """
+    same as osd_remove, with one exception: the OSD is not permanently
+    removed from the CRUSH hierarchy, but is instead assigned a ‘destroyed’ flag.
+    Args:
+        ceph_cluster: ceph cluster
+        osd_id: osd id
+    """
+    config = {
+        "command": "rm",
+        "service": "osd",
+        "pos_args": [osd_id],
+        "base_cmd_args": {"zap": True, "replace": True},
+        "validate": False,
+    }
+    log.info(f"Executing OSD {config.pop('command')} service")
+    osd = OSD(cluster=ceph_cluster, **config)
+    osd.rm(config)
+
+
 def zap_device(ceph_cluster, host, device_path):
     """
     Zap device

--- a/suites/pacific/rados/tier-4_rados_tests.yaml
+++ b/suites/pacific/rados/tier-4_rados_tests.yaml
@@ -155,6 +155,12 @@ tests:
       polarion-id: CEPH-83574780
 
   - test:
+      name: replacement of OSD
+      module: test_osd_replacement.py
+      polarion-id: CEPH-83572702
+      desc: Replace an OSD by retaining its ID
+
+  - test:
       name: mon replacement test
       polarion-id: CEPH-9407
       module: test_mon_addition_removal.py

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -155,6 +155,12 @@ tests:
       polarion-id: CEPH-83574780
 
   - test:
+      name: replacement of OSD
+      module: test_osd_replacement.py
+      polarion-id: CEPH-83572702
+      desc: Replace an OSD by retaining its ID
+
+  - test:
       name: mon replacement test
       polarion-id: CEPH-9407
       module: test_mon_addition_removal.py

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -155,6 +155,12 @@ tests:
       polarion-id: CEPH-83574780
 
   - test:
+      name: replacement of OSD
+      module: test_osd_replacement.py
+      polarion-id: CEPH-83572702
+      desc: Replace an OSD by retaining its ID
+
+  - test:
       name: Test ceph osd command arguments
       desc: Provide invalid values as argument to different ceph osd commands
       module: test_osd_args.py

--- a/tests/rados/test_osd_replacement.py
+++ b/tests/rados/test_osd_replacement.py
@@ -1,0 +1,111 @@
+import datetime
+import random
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados import utils
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83572702
+    Verify replacement of an OSD along with retaining its OSD ID
+    1. Create a cluster with few OSDs
+    2. Choose on OSD from the existing OSD list
+    3. Fetch OSD metadata to get the disk and hostname
+    4. Set OSD service unmanaged to True
+    5. Use ceph osd rm with --replace and --zap flags to replace the OSD
+    6. Add the OSD back to the cluster using ceph orch daemon add method
+    7. Set OSD service unmanaged to False
+    8. Repeat steps 5
+    9. Cluster should add the OSD back with the same ID automatically
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    log.info("Running test case to verify addition of new OSD on existing OSD disk")
+
+    try:
+        out, _ = cephadm.shell(args=["ceph osd ls"])
+        osd_list = out.strip().split("\n")
+        osd_id = int(random.choice(osd_list))
+        osd_list.pop(osd_id)
+        osd_metadata = ceph_cluster.get_osd_metadata(osd_id=int(osd_id), client=client)
+        log.debug(osd_metadata)
+        osd_device = f"/dev/{osd_metadata['devices']}"
+        osd_hostname = osd_metadata["hostname"]
+
+        # set unmanaged to True for OSD
+        utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
+        # Replace the OSD
+        utils.osd_replace(ceph_cluster, osd_id)
+
+        time.sleep(15)
+        # check status of OSD from ceph osd tree output
+        assert rados_obj.fetch_osd_status(_osd_id=osd_id) == "destroyed"
+
+        # Attempt to add the OSD back to the cluster
+        out, err = cephadm.shell(
+            [f"ceph orch daemon add osd {osd_hostname}:{osd_device}"]
+        )
+        log.info(out)
+        assert f"Created osd(s) {osd_id} on host '{osd_hostname}'" in out
+        destroyed_osd = rados_obj.run_ceph_command(cmd="ceph osd tree destroyed")[
+            "nodes"
+        ]
+        log.debug(destroyed_osd)
+        if len(destroyed_osd) != 0:
+            raise AssertionError("Cluster still has OSD(s) with destroyed status")
+        time.sleep(5)
+        assert rados_obj.fetch_osd_status(_osd_id=osd_id) == "up"
+
+        # set unmanaged to False for OSD
+        log.info("Set OSD service unmanaged to false")
+        utils.set_osd_devices_unmanaged(ceph_cluster, osd_list[0], unmanaged=False)
+
+        # Second workflow where unmanaged is not set to True
+        # Cluster will recover and add the new OSD on the same device itself
+        log.info(
+            "***** Initiating second workflow - unmanaged is not set to False \n"
+            "Cluster will recover and add the new OSD on the same device itself *********"
+        )
+        osd_id = random.choice(osd_list)
+        # Replace the OSD
+        utils.osd_replace(ceph_cluster, osd_id)
+        # wait for 15 mins for ceph cluster to add back the OSD
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=900)
+        while datetime.datetime.now() < endtime:
+            destroyed_osd = rados_obj.run_ceph_command(cmd="ceph osd tree destroyed")[
+                "nodes"
+            ]
+            if (
+                len(destroyed_osd) == 0
+                and rados_obj.fetch_osd_status(_osd_id=osd_id) == "up"
+            ):
+                log.info("No more OSDs have status 'destroyed'")
+                log.info(f"OSD {osd_id} status is UP")
+                break
+            log.info(
+                f"Cluster still has OSDs with status 'destroyed' or OSD {osd_id} is yet to come up, "
+                f"sleeping for 15 secs"
+            )
+            time.sleep(15)
+        else:
+            log.error(
+                f"Cluster failed to add back OSD {osd_id} or it couldn't come up within timeout"
+            )
+            log.info(f"List of OSD(s) with destroyed status: {destroyed_osd}")
+            raise Exception(f"Cluster failed to add back OSD {osd_id}")
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    log.info("Verification complete for replacement of OSD by retaining its ID")
+    return 0


### PR DESCRIPTION
Jira: [RHCEPHQE-11979](https://issues.redhat.com/browse/RHCEPHQE-11979)
[CEPH-83572702](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83572702): Tier-3 test to verify replacement of an OSD along with retention of its ID

Test modules added/modified:
- `osd_replace` in `ceph/rados/utils.py`
- `fetch_osd_status` in `ceph/rados/core_workflows.py`
- `ceph/ceph_admin/osd.py` in `ceph/ceph_admin/osd.py`
- tests/rados/test_osd_replacement.py

Test suites modified:
- suites/pacific/rados/tier-4_rados_tests.yaml
- suites/quincy/rados/tier-4_rados_tests.yaml
- suites/reef/rados/tier-4_rados_tests.yaml

Steps:
1. Create a cluster with few OSDs
2. Choose on OSD from the existing OSD list
3. Fetch OSD metadata to get the disk and hostname
4. Set OSD service unmanaged to True
5. Use `ceph orch osd rm` with `--replace` and `--zap` flags to replace the OSD
6. Add the OSD back to the cluster using ceph orch daemon add method
7. Set OSD service unmanaged to False
8. Repeat step 5
9. Cluster should add the OSD back with the same ID automatically

Logs:
Pacific - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6V1T1C
Quincy - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4LR79S
Reef - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-J9357Q

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

