### PR TITLE
Changes after analysing baremetal pipeline failures

### DIFF
--- a/ceph/rbd/workflows/krbd_io_handler.py
+++ b/ceph/rbd/workflows/krbd_io_handler.py
@@ -83,7 +83,7 @@ def krbd_io_handler(**kw):
                 out = exec_cmd(
                     cmd="rpm -qa|grep rbd-nbd", node=client, sudo=True, output=True
                 )
-                if not out or out == 1:
+                if not out or out == 1 or "rbd-nbd" not in out:
                     exec_cmd(cmd="dnf install rbd-nbd -y", node=client, sudo=True)
 
                 map_config = {

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -5,7 +5,7 @@ from utility.log import Log
 log = Log(__name__)
 
 
-def create_snap_and_clone(rbd, snap_spec, clone_spec):
+def create_snap_and_clone(rbd, snap_spec, clone_spec, **kw):
     """_summary_
 
     Args:
@@ -25,6 +25,8 @@ def create_snap_and_clone(rbd, snap_spec, clone_spec):
         return 1
 
     clone_config = {"source-snap-spec": snap_spec, "dest-image-spec": clone_spec}
+    if kw.get("clone_format"):
+        clone_config.update({"rbd-default-clone-format": kw.get("clone_format")})
 
     out, err = rbd.clone(**clone_config)
     if out or err:

--- a/suites/quincy/rbd/tier-2_rbd_cache_scenarios.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_cache_scenarios.yaml
@@ -89,25 +89,6 @@ tests:
         client: node4
         rep-pool-only: True
         rep_pool_config:
-          pool: pool_test
-          image1: image1
-          image2: image2
-          image3: image3
-          size: 20G
-        fio:
-          runtime: 120
-      desc: Validate dm-cache and dm-write cache for RBD based image disk
-      destroy-cluster: false
-      module: test_rbd_dm_cache.py
-      name: DM cache and DM write cache creation
-      polarion-id: CEPH-83575581
-
-  - test:
-      abort-on-fail: true
-      config:
-        client: node4
-        rep-pool-only: True
-        rep_pool_config:
           pool: test_pool
           image1: immutable_image
           size: 10G

--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -361,6 +361,7 @@ tests:
               pool: pool1
               image: image1
               size: 10G
+              resize_to: 20G
             fio:
               image_name: image1
               pool_name: pool1
@@ -382,6 +383,7 @@ tests:
               pool: pool2
               image: image2
               size: 20G
+              resize_to: 30G
             fio:
               image_name: image2
               pool_name: pool2

--- a/suites/reef/rbd/tier-1_rbd.yaml
+++ b/suites/reef/rbd/tier-1_rbd.yaml
@@ -95,6 +95,16 @@ tests:
       module: test_client.py
       name: "configure client"
       polarion-id: CEPH-83573758
+
+  - test:
+      desc: Remove any epel packages
+      module: exec.py
+      name: Remove epel packages
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+
   -
     test:
       config:

--- a/suites/reef/rbd/tier-2_rbd_cache_scenarios.yaml
+++ b/suites/reef/rbd/tier-2_rbd_cache_scenarios.yaml
@@ -84,28 +84,18 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
-      abort-on-fail: true
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
       config:
-        client: node4
-        rep-pool-only: True
-        rep_pool_config:
-          pool: pool_test
-          image1: image1
-          image2: image2
-          image3: image3
-          size: 20G
-        fio:
-          runtime: 120
-      desc: Validate dm-cache and dm-write cache for RBD based image disk
-      destroy-cluster: false
-      module: test_rbd_dm_cache.py
-      name: DM cache and DM write cache creation
-      polarion-id: CEPH-83575581
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd"
 
   - test:
       abort-on-fail: true
       config:
-        client: node4
         rep-pool-only: True
         rep_pool_config:
           pool: test_pool

--- a/suites/reef/rbd/tier-2_rbd_encryption.yaml
+++ b/suites/reef/rbd/tier-2_rbd_encryption.yaml
@@ -73,6 +73,16 @@ tests:
       name: configure client
 
   - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd"
+
+  - test:
       desc: Encrypt & decrypt file using same keys and different keys
       config:
         encryption_type: #parent,clone

--- a/suites/reef/rbd/tier-2_rbd_regression_Image_migration.yaml
+++ b/suites/reef/rbd/tier-2_rbd_regression_Image_migration.yaml
@@ -177,8 +177,8 @@ tests:
       polarion-id: CEPH-83574092
       config:
         ec_pool_config:
-          pool: rbd_pool
-          data_pool: rbd_ec_pool
+          pool: rbd_ec_pool
+          data_pool: rbd_data_pool
           image: rbd_image
           size: 100M
         rep_pool_config:

--- a/suites/reef/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/reef/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -58,11 +58,10 @@ tests:
       config:
         command: add
         id: client.1
-        node: node4
+        node: node10
         install_packages:
           - ceph-common
           - fio
-          - rbd-nbd
         copy_admin_keyring: true
       desc: Configure client node
       destroy-cluster: false
@@ -71,232 +70,109 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
-      name: RBD PWL cache validation.
-      desc: PWL Cache validation at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574707
-      abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: PWL validation at client level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: RBD Persistent Cache - Client level configuration
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: PWL validation at pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: RBD Persistent Cache - Pool level configuration
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: PWL validation at image level
-          module: test_rbd_persistent_write_back_cache.py
-          name: RBD Persistent Cache - image level configuration
-
-  - test:
-      name: RBD PWL cache size validation.
-      desc: PWL cache size validation at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574722
-      abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            validate_cache_size: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: RBD Persistent Cache cache size validation Client level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name:  PWL cache size validation at client level
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            validate_cache_size: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: RBD Persistent Cache cache size validation pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache size validation at pool level
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            validate_cache_size: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: RBD Persistent Cache cache size validation image level
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache size validation at image level
-
-  - test:
-      name: RBD PWL cache path validation.
-      desc: PWL cache path validation at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574721
-      abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            validate_cache_path: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: RBD Persistent Cache path validation Client level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name:  PWL cache path validation at client level
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            validate_cache_path: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: RBD Persistent Cache cache path validation pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache path validation at pool level
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            validate_cache_path: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-              resize_to: 50G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: RBD Persistent Cache cache path validation image level
-          module: test_rbd_persistent_write_back_cache.py
-          name: PWL cache path validation at image level
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd"
 
   - test:
       abort-on-fail: true
       config:
-        level: client                        # PWL at client
+        levels:
+          - client
+          - pool
+          - image                        # PWL at client
         cache_file_size: 1073741824          # 1 GB
         rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-        client: node6
+        client: node10
+        drive: /dev/nvme0n1
+        cleanup: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          runtime: 120
+      desc: PWL Cache validation at client pool and image level.
+      destroy-cluster: false
+      module: test_rbd_persistent_write_back_cache.py
+      name: RBD PWL cache validation.
+      polarion-id: CEPH-83574707
+
+  - test:
+      abort-on-fail: true
+      polarion-id: CEPH-83574722
+      config:
+        levels:
+          - client
+          - pool
+          - image                        # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node10
+        drive: /dev/nvme0n1
+        cleanup: true
+        validate_cache_size: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          runtime: 120
+      desc: PWL cache size validation at client pool and image level.
+      destroy-cluster: false
+      module: test_rbd_persistent_write_back_cache.py
+      name:  RBD PWL cache size validation.
+
+  - test:
+      abort-on-fail: true
+      polarion-id: CEPH-83574721
+      config:
+        levels:
+          - client
+          - pool
+          - image                # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node10
+        drive: /dev/nvme0n1
+        cleanup: true
+        validate_cache_path: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+          resize_to: 20G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          runtime: 120
+      desc: PWL cache path validation at client pool and image level.
+      destroy-cluster: false
+      module: test_rbd_persistent_write_back_cache.py
+      name:  RBD PWL cache path validation.
+
+  - test:
+      abort-on-fail: true
+      config:
+        levels:
+          - client
+          - pool
+          - image                           # PWL at client, pool, image
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node10
         drive: /dev/nvme0n1
         cleanup: true
         validate_exclusive_lock: true
@@ -321,7 +197,7 @@ tests:
         level: client                        # PWL at client
         cache_file_size: 1073741824          # 1 GB
         rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-        client: node5
+        client: node10
         drive: /dev/nvme0n1
         cleanup: true
         # validate_exclusive_lock: true
@@ -341,76 +217,31 @@ tests:
       polarion-id: CEPH-83574893
 
   - test:
-      name: RBD PWL cache invalidate.
-      desc: PWL cache invalidate at client pool and image level.
-      module: test_parallel.py
-      polarion-id: CEPH-83574709
       abort-on-fail: true
-      parallel:
-      - test:
-          abort-on-fail: true
-          config:
-            level: client                        # PWL at client
-            cache_file_size: 1073741824          # 1 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool1
-              image: image1
-              size: 10G
-            fio:
-              image_name: image1
-              pool_name: pool1
-              runtime: 120
-          desc: RBD Persistent Cache invalidate Client level
-          destroy-cluster: false
-          module: test_rbd_persistent_writeback_cache_invalidate.py
-          name:  PWL cache path validation at client level
-      - test:
-          config:
-            level: pool                          # PWL at Pool level
-            cache_file_size: 2147483648          # 2 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool2
-              image: image2
-              size: 20G
-            fio:
-              image_name: image2
-              pool_name: pool2
-              runtime: 120
-          desc: RBD Persistent Cache invalidate pool level
-          destroy-cluster: false
-          module: test_rbd_persistent_writeback_cache_invalidate.py
-          name: PWL cache path validation at pool level
-      - test:
-          config:
-            level: image                         # PWL at image level
-            cache_file_size: 4294967296          # 4 GB
-            rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
-            client: node6
-            drive: /dev/nvme0n1
-            cleanup: true
-            rep-pool-only: True
-            rep_pool_config:
-              pool: pool3
-              image: image3
-              size: 40G
-              resize_to: 50G
-            fio:
-              image_name: image3
-              pool_name: pool3
-              runtime: 120
-          desc: RBD Persistent Cache invalidate image level
-          module: test_rbd_persistent_writeback_cache_invalidate.py
-          name: PWL cache path validation at image level
+      polarion-id: CEPH-83574709
+      config:
+        levels:
+          - client
+          - pool
+          - image                        # PWL at client
+        cache_file_size: 1073741824          # 1 GB
+        rbd_persistent_cache_mode: ssd       # "ssd" or "rwl" on pmem device
+        client: node10
+        drive: /dev/nvme0n1
+        cleanup: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          runtime: 120
+      desc: PWL cache invalidate at client pool and image level.
+      destroy-cluster: false
+      module: test_rbd_persistent_writeback_cache_invalidate.py
+      name: RBD PWL cache invalidate.
 
   - test:
       abort-on-fail: true

--- a/suites/reef/rbd/tier-4_rbd_negative_scenario_regression.yaml
+++ b/suites/reef/rbd/tier-4_rbd_negative_scenario_regression.yaml
@@ -90,7 +90,13 @@ tests:
       config:
         rep_pool_config:
           num_pools: 1
-          num_images: 1
+          num_images: 2
+          clone_formats:
+            - 1
+            - 2
         ec_pool_config:
           num_pools: 1
-          num_images: 1
+          num_images: 2
+          clone_formats:
+            - 1
+            - 2

--- a/tests/rbd/krbd_io_handler.py
+++ b/tests/rbd/krbd_io_handler.py
@@ -68,7 +68,7 @@ def krbd_io_handler(**kw):
 
             if operations.get("device_map"):
                 out = rbd.exec_cmd(cmd="rpm -qa|grep rbd-nbd", sudo=True, output=True)
-                if not out or out == 1:
+                if not out or out == 1 or "rbd-nbd" not in out:
                     rbd.exec_cmd(cmd="dnf install rbd-nbd -y", sudo=True)
 
                 out, err = rbd.device_map(
@@ -121,6 +121,7 @@ def krbd_io_handler(**kw):
                         runtime=config.get("runtime", 30),
                         size=config.get("file_size", "100M"),
                         get_time_taken=config.get("get_time_taken", False),
+                        cmd_timeout=config.get("cmd_timeout"),
                     )
                 else:
                     fio_args = {
@@ -135,6 +136,8 @@ def krbd_io_handler(**kw):
                         fio_args.update(
                             {"get_time_taken": config.get("get_time_taken")}
                         )
+                    if config.get("cmd_timeout"):
+                        fio_args.update({"cmd_timeout": config.get("cmd_timeout")})
 
                     config["time_taken"] = run_fio(**fio_args)
 

--- a/tests/rbd/rbd_clone_delete_parent_image.py
+++ b/tests/rbd/rbd_clone_delete_parent_image.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from ceph.parallel import parallel
 from tests.rbd.exceptions import RbdBaseException
 from tests.rbd.rbd_utils import initial_rbd_config, rbd_remove_image_negative_validate
@@ -63,6 +65,7 @@ def rbd_clone_delete_parent_image(rbd, pool_type, **kw):
             p.spawn(rbd_remove_image_negative_validate, rbd, pool, image)
 
         # move image to trash and delete permanantly and verify trash
+        sleep(60)
         rbd.move_image_trash(pool, image)
         image_id = rbd.get_image_id(pool, image)
         log.info(f"image id is {image_id}")

--- a/tests/rbd/rbd_utils.py
+++ b/tests/rbd/rbd_utils.py
@@ -29,6 +29,7 @@ class Rbd:
         self.flag = 0
         self.k_m = self.config.get("ec-pool-k-m", None)
         self.failure_domain = self.config.get("crush-failure-domain", None)
+        self.ceph_client = kw.get("ceph_client")
 
         if kw.get("req_cname"):
             self.ceph_nodes = kw["ceph_cluster_dict"][kw["req_cname"]]
@@ -40,7 +41,7 @@ class Rbd:
             if node.role == "mon":
                 self.ceph_mon = node
                 continue
-            if node.role == "client":
+            if not self.ceph_client and node.role == "client":
                 self.ceph_client = node
                 continue
 

--- a/tests/rbd/test_performance_pwl_cache.py
+++ b/tests/rbd/test_performance_pwl_cache.py
@@ -72,6 +72,7 @@ def write_data_compare_time_taken(cache, cfg, client):
                     "device_map": True,
                 },
                 "skip_mkfs": False,
+                "cmd_timeout": 2400,
             },
         }
         krbd_io_handler(**io_config)
@@ -154,8 +155,9 @@ def run(ceph_cluster, **kw):
     )
     config = kw.get("config")
     for level in config.get("levels"):
-        rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
         cache_client = get_node_by_id(ceph_cluster, config["client"])
+        kw["ceph_client"] = cache_client
+        rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
         pool = config["rep_pool_config"]["pool"]
         image = (
             f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"

--- a/tests/rbd/test_rbd.py
+++ b/tests/rbd/test_rbd.py
@@ -44,6 +44,13 @@ def one_time_setup(node, rhbuild, branch: str) -> None:
         branch: The branch that needs to be cloned
         rhbuild: specification of rhbuild. ex: 4.3-rhel-7
     """
+    node.exec_command(cmd="sudo rm -rf /etc/yum.repos.d/epel*")
+    out, _ = node.exec_command(cmd="ceph osd pool ls")
+    if out:
+        pool_list = out.split("\n")
+        if "rbd" not in pool_list:
+            node.exec_command(cmd="ceph osd pool create rbd")
+
     node.exec_command(
         cmd=f"sudo rm -rf ceph && git clone --branch {branch} --single-branch --depth 1 {TEST_REPO}"
     )

--- a/tests/rbd/test_rbd_deep_flatten_negative.py
+++ b/tests/rbd/test_rbd_deep_flatten_negative.py
@@ -9,14 +9,71 @@ from utility.log import Log
 log = Log(__name__)
 
 
+def verify_deep_flatten(clone_format, rbd, pool, image, snap_spec):
+    """ """
+    snap_conf = {"snap-spec": snap_spec}
+    out, err = rbd.snap.unprotect(**snap_conf)
+    if clone_format == 1:
+        if out or err:
+            err_msg = f"Snapshot unprotect failed as expected for {snap_spec} since deep-flatten"
+            err_msg += (
+                f" is not enabled on the image {image} and v1 clone contains snapshots"
+            )
+            log.info(err_msg)
+            log.info(f"Error message for snapshot unprotect: {out} {err}")
+        else:
+            log.error("Snapshot unprotect succeeded even though v1 clone had snapshots")
+            return 1
+    else:
+        out, err = rbd.snap.rm(**snap_conf)
+        if out or err and "100% complete" not in err:
+            err_msg = f"Snapshot remove failed for {snap_spec}"
+            log.info(err_msg)
+            log.info(f"Error message for snapshot remove {out} {err}")
+        else:
+            snap_ls_conf = {
+                "image-spec": f"{pool}/{image}",
+                "all": True,
+                "format": "json",
+            }
+            out, err = rbd.snap.ls(**snap_ls_conf)
+            if err:
+                log.error("Error while fetch snap list")
+                return 1
+            else:
+                snap_list = json.loads(out)
+                snap_name = snap_spec.replace(f"{pool}/{image}@", "")
+                snap_req = [
+                    snap_ls
+                    for snap_ls in snap_list
+                    if snap_name in snap_ls.get("namespace")
+                ]
+                if all(
+                    x in snap_ls.get("namespace")
+                    for snap_ls in snap_req
+                    for x in ["trash", snap_name]
+                ):
+                    err_msg = f"Snapshot remove resulted in snapshot {snap_spec} moving to trash as expected"
+                    err_msg += f" since deep-flatten is not enabled on the image {image} and v2 clone"
+                    err_msg += " contains snapshots"
+                    log.info(err_msg)
+                    log.info(f"Snap list: {snap_list}")
+                else:
+                    log.error(
+                        "Snapshot removed completely even though v2 clone had snapshots"
+                    )
+                    return 1
+
+
 def test_deep_flatten_negative_scenario(rbd_obj, **kw):
     """ """
     for pool_type in rbd_obj.get("pool_types"):
         rbd_config = kw.get("config", {}).get(pool_type, {})
         multi_pool_config = getdict(rbd_config)
+        clone_formats = rbd_config.pop("clone_formats")
         for pool, pool_config in multi_pool_config.items():
             multi_image_config = getdict(pool_config)
-            for image in multi_image_config.keys():
+            for image, clone_format in zip(multi_image_config.keys(), clone_formats):
                 log.info(f"Creating snapshot and clone for image {pool}/{image}")
                 rbd = rbd_obj.get("rbd")
                 # Start by creating cli for rbd feature commands
@@ -42,7 +99,9 @@ def test_deep_flatten_negative_scenario(rbd_obj, **kw):
 
                 snap_spec = f"{pool}/{image}@snap_{image}"
                 clone_spec = f"{pool}/clone_{image}"
-                create_snap_and_clone(rbd, snap_spec, clone_spec)
+                create_snap_and_clone(
+                    rbd, snap_spec, clone_spec, clone_format=clone_format
+                )
                 # Create snapshot for the clone
                 clone_snap_spec = {
                     "snap-spec": f"{pool}/clone_{image}@snap_clone_{image}"
@@ -58,17 +117,8 @@ def test_deep_flatten_negative_scenario(rbd_obj, **kw):
                     log.error(f"Flatten clone failed for {clone_spec}")
                     return 1
 
-                snap_conf = {"snap-spec": snap_spec}
-                out, err = rbd.snap.unprotect(**snap_conf)
-                if out or err:
-                    err_msg = f"Snapshot unprotect failed as expected for {snap_spec} since deep-flatten"
-                    err_msg += f" is not enabled on the image {image} and clone contains snapshots"
-                    log.info(err_msg)
-                    log.info(f"Error message for snapshot unprotect: {out} {err}")
-                else:
-                    log.error(
-                        "Snapshot unprotect succeeded even though clone had snapshots"
-                    )
+                if verify_deep_flatten(clone_format, rbd, pool, image, snap_spec):
+                    log.error(f"deep-flatten verification failed for {clone_format}")
                     return 1
     return 0
 

--- a/tests/rbd/test_rbd_dm_cache.py
+++ b/tests/rbd/test_rbd_dm_cache.py
@@ -20,7 +20,6 @@
     10. check ceph health status
 """
 
-from ceph.utils import get_node_by_id
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.lvm_utils import lvconvert, lvm_create, lvm_uncache, pvcreate, vgcreate
@@ -153,7 +152,7 @@ def run(ceph_cluster, **kw):
 
     config = kw.get("config")
     rbd = initial_rbd_config(**kw)["rbd_reppool"]
-    cache_client = get_node_by_id(ceph_cluster, config["client"])
+    cache_client = rbd.ceph_client
 
     pool_name = config["rep_pool_config"]["pool"]
 

--- a/tests/rbd/test_rbd_immutable_cache.py
+++ b/tests/rbd/test_rbd_immutable_cache.py
@@ -19,7 +19,6 @@
 """
 import time
 
-from ceph.utils import get_node_by_id
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.utils import run_fio
@@ -213,9 +212,8 @@ def run(ceph_cluster, **kw):
         "ceph immutable object cache files."
     )
 
-    config = kw.get("config")
     rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
-    client_node = get_node_by_id(ceph_cluster, config["client"])
+    client_node = rbd_obj.ceph_client
 
     # To configure immutable object cache
     if configure_immutable_cache(rbd_obj, client_node, "user1"):

--- a/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
+++ b/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
@@ -42,7 +42,7 @@ def kill_fio(rbd):
     sleep(60)
     cmd = "ps -ef | grep fio"
     out = rbd.exec_cmd(cmd=cmd, sudo=True, output=True)
-    if out and "fio --name=" in out:
+    if out and re.findall(r"(fio).*(--name)", out, re.I):
         proc_id = re.search(r"\d+", out).group()
         cmd = f"kill -9 {proc_id}"
         rbd.exec_cmd(cmd=cmd, sudo=True)
@@ -96,8 +96,9 @@ def run(ceph_cluster, **kw):
         "Running test - Concurrent writes with exclusive lock. persistent write cache"
     )
     config = kw.get("config")
