### PR TITLE
Fixing NFS Issues

### DIFF
--- a/tests/cephfs/cephfs_nfs/2_node_nfs.py
+++ b/tests/cephfs/cephfs_nfs/2_node_nfs.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -72,8 +73,11 @@ def run(ceph_cluster, **kw):
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
 
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/nfs_config_reset.py
+++ b/tests/cephfs/cephfs_nfs/nfs_config_reset.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -70,8 +71,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/nfs_export_config.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_config.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -60,8 +61,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
+++ b/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
@@ -57,7 +57,11 @@ def run(ceph_cluster, **kw):
         export_id = "1"
         fs_name = "cephfs"
         bind = "/ceph"
-        user_id = f"nfs.{cluster_id}.{export_id}"
+        user_id = (
+            f"nfs.{cluster_id}.{fs_name}"
+            if int(build.split(".")[0]) > 7
+            else f"nfs.{cluster_id}.{export_id}"
+        )
 
         passed = []
         client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/nfs_io_network_failures.py
+++ b/tests/cephfs/cephfs_nfs/nfs_io_network_failures.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from ceph.parallel import parallel
@@ -20,8 +21,11 @@ def run_io_commands(client, io_commands):
 
 @retry(CommandFailed, tries=3, delay=60)
 def check_nfs_ls(client, nfs_cluster):
-    out, rc = client.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-    output = json.loads(out)
+    try:
+        out, rc = client.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+        output = json.loads(out)
+    except JSONDecodeError:
+        output = json.dumps([out])
     if nfs_cluster in output:
         log.info("ceph nfs cluster created successfully")
     else:

--- a/tests/cephfs/cephfs_nfs/nfs_mount_with_fstab.py
+++ b/tests/cephfs/cephfs_nfs/nfs_mount_with_fstab.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -66,8 +67,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/nfs_multiple_export_using_single_conf.py
+++ b/tests/cephfs/cephfs_nfs/nfs_multiple_export_using_single_conf.py
@@ -1,5 +1,4 @@
 import random
-import secrets
 import string
 import traceback
 
@@ -46,8 +45,7 @@ def run(ceph_cluster, **kw):
         else:
             raise CommandFailed("Failed to create nfs cluster")
         # create nfs
-        export_id1 = secrets.randbelow(1000)
-        export_id2 = secrets.randbelow(1000)
+        export_id1, export_id2 = random.sample(range(1000), 2)
         psuedo1 = f"/cephfs1_{export_id1}"
         psuedo2 = f"/cephfs2_{export_id2}"
         user_id1 = f"nfs.{nfs_name}.{export_id1}"

--- a/tests/cephfs/cephfs_nfs/nfs_non_exist_export_path.py
+++ b/tests/cephfs/cephfs_nfs/nfs_non_exist_export_path.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -54,8 +55,11 @@ def run(ceph_cluster, **kw):
             log.info("ceph nfs cluster created successfully")
         else:
             raise CommandFailed("Failed to create nfs cluster")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -64,8 +65,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/recreate_same_name_nfs.py
+++ b/tests/cephfs/cephfs_nfs/recreate_same_name_nfs.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -62,8 +63,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster is present")
         else:
@@ -73,8 +77,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=False):
             raise CommandFailed("Cluster has not been deleted")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name not in output:
             log.info("ceph nfs cluster deleted successfully")
         else:
@@ -84,8 +91,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/subvolume_export.py
+++ b/tests/cephfs/cephfs_nfs/subvolume_export.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -57,8 +58,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:

--- a/tests/cephfs/cephfs_nfs/zip_unzip_files_nfs.py
+++ b/tests/cephfs/cephfs_nfs/zip_unzip_files_nfs.py
@@ -2,6 +2,7 @@ import json
 import secrets
 import string
 import traceback
+from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
@@ -53,8 +54,11 @@ def run(ceph_cluster, **kw):
         )
         if not wait_for_process(client=client1, process_name=nfs_name, ispresent=True):
             raise CommandFailed("Cluster has not been created")
-        out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
-        output = json.loads(out)
+        try:
+            out, rc = client1.exec_command(sudo=True, cmd="ceph nfs cluster ls -f json")
+            output = json.loads(out)
+        except JSONDecodeError:
+            output = json.dumps([out])
         if nfs_name in output:
             log.info("ceph nfs cluster created successfully")
         else:


### PR DESCRIPTION
# Description
Fixing NFS Issues

Failed Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-127/Regression/cephfs/34/tier-2_cephfs_test-nfs/
It has 3 failures
1.[CEPH-83573992](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573992) -- Product bug --json-pretty is been not supported 
2. [CEPH-83574013](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574013) 
There is some change in behaviour 
earlier we used to get user_id in format as user_id = f"nfs.{cluster_id}.{export_id}" --> this has been changed to user_id = f"nfs.{cluster_id}.{fs_name}"

3. [CEPH-83575082](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575082)
This is an automation Bug where we are getting export_ids the same values because of this export creations were failing.
Changed the code to get 2 unique values 

Passed Log : 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RQTK6W/

Passed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VZMJX7

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
