### PR TITLE
Test suite changes with respect to baremetal pipeline

### DIFF
--- a/conf/quincy/baremetal_pipeline/mero_conf.yaml
+++ b/conf/quincy/baremetal_pipeline/mero_conf.yaml
@@ -76,6 +76,7 @@ globals:
             - osd
             - rgw
             - nfs
+            - nvmeof
           root_password: passwd
           volumes:
             - /dev/sda

--- a/conf/reef/nvmeof/ceph_nvmeof_functional.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_functional.yaml
@@ -40,8 +40,10 @@ globals:
         no-of-volumes: 4
         disk-size: 20
       node7:
+        id: node10
         role:
           - client
       node8:
+        id: node11
         role:
           - client

--- a/conf/reef/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
@@ -33,8 +33,10 @@ globals:
         no-of-volumes: 4
         disk-size: 20
       node6:
+        id: node10
         role:
           - client
       node7:
+        id: node11
         role:
           - client

--- a/conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
@@ -36,5 +36,6 @@ globals:
           - client
           - nvmeof-gw
       node7:
+        id: node10
         role:
           - client

--- a/conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml
@@ -33,5 +33,6 @@ globals:
         no-of-volumes: 4
         disk-size: 20
       node6:
+        id: node10
         role:
           - client

--- a/suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml
@@ -54,8 +54,7 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -219,7 +218,7 @@ tests:
         initiators:                             # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001
-            node: node7
+            node: node10
       desc: E2E-Test NVMEoF Gateway on dedicated node and Run IOs on targets
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway.py
@@ -252,7 +251,7 @@ tests:
         initiators:                             # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001
-            node: node7
+            node: node10
       desc: E2E-Test NVMEoF Gateway collocated and Run IOs on targets
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway.py

--- a/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -51,8 +51,8 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node7
-          - node8
+          - node10
+          - node11
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -89,7 +89,7 @@ tests:
         initiator:                              # Configure Initiators with all pre-req
             subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001
-            node: node7
+            node: node10
       desc: Perform Data integrity test over NVMEoF targets
       destroy-cluster: false
       module: test_ceph_nvmeof_data_integrity.py
@@ -123,7 +123,7 @@ tests:
         initiators:                            # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode2
             listener_port: 5002
-            node: node7
+            node: node10
       desc: E2E-Test NVMEoF Gateway collocated with OSD node and Run IOs on targets
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway.py
@@ -157,7 +157,7 @@ tests:
         initiators:                             # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode6
             listener_port: 5006
-            node: node7
+            node: node10
       desc: E2E-Test NVMEoF Gateway collocated with MON-MGR node and Run IOs on targets
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway.py
@@ -198,10 +198,10 @@ tests:
         initiators:                             # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode3
             listener_port: 5003
-            node: node7
+            node: node10
           - subnqn: nqn.2016-06.io.spdk:cnode4
             listener_port: 5004
-            node: node8
+            node: node11
       desc: Perform IOs on multi-subsystems with Multiple-Initiators
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway.py
@@ -235,7 +235,7 @@ tests:
         initiators: # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode5
             listener_port: 5005
-            node: node8
+            node: node10
       desc: Deploy multiple NVMEoF Gateway on the cluster
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway.py
@@ -251,8 +251,8 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node7
-        operation: remove
+        initiator_node: node10
+        operation: CEPH-83575812
       desc: Test remove RBD image used as NVMe namespace
       destroy-cluster: false
       module: test_ceph_nvmeof_neg_tests.py
@@ -268,7 +268,7 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node7
+        initiator_node: node10
         operation: CEPH-83576084
       desc: Delete-recreate bdev in loop and rediscover namespace
       destroy-cluster: false
@@ -285,7 +285,7 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node7
+        initiator_node: node10
         operation: CEPH-83575467
       desc: Perform restart and validate the gateway entities
       destroy-cluster: false
@@ -302,7 +302,7 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node7
+        initiator_node: node10
         operation: CEPH-83576085
       desc: Perform map and unmap NVMe namespaces in loop
       destroy-cluster: false
@@ -319,7 +319,7 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node7
+        initiator_node: node10
         operation: CEPH-83576087
       desc: Perform reboot on initiator node and validate the namespaces.
       destroy-cluster: false
@@ -336,7 +336,7 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node7
+        initiator_node: node10
         operation: CEPH-83575813
       desc: Perform RBD operations shrink and expand on images.
       destroy-cluster: false
@@ -346,19 +346,6 @@ tests:
 
 # Reboot GW node
   - test:
