### PR TITLE
adding tier-3 suite for rgw baremetal execution and adding rgw role for node5 in mero conf

### DIFF
--- a/conf/reef/baremetal/mero_conf.yaml
+++ b/conf/reef/baremetal/mero_conf.yaml
@@ -55,6 +55,7 @@ globals:
           ip: 10.8.129.227
           role:
             - osd
+            - rgw
           root_password: passwd
           volumes:
             - /dev/sda

--- a/suites/reef/baremetal/tier-3_rgw.yaml
+++ b/suites/reef/baremetal/tier-3_rgw.yaml
@@ -1,0 +1,198 @@
+# RGW build evaluation
+# The following evaluations are carried out
+# - Build can be deployed using CephADM
+# - The cluster health is good
+# - End users can perform object operations.
+
+# tested with conf file: conf/quincy/baremetal_pipeline/mero_conf.yaml
+
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: bootstrap with registry-url option and deployment services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: RHCS deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+        git_clone: true
+        git_node_role: rgw
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  # Testing stage
+
+  - test:
+      name: Parallel run
+      desc: RGW tier-0 parallelly.
+      module: test_parallel.py
+      parallel:
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects.yaml
+              timeout: 300
+              install_common: false
+              run-on-rgw: true
+            desc: test to create "M" no of buckets and "N" no of objects
+            module: sanity_rgw.py
+            name: Test M buckets with N objects
+            polarion-id: CEPH-9789
+
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+              timeout: 300
+              install_common: false
+              run-on-rgw: true
+            desc: test to create "M" no of buckets and "N" no of objects with delete
+            module: sanity_rgw.py
+            name: Test delete using M buckets with N objects
+            polarion-id: CEPH-14237
+
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+              timeout: 300
+              install_common: false
+              run-on-rgw: true
+            desc: test to create "M" no of buckets and "N" no of objects with download
+            module: sanity_rgw.py
+            name: Test download with M buckets with N objects
+            polarion-id: CEPH-14237
+
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+              timeout: 300
+              install_common: false
+              run-on-rgw: true
+            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+            module: sanity_rgw.py
+            name: Test multipart upload of M buckets with N objects
+            polarion-id: CEPH-9801
+
+        - test:
+            config:
+              script-name: test_swift_basic_ops.py
+              config-file-name: test_swift_basic_ops.yaml
+              timeout: 300
+              install_common: false
+              run-on-rgw: true
+            desc: Test object operations with swift
+            module: sanity_rgw.py
+            name: Swift based tests
+            polarion-id: CEPH-11019
+
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node10
+        rgw_endpoints:
+          - "node4:80"
+          - "node5:80"
+          - "node6:80"
+          - "node14:80"
+          - "node15:80"
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+      polarion-id: CEPH-83572703
+
+  - test:
+      abort-on-fail: true
+      config:
+        controllers:
+          - node10
+        drivers:
+          count: 2
+          hosts:
+            - node10
+      desc: Start COS Bench controller and driver
+      module: cosbench.py
+      name: deploy cosbench
+
+  - test:
+      abort-on-fail: true
+      config:
+        controllers:
+          - node10
+        drivers: # if drivers are not specified will use one of the rgw node
+          - node10
+        fill_percent: 20
+        bucket_prefix: test-bkt-
+      desc: prepare and push cosbench fill workload
+      module: push_cosbench_workload.py
+      name: push cosbench fill workload
+
+  - test:
+      abort-on-fail: true
+      config:
+        controllers:
+          - node10
+        drivers: # if drivers are not specified will use one of the rgw node
+          - node10
+        fill_percent: 20
+        workload_type: hybrid
+        bucket_prefix: test-bkt-
+        run_time: 600 # value in seconds
+      desc: initiate cosbench hybrid workload
+      module: push_cosbench_workload.py
+      name: push cosbench hybrid workload


### PR DESCRIPTION
this PR is to add tier-3 suite for baremetal execution and to add rgw role to node5 in mero conf as many of our rgw suites assumes node5 as rgw node

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
