### PR TITLE
Stretch_cluster.py: Commenting test due to active bug: 2249962

### DIFF
--- a/suites/pacific/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/pacific/rados/tier-2-rados-basic-regression.yaml
@@ -350,8 +350,3 @@ tests:
       polarion-id: CEPH-83574794
       desc: verify autoscaler flags functionality
 
-  - test:
-      name: crash warning upon daemon crash
-      module: test_crash_daemon.py
-      polarion-id: CEPH-83573855
-      desc: Verify crash warning in ceph health upon crashing a daemon

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -303,16 +303,17 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-  - test:
-      name: Netsplit Scenarios data-data sites
-      module: test_stretch_netsplit_scenarios.py
-      polarion-id: CEPH-83574979
-      config:
-        pool_name: test_stretch_pool8
-        netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
-        delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data sites
+# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+#  - test:
+#      name: Netsplit Scenarios data-data sites
+#      module: test_stretch_netsplit_scenarios.py
+#      polarion-id: CEPH-83574979
+#      config:
+#        pool_name: test_stretch_pool8
+#        netsplit_site: DC1
+#        tiebreaker_mon_site_name: arbiter
+#        delete_pool: true
+#      desc: Test stretch Cluster netsplit scenario between data sites
 
   - test:
       name: Netsplit Scenarios data-arbiter sites

--- a/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -242,3 +242,10 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+
+  - test:
+      name: crash warning upon daemon crash
+      module: test_crash_daemon.py
+      polarion-id: CEPH-83573855
+      desc: Verify crash warning in ceph health upon crashing a daemon

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -369,14 +369,9 @@ tests:
       polarion-id: CEPH-83573478
       desc: Config sources - Verify config source changes and reset config
 
-  - test:
-      name: autoscaler flags
-      module: test_pg_autoscale_flag.py
-      polarion-id: CEPH-83574794
-      desc: verify autoscaler flags functionality
-
-  - test:
-      name: crash warning upon daemon crash
-      module: test_crash_daemon.py
-      polarion-id: CEPH-83573855
-      desc: Verify crash warning in ceph health upon crashing a daemon
+# Commenting untill bug fix : https://bugzilla.redhat.com/show_bug.cgi?id=2252788
+#  - test:
+#      name: autoscaler flags
+#      module: test_pg_autoscale_flag.py
+#      polarion-id: CEPH-83574794
+#      desc: verify autoscaler flags functionality

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -304,16 +304,17 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-  - test:
-      name: Netsplit Scenarios data-data sites
-      module: test_stretch_netsplit_scenarios.py
-      polarion-id: CEPH-83574979
-      config:
-        pool_name: test_stretch_pool8
-        netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
-        delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data sites
+# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+#  - test:
+#      name: Netsplit Scenarios data-data sites
+#      module: test_stretch_netsplit_scenarios.py
+#      polarion-id: CEPH-83574979
+#      config:
+#        pool_name: test_stretch_pool8
+#        netsplit_site: DC1
+#        tiebreaker_mon_site_name: arbiter
+#        delete_pool: true
+#      desc: Test stretch Cluster netsplit scenario between data sites
 
   - test:
       name: Netsplit Scenarios data-arbiter sites

--- a/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -242,3 +242,9 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  - test:
+      name: crash warning upon daemon crash
+      module: test_crash_daemon.py
+      polarion-id: CEPH-83573855
+      desc: Verify crash warning in ceph health upon crashing a daemon

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -376,9 +376,3 @@ tests:
       module: test_pg_autoscale_flag.py
       polarion-id: CEPH-83574794
       desc: verify autoscaler flags functionality
