### PR TITLE
Automation of the CEPH-9369 - RADOS: Time scheduled scrubbing: Observe cpu and memory usage during scrubbing

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -2636,3 +2636,43 @@ class RadosOrchestrator:
 
         lvm_list = (osd_node.exec_command(sudo=True, cmd=cmd_get_lvm_list))[0]
         return json.loads(lvm_list)
+
+    def get_osd_memory_usage(self, node_object, osd_id):
+        """
+        Methods returns the OSD memory usage
+        Args:
+            node_object: The osd node object
+            osd_id:  The osd id(number)
+
+        Returns: Memory usage of the OSD at that time
+
+        """
+        try:
+            cmd_get_memory = (
+                f'ps -eo pmem,args | grep -E "ceph-osd.*osd.{osd_id}\\b" | '
+                + ('grep -v "init\\| grep" ' "| awk '{print $1}'")
+            )
+            memory_usage = node_object.exec_command(cmd=cmd_get_memory, sudo=True)
+            return float(memory_usage[0].strip())
+        except Exception:
+            raise
+
+    def get_osd_cpu_usage(self, node_object, osd_id):
+        """
+        Methods returns the CPU usage
+        Args:
+            node_object:  The osd node object
+            osd_id: The osd id(number)
+
+        Returns: CPU usage of the OSD at that time.
+
+        """
+        try:
+            cmd_get_cpu = (
+                f'ps -eo pcpu,args | grep -E "ceph-osd.*osd.{osd_id}\\b" | '
+                + ('grep -v "init\\| grep" ' "| awk '{print $1}'")
+            )
+            cpu_usage = node_object.exec_command(cmd=cmd_get_cpu, sudo=True)
+            return float(cpu_usage[0].strip())
+        except Exception:
+            raise

--- a/suites/pacific/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-scrubbing.yaml
@@ -74,7 +74,23 @@ tests:
       config:
         delete_pool: true
       desc: Scrub Chunk max validation
-
+  - test:
+      name: CPU and Memory check during scheduled scrub
+      module: test_scrub_cpu_memory_usage.py
+      desc: Verify CPU and Memory check during scheduled scrub
+      polarion-id: CEPH-9369
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scheduled_scrub
+              pg_num: 32
+              pg_num_min: 32
+              pool_type: replicated
+              rados_write_duration: 120
+              rados_read_duration: 120
+              byte_size: 1KB
+        delete_pools:
+          - scheduled_scrub
   - test:
       name: Default scheduled scrub
       polarion-id: CEPH-9361

--- a/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
@@ -74,7 +74,23 @@ tests:
       config:
         delete_pool: true
       desc: Scrub Chunk max validation
-
+  - test:
+      name: CPU and Memory check during scheduled scrub
+      module: test_scrub_cpu_memory_usage.py
+      desc: Verify CPU and Memory check during scheduled scrub
+      polarion-id: CEPH-9369
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scheduled_scrub
+              pg_num: 32
+              pg_num_min: 32
+              pool_type: replicated
+              rados_write_duration: 120
+              rados_read_duration: 120
+              byte_size: 1KB
+        delete_pools:
+          - scheduled_scrub
   - test:
       name: Default scheduled scrub
       polarion-id: CEPH-9361

--- a/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
@@ -89,6 +89,23 @@ tests:
         delete_pools:
           - scrub_pool
   - test:
+      name: CPU and Memory check during scheduled scrub
+      module: test_scrub_cpu_memory_usage.py
+      desc: Verify CPU and Memory check during scheduled scrub
+      polarion-id: CEPH-9369
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scheduled_scrub
+              pg_num: 32
+              pg_num_min: 32
+              pool_type: replicated
+              rados_write_duration: 120
+              rados_read_duration: 120
+              byte_size: 1KB
+        delete_pools:
+          - scheduled_scrub
+  - test:
       name: Default scheduled scrub
       polarion-id: CEPH-9361
       module: scheduled_scrub_scenarios.py

