### PR TITLE
Rados: Added methods to increase recovery threads during mon replacement

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -567,7 +567,7 @@ class RadosOrchestrator:
             )
         for cmd in cfg_map:
             if action == "set":
-                command = f"{cfg_map[cmd]} {config.get(cmd, 8)}"
+                command = f"{cfg_map[cmd]} {config.get(cmd, 12)}"
             else:
                 command = cfg_map[cmd]
             self.node.shell([command])

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -195,7 +195,8 @@ class MonConfigMethods:
         cmd = f"{cmd} {kwargs['name']} {kwargs['value']}"
         self.rados_obj.node.shell([cmd])
 
-        # Sleeping for 1 second for config to be applied
+        # Sleeping for 10 second for config to be applied
+        time.sleep(10)
         log.debug("verifying the value set")
         if not self.verify_set_config(**kwargs):
             log.error(f"Value for config: {kwargs['name']} could not be set")
@@ -252,7 +253,8 @@ class MonConfigMethods:
         cmd = f"{cmd} {kwargs['name']}"
         self.rados_obj.node.shell([cmd])
 
-        # Sleeping for 1 second for config to be applied
+        # Sleeping for 10 second for config to be applied
+        time.sleep(10)
         log.debug("verifying the value set")
         if self.verify_set_config(**kwargs):
             log.error(f"Value for config: {kwargs['name']} is still set")

--- a/tests/rados/test_mon_system_operations.py
+++ b/tests/rados/test_mon_system_operations.py
@@ -40,6 +40,9 @@ def run(ceph_cluster, **kw):
 
     rados_obj.bench_write(pool_name=pool_name, byte_size=1024, rados_write_duration=50)
 
+    # Increasing backfill & recovery rate
+    rados_obj.change_recovery_threads(config={}, action="set")
+
     log.info("---------- starting workflow 1 - Addition of new mons --------")
     # Setting the mon service as unmanaged by cephadm
     if not mon_obj.set_mon_service_managed_type(unmanaged=True):
@@ -273,6 +276,10 @@ def run(ceph_cluster, **kw):
             log.error("Checks failed post mon reboots")
             raise Exception("Sanity check failed post mon reboots")
         log.debug(f"Successfully restarted mon : {mon_node.hostname}")
+
+    # setting the backfill & recovery rate to default
+    rados_obj.change_recovery_threads(config={}, action="rm")
+
     log.info(
         "Completed rolling reboot of all mon daemons and sanity check."
         " All scenarios Passed"

--- a/tests/rados/test_pg_autoscale_flag.py
+++ b/tests/rados/test_pg_autoscale_flag.py
@@ -46,8 +46,8 @@ def run(ceph_cluster, **kw):
     cmd = "ceph osd pool set noautoscale"
     rados_obj.run_ceph_command(cmd=cmd)
 
-    # sleeping for 5 seconds as the command takes some time to affect the status of pools
-    time.sleep(5)
+    # sleeping for 20 seconds as the command takes some time to affect the status of pools
+    time.sleep(20)
 
     # Getting the autoscale configurations after setting the flag
     # all the pools should have autoscale set to off


### PR DESCRIPTION
1. Added method to increase recovery and backfill threads during mon replacement and backfill tests.
2. Added additional time delay of 20 seconds to verify the autoscale flag functionality