-
-  - test:
-      name: crash warning upon daemon crash
-      module: test_crash_daemon.py
-      polarion-id: CEPH-83573855
-      desc: Verify crash warning in ceph health upon crashing a daemon

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -307,16 +307,17 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-  - test:
-      name: Netsplit Scenarios data-data sites
-      module: test_stretch_netsplit_scenarios.py
-      polarion-id: CEPH-83574979
-      config:
-        pool_name: test_stretch_pool8
-        netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
-        delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data sites
+# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+#  - test:
+#      name: Netsplit Scenarios data-data sites
+#      module: test_stretch_netsplit_scenarios.py
+#      polarion-id: CEPH-83574979
+#      config:
+#        pool_name: test_stretch_pool8
+#        netsplit_site: DC1
+#        tiebreaker_mon_site_name: arbiter
+#        delete_pool: true
+#      desc: Test stretch Cluster netsplit scenario between data sites
 
   - test:
       name: Netsplit Scenarios data-arbiter sites

--- a/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -242,3 +242,9 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  - test:
+      name: crash warning upon daemon crash
+      module: test_crash_daemon.py
+      polarion-id: CEPH-83573855
+      desc: Verify crash warning in ceph health upon crashing a daemon

--- a/tests/rados/test_stretch_netsplit_scenarios.py
+++ b/tests/rados/test_stretch_netsplit_scenarios.py
@@ -238,7 +238,7 @@ def run(ceph_cluster, **kw):
                 f"The expected health warnings are generated on the cluster. Warnings : {ceph_health_status}"
             )
             log.info(
-                f"Completed shutdown of hosts in site {netsplit_site}. Host names :{tiebreaker_hosts}."
+                f"Completed adding netsplits in hosts in site {netsplit_site}. Host names :{tiebreaker_hosts}."
                 f" Proceeding to write"
             )
 
@@ -247,9 +247,10 @@ def run(ceph_cluster, **kw):
         # Starting checks to see availability of cluster during netsplit scenario
         # perform rados put to check if write ops is possible
         pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=200, timeout=100)
+        # rados_obj.bench_write(pool_name=pool_name, rados_write_duration=100)
 
-        log.debug("sleeping for 2 minutes for the objects to be displayed in ceph df")
-        time.sleep(120)
+        log.debug("sleeping for 4 minutes for the objects to be displayed in ceph df")
+        time.sleep(240)
 
         # Getting the number of objects post write, to check if writes were successful
         pool_stat_final = rados_obj.get_cephdf_stats(pool_name=pool_name)

--- a/tests/rados/test_stretch_site_maintenance_modes.py
+++ b/tests/rados/test_stretch_site_maintenance_modes.py
@@ -114,17 +114,20 @@ def run(ceph_cluster, **kw):
                 time.sleep(10)
 
             # Moving host into maintenance mode
-            time.sleep(5)
-            if not rados_obj.host_maintenance_enter(hostname=host, retry=15):
+            time.sleep(10)
+            if not rados_obj.host_maintenance_enter(hostname=host, retry=25):
                 log.error(f"Failed to add host : {host} into maintenance mode")
                 raise Exception("Test execution Failed")
-
+            log.debug(
+                f"Host {host} added to maintenance mode, sleeping for 40 seconds before proceeding to next node"
+            )
+            time.sleep(40)
         log.info(
             f"Completed addition of all the hosts in data site {dc_1_name} into maintenance mode"
         )
 
-        # sleeping for 120 seconds for the DC to be identified as in maintenance mode and proceeding to next checks
-        time.sleep(120)
+        # sleeping for 240 seconds for the DC to be identified as in maintenance mode and proceeding to next checks
+        time.sleep(240)
 
         # Checking the health status of the cluster and the active alerts for maintenance mode
         # These should be generated on the cluster


### PR DESCRIPTION
1. commenting out the test to verify access to cluster during netsplits in stretch mode. bug :: https://bugzilla.redhat.com/show_bug.cgi?id=2249962 
2. Increasing the number of retries to add host into maintenance mode.
3. Increased timeout for objects to be shown in the ceph df status post IO's.
4. Updated the method for setting the noautoscale flag on the cluster. There exists a bug in 6.1z3 : https://bugzilla.redhat.com/show_bug.cgi?id=2252788 