### PR TITLE
Persistent write back cache test with cluster operations

### DIFF
--- a/ceph/rbd/workflows/cluster_operations.py
+++ b/ceph/rbd/workflows/cluster_operations.py
@@ -1,0 +1,198 @@
+import re
+import time
+from importlib import import_module
+
+from ceph.rados import utils
+from tests.rados.rados_test_util import get_device_path, wait_for_device
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.log import Log
+from utility.utils import method_should_succeed
+
+log = Log(__name__)
+
+
+def restart_ceph_target(admin_node):
+    """
+    Restart the Ceph target service.
+
+    Args:
+        admin_node (Node): The cephadm admin node.
+
+    Raises:
+        Exception: If the Ceph target service restart fails.
+    """
+    log.info("Restarting Ceph target service")
+
+    cmd = "systemctl restart ceph.target"
+    out, err = admin_node.exec_command(cmd=cmd, sudo=True)
+
+    # Check for errors
+    if err:
+        log.error(err)
+        raise Exception("Failed to restart ceph target service")
+
+
+def restart_osd(client_node):
+    """
+    Method to restart ceph osd service.
+
+    Args:
+        client_node (Node): The ceph client node.
+
+    Raises:
+        Exception: If Ceph health check fails.
+    """
+    log.info("Restarting Ceph osd service")
+    try:
+        cmd = "ceph orch ls osd"
+        out, err = client_node.exec_command(cmd=cmd, sudo=True)
+
+        # Check for errors
+        if err:
+            raise Exception("Listing OSD daemon failed")
+
+        # Regular expression to extract the OSD name
+        osd_daemon = re.search(r"osd\.(\S+)", str(out))
+        cmd = f"ceph orch restart {osd_daemon[0]}"
+
+        out, err = client_node.exec_command(cmd=cmd, sudo=True)
+
+        # Check for errors
+        if err:
+            raise Exception("Failed to restart ceph osd service")
+    except Exception as err:
+        log.error(err)
+        raise Exception("Failed to restart ceph osd service")
+
+
+def check_health(client_node):
+    """
+    Check Ceph health status.
+
+    Args:
+        client_node (Node): The ceph client node.
+
+    Raises:
+        Exception: If Ceph health check fails.
+    """
+    log.info("Checking Ceph health status")
+    try:
+        out, err = client_node.exec_command(cmd="ceph -s", sudo=True)
+
+        if "HEALTH_ERR" in out:
+            log.debug(out)
+            raise Exception("Cluster went to error health state")
+
+        log.info(f"Ceph health status: {out}")
+
+        # Check for errors
+        if err:
+            raise Exception(f"ceph health check error out as {err}")
+
+    except Exception as err:
+        log.error(err)
+        raise Exception("Failed to check Ceph health status")
+
+
+def osd_remove_and_add_back(
+    ceph_cluster,
+    rados_obj,
+    pool,
+):
+    """
+    Method to remove osd and add back the removed osd.
+
+    Args:
+        ceph_cluster: The Ceph cluster object.
+        rados_obj: RadosObject for interacting with Ceph.
+        pool: The name of the Ceph pool.
+
+    Raises:
+        Exception: If any ceph operation fails.
+    """
+    try:
+        client_node = ceph_cluster.get_nodes(role="client")[0]
+        pg_set = rados_obj.get_pg_acting_set(pool_name=pool)
+        log.info(f"Acting set for removal and addition of OSDs {pg_set}")
+        target_osd = pg_set[0]
+        host = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=target_osd)
+
+        timeout = 300
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            try:
+                dev_path = get_device_path(host, target_osd)
+                if dev_path:
+                    # Device path exist, break the loop
+                    break
+                time.sleep(10)
+            except Exception as e:
+                log.info(e)
+                time.sleep(10)
+
+        else:
+            raise Exception("Timeout: Unable to get device path within timeout")
+
+        log.info(
+            f"osd device path  : {dev_path}, osd_id : {target_osd}, host.hostname : {host.hostname}"
+        )
+
+        utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=True)
+        method_should_succeed(utils.set_osd_out, ceph_cluster, target_osd)
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        utils.osd_remove(ceph_cluster, target_osd)
+        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
+        method_should_succeed(utils.zap_device, ceph_cluster, host.hostname, dev_path)
+        method_should_succeed(wait_for_device, host, target_osd, action="remove")
+
+        # Checking cluster health after OSD removal
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        log.info(
+            f"Removal of OSD : {target_osd} is successful. Proceeding to add back the OSD daemon."
+        )
+
+        # Adding the removed OSD back and checking the cluster status
+        utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
+
+        # Checking cluster health after OSD removal
+        method_should_succeed(rados_obj.run_pool_sanity_check)
+        cmd = f"ceph osd tree | grep {target_osd}"
+        timeout = 300
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            osd_tree_out = client_node.exec_command(cmd=cmd, sudo=True)[0]
+            if "up" in osd_tree_out:
+                log.info(
+                    f"Addition of OSD : {target_osd} back into the cluster is successful"
+                )
+                break
+
+            time.sleep(10)
+
+        else:
+            raise Exception(
+                f"Timeout: OSD {target_osd} did not become 'up' within {timeout} seconds."
+            )
+
+        utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=False)
+
+    except Exception as err:
+        log.error(err)
+        raise Exception("Failed to perform osd remove and add back the removed osd")
+
+
+def operation(obj, test, **kw):
+    """
+    Executes the test specified in test parameter with inputs args and returns results
+    Args:
+        obj: rbd object or module to be imported
+        test: test to be executed
+        **kwargs: input args required for the test
+    """
+    if isinstance(obj, str):
+        obj = import_module(obj)
+    method = getattr(obj, test)
+    rc = method(**kw)
+    if (type(rc) is bool and rc is False) or (type(rc) is int and rc == 1):
+        raise Exception(f"method {test} failed")