-      name: Add Host
-      desc: Add host to Bootstrapped Cluster
-      module: test_host.py
-      polarion-id: CEPH-83573729
-      config:
-        service: host
-        command: add
-        args:                     # arguments to ceph orch
-          attach_ip_address: true
-          node: node7
-      destroy-cluster: false
-
-  - test:
       abort-on-fail: true
       config:
         gw_node: node6
@@ -367,24 +354,10 @@ tests:
         rep-pool-only: true
         rep_pool_config:
           pool: rbd
-        initiator_node: node8
+        initiator_node: node10
         operation: CEPH-83576093
       desc: Perform reboot on GW node and validate the namespaces.
       destroy-cluster: false
       module: test_ceph_nvmeof_neg_tests.py
       name: Reboot GW node and check NVMe namespaces
       polarion-id: CEPH-83576093
-
-  - test:
-      name: Remove host
-      desc: Remove node from cluster
-      module: test_host.py
-      polarion-id: CEPH-83573747
-      config:
-        service: host
-        command: remove
-        base_cmd_args:
-          verbose: true
-        args:
-          node: node7
-      destroy-cluster: false

--- a/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_128k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_128k_block_size.yaml
@@ -56,7 +56,7 @@ tests:
         id: client.1
         nodes:
           - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
           - fio
@@ -87,13 +87,13 @@ tests:
                 image:
                     size: 10G
                     count: 1
-                node: node7             # client node
+                node: node10             # client node
             -   proto: nvmeof
                 image:
                     size: 10G
                     count: 1
                 gw_node: node6          # gateway node
-                initiator_node: node7   # client node
+                initiator_node: node10   # client node
                 install_gw: true
 
   - test:
@@ -114,13 +114,13 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType 128k blocksize
@@ -141,13 +141,13 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType
@@ -168,10 +168,10 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
@@ -56,7 +56,7 @@ tests:
         id: client.1
         nodes:
           - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
           - fio
@@ -87,13 +87,13 @@ tests:
                 image:
                     size: 5G
                     count: 10
-                node: node7             # client node
+                node: node10             # client node
             -   proto: nvmeof
                 image:
                     size: 5G
                     count: 10
                 gw_node: node6          # gateway node
-                initiator_node: node7   # client node
+                initiator_node: node10   # client node
                 install_gw: true
 
   - test:
@@ -114,13 +114,13 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random ReadNWrite IOType 128kb-bs multi volumes
@@ -141,13 +141,13 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random-ReadWrite IOType 128k-bs multi-volumes
@@ -168,10 +168,10 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
@@ -56,7 +56,7 @@ tests:
         id: client.1
         nodes:
           - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
           - fio
@@ -87,13 +87,13 @@ tests:
                 image:
                     size: 5G
                     count: 10
-                node: node7             # client node
+                node: node10             # client node
             -   proto: nvmeof
                 image:
                     size: 5G
                     count: 10
                 gw_node: node6          # gateway node
-                initiator_node: node7   # client node
+                initiator_node: node10   # client node
                 install_gw: true
 
   - test:
@@ -114,13 +114,13 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random ReadNWrite IOType 16kb-bs multi volumes
@@ -141,13 +141,13 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random-ReadWrite IOType 16k-bs multi-volumes
@@ -168,10 +168,10 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
@@ -56,7 +56,7 @@ tests:
         id: client.1
         nodes:
           - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
           - fio
@@ -85,13 +85,13 @@ tests:
                 image:
                     size: 5G
                     count: 10
-                node: node7             # client node
+                node: node10             # client node
             -   proto: nvmeof
                 image:
                     size: 5G
                     count: 10
                 gw_node: node6          # gateway node
-                initiator_node: node7   # client node
+                initiator_node: node10   # client node
                 install_gw: true
 
   - test:
@@ -110,13 +110,13 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
@@ -135,13 +135,13 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
@@ -160,10 +160,10 @@ tests:
               image:
                 size: 5G
                 count: 10
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 5G
                 count: 10
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
@@ -56,7 +56,7 @@ tests:
         id: client.1
         nodes:
           - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
           - fio
@@ -87,13 +87,13 @@ tests:
                 image:
                     size: 10G
                     count: 1
-                node: node7             # client node
+                node: node10             # client node
             -   proto: nvmeof
                 image:
                     size: 10G
                     count: 1
                 gw_node: node6          # gateway node
-                initiator_node: node7   # client node
+                initiator_node: node10   # client node
                 install_gw: true
 
   - test:
@@ -114,13 +114,13 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType 16k blocksize
@@ -141,13 +141,13 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType
@@ -168,10 +168,10 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
@@ -55,8 +55,7 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
-          - node7
+          - node10
         install_packages:
           - ceph-common
           - fio
@@ -85,13 +84,13 @@ tests:
                 image:
                     size: 10G
                     count: 1