--- a/tests/rados/test_scrub_cpu_memory_usage.py
+++ b/tests/rados/test_scrub_cpu_memory_usage.py
@@ -1,0 +1,152 @@
+"""
+The program verifies the CPU and memory consumption of OSD during the scheduled scrub
+"""
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.rados_scrub import RadosScrubber
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+from utility.utils import method_should_succeed
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    scrub_object = RadosScrubber(node=cephadm)
+    rados_object = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_object)
+    ceph_nodes = kw.get("ceph_nodes")
+    # Storing the pg dump log before setting the scrub parameters
+    before_scrub_log = scrub_object.get_pg_dump("pgid", "last_scrub_stamp")
+    scrub_check_flag = True
+
+    osd_scrub_min_interval = 120
+    osd_scrub_max_interval = 3600
+
+    try:
+        # creating pool
+        pools = config["create_pools"]
+        cr_pool = pools[0]["create_pool"]
+        pool_name = config["create_pools"][0]["create_pool"]["pool_name"]
+        log.info(f"Creating the {pool_name}")
+        method_should_succeed(rados_object.create_pool, **cr_pool)
+        log.info(f"The {pool_name} pool created")
+        log.info(f"writing test data into the {pool_name}pool")
+        method_should_succeed(rados_object.bench_write, **cr_pool)
+        log.info(f"writing test data into the {pool_name}pool is completed")
+        (
+            scrub_begin_hour,
+            scrub_begin_weekday,
+            scrub_end_hour,
+            scrub_end_weekday,
+        ) = scrub_object.add_begin_end_hours(0, 1)
+
+        scrub_object.set_osd_configuration(
+            "osd_scrub_begin_week_day", scrub_begin_weekday
+        )
+        scrub_object.set_osd_configuration(
+            "osd_scrub_begin_week_day", scrub_begin_weekday
+        )
+        scrub_object.set_osd_configuration("osd_scrub_end_week_day", scrub_end_weekday)
+        scrub_object.set_osd_configuration("osd_scrub_begin_hour", scrub_begin_hour)
+        scrub_object.set_osd_configuration("osd_scrub_end_hour", scrub_end_hour)
+        scrub_object.set_osd_configuration(
+            "osd_scrub_min_interval", osd_scrub_min_interval
+        )
+        scrub_object.set_osd_configuration(
+            "osd_scrub_max_interval", osd_scrub_max_interval
+        )
+
+        # Scheduled scrub verification
+        endTime = datetime.datetime.now() + datetime.timedelta(minutes=60)
+        while datetime.datetime.now() <= endTime:
+            after_scrub_log = scrub_object.get_pg_dump("pgid", "last_scrub_stamp")
+            scrub_status = scrub_object.verify_scrub_deepscrub(
+                before_scrub_log, after_scrub_log, "scrub"
+            )
+            if scrub_status == 0:
+                scrub_check_flag = False
+                log.info(f'{"Scrubbing is in progress.."}')
+                # After scheduled scrub starts, and for the next thirty minutes CPU and memory verification
+                # will get continue.
+                time_execution = datetime.datetime.now() + datetime.timedelta(
+                    minutes=30
+                )
+
+                while datetime.datetime.now() < time_execution:
+                    # Get the memory usage of the OSDs
+                    for node in ceph_nodes:
+                        if node.role == "osd":
+                            node_osds = rados_object.collect_osd_daemon_ids(node)
+                            for osd_id in node_osds:
+                                # Get the OSD memory
+                                osd_memory_usage = rados_object.get_osd_memory_usage(
+                                    node, osd_id
+                                )
+                                time.sleep(3)
+                                if osd_memory_usage > 80:
+                                    log.error(
+                                        f"The memory usage on the {node.hostname} -{osd_id} is {osd_memory_usage} "
+                                    )
+                                    return 1
+                                log.info(
+                                    f"The memory usage on the {node.hostname} -{osd_id} is {osd_memory_usage} "
+                                )
+                                # Get the OSD CPU usage
+                                osd_cpu_usage = rados_object.get_osd_cpu_usage(
+                                    node, osd_id
+                                )
+                                if osd_cpu_usage > 80:
+                                    log.error(
+                                        f"The cpu usage on the {node.hostname} -{osd_id} is {osd_cpu_usage} "
+                                    )
+                                    return 1
+                                log.info(
+                                    f"The cpu usage on the {node.hostname} -{osd_id} is {osd_cpu_usage} "
+                                )
+                            log.info(
+                                f"Memory and CPU check completed on the node-{node.hostname}."
+                            )
+                    log.info("Memory and CPU usage verification are in progress")
+                    # intentional sleep for 10 seconds  after calculating memory and CPU usage.
+                    time.sleep(10)
+                # Break after the verification of 30 minutes
+                break
+            log.info("Scrub not started.Wait for 30 seconds")
+            time.sleep(30)
+        if scrub_check_flag:
+            log.error("The scrub not initiated on the cluster")
+            return 1
+    except Exception as er:
+        log.error(f"Exception hit while command execution. {er}")
+        return 1
+    finally:
+        log.info("\n--Executing finally block--\n")
+        log.info(f"Deleting the {pool_name} pool")
+        method_should_succeed(rados_object.detete_pool, pool_name)
+        log.info(f"{pool_name} pool is deleted")
+        log.info("Setting the parameters in to default  values")
+        set_default_params(mon_obj)
+    return 0
+
+
+def set_default_params(mon_object):
+    """
+    Used to set the default osd scrub parameter value
+    Args:
+        mon_object: Monitor Object
+
+    Returns : None
+    """
+    mon_object.remove_config(section="osd", name="osd_scrub_min_interval")
+    mon_object.remove_config(section="osd", name="osd_scrub_max_interval")
+    mon_object.remove_config(section="osd", name="osd_scrub_begin_week_day")
+    mon_object.remove_config(section="osd", name="osd_scrub_end_week_day")
+    mon_object.remove_config(section="osd", name="osd_scrub_begin_hour")
+    mon_object.remove_config(section="osd", name="osd_scrub_end_hour")


### PR DESCRIPTION
# Description

Test Case: CEPH-9369 - RADOS: Time scheduled scrubbing: Observe cpu and memory usage during scrubbing

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
