### PR TITLE
[Test][Cephadm] Add test to validate pid limit of services

### DIFF
--- a/cli/utilities/containers.py
+++ b/cli/utilities/containers.py
@@ -179,3 +179,19 @@ class Container(Cli):
             return 0
         else:
             return 1
+
+    def ps(self, all=None, filter=None):
+        """
+        Returns the details of running containers
+        Args:
+            all (bool): Show all containers
+            filter (dict): Key value to filter
+        """
+        cmd = f"{self.base_cmd} ps"
+        if all:
+            cmd += " --all"
+
+        if filter:
+            for key, val in filter.items():
+                cmd += f" --filter {key}={val}"
+        return self.execute(sudo=True, cmd=cmd)

--- a/suites/reef/cephadm/tier4-service-operations.yaml
+++ b/suites/reef/cephadm/tier4-service-operations.yaml
@@ -102,3 +102,11 @@ tests:
       polarion-id: CEPH-83573802
       destroy-cluster: false
       abort-on-fail: true
+
+  - test:
+      name: Validate pid limits are enforced
+      desc: Verify the pid limits are set for different daemons
+      module: test_validate_pid_limit.py
+      polarion-id: CEPH-83575590
+      destroy-cluster: false
+      abort-on-fail: true

--- a/tests/cephadm/test_validate_pid_limit.py
+++ b/tests/cephadm/test_validate_pid_limit.py
@@ -1,0 +1,18 @@
+from cli.exceptions import OperationFailedError
+from cli.utilities.utils import get_pid_limit
+
+
+def run(ceph_cluster, **kw):
+    """Verify redeploy for a specific service
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    # Check for mgr nodes
+    for service in ["rgw", "mon", "mds"]:
+        node = ceph_cluster.get_nodes(role=service)[0]
+        pid_limit = get_pid_limit(node, service)
+        if pid_limit != "-1":
+            raise OperationFailedError(
+                f"The pid limit is not set to -1 for {service} but instead to {pid_limit}"
+            )
+    return 0


### PR DESCRIPTION
# Description

CEPH-83575590 - RHEL 9 (cgroups v2) - the pid limits ARE enforced as compared to RHEL8 (cgroup v1)


- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