--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -463,3 +463,31 @@ tests:
       module: test_performance_pwl_cache.py
       name: Performance comparison with or without pwl cache
       polarion-id: CEPH-83574711
+
+  - test:
+      abort-on-fail: true
+      config:
+        levels:
+          - client
+          - pool
+          - image
+        cache_file_size: 1073741824         # 1 GB
+        rbd_persistent_cache_mode: ssd      # "ssd" or "rwl" on pmem device
+        drive: /dev/nvme0n1
+        client: node10
+        cleanup: true
+        validate_cache_path: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          size: 100M
+      desc: Validate cache status and IO interruption
+      destroy-cluster: false
+      module: test_rbd_pwl_cache_cluster_operation.py
+      name: Validate cluster operation with persistent cache enabled
+      polarion-id: CEPH-83574891

--- a/suites/reef/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/reef/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -295,3 +295,32 @@ tests:
       module: test_performance_pwl_cache.py
       name: Performance comparison with or without pwl cache
       polarion-id: CEPH-83574711
+
+  - test:
+      abort-on-fail: true
+      config:
+        levels:
+          - client
+          - pool
+          - image
+        cache_file_size: 1073741824         # 1 GB
+        rbd_persistent_cache_mode: ssd      # "ssd" or "rwl" on pmem device
+        drive: /dev/nvme0n1
+        client: node10
+        cleanup: true
+        validate_cache_path: true
+        rep-pool-only: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          image_name: image1
+          pool_name: pool1
+          size: 100M
+      desc: Validate cache status and IO interruption
+      destroy-cluster: false
+      module: test_rbd_pwl_cache_cluster_operation.py
+      name: Validate cluster operation with persistent cache enabled
+      polarion-id: CEPH-83574891
+

--- a/tests/rbd/rbd_peristent_writeback_cache.py
+++ b/tests/rbd/rbd_peristent_writeback_cache.py
@@ -1,7 +1,9 @@
 """RBD Persistent write back cache."""
 
 import datetime
+import re
 from json import loads
+from time import sleep
 
 from utility.log import Log
 
@@ -274,3 +276,16 @@ def device_cleanup(rbd):
             )
             if out_2:
                 log.error(f"RBD unmap failed for {device_name} ")
+
+
+def kill_fio(rbd):
+    """
+    Kill the fio process running on the client
+    """
+    sleep(60)
+    cmd = "ps -ef | grep fio"
+    out = rbd.exec_cmd(cmd=cmd, sudo=True, output=True)
+    if out and re.findall(r"(fio).*(--name)", out, re.I):
+        proc_id = re.search(r"\d+", out).group()
+        cmd = f"kill -9 {proc_id}"
+        rbd.exec_cmd(cmd=cmd, sudo=True)

