### PR TITLE
[TFA] re-arranging rgw testcase

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
@@ -117,7 +117,6 @@ tests:
       name: deploy cluster
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -286,6 +285,18 @@ tests:
       name: create non-tenanted user
 
   - test:
+      name: Test multisite sync policy
+      desc: Test multisite sync policy
+      polarion-id: CEPH-83575360
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_sync_policy.py
+            config-file-name: test_multisite_sync_policy.yaml
+            timeout: 300
+
+  - test:
       name: Bucket Granular Sync policy test for prefix and tag
       desc: Bucket sync policy test for prefix and tag
       polarion-id: CEPH-83575142
@@ -299,30 +310,6 @@ tests:
             timeout: 300
 
   - test:
-      name: Granular multisite sync policy group transition
-      desc: Test multisite sync policy group transition
-      polarion-id: CEPH-83575135
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name:  test_multisite_sync_policy.py
-            config-file-name:  test_sync_policy_state_change.yaml
-            timeout: 300
-
-  - test:
-      name: Test multisite sync policy
-      desc: Test multisite sync policy
-      polarion-id: CEPH-83575360
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name:  test_multisite_sync_policy.py
-            config-file-name:  test_multisite_sync_policy.yaml
-            timeout: 300
-
-  - test:
       name: Bucket Granular Sync policy tests
       desc: test_multisite_mirror_sync_policy.yaml on primary
       polarion-id: CEPH-83575136
@@ -333,6 +320,18 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+
+  - test:
+      name: Granular multisite sync policy group transition
+      desc: Test multisite sync policy group transition
+      polarion-id: CEPH-83575135
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_sync_policy.py
+            config-file-name: test_sync_policy_state_change.yaml
             timeout: 300
 
   - test:

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -110,7 +110,7 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
-   #Basic Bucket Operation Tests
+  # Basic Bucket Operation Tests
   - test:
       name: compresstion_with_zstd_type
       desc: test compresstion with zstd type
@@ -570,3 +570,15 @@ tests:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
         timeout: 500
+
+  # rate limits tests with s3cmd
+  - test:
+      name: Test Rate limits on a User and Bucket level using s3cmd
+      desc: Test Rate limits on a User and Bucket level using s3cmd
+      polarion-id: CEPH-83574910
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
+        timeout: 300

--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -267,17 +267,6 @@ tests:
         timeout: 300
 
   - test:
-      name: Test Rate limits on a User and Bucket level using s3cmd
-      desc: Test Rate limits on a User and Bucket level using s3cmd
-      polarion-id: CEPH-83574910
-      module: sanity_rgw.py
-      config:
-        run-on-rgw: true
-        script-name: ../s3cmd/test_rate_limit.py
-        config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300
-
-  - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create
       polarion-id: CEPH-83574597


### PR DESCRIPTION
# Description
re-arranging rgw testcase
1. seeing issue with rate limit testcase using s3cmd for ssl certification verification : moved testcase to non-ssl suite
    log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-983Y2X/
2. rearraging the sync policy test case as issue seen due to timing:  
   log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-ERRQ36/



<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
