### PR TITLE
[TFA issue fix]TypeError: the JSON object must be str, bytes or bytearray, not bool'

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -223,7 +223,7 @@ tests:
             config-file-name: test_bucket_generation.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
 
-    #  Dynamic resharding tests
+#  Dynamic resharding tests
   - test:
       name: Disable DBR feature on zonegroup
       desc: Disable DBR feature on zonegroup

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -225,7 +225,7 @@ tests:
 
   - test:
       name: create user
-      desc: create non-tenanted user
+      desc: create tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
       clusters:
@@ -233,7 +233,7 @@ tests:
           config:
             set-env: true
             script-name: user_create.py
-            config-file-name: non_tenanted_user.yaml
+            config-file-name: tenanted_user.yaml
             timeout: 300
 
   #  Dynamic resharding tests
@@ -403,7 +403,7 @@ tests:
 
   - test:
       name: create user
-      desc: create tenanted user
+      desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
       clusters:
@@ -411,7 +411,7 @@ tests:
           config:
             set-env: true
             script-name: user_create.py
-            config-file-name: tenanted_user.yaml
+            config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
             timeout: 300
 


### PR DESCRIPTION
# Description
Multipart with lc was failing with error: TypeError: the JSON object must be str, bytes or bytearray, not bool'
reason bucket was created with tenant user as after multisite system user was tenant user. 
failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-95/Weekly/rgw/11/tier-2_rgw_singlesite_to_multisite/RGW_multipart_object_expiration_through_lc_on_Secondary_0.log

pass log from local run: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-22O7O3/
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
