### PR TITLE
Enhance nvmeof scale tests to 7.1 requirements

### DIFF
--- a/suites/reef/nvmeof/tier-2_nvmeof_namespace_limit.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_namespace_limit.yaml
@@ -53,14 +53,26 @@ tests:
               service: osd
               args:
                 all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Configure Initiators
+#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
           - config:
               command: shell
               args:
-                - ceph osd pool create rbd
+                - ceph osd pool create nvmeof_pool
           - config:
               command: shell
               args:
-                - ceph osd pool application enable rbd rbd
+                - rbd pool init nvmeof_pool
           - config:
               command: apply
               service: nvmeof
@@ -68,11 +80,20 @@ tests:
                 placement:
                   label: nvmeof-gw
               pos_args:
-                - rbd
-      desc: RHCS cluster deployment along with nvmeof gateway using cephadm
+                - nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+      desc: deploy NVMeoF service on GW node
       destroy-clster: false
+      do-not-skip-tc: true
       module: test_cephadm.py
-      name: deploy cluster with NVMeOF GW
+      name: deploy NVMeoF service on GW node
 
 ##  Test cases to be executed
   - test:
@@ -82,7 +103,6 @@ tests:
         id: client.1
         nodes:
           - node10
-          - node11
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -107,13 +127,13 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
                 serial_num: 1
-                max_ns: 5000
+                max_ns: 10000
           - config:
               command: create_listener
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
-                port: 5001
-                pool: rbd
+                port: 4420
+                pool: nvmeof_pool
           - config:
               command: add_host
               args:
@@ -124,14 +144,14 @@ tests:
               args:
                 start_count: 1
                 end_count: 1000
-                image_size: 500M
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
+            listener_port: 4420
             node: node10
         run_io:
           - node: node10
@@ -155,20 +175,147 @@ tests:
               args:
                 start_count: 1001
                 end_count: 2000
-                image_size: 500M
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
-        initiators:
-            subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
-            node: node11
         run_io:
-          - node: node11
+          - node: node10
             io_type: write
       desc: test namespace limitations with 2K namespaces
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
       name: test 2k namespace with 1 subsystem in Single GW
       polarion-id: CEPH-83576691
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              command: add_namespace
+              args:
+                start_count: 2001
+                end_count: 3000
+                image_size: 1T
+                pool: rbd
+                subnqn: nqn.2016-06.io.spdk:cnode1
+          - config:
+              command: get_subsystems
+        run_io:
+          - node: node10
+            io_type: write
+      desc: test namespace limitations with 3K namespaces
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_scale.py
+      name: test 3k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              command: add_namespace
+              args:
+                start_count: 3001
+                end_count: 4000
+                image_size: 1T
+                pool: rbd
+                subnqn: nqn.2016-06.io.spdk:cnode1
+          - config:
+              command: get_subsystems
+        run_io:
+          - node: node10
+            io_type: write
+      desc: test namespace limitations with 4K namespaces
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_scale.py
+      name: test 4k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              command: add_namespace
+              args:
+                start_count: 4001
+                end_count: 5000
+                image_size: 1T
+                pool: rbd
+                subnqn: nqn.2016-06.io.spdk:cnode1
+          - config:
+              command: get_subsystems
+        run_io:
+          - node: node10
+            io_type: write
+      desc: test namespace limitations with 5K namespaces
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_scale.py
+      name: test 5k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node5
+        steps:
+          - config:
+              command: delete_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode1
+      desc: Manage NVMeoF Subsystem entities
+      destroy-clster: false
+      module: test_nvme_cli.py
+      name: Delete NVMeOF targets
+      polarion-id: CEPH-83575783
+
+  - test:
+      abort-on-fail: false
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.nvmeof_pool
+           verify: true
+      desc: Remove nvmeof service on GW node
+      destroy-clster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: Delete nvmeof and rbd pool from ceph cluster
+      destroy-clster: false
+      module: test_cephadm.py
+      name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-2_nvmeof_scale_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_scale_ns.yaml
@@ -3,7 +3,7 @@
 # Test attributes
   #  Single ceph-nvmeof GW colocated with osd on node5, node 6 is nvmeof initiators
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 256 namespaces,  256 RBD images of 500M size each
+     # Scale-1 : 1 subsystem, 500 namespaces,  500 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
@@ -53,14 +53,26 @@ tests:
               service: osd
               args:
                 all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Configure Initiators