-                node: node7             # client node
+                node: node10             # client node
             -   proto: nvmeof
                 image:
                     size: 10G
                     count: 1
                 gw_node: node6          # gateway node
-                initiator_node: node7   # client node
+                initiator_node: node10   # client node
                 install_gw: true
 
   - test:
@@ -110,13 +109,13 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random-WRITE-READ-IOType 4kblocksize single-10G-vol
@@ -135,13 +134,13 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node
 
   - test:
       name: libRBD VS NVMeoF Random-READWRITE-IOType 4kblocksize single-10G-vol
@@ -160,10 +159,10 @@ tests:
               image:
                 size: 10G
                 count: 1
-              node: node7             # client node
+              node: node10             # client node
           -   proto: nvmeof
               image:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
-              initiator_node: node7   # client node
+              initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-2_nvmeof_namespace_limit.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_namespace_limit.yaml
@@ -81,8 +81,8 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
-          - node7
+          - node10
+          - node11
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -132,9 +132,9 @@ tests:
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001
-            node: node6
+            node: node10
         run_io:
-          - node: node6
+          - node: node10
             io_type: write
       desc: test namespace limitations with 1K namespaces
       destroy-cluster: false
@@ -163,9 +163,9 @@ tests:
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001
-            node: node7
+            node: node11
         run_io:
-          - node: node7
+          - node: node11
             io_type: write
       desc: test namespace limitations with 2K namespaces
       destroy-cluster: false

--- a/suites/reef/nvmeof/tier-2_nvmeof_scale_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_scale_ns.yaml
@@ -131,9 +131,9 @@ tests:
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001
-            node: node6
+            node: node10
         run_io:
-          - node: node6
+          - node: node10
             io_type: write
       desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false

--- a/suites/reef/nvmeof/tier-2_nvmeof_subsystem_limit.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_subsystem_limit.yaml
@@ -79,7 +79,7 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
+          - node10
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -105,9 +105,9 @@ tests:
           - config:
               command: get_subsystems
         initiators:
-          node: node6
+          node: node10
         run_io:
-          - node: node6
+          - node: node10
             io_type: write
       desc: test subsystem limitations
       destroy-cluster: false


### PR DESCRIPTION
- Introduced node level ids to run same test suites aginst OSP and baremetal pipeline.

Executed tests at OSP and here are the results,

```
All test logs located here: /tmp/cephci-run-HGQQ89

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:07:30.274820                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm                          0:11:25.597881                   Pass                             
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:00:47.996727                   Pass                             
Test to perform Data Integrity   Perform Data integrity test over NVMEoF targets                0:06:02.339052                   Pass                             
Basic E2E-Test Ceph NVMEoF GW    E2E-Test NVMEoF Gateway collocated with OSD node and Run IOs   0:17:05.151168                   Pass                             
Basic E2E-Test Ceph NVMEoF GW    E2E-Test NVMEoF Gateway collocated with MON-MGR node and Run   0:14:03.956715                   Pass                             
Test to run IOs using multiple   Perform IOs on multi-subsystems with Multiple-Initiators       0:15:19.149808                   Pass                             
Test to Deploy multiple NVMEoF   Deploy multiple NVMEoF Gateway on the cluster                  0:13:46.228164                   Pass                             
Remove-image ops on NVMe Names   Test remove RBD image used as NVMe namespace                   0:04:18.992765                   Pass                             
Delete-recreate bdev namespace   Delete-recreate bdev in loop and rediscover namespace          0:04:18.576097                   Pass                             
Perform restart of NVMeOF gate   Perform restart and validate the gateway entities              0:04:54.497325                   Pass                             
Map-Unmap NVMe namespaces cont   Perform map and unmap NVMe namespaces in loop                  0:03:41.586722                   Pass                             
Reboot client node and check N   Perform reboot on initiator node and validate the namespaces   0:03:47.948378                   Pass                             
RBD operations shrink and expa   Perform RBD operations shrink and expand on images.            0:15:11.199942                   Failed                           
Reboot GW node and check NVMe    Perform reboot on GW node and validate the namespaces.         0:02:13.848334                   Pass    
```

```
All test logs located here: /tmp/cephci-run-8Q13U3

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:06:52.829310                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm                          0:12:03.265763                   Pass                             
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:00:31.654298                   Pass                             
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:02:23.866228                   Pass                             
Manage nvmeof gateway entities   Manage NVMeoF Subsystem entities                               0:00:53.285667                   Failed                           
Delete nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:26.809960                   Pass                             
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:26.690864                   Pass                             
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway on dedicated node and Run IOs on tar   0:15:57.430664                   Pass                             
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway collocated and Run IOs on targets      0:03:28.194273                   Pass   

```