### PR TITLE
fixing FS script issues

### DIFF
--- a/tests/cephfs/cephfs_bugs/test_custom_fscid_cephfs.py
+++ b/tests/cephfs/cephfs_bugs/test_custom_fscid_cephfs.py
@@ -86,6 +86,8 @@ def run(ceph_cluster, **kw):
         commands = [
             "ceph config set mon mon_allow_pool_delete true",
             f"ceph fs volume rm {fs_name} --yes-i-really-mean-it",
+            "ceph osd pool rm cfs_data  cfs_data --yes-i-really-really-mean-it",
+            "ceph osd pool rm cfs_metadata  cfs_metadata --yes-i-really-really-mean-it",
         ]
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -3158,7 +3158,7 @@ os.system('sudo systemctl start  network')
             raise CommandFailed(f"Ceph Cluster is in {health_status} State")
         log.info("Ceph Cluster is Healthy")
 
-    @retry(CommandFailed, tries=5, delay=30)
+    @retry(CommandFailed, tries=10, delay=30)
     def wait_for_host_online(self, client1, node):
         out, rc = client1.exec_command(sudo=True, cmd="ceph orch host ls -f json")
         hosts = json.loads(out)


### PR DESCRIPTION
# Description

Failed Logs : 
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-157/Weekly/cephfs/12/tier-3_cephfs_bugs/
1.Validate deadlock between unlink and rename
2.Run fsstress on kernel and fuse mounts
3.Remove Contents of lost+found dir
4.Check for Standby-reply nodes changes if there is network glitch for more than 60 sec
5. Run create and unlink operations concurrently.

1,2,5 are failed because of cluster in HEALTH_WARN State. which caused because of tests/cephfs/cephfs_bugs/test_custom_fscid_cephfs.py.
Fixed: Added cleanup of pools after test completion 

3 : This is failing in only 6.1 builds as cephfs-data-scan command is updated from 6.1 to 7.0
Added correct commands for 6.1

4 : Increased the network glitch from 20 --> 60

Passed Logs : 
RHCS 7.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AZVQH8
RHCS 6.1 - <In Progress>

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
