### PR TITLE
Ceph-ci integration: dellifecycle via s3cmd

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -200,3 +200,13 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
         timeout: 300
+
+  - test:
+      name: Test deletlifecycle rule via s3cmd
+      desc: Test deletlifecycle rule via s3cmd
+      polarion-id: CEPH-83575469
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
+        timeout: 300

--- a/suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -240,3 +240,13 @@ tests:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
         timeout: 300
+
+  - test:
+      name: Test deletlifecycle rule via s3cmd
+      desc: Test deletlifecycle rule via s3cmd
+      polarion-id: CEPH-83575469
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
+        timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -280,3 +280,13 @@ tests:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_sync.yaml
         timeout: 300
+
+  - test:
+      name: Test deletlifecycle rule via s3cmd
+      desc: Test deletlifecycle rule via s3cmd
+      polarion-id: CEPH-83575469
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
+        timeout: 300


### PR DESCRIPTION
# Description

Ceph-ci integration: dellifecycle via s3cmd
polarian: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575469

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-6LOY22/Test_deletlifecycle_rule_via_s3cmd_0.log

Dependent on ceph-qe-script PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/511

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
