### PR TITLE
[TFA]Remove duplicate testcase in a suite

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -341,20 +341,6 @@ tests:
             timeout: 300
 
   - test:
-      name: create tenanted user
-      desc: create tenanted user
-      polarion-id: CEPH-83575199
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            set-env: true
-            script-name: user_create.py
-            config-file-name: tenanted_user.yaml
-            copy-user-info-to-site: ceph-sec
-            timeout: 300
-
-  - test:
       name: replace bucket policy on primary
       desc: test_bucket_policy_replace on primary
       polarion-id: CEPH-11215


### PR DESCRIPTION
# Description
[TFA]Remove duplicate testcase in a suite
this suite has 2 testcase for user creation removing one testcase as its a duplicate TC
log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-TOJ8IO/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