+#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
           - config:
               command: shell
               args:
-                - ceph osd pool create rbd
+                - ceph osd pool create nvmeof_pool
           - config:
               command: shell
               args:
-                - ceph osd pool application enable rbd rbd
+                - rbd pool init nvmeof_pool
           - config:
               command: apply
               service: nvmeof
@@ -68,11 +80,20 @@ tests:
                 placement:
                   label: nvmeof-gw
               pos_args:
-                - rbd
-      desc: RHCS cluster deployment along with nvmeof gateway using cephadm
+                - nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+      desc: deploy NVMeoF service on GW node
       destroy-clster: false
+      do-not-skip-tc: true
       module: test_cephadm.py
-      name: deploy cluster with NVMeOF GW
+      name: deploy NVMeoF service on GW node
 
 ##  Test cases to be executed
   - test:
@@ -81,7 +102,7 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
+          - node10
         install_packages:
           - ceph-common
         copy_admin_keyring: true
@@ -91,8 +112,6 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
   - test:
       abort-on-fail: true
       config:
@@ -106,13 +125,13 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
                 serial_num: 1
-                max_ns: 256
+                max_ns: 500
           - config:
               command: create_listener
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
-                port: 5001
-                pool: rbd
+                port: 4420
+                pool: nvmeof_pool
           - config:
               command: add_host
               args:
@@ -122,21 +141,71 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 256
-                image_size: 500M
+                end_count: 500
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
+            listener_port: 4420
             node: node10
         run_io:
           - node: node10
             io_type: write
-      desc: test with 1 subsystem and 256 namespaces in Single GW
+      desc: test with 1 subsystem and 500 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      name: Scale to 500 namespaces in single subsystem on NVMeOF GW
       polarion-id: CEPH-83576686
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node5
+        steps:
+          - config:
+              command: delete_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode1
+      desc: Manage NVMeoF Subsystem entities
+      destroy-clster: false
+      module: test_nvme_cli.py
+      name: Delete NVMeOF targets
+      polarion-id: CEPH-83575783
+
+  - test:
+      abort-on-fail: false
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.nvmeof_pool
+           verify: true
+      desc: Remove nvmeof service on GW node
+      destroy-clster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: Delete nvmeof and rbd pool from ceph cluster
+      destroy-clster: false
+      module: test_cephadm.py
+      name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-2_nvmeof_scale_sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_scale_sub_ns.yaml
@@ -1,12 +1,12 @@
-# Test module to scale Single GW components - scale factor being 1 subsystem and 32 namespaces with 4 scale steps
+# Test module to scale Single GW components - scale factor being 1 subsystem and 256 namespaces with 4 scale steps
 # Test conf at conf/reef/nvmeof/ceph_nvmeof_scale_cluster.yaml
 # Test attributes
   #  Single ceph-nvmeof GW colocated with osd on node5, node 6,7,8 and 9 are nvmeof initiators
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 32 namespaces,  32 RBD images of 500M size each
-     # Scale-2 : 2 subsystem, 64 namespaces, 64 RBD images of 500M size each
-     # Scale-3 : 3 subsystem, 96 namespaces, 96 RBD images of 500M size each
-     # Scale-4 : 4 subsystem, 128 namespaces, 128 RBD images of 500M size each
+     # Scale-1 : 1 subsystem, 256 namespaces,  256 RBD images of 500M size each
+     # Scale-2 : 2 subsystem, 512 namespaces, 512 RBD images of 500M size each
+     # Scale-3 : 3 subsystem, 512 namespaces, 512 RBD images of 500M size each
+     # Scale-4 : 4 subsystem, 1024 namespaces, 1024 RBD images of 500M size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 4 initiator : 4 subsystems)
   #  io test (no performance tests)
      # Tool : fio
@@ -56,14 +56,24 @@ tests:
               service: osd
               args:
                 all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
           - config:
               command: shell
               args:
-                - ceph osd pool create rbd
+                - ceph osd pool create nvmeof_pool
           - config:
               command: shell
               args:
