### PR TITLE
[test-fix] Add fix for OSD deployed with limit filter spec test failure

### DIFF
--- a/suites/quincy/cephadm/tier-1_cephadm-clients.yaml
+++ b/suites/quincy/cephadm/tier-1_cephadm-clients.yaml
@@ -134,6 +134,7 @@ tests:
                 data_devices:
                   all: "true"                         # boolean as string
                 encrypted: "true"                     # boolean as string
+                unmanaged: "true"                     # boolean as string
         - config:
             command: shell
             args:                 # sleep to get all services deployed
@@ -171,3 +172,39 @@ tests:
           client_group: clients
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
           keyring_dest: /etc/ceph/custom_name_ceph.keyring
+  - test:
+      name: Deploy OSD with limit filter spec
+      desc: Deploy OSD with limit filter spec
+      module: test_cephadm.py
+      config:
+        steps:                          # Deploy OSD with limit filter
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: osd
+                  service_id: small_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+                - service_type: osd
+                  service_id: big_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+          - config:
+              command: shell
+              args:                 # sleep to get all services deployed
+                - sleep
+                - "300"
+  - test:
+      name: Verify OSD deployed with limit filter spec
+      desc: Verify OSD deployed with limit filter spec
+      polarion-id: CEPH-83575588
+      module: test_osd_limit_filter.py

--- a/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/quincy/cephadm/tier-1_service_apply_spec.yaml
@@ -66,7 +66,7 @@ tests:
       abort-on-fail: true
   - test:
       name: Host addition with spec file
-      desc: add hosts using spec file.
+      desc: Add hosts using spec file.
       module: test_cephadm.py
       polarion-id: CEPH-83574726
       config:
@@ -99,8 +99,8 @@ tests:
                     - node4
       abort-on-fail: true
   - test:
-      name: Service deployment with spec
-      desc: Add services using spec file.
+      name: MON stack Service deployment with spec
+      desc: Add MON stack services using spec file.
       module: test_cephadm.py
       polarion-id: CEPH-83574727
       config:
@@ -143,8 +143,8 @@ tests:
                 - sleep
                 - "300"
   - test:
-      name: Service deployment with spec
-      desc: Add services using spec file.
+      name: OSD Service deployment with spec
+      desc: Add OSD services using spec file.
       module: test_cephadm.py
       polarion-id: CEPH-83573746
       config:
@@ -161,7 +161,6 @@ tests:
                     data_devices:
                       all: "true"                         # boolean as string
                     encrypted: "true"                     # boolean as string
-                    unmanaged: "true"
           - config:
               command: shell
               args:                 # sleep to get all services deployed
@@ -194,7 +193,7 @@ tests:
               command: shell
               args:              # sleep to get all services deployed
                 - sleep
-                - "120"
+                - "300"
 
   - test:
       name: RGW Service deployment with spec
@@ -238,7 +237,7 @@ tests:
               command: shell
               args:              # sleep to get all services deployed
                 - sleep
-                - "120"
+                - "300"
   - test:
       name: test_label_no_schedule
       desc: Adding  "__no_schedule" label to a node and verify its functionality in a cluster.
@@ -261,52 +260,3 @@ tests:
       module: test_cephadm_log_spam.py
       config:
         type: command
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        node: node5
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Configure the RGW,RBD client system
-      destroy-cluster: false
-      module: test_client.py
-      name: configure client
-  - test:
-      name: Deploy OSD with limit filter spec
-      desc: Deploy OSD with limit filter spec
-      module: test_cephadm.py
-      config:
-        steps:                          # Deploy OSD with limit filter
-          - config:
-              command: apply_spec
-              service: orch
-              specs:
-                - service_type: osd
-                  service_id: small_db
-                  placement:
-                    label: osd
-                  spec:
-                    data_devices:
-                      size: '11GB:16GB'
-                      limit: 2
-                - service_type: osd
-                  service_id: big_db
-                  placement:
-                    label: osd
-                  spec:
-                    data_devices:
-                      size: '11GB:16GB'
-                      limit: 2
-          - config:
-              command: shell
-              args:                 # sleep to get all services deployed
-                - sleep
-                - "300"
-  - test:
-      name: Verify OSD deployed with limit filter spec
-      desc: Verify OSD deployed with limit filter spec
-      polarion-id: CEPH-83575588
-      module: test_osd_limit_filter.py


### PR DESCRIPTION
# Description

Moved the test case "Verify OSD deployed with limit filter spec" from the suite "tier-1_service_apply_spec.yaml" to "tier-1_cephadm-clients.yaml"

Additional changes have also been made to "tier-1_service_apply_spec.yaml" to fix MDS deployment failures.