### PR TITLE
CEPH-11681: Tier-2 test to perform various operations on OMAPs and OSD OMAP compaction

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -404,14 +404,14 @@ class RadosOrchestrator:
         Args:
             pool_name: pool on which the operation will be performed
             kwargs: Any other param that needs to passed
-            1. rados_write_duration -> duration of write operation (int)
-            2. byte_size -> size of objects to be written (str)
-                eg : 10KB, 4096
-            3. max_objs -> max number of objects to be written (int)
-            4. verify_stats -> arg to control whether obj stats need to
-            be verified after write (bool) | default: True
-            5. rados_write_duration -> Duration for which the bench should be written on pool
-            6. check_ec -> If true, the method will wait to collect the exit status of the run, else will return
+                - rados_write_duration -> duration of write operation (int)
+                - byte_size -> size of objects to be written (str)
+                    eg : 10KB, 4096
+                - max_objs -> max number of objects to be written (int)
+                - verify_stats -> arg to control whether obj stats need to
+                  be verified after write (bool) | default: True
+                - check_ec (bool) -> boolean to control exit code check
+                - background (bool) -> run rados bench as background process and continue with test execution
         Returns: True -> pass, False -> fail
         """
         duration = kwargs.get("rados_write_duration", 200)
@@ -423,6 +423,10 @@ class RadosOrchestrator:
         org_objs = self.get_cephdf_stats(pool_name=pool_name)["stats"]["objects"]
         if max_objs:
             cmd = f"{cmd} --max-objects {max_objs}"
+        log.info(f"check_ec: {check_ec}")
+        if kwargs.get("background"):
+            check_ec = False
+            cmd = f"{cmd} &> /dev/null &"
 
         try:
             self.node.shell([cmd], check_status=check_ec)

--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -124,6 +124,24 @@ tests:
         delete_pool: true
 
   - test:
+      name: OSD compaction with failures
+      module: test_osd_compaction.py
+      polarion-id: CEPH-11681
+      config:
+        omap_config:
+          pool_name: re_pool_large_omap
+          large_warn: true
+          obj_start: 0
+          obj_end: 5
+          normal_objs: 400
+          num_keys_obj: 200001
+        bench_config:
+          pool_name: re_pool_bench
+          pg_num: 128
+          pgp_num: 128
+      desc: Perform OSD compaction with & without failures
+
+  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -124,6 +124,24 @@ tests:
         delete_pool: true
 
   - test:
+      name: OSD compaction with failures
+      module: test_osd_compaction.py
+      polarion-id: CEPH-11681
+      config:
+        omap_config:
+          pool_name: re_pool_large_omap
+          large_warn: true
+          obj_start: 0
+          obj_end: 5
+          normal_objs: 400
+          num_keys_obj: 200001
+        bench_config:
+          pool_name: re_pool_bench
+          pg_num: 128
+          pgp_num: 128
+      desc: Perform OSD compaction with & without failures
+
+  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -124,6 +124,24 @@ tests:
         delete_pool: true
 
   - test:
+      name: OSD compaction with failures
+      module: test_osd_compaction.py
+      polarion-id: CEPH-11681
+      config:
+        omap_config:
+          pool_name: re_pool_large_omap
+          large_warn: true
+          obj_start: 0
+          obj_end: 5
+          normal_objs: 400
+          num_keys_obj: 200001
+        bench_config:
+          pool_name: re_pool_bench
+          pg_num: 128
+          pgp_num: 128
+      desc: Perform OSD compaction with & without failures
+
+  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -1,0 +1,247 @@
+"""
+Tier-3 test module to perform various operations on large OMAPS
+and execute OSD compaction during IOPS with and without OSD failure
+"""
+import random
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from utility.log import Log
+from utility.utils import method_should_succeed
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-11681
+    This test is to perform various operations on OMAPS and execute
+    OSD compaction during IOPS with and without OSD failure
+    1. Create cluster with default configuration
+    2. Create a pool and write large number of OMAPS to few objects
+    3. Perform various operations on the OMAP entries, list, get,
+     add new, delete, clear, etc
+    4. Trigger background IOPS using rados bench
+    5. Execute OSD compaction for a healthy OSD
+    6. Stop the OSD using systemctl
+    7. Execute OSD compaction on the down OSD, expected to fail
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    omap_config = config["omap_config"]
+    bench_config = config["bench_config"]
+
+    # Creating pools and starting the test
+    try:
+        log.debug(
+            f"Creating replicated pool on the cluster with name {omap_config['pool_name']}"
+        )
+        method_should_succeed(rados_obj.create_pool, **omap_config)
+        pool_name = omap_config.pop("pool_name")
+        normal_objs = omap_config["normal_objs"]
+        bench_pool_name = bench_config["pool_name"]
+        if normal_objs > 0:
+            # create n number of objects without any omap entry
+            rados_obj.bench_write(
+                pool_name=pool_name,
+                **{
+                    "rados_write_duration": 600,
+                    "byte_size": "4096KB",
+                    "max_objs": normal_objs,
+                    "verify_stats": False,
+                },
+            )
+
+        # calculate objects to be written with omaps and begin omap creation process
+        omap_obj_num = omap_config["obj_end"] - omap_config["obj_start"]
+        log.debug(
+            f"Created the pool. beginning to create omap entries on the pool. Count : {omap_obj_num}"
+        )
+        if not pool_obj.fill_omap_entries(pool_name=pool_name, **omap_config):
+            log.error(f"Omap entries not generated on pool {pool_name}")
+            raise Exception(f"Omap entries not generated on pool {pool_name}")
+
+        assert pool_obj.check_large_omap_warning(
+            pool=pool_name,
+            obj_num=omap_obj_num,
+            check=omap_config["large_warn"],
+            obj_check=False,
+        )
+
+        # getting list of omap objects present in the pool
+        out, _ = cephadm.shell([f"rados ls -p {pool_name} | grep 'omap_obj'"])
+        omap_obj_list = out.split()
+        log.info(f"List of Objects having large omaps in {pool_name}: {omap_obj_list}")
+
+        # performing various operations on large omap objects
+        # 1. List omap key entries for an object
+        obj_rand = random.choice(omap_obj_list)
+        log.info(f"#1 Listing OMAP key entries for obj: {obj_rand}")
+        omap_keys, _ = pool_obj.perform_omap_operation(
+            pool=pool_name, obj=obj_rand, ops="listomapkeys"
+        )
+        log.info(
+            f"Printing first 20 OMAP keys present for Object {obj_rand}: \n"
+            f"{omap_keys.split()[:20]}"
+        )
+
+        # 2. List omap keys & values entries for an object
+        obj_rand = random.choice(omap_obj_list)
+        log.info(f"#2 Listing OMAP key & value entries for obj: {obj_rand}")
+        omap_key_val, _ = pool_obj.perform_omap_operation(
+            pool=pool_name, obj=obj_rand, ops="listomapvals"
+        )
+        omap_kv_trim = "\n".join(omap_key_val.split("\n")[-21:-1])
+        log.info(
+            f"Printing last few OMAP keys and values present for Object {obj_rand}: "
+            f"{omap_kv_trim}"
+        )
+
+        # 3. create a custom omap key & value entry for an object
+        obj_rand = random.choice(omap_obj_list)
+        log.info(f"#3 Creating a custom OMAP key & value entry for obj: {obj_rand}")
+        custom_val = random.randint(pow(10, 5), pow(10, 6) - 1)
+        custom_key = f"key_{custom_val}"
+        pool_obj.perform_omap_operation(
+            pool=pool_name,
+            obj=obj_rand,
+            ops="setomapval",
+            key=custom_key,
+            val=custom_val,
+        )
+        time.sleep(5)
+
+        # verifying addition of custom OMAP key
+        # 4. Fetch value of a particular omap key
+        log.info(f"#4 Fetching value of a particular OMAP key obj: {obj_rand}")
+        omap_val, _ = pool_obj.perform_omap_operation(
+            pool=pool_name, obj=obj_rand, ops="getomapval", key=custom_key
+        )
+        assert str(custom_val) in omap_val
+        log.info(f"Value of OMAP key {custom_key} is: {omap_val}")
+
+        # 5. Remove the newly added OMAP entry
+        log.info(f"#5 Removing a custom OMAP entry for obj: {obj_rand}")
+        pool_obj.perform_omap_operation(
+            pool=pool_name, obj=obj_rand, ops="rmomapkey", key=custom_key
+        )
+        time.sleep(5)
+
+        # verifying successful removal of custom OMAP key
+        # below validation does not help as failure is not getting
+        # caught correctly
+        # try:
+        #     _, err = pool_obj.perform_omap_operation(
+        #         pool=pool_name, obj=obj_rand, ops="listomapkeys", key=custom_key
+        #     )
+        # except Exception as ex:
+        #     log.info(f"Expected to fail | STDERR:\n {ex}")
+        # if "No such key" not in ex:
+        #     raise AssertionError(f"{custom_key} should have been deleted, expected error msg not found")
+        omap_keys, _ = pool_obj.perform_omap_operation(
+            pool=pool_name, obj=obj_rand, ops="listomapkeys"
+        )
+        assert custom_key not in omap_keys
+        log.info(f"{custom_key} key successfully removed from OMAP entries")
+
+        # 6. Clear all OMAP entries from an object
+        obj_rand = random.choice(omap_obj_list)
+        omap_obj_list.remove(obj_rand)
+        log.info(f"#6 Clearing all OMAP entries for obj: {obj_rand}")
+        pool_obj.perform_omap_operation(pool=pool_name, obj=obj_rand, ops="clearomap")
+        time.sleep(5)
+
+        # verifying removal of all omap entries for the obj
+        omap_keys, _ = pool_obj.perform_omap_operation(
+            pool=pool_name, obj=obj_rand, ops="listomapkeys"
+        )
+        assert len(omap_keys) == 0
+        log.info(f"All OMAP entries succesfully removed for obj: {obj_rand}")
+
+        log.info("OMAP operations have been successfully executed")
+
+        # Fetch an Object with OMAPs and its primary OSD to perform OSD compaction
+        obj_compact = random.choice(omap_obj_list)
+        osd_id = rados_obj.get_osd_map(pool=pool_name, obj=obj_compact)[
+            "acting_primary"
+        ]
+        log.info(
+            f"Primary OSD of the object {obj_compact} to be used for compaction: {osd_id}"
+        )
+
+        # fetch the initial use % for the chosen OSD
+        log.debug("Fetching the initial use % for the chosen OSD before compaction")
+        osd_df_init = rados_obj.get_osd_df_stats(filter=f"osd.{osd_id}")["nodes"][0]
+        osd_util_init = osd_df_init["utilization"]
+
+        # without IOPS in-progress perform OSD compaction of chosen OSD
+        log.info(f"Starting OSD compaction for OSD {osd_id}")
+        out, _ = cephadm.shell([f"ceph tell osd.{osd_id} compact"])
+        log.info(out)
+        assert "elapsed_time" in out
+        time.sleep(10)
+
+        # fetch the final use % for the chosen OSD after compaction
+        log.debug("Fetching the final use % for the chosen OSD after compaction")
+        osd_df_final = rados_obj.get_osd_df_stats(filter=f"osd.{osd_id}")["nodes"][0]
+        osd_util_final = osd_df_final["utilization"]
+
+        log.info(f"Initial OSD utilization before compaction: {osd_util_init}")
+        log.info(f"Final OSD utilization after compaction: {osd_util_final}")
+        assert osd_util_final <= osd_util_init
+
+        # Fetch an Object with OMAPs and its primary OSD to perform OSD compaction
+        obj_compact = random.choice(omap_obj_list)
+        osd_id = rados_obj.get_osd_map(pool=pool_name, obj=obj_compact)[
+            "acting_primary"
+        ]
+        log.info(
+            f"Primary OSD of the object {obj_compact} to be used for compaction: {osd_id}"
+        )
+
+        # create another pool for background IOPS
+        assert rados_obj.create_pool(**bench_config)
+
+        # Initiating background IOPS using rados bench for 5 mins
+        log.info("Initiating background IOPS using rados bench for 5 mins")
+        rados_obj.bench_write(
+            pool_name=bench_pool_name, rados_write_duration=300, background=True
+        )
+
+        # with IOPS in-progress perform OSD compaction of chosen OSD
+        log.info(f"Starting OSD compaction for OSD {osd_id}")
+        out, _ = cephadm.shell([f"ceph tell osd.{osd_id} compact"])
+        log.info(out)
+        assert "elapsed_time" in out
+        time.sleep(10)
+
+        # stop the OSD to check compaction failure
+        log.info(f"Stopping OSD {osd_id} to perform compaction again")
+        rados_obj.change_osd_state(action="stop", target=osd_id)
+        try:
+            _, err = cephadm.shell([f"ceph tell osd.{osd_id} compact"])
+        except Exception as e:
+            log.info("expected to fail with below error:")
+            log.info(e)
+            assert "problem getting command descriptions" in str(e)
+
+        log.info(
+            "OSD compaction with and without failure has been successfully verified."
+        )
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        log.info("**************** Executing finally block **************")
+        rados_obj.detete_pool(pool=pool_name)
+        rados_obj.detete_pool(pool=bench_pool_name)
+        rados_obj.change_osd_state(action="start", target=osd_id)
+
+    log.info("Completed testing effects of large number of omap entries on pools ")
+    return 0

--- a/tests/rados/test_osd_inconsistency_pg.py
+++ b/tests/rados/test_osd_inconsistency_pg.py
@@ -95,7 +95,7 @@ def run(ceph_cluster, **kw):
         osd_map_output = rados_obj.get_osd_map(pool=pool_name, obj=oname)
         primary_osd = osd_map_output["acting_primary"]
         # Executing the fsck on the OSD
-        log.info(f" Performing the ceph-bluestore-ttol fsck on the OSD-{primary_osd}")
+        log.info(f" Performing the ceph-bluestore-tool fsck on the OSD-{primary_osd}")
         fsck_output = bluestore_obj.run_consistency_check(primary_osd)
         log.info(f"The fsck output is ::{fsck_output}")
         # Reparing the OSD using the bluestore tool


### PR DESCRIPTION
[CEPH-11681](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11681): Tier-2 test to perform various operations on OMAPs and OSD OMAP compaction

Test modules added/modified:
- `bench_write` in `ceph/rados/core_workflows.py`
- `perform_omap_operation` in `ceph/rados/pool_workflows.py`
- tests/rados/test_osd_compaction.py

Test suites modified:
- pacific/rados/tier-2_rados_test_omap.yaml
- quincy/rados/tier-2_rados_test_omap.yaml
- reef/rados/tier-2_rados_test_omap.yaml

Steps:
1. Create cluster with default configuration
2. Create a pool and write large number of OMAPS to few objects
3. Perform various operations on the OMAP entries, list, get,
    add new, delete, clear, etc
4. Trigger background IOPS using rados bench
5. Execute OSD compaction for a healthy OSD
6. Stop the OSD using systemctl
7. Execute OSD compaction on the down OSD, expected to fail

Logs:
Reef - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CYJXY1/
Quincy - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AQXX3Q/
Pacific - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G58ST3/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ERRA0H

Signed-off-by: Harsh Kumar <hakumar@redhat.com>