-                - ceph osd pool application enable rbd rbd
+                - rbd pool init nvmeof_pool
           - config:
               command: apply
               service: nvmeof
@@ -71,11 +81,20 @@ tests:
                 placement:
                   label: nvmeof-gw
               pos_args:
-                - rbd
-      desc: RHCS cluster deployment along with nvmeof gateway using cephadm
+                - nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+      desc: deploy NVMeoF service on GW node
       destroy-clster: false
+      do-not-skip-tc: true
       module: test_cephadm.py
-      name: deploy cluster with NVMeOF GW
+      name: deploy NVMeoF service on GW node
 
   #  Test cases to be executed
   - test:
@@ -84,7 +103,6 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node5
           - node6
           - node7
           - node8
@@ -114,12 +132,13 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
                 serial_num: 1
+                max_ns: 400
           - config:
               command: create_listener
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
-                port: 5001
-                pool: rbd
+                port: 4420
+                pool: nvmeof_pool
           - config:
               command: add_host
               args:
@@ -129,24 +148,24 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 32
-                image_size: 500M
+                end_count: 256
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
+            listener_port: 4420
             node: node6
         run_io:
           - node: node6
             io_type: write
-      desc: test with 1 subsystem and 32 namespaces in Single GW
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 32 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576690
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: true
@@ -161,12 +180,13 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode2
                 serial_num: 2
+                max_ns: 400
           - config:
               command: create_listener
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode2
                 port: 5002
-                pool: rbd
+                pool: nvmeof_pool
           - config:
               command: add_host
               args:
@@ -176,8 +196,8 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 32
-                image_size: 500M
+                end_count: 256
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode2
           - config:
@@ -191,11 +211,11 @@ tests:
             io_type: read
           - node: node7
             io_type: write
-      desc: test with 2 subsystems and 64 namespaces in Single GW
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 32 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576690
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: true
@@ -210,12 +230,13 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode3
                 serial_num: 3
+                max_ns: 400
           - config:
               command: create_listener
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode3
                 port: 5003
-                pool: rbd
+                pool: nvmeof_pool
           - config:
               command: add_host
               args:
@@ -225,8 +246,8 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 32
-                image_size: 500M
+                end_count: 256
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode3
           - config:
@@ -242,11 +263,11 @@ tests:
             io_type: read
           - node: node8
             io_type: write
-      desc: test with 3 subsystems and 96 namespaces in Single GW
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 32 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576690
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: true
@@ -261,12 +282,13 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode4
                 serial_num: 4
+                max_ns: 400
           - config:
               command: create_listener
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode4
                 port: 5004
-                pool: rbd
+                pool: nvmeof_pool
           - config:
               command: add_host
               args:
@@ -276,8 +298,8 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 32
-                image_size: 500M
+                end_count: 256
+                image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode4
           - config:
@@ -297,8 +319,43 @@ tests:
             io_type: write
           - node: node9
             io_type: read
-      desc: test with 4 subsystems and 128 namespaces in Single GW
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 32 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576690
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
+
+  - test:
+      abort-on-fail: false
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.nvmeof_pool
+           verify: true
+      desc: Remove nvmeof service on GW node
+      destroy-clster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: Delete nvmeof and rbd pool from ceph cluster
+      destroy-clster: false
+      module: test_cephadm.py
+      name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-2_nvmeof_subsystem_limit.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_subsystem_limit.yaml
@@ -54,11 +54,11 @@ tests:
           - config:
               command: shell
               args:
-                - ceph osd pool create rbd
+                - ceph osd pool create nvmeof_pool
           - config:
               command: shell
               args:
-                - ceph osd pool application enable rbd rbd
+                - rbd pool init nvmeof_pool
           - config:
               command: apply
               service: nvmeof
@@ -66,7 +66,15 @@ tests:
                 placement:
                   label: nvmeof-gw
               pos_args:
