### PR TITLE
[TestFix] Fix nfs scale down test

### DIFF
--- a/suites/reef/cephadm/tier2-cluster-elasticity.yaml
+++ b/suites/reef/cephadm/tier2-cluster-elasticity.yaml
@@ -707,7 +707,7 @@ tests:
           placement:
             nodes:
               - node10
-            limit: 2
+            limit: 1
             sep: ";"
       destroy-cluster: false
 


### PR DESCRIPTION
# Description

The scale down nfs test was failing as the limit was not reduced. This caused the apply command to fail. 
Solution: Update the limit 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
