### PR TITLE
Updating the daemon placement in stretch mode

### DIFF
--- a/conf/pacific/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/pacific/rados/stretch-mode-host-location-attrs.yaml
@@ -12,6 +12,8 @@ globals:
           - _admin
           - installer
           - mon
+# Keeping the mgr daemon in the arbiter node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+          - mgr
           - alertmanager
           - grafana
           - prometheus
@@ -20,7 +22,6 @@ globals:
           - mon
           - mgr
           - _admin
-          - mds
           - osd
         no-of-volumes: 4
         disk-size: 25
@@ -28,14 +29,15 @@ globals:
         role:
           - mon
           - mgr
-          - osd
           - nfs
+          - osd
         no-of-volumes: 4
         disk-size: 25
       node4:
         role:
           - rgw
           - osd
+          - mds
         no-of-volumes: 4
         disk-size: 25
       node5:
@@ -51,14 +53,14 @@ globals:
           - mon
           - mgr
           - osd
-          - rgw
+          - nfs
         no-of-volumes: 4
         disk-size: 25
       node7:
         role:
           - osd
+          - rgw
           - mds
-          - nfs
         no-of-volumes: 4
         disk-size: 25
       node8:

--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -3,7 +3,6 @@
 # Example of the cluster taken from the MDR deployment guide for ODF.
 # ref: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/
 # configuring_openshift_data_foundation_disaster_recovery_for_openshift_workloads/metro-dr-solution#hardware_requirements
-
 globals:
   - ceph-cluster:
       name: ceph
@@ -12,6 +11,8 @@ globals:
           - _admin
           - installer
           - mon
+# Keeping the mgr daemon in the arbiter node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+          - mgr
           - alertmanager
           - grafana
           - prometheus
@@ -20,7 +21,6 @@ globals:
           - mon
           - mgr
           - _admin
-          - mds
           - osd
         no-of-volumes: 4
         disk-size: 25
@@ -36,6 +36,7 @@ globals:
         role:
           - rgw
           - osd
+          - mds
         no-of-volumes: 4
         disk-size: 25
       node5:
@@ -51,13 +52,13 @@ globals:
           - mon
           - mgr
           - osd
-          - rgw
+          - nfs
         no-of-volumes: 4
         disk-size: 25
       node7:
         role:
           - osd
-          - nfs
+          - rgw
           - mds
         no-of-volumes: 4
         disk-size: 25

--- a/conf/reef/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/reef/rados/stretch-mode-host-location-attrs.yaml
@@ -12,6 +12,8 @@ globals:
           - _admin
           - installer
           - mon
+# Keeping the mgr daemon in the arbiter node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+          - mgr
           - alertmanager
           - grafana
           - prometheus
@@ -20,7 +22,6 @@ globals:
           - mon
           - mgr
           - _admin
-          - mds
           - osd
         no-of-volumes: 4
         disk-size: 25
@@ -36,6 +37,7 @@ globals:
         role:
           - rgw
           - osd
+          - mds
         no-of-volumes: 4
         disk-size: 25
       node5:
@@ -51,13 +53,13 @@ globals:
           - mon
           - mgr
           - osd
-          - rgw
+          - nfs
         no-of-volumes: 4
         disk-size: 25
       node7:
         role:
           - osd
-          - nfs
+          - rgw
           - mds
         no-of-volumes: 4
         disk-size: 25

--- a/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
@@ -86,7 +86,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node8
+        node: node7
         install_packages:
           - ceph-common
           - ceph-base


### PR DESCRIPTION
1. added a mgr daemon in Arbiter node in stretch mode deployment
2. Corrected the client placement in upstream test suite.