-                - rbd
+                - nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
       desc: RHCS cluster deployment along with nvmeof gateway using cephadm
       destroy-clster: false
       module: test_cephadm.py

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
@@ -37,7 +37,13 @@ def initiators(ceph_cluster, gateway, config):
     """
     client = get_node_by_id(ceph_cluster, config["node"])
     initiator = Initiator(client)
-    cmd_args = {
+    initiator.disconnect_all()
+    discover_cmd_args = {
+        "transport": "tcp",
+        "traddr": gateway.ip_address,
+        "trsvcid": "4420",
+    }
+    connect_cmd_args = {
         "transport": "tcp",
         "traddr": gateway.ip_address,
         "trsvcid": config["listener_port"],
@@ -45,17 +51,17 @@ def initiators(ceph_cluster, gateway, config):
     json_format = {"output-format": "json"}
 
     # Discover the subsystems
-    sub_nqns, _ = initiator.discover(**{**cmd_args | json_format})
+    sub_nqns, _ = initiator.discover(**{**discover_cmd_args | json_format})
     LOG.debug(sub_nqns)
     for nqn in json.loads(sub_nqns)["records"]:
-        if nqn["trsvcid"] == str(config["listener_port"]):
-            cmd_args["nqn"] = nqn["subnqn"]
+        if nqn["subnqn"] == str(config["subnqn"]):
+            connect_cmd_args["nqn"] = nqn["subnqn"]
             break
     else:
-        raise Exception(f"Subsystem not found -- {cmd_args}")
+        raise Exception(f"Subsystem not found -- {connect_cmd_args}")
 
     # Connect to the subsystem
-    LOG.debug(initiator.connect(**cmd_args))
+    LOG.debug(initiator.connect(**connect_cmd_args))
 
 
 @retry(Exception, tries=5, delay=10)
@@ -211,7 +217,15 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                     namespace_func(**cfg["args"])
                     for io in config["run_io"]:
                         run_io(ceph_cluster, num, io)
-
+                    mem_usage, _ = node.exec_command(
+                        cmd="ps -eo pid,ppid,cmd,comm,%mem,%cpu --sort=-%mem | head -20",
+                        sudo=True,
+                    )
+                    LOG.info(mem_usage)
+                    top_usage, _ = node.exec_command(
+                        cmd="top -b | head -n 20", sudo=True
+                    )
+                    LOG.info(top_usage)
             else:
                 func = fetch_method(nvme_cli, command)
 
@@ -235,6 +249,16 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             cmd="cephadm shell ceph -s", sudo=True
         )
         LOG.info(health)
+        health_detail, _ = instance.installer.exec_command(
+            cmd="cephadm shell ceph health detail", sudo=True
+        )
+        LOG.info(health_detail)
+        mem_usage, _ = node.exec_command(cmd="cat /proc/meminfo", sudo=True)
+        LOG.info(mem_usage)
+        cpu, _ = node.exec_command(cmd="cat /proc/cpuinfo", sudo=True)
+        LOG.info(cpu)
+        top_usage, _ = node.exec_command(cmd="top -b | head -n 20", sudo=True)
+        LOG.info(top_usage)
 
     except BaseException as be:  # noqa
         LOG.error(be, exc_info=True)
@@ -253,5 +277,19 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             cmd="cephadm shell ceph -s", sudo=True
         )
         LOG.info(health)
+        health_detail, _ = instance.installer.exec_command(
+            cmd="cephadm shell ceph health detail", sudo=True
+        )
+        LOG.info(health_detail)
+        memory, _ = node.exec_command(cmd="cat /proc/meminfo", sudo=True)
+        LOG.info(memory)
+        cpu, _ = node.exec_command(cmd="cat /proc/cpuinfo", sudo=True)
+        LOG.info(cpu)
+        mem_usage, _ = node.exec_command(
+            cmd="ps -eo pid,ppid,cmd,comm,%mem,%cpu --sort=-%mem | head -20", sudo=True
+        )
+        LOG.info(mem_usage)
+        top_usage, _ = node.exec_command(cmd="top -b | head -n 20", sudo=True)
+        LOG.info(top_usage)
         return 1
     return 0


### PR DESCRIPTION
Enhance nvmeof scale tests towards 7.1 requirements

Test run logs 
tier-2_nvmeof_scale_ns.yaml - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TEDYQQ/
tier-2_nvmeof_scale_sub_ns.yaml - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WYTI3G and http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9XJ3WR/
