### PR TITLE
minor updates for reef-nvmeotcp

### DIFF
--- a/conf/reef/baremetal/mero_conf.yaml
+++ b/conf/reef/baremetal/mero_conf.yaml
@@ -76,6 +76,7 @@ globals:
             - osd
             - rgw
             - nfs
+            - nvmeof-gw
           root_password: passwd
           volumes:
             - /dev/sda


### PR DESCRIPTION
minor updates for reef-nvmeotcp - Update the nvmeof-gw tag to mero node.