### PR TITLE
RHCEPHQE-12173: TFA fix for MON daemon crash in RADOS regression

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -2297,8 +2297,8 @@ class RadosOrchestrator:
                 log.error("Crash warning not found even after manual injection")
                 return False
         else:
-            # wait for 500 secs for crash to be reported in ceph health
-            if not warning_check(timeout=500):
+            # wait for 900 secs for crash to be reported in ceph health
+            if not warning_check(timeout=900):
                 log.error("Crash warning was not generated automatically")
 
         # ensure crash detail is populated in crash ls-new
@@ -2306,7 +2306,9 @@ class RadosOrchestrator:
         if not len(crash_ls_post) > init_crash_ls:
             log.error("New crash not listed in crash ls-new output")
             return False
-        log.debug(f"Output of crash ls-new: {init_crash_ls}")
+        log.debug(
+            f"Output of crash ls-new: {crash_ls_post}" f"\n Count: {len(crash_ls_post)}"
+        )
 
         log.info("Daemon crash warning found in ceph health")
         return True

--- a/suites/pacific/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/pacific/rados/tier-2-rados-basic-regression.yaml
@@ -23,6 +23,7 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 allow-fqdn-hostname: true
+                orphan-initial-daemons: true
           - config:
               command: add_hosts
               service: host

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -23,6 +23,7 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 allow-fqdn-hostname: true
+                orphan-initial-daemons: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -23,6 +23,7 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 allow-fqdn-hostname: true
+                orphan-initial-daemons: true
           - config:
               command: add_hosts
               service: host

--- a/tests/rados/test_osd_replacement.py
+++ b/tests/rados/test_osd_replacement.py
@@ -35,6 +35,7 @@ def run(ceph_cluster, **kw):
     try:
         out, _ = cephadm.shell(args=["ceph osd ls"])
         osd_list = out.strip().split("\n")
+        log.debug(f"List of OSDs: {osd_list}")
         osd_id = int(random.choice(osd_list))
         osd_list.pop(osd_id)
         osd_metadata = ceph_cluster.get_osd_metadata(osd_id=int(osd_id), client=client)


### PR DESCRIPTION
[RHCEPHQE-12173](https://issues.redhat.com/browse/RHCEPHQE-12173): [TFA] CEPHQE-REEF-SANITY-OPENSTACK-IBM-18.2.0-128 - tier-2-rados-basic-regression.yaml - Mon crash not generated

The workflow is divided into 2 sections -
- a random OSD daemon is crashed and the generated crash is manually injected into the cluster
- a random MON daemon is crashed and the test wait for the crash to appear organically in the cluster health detail and crash list outputs

The failure reported in the regression run seems to be a one-off timing issue where the crash did not appear automatically within the timeout of 500 secs.
Another observation was made about the first OSD daemon crash, the crash generated in the first part of the workflow was still part of the cluster health detail when the test is waiting for the 2nd crash report to appear, this creates confusion while debugging the logs.
To overcome the above issue, the first crash generated is archived post verification so that it no longer appears under ceph health detail.

Additionally a command which was not part of the test workflow due to logical limitations has now been included - `ceph crash archive-all`

`orphan-initial-daemons: true`  restored in all the test suites to avoid the unwanted warning of `stray daemon mon.ceph-hakumar-jivu6k-node5 on host ceph-hakumar-jivu6k-node5 not managed by cephadm`

Test modules modified:
- `ceph/rados/core_workflows.py`
- `tests/rados/test_crash_daemon.py`
- `tests/rados/test_osd_replacement.py`

Test suites modified:
- suites/pacific/rados/tier-2-rados-basic-regression.yaml
- suites/quincy/rados/tier-2-rados-basic-regression.yaml
- suites/reef/rados/tier-2-rados-basic-regression.yaml

Logs:
- Pacific:
- Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JIVU6K/

Signed-off-by: Harsh Kumar [hakumar@redhat.com](mailto:hakumar@redhat.com)
