### PR TITLE
CEPH-83575917: Test archive site on/off on an upload of 5K objects

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -568,3 +568,28 @@ tests:
       module: sanity_rgw_multisite.py
       name: test versioning suspend on archive
       polarion-id: CEPH-83575578
+  - test:
+      clusters:
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph orch stop rgw.shared.arc"
+            timeout: 120
+      desc: Test full sync at archive, power off archive zone with IOs in active zone
+      module: exec.py
+      name: Test full sync at archive, power off archive zone with IOs in active zone
+      polarion-id: CEPH-83575917
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd.yaml
+            run-on-haproxy: true
+            timeout: 300
+      desc: Upload 5000 objects via s3cmd to test full sync at archive
+      polarion-id: CEPH-83575917
+      module: sanity_rgw_multisite.py
+      name: Upload 5000 objects via s3cmd to test full sync at archive


### PR DESCRIPTION
Automate a full sync of an RGW bucket to the archive zone having at least 5000 objects.

- https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575917
- https://issues.redhat.com/browse/RHCEPHQE-12010
- dependent ceph-qe-scripts PR https://github.com/red-hat-storage/ceph-qe-scripts/pull/513

logs:

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UOTHQW
