### PR TITLE
[Libfix] Fix wrongly typed volume to attach_volume

### DIFF
--- a/cli/cluster/node.py
+++ b/cli/cluster/node.py
@@ -125,7 +125,7 @@ class Node:
         node = self.cloud.get_node_by_id(self.id)
 
         # Attach volumes to node
-        volumes = volume if type(volume) in (list, tuple) else (volume)
+        volumes = volume if type(volume) in (list, tuple) else [volume]
         for v in volumes:
             self.cloud.attach_volume(node, self.cloud.get_volume_by_name(v))
 


### PR DESCRIPTION
PR fixes the wrongly typed list for attach_volume in cli/cluster/node.py

