### PR TITLE
test_osd_inconsistency_pg script code fix for TFA issue

### DIFF
--- a/tests/rados/test_osd_inconsistency_pg.py
+++ b/tests/rados/test_osd_inconsistency_pg.py
@@ -102,9 +102,9 @@ def run(ceph_cluster, **kw):
         log.info(f"Performing the repair on the osd-{primary_osd}")
         repair_output = bluestore_obj.repair(primary_osd)
         log.info(f"The repair status is:{repair_output}")
-        health_check = rados_obj.check_inconsistent_health()
+        health_check = rados_obj.check_inconsistent_health(False)
         log.info(f"The health status after the repair is ::{health_check}")
-        assert not health_check
+        assert health_check
         log.info("The inconsistent objects are repaired")
         # Checking for the inconsistent pg's
         inconsistent_pg_list = rados_obj.get_inconsistent_pg_list(pool_name)


### PR DESCRIPTION
 **The script execution failed due to the following error-**

023-11-23 18:43:12,003 (cephci.test_osd_inconsistency_pg) [INFO] - cephci.Regression.rados.37.cephci.tests.rados.test_osd_inconsistency_pg.py:117 -
2023-11-23 18:43:12,003 (cephci.test_osd_inconsistency_pg) [INFO] - cephci.Regression.rados.37.cephci.tests.rados.test_osd_inconsistency_pg.py:118 - Traceback (most recent call last):
File "/home/jenkins/ceph-builds/18.2.0-128/Regression/rados/37/cephci/tests/rados/test_osd_inconsistency_pg.py", line 107, in run
_assert not health_check
AssertionError_

**Root cause:**
After creating or cleaning inconsistent objects, The "ceph health detail" output is not getting reflected immediately. 

**Suite fail log** : http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-128/Regression/rados/36/tier-2_rados_test_omap/

**Jira ticket**-  https://issues.redhat.com/browse/RHCEPHQE-12170

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