--- a/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
+++ b/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
@@ -18,34 +18,19 @@ Support
 - Configure cluster with PWL Cache.
 - Only replicated pool supported, No EC pools.
 """
-import re
-from time import sleep
-
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
 from tests.rbd.rbd_peristent_writeback_cache import (
     PersistentWriteAheadLog,
     fio_ready,
     get_entity_level,
+    kill_fio,
 )
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.utils import run_fio
 
 log = Log(__name__)
-
-
-def kill_fio(rbd):
-    """
-    Kill the fio process running on the client
-    """
-    sleep(60)
-    cmd = "ps -ef | grep fio"
-    out = rbd.exec_cmd(cmd=cmd, sudo=True, output=True)
-    if out and re.findall(r"(fio).*(--name)", out, re.I):
-        proc_id = re.search(r"\d+", out).group()
-        cmd = f"kill -9 {proc_id}"
-        rbd.exec_cmd(cmd=cmd, sudo=True)
 
 
 def validate_cache_flush(cache, cfg, client):

--- a/tests/rbd/test_rbd_pwl_cache_cluster_operation.py
+++ b/tests/rbd/test_rbd_pwl_cache_cluster_operation.py
@@ -1,0 +1,214 @@
+"""RBD Persistent write back cache with cluster operations.
+
+Test Case Covered:
+CEPH-83574891 - Verify ceph cluster operations with persistent
+cache enabled in SSD mode with IO in-progress.
+
+Steps :
+1) Setup persistent write cache for an image
+2) Write data to the image using fio jobs check cache status
+3) Stop writing data to the image by killing the fio process, then start again
+4) Perform cluster operation like restarting mon, osd, overall ceph.target
+5) Remove mon node then add it back while IO keeps going
+6) Remove osd node then add it back while IO keeps going
+7) Initiate OSD scrub operation while IO keeps going
+8) check ceph health and data corruption every time while IO keeps going
+9) Repeat the test on client, pool and image level
+
+Pre-requisites :
+- need client node with ceph-common package, conf and keyring files
+- FIO should be installed on the client.
+
+Environment and limitations:
+- The cluster should have 5 nodes + 1 SSD cache node
+- cluster/global-config-file: config/quincy/upi/octo-5-node-env.yaml
+- Should be Bare-metal.
+
+Support
+- Configure cluster with PWL Cache.
+- Only replicated pool supported, No EC pools."""
+
+
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.parallel import parallel
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.monitor_workflows import MonitorWorkflows
+from ceph.rbd.workflows.cluster_operations import (
+    check_health,
+    operation,
+    osd_remove_and_add_back,
+    restart_ceph_target,
+    restart_osd,
+)
+from tests.rbd.rbd_peristent_writeback_cache import (
+    PersistentWriteAheadLog,
+    fio_ready,
+    get_entity_level,
+    kill_fio,
+)
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def verify_cache(pwl, config, cache_client, image_spec):
+    """Method to verify rbd persistant cache test.
+
+    Args:
+        pwl (PersistentWriteAheadLog): The PersistentWriteAheadLog instance.
+        config (dict): The test configuration.
+        cache_client (Node): The client node for cache testing.
+        image_spec (str): The image specification for testing.
+    """
+    log.info("Writing data to the image using FIO jobs and checking cache status")
+    with parallel() as p:
+        p.spawn(
+            run_fio, **fio_ready(config, cache_client, verify="crc32", verify_fatal=1)
+        )
+        p.spawn(
+            pwl.check_cache_file_exists,
+            image_spec,
+            config["fio"].get("runtime", 30),
+            **config,
+        )
+
+
+def run(ceph_cluster, **kw):
+    """RBD Persistent write back cache with cluster operations.
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test parameters
+    """
+    log.info(
+        "Running test - CEPH-83574891 - Verify ceph cluster operations "
+        "with persistent cache enabled in SSD mode with IO in-progress"
+    )
+    config = kw.get("config")
+    for level in config.get("levels"):
+        config["level"] = level
+        rbd_obj = initial_rbd_config(**kw)["rbd_reppool"]
+        pool = config["rep_pool_config"]["pool"]
+        image_spec = (
+            f"{config['rep_pool_config']['pool']}/{config['rep_pool_config']['image']}"
+        )
+        cache_client = ceph_cluster.get_nodes(role="client")[0]
+        admin_node = ceph_cluster.get_nodes(role="_admin")[0]
+        cephadm = CephAdmin(cluster=ceph_cluster, **config)
+        rados_obj = RadosOrchestrator(node=cephadm)
+        mon_obj = MonitorWorkflows(node=cephadm)
+        pwl = PersistentWriteAheadLog(rbd_obj, cache_client, config.get("drive"))
+        config_level, entity = get_entity_level(config)
+
+        try:
+            # Configute cache client
+            pwl.configure_cache_client()
+
+            # Configure PWL
+            pwl.configure_pwl_cache(
+                config["rbd_persistent_cache_mode"],
+                config_level,
+                entity,
+                config["cache_file_size"],
+            )
+
+            # Test to verify persistent write back cache test
+            verify_cache(pwl, config, cache_client, image_spec)
+
+            log.info(
+                "Test to kill FIO process and restarting FIO to check cache status"
+            )
+            with parallel() as p:
+                p.spawn(run_fio, **fio_ready(config, cache_client))
+                p.spawn(kill_fio, pwl.rbd)
+
+            verify_cache(pwl, config, cache_client, image_spec)
+
+            # Parallel execution of cluster operations with corresponding verify cache tests
+            with parallel() as p:
+                log.info("Test to restart mon service along with cache test")
+                p.spawn(operation, rados_obj, "restart_daemon_services", daemon="mon")
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            with parallel() as p:
+                log.info("Test to restart osd service along with cache test")
+                p.spawn(restart_osd, client_node=cache_client)
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            with parallel() as p:
+                log.info(
+                    "Test to restart ceph target service along with pwl cache test"
+                )
+                p.spawn(restart_ceph_target, admin_node=admin_node)
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            mon_host = ceph_cluster.get_nodes(role="mon")[0]
+            with parallel() as p:
+                log.info("Test to remove mon service along with pwl cache test")
+                cmd = f"ceph orch host label rm {mon_host.hostname} mon"
+                out, err = cache_client.exec_command(cmd=cmd, sudo=True)
+
+                # Check for errors
+                if err:
+                    raise Exception(f"ceph mon remove command failed as {err}")
+
+                p.spawn(
+                    operation, mon_obj, "remove_mon_service", host=mon_host.hostname
+                )
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            with parallel() as p:
+                log.info(
+                    "Test to add the mon service back to the cluster with pwl cache test"
+                )
+                cmd = f"ceph orch host label add {mon_host.hostname} mon"
+                out, err = cache_client.exec_command(cmd=cmd, sudo=True)
+
+                # Check for errors
+                if err:
+                    raise Exception(f"ceph mon add command failed as {err}")
+
+                time.sleep(10)
+                p.spawn(
+                    operation,
+                    mon_obj,
+                    "check_mon_exists_on_host",
+                    host=mon_host.hostname,
+                )
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            with parallel() as p:
+                log.info(
+                    "Test to remove the osd service and add back to the cluster with pwl cache test"
+                )
+                p.spawn(
+                    osd_remove_and_add_back,
+                    ceph_cluster=ceph_cluster,
+                    rados_obj=rados_obj,
+                    pool=pool,
+                )
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            with parallel() as p:
+                log.info("Test to initiate OSD scrub operation with pwl cache test")
+                p.spawn(operation, rados_obj, "run_scrub")
+                p.spawn(verify_cache, pwl, config, cache_client, image_spec)
+
+            # Test to check ceph health
+            check_health(cache_client)
+
+        except Exception as err:
+            log.error(err)
+            return 1
+
+        finally:
+            if config.get("cleanup"):
+                pwl.remove_pwl_configuration(config_level, entity)
+                rbd_obj.clean_up(pools=[pool])
+                pwl.cleanup()
+
+    return 0

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2079,6 +2079,14 @@ def run_fio(**fio_args):
     if fio_args.get("rwmixread"):
         cmd_args.update({"rwmixread": fio_args["rwmixread"]})
 
+    # add verify and verify_fatal for data corruption test
+    # e.g verify="crc32", verify_fatal=1
+    if fio_args.get("verify"):
+        cmd_args.update({"verify": fio_args["verify"]})
+
+    if fio_args.get("verify_fatal"):
+        cmd_args.update({"verify_fatal": fio_args["verify_fatal"]})
+
     cmd_args.update(
         {
             "name": fio_args.get("test_name", "test-1"),


### PR DESCRIPTION
# Description
Automation of test case:
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574891

Test steps:
1) Setup persistent write cache for an image
2) Write data to the image using fio jobs check cache status
3) Stop writing data to the image by killing the fio process, then start again
4) Perform cluster operation like restarting mon, osd, overall ceph.target
5) Remove mon node then add it back while IO keeps going
6) Remove osd node then add it back while IO keeps going
7) Initiate OSD scrub operation while IO keeps going
8) check data corruption every time while IO keeps going

Test result: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XKMEKC

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
