### PR TITLE
nvmeotcp changes needed for baremetal pipeline

### DIFF
--- a/ceph/nvmeof/nvme_cli.py
+++ b/ceph/nvmeof/nvme_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from ceph.ceph_admin.common import config_dict_to_string
 from cli import Cli
 
@@ -59,6 +61,17 @@ class NVMeCLI(Cli):
                 output-format: json             # output format
         """
         return self.execute(cmd=f"nvme list {config_dict_to_string(kwargs)}", sudo=True)
+
+    def list_spdk_drives(self):
+        """List the NVMe Targets only SPDK drives.
+
+        Return:
+            Dict: Dict of SPDK drives else empty list
+        """
+        json_kwargs = {"output-format": "json"}
+        out, _ = self.list(**json_kwargs)
+        devs = json.loads(out)["Devices"]
+        return [dev for dev in devs if dev["ModelNumber"].startswith("SPDK")]
 
     def disconnect(self, **kwargs):
         """Disconnect controller connected to the subsystem.

--- a/suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml
@@ -192,7 +192,7 @@ tests:
       do-not-skip-tc: true
       destroy-clster: false
       module: test_cephadm.py
-      name: deploy nvmeof gateway
+      name: Delete nvmeof gateway pre-reqs
 
   - test:
       abort-on-fail: true
@@ -206,7 +206,7 @@ tests:
         install: true                           # Run SPDK with all pre-requisites
         cleanup:
           - subsystems
-          - intiators
+          - initiators
           - pool
           - gateway
         subsystems:                             # Configure subsystems with all sub-entities
@@ -239,7 +239,7 @@ tests:
         install: true                           # Run SPDK with all pre-requisites
         cleanup:
           - subsystems
-          - intiators
+          - initiators
           - pool
           - gateway
         subsystems:                             # Configure subsystems with all sub-entities

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -96,14 +96,16 @@ def initiators(ceph_cluster, gateway, config):
     LOG.debug(initiator.connect(**_conn_cmd))
 
     # List NVMe targets
-    targets, _ = initiator.list(**json_format)
+    targets = initiator.list_spdk_drives()
+    if not targets:
+        raise Exception(f"NVMe Targets not found on {client.hostname}")
     LOG.debug(targets)
     results = []
     io_args = {"size": "100%"}
     if config.get("io_args"):
         io_args = config["io_args"]
     with parallel() as p:
-        for target in json.loads(targets)["Devices"]:
+        for target in targets:
             _io_args = {}
             if io_args.get("test_name"):
                 test_name = (

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_scale.py
@@ -67,19 +67,15 @@ def run_io(ceph_cluster, num, io):
         num: Current Namespace number
         ceph_cluster: Ceph cluster
     """
-    json_format = {"output-format": "json"}
     LOG.info(io)
     client = get_node_by_id(ceph_cluster, io["node"])
     initiator = Initiator(client)
     # List NVMe targets.
-    targets, _ = initiator.list(**json_format)
-    data = json.loads(targets)
+    targets = initiator.list_spdk_drives()
+    if not targets:
+        raise Exception(f"NVMe Targets not found on {client.hostname}")
     device_path = next(
-        (
-            device["DevicePath"]
-            for device in data["Devices"]
-            if device["NameSpace"] == num
-        ),
+        (device["DevicePath"] for device in targets if device["NameSpace"] == num),
         None,
     )
     LOG.debug(device_path)

--- a/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
@@ -50,9 +50,11 @@ def run_io(ceph_cluster, node, config, io):
     # Connect to the subsystem
     LOG.debug(initiator.connect(**cmd_args))
     # List NVMe targets.
-    targets, _ = initiator.list(**json_format)
+    targets = initiator.list_spdk_drives()
+    if not targets:
+        raise Exception(f"NVMe Targets not found on {client.hostname}")
     LOG.debug(targets)
-    for target in json.loads(targets)["Devices"]:
+    for target in targets:
         io_args = {
             "device_name": target["DevicePath"],
             "client_node": client,


### PR DESCRIPTION

**Fixed Issues:**
- Pick only spdk drives 
- Cleanup
- remove service needs to be updated in io perf module

**Results:**
```

All test logs located here: /tmp/cephci-run-DSS0J4

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:00:01.941526                   Skipped                          
deploy cluster                   RHCS cluster deployment using cephadm                          0:00:01.862942                   Skipped                          
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:00:01.861297                   Skipped                          
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway on dedicated node and Run IOs on tar   0:05:26.365461                   Pass                             
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway collocated and Run IOs on targets      0:06:15.680501                   Pass                             

```

**Test Results**
|Test Name | Test Description | Duration | Status | Comments
-- | -- | -- | -- | --
|Test to perform Data Integrity test over NVMe-OF targets | Perform Data integrity test over NVMEoF targets | 0:05:36.996674 | Pass |  
|Basic E2E-Test Ceph NVMEoF GW sanity test collocated with OSD node | E2E-Test NVMEoF Gateway collocated with OSD node and Run IOs on targets | 0:23:26.132007 | Pass |  
|Basic E2E-Test Ceph NVMEoF GW sanity test collocated with MON-MGR node | E2E-Test NVMEoF Gateway collocated with MON-MGR node and Run IOs on targets | 0:22:35.418972 | Pass |  
|Test to run IOs using multiple-initiators against multi-subsystems | Perform IOs on multi-subsystems with Multiple-Initiators | 0:36:00.288572 | Pass |  
|Test to Deploy multiple NVMEoF Gateway on the cluster | Deploy multiple NVMEoF Gateway on the cluster | 0:17:15.073166 | Pass |  
|Remove-image ops on NVMe Namespace | Test remove RBD image used as NVMe namespace | 0:05:18.763848 | Pass |  
|Delete-recreate bdev namespace | Delete-recreate bdev in loop and rediscover namespace | 0:04:18.967220 | Pass |  
|Perform restart of NVMeOF gateway | Perform restart and validate the gateway entities | 0:04:41.088647 | Pass |  
|Map-Unmap NVMe namespaces continuously | Perform map and unmap NVMe namespaces in loop | 0:03:39.014777 | Pass | 
|Reboot client node and check NVMe namespaces | Perform reboot on initiator node and validate the namespaces. | 0:04:04.146348 | Pass |  
|RBD operations shrink and expand on images | Perform RBD operations shrink and expand on images. | 0:33:43.650900 | Failed |  
|Reboot GW node and check NVMe namespaces | Perform reboot on GW node and validate the namespaces. | 0:33:42.018642 | Failed |  