-    rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
     cache_client = get_node_by_id(ceph_cluster, config["client"])
+    kw["ceph_client"] = cache_client
+    rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
     pool = config["rep_pool_config"]["pool"]
     image = f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
     config["image_spec"] = image


### PR DESCRIPTION
This PR is to make changes to existing test suites for RBD so that they can be executed in both rhosd and baremetal pipelines.

The changes done to accomodate this are.

1. Since baremetal setup, doesn't install rbd-nbd as part of adding client node, we have added code in test suites and also in krbd_io_handler module to install rbd-nbd if its not already installed.
2. By default we were creating clones with v2 format as that is the default being used while creating clones, now we have added a new configuration option supported by CLI rbd-default-clone-format while creating clones, so that user can use this to add clones with required format.
3. Removed dm-cache test from quincy and reef, since it is applicable only for rhel-8
4. Added tests to remove all unnecessary epel packages from baremetal client node, since these come in the way of installing few packages required by RBD tests.
5. tier-2_rbd_regression_Image_migration.yaml was using same pool name for both replicated and ec pools causing errors, so changed the name of ec pool
6. In persistent cache tests, made changes to execute client, pool and image level tests sequentially since our baremetal client has only one nvme node and we can execute only one test at a time
7. tier-4_rbd_negative_scenario_regression.yaml - added tests to be performed for both v1 clone and v2 clone formats
8. Added code in rbd_utils to fetch client node from calling method, if passed.
9. test_concurrent_write_pwl_cache.py - In this module added logic to check for image watchers before cleaning up persistent cache settings, since clean up fails if image still has watchers.
10. test_rbd.py - Added code to create rbd pool if it doesn't exist.
11. test_rbd_deep_flatten_negative.py - Modified steps for verification based on clone format whether it is v1 or v2.
12. test_rbd_dm_cache.py and test_rbd_immutable_cache.py - Added logic to get client node from rbd object instead of test suite config
13. test_rbd_migration_image_s3_object.py - Added logic to deploy rgw daemon if it doesn't exist in the cluster.
14. All rbd_persistent_cache tests - Changed login to execute client, pool and image level sequentially.

Success Logs for the same is present in http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/baremetal/18.2.0-128/rbd/9/ 