### PR TITLE
Recreating secondary cluster after permanent failure

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
@@ -1,0 +1,271 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/reef/rbd/3_clusters_5_node.yaml
+#    No of Clusters : 3
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    fsid: 97901760-9328-11ee-8807-fa163ece848d
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy 3 cluster for mirror failback test
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+        ceph-rbd3:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+      desc: Configure the client system
+      destroy-cluster: false
+      module: test_client.py
+      name: Test to configure client
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd3:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: true
+      name: test to configure snapshot based mirroring
+      module: test_configure_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            stop_rbd_mirror_on_primary: true
+            poolname: pool_failback
+            mirrormode: snapshot
+            mode: image
+            imagesize: 1G
+            image-count: 10
+            io-total: 100M
+      polarion-id: CEPH-83573332
+      desc: Configures user specified mirrored images with snapshot schedule
+
+  - test:
+      name: Test to remove site-b cluster for failback
+      module: test_cephadm_ansible.py
+      clusters:
+        ceph-rbd2:
+          config:
+            playbook: cephadm-purge-cluster.yml
+            extra-vars:
+              ceph_origin: rhcs
+              fsid: 97901760-9328-11ee-8807-fa163ece848d
+              ireallymeanit: 'yes'
+      polarion-id: CEPH-83574414
+      desc: purge the ceph from site-b secondary clusters
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd3:
+          config:
+            poolname: pool_failback
+            io-total: 100M
+      desc: Test to verify rbd mirroring failback
+      module: rbd_mirror_reconfigure_secondary_cluster.py
+      polarion-id: CEPH-9477
+      name: Reconfigure mirror with newly created cluster as secondary

--- a/suites/quincy/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
@@ -1,0 +1,271 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/reef/rbd/3_clusters_5_node.yaml
+#    No of Clusters : 3
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    fsid: 97901760-9328-11ee-8807-fa163ece848d
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy 3 cluster for mirror failback test
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+        ceph-rbd3:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+      desc: Configure the client system
+      destroy-cluster: false
+      module: test_client.py
+      name: Test to configure client
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd3:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: true
+      name: test to configure snapshot based mirroring
+      module: test_configure_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            stop_rbd_mirror_on_primary: true
+            poolname: pool_failback
+            mirrormode: snapshot
+            mode: image
+            imagesize: 1G
+            image-count: 10
+            io-total: 100M
+      polarion-id: CEPH-83573332
+      desc: Configures user specified mirrored images with snapshot schedule
+
+  - test:
+      name: Test to remove site-b cluster for failback
+      module: test_cephadm_ansible.py
+      clusters:
+        ceph-rbd2:
+          config:
+            playbook: cephadm-purge-cluster.yml
+            extra-vars:
+              ceph_origin: rhcs
+              fsid: 97901760-9328-11ee-8807-fa163ece848d
+              ireallymeanit: 'yes'
+      polarion-id: CEPH-83574414
+      desc: purge the ceph from site-b secondary clusters
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd3:
+          config:
+            poolname: pool_failback
+            io-total: 100M
+      desc: Test to verify rbd mirroring failback
+      module: rbd_mirror_reconfigure_secondary_cluster.py
+      polarion-id: CEPH-9477
+      name: Reconfigure mirror with newly created cluster as secondary

--- a/suites/reef/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+++ b/suites/reef/rbd/tier-2_rbd_mirror_recreate_secondary_cluster.yaml
@@ -1,0 +1,271 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_mirror_recreate_secondary_cluster.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/reef/rbd/3_clusters_5_node.yaml
+#    No of Clusters : 3
+#    Each cluster configuration
+#    5-Node cluster(RHEL-8.3 and above)
+#    1 MONS, 1 MGR, 3 OSD and 1 RBD MIRROR service daemon(s)
+#     Node1 - Mon, Mgr, Installer
+#     Node2 - client
+#     Node3 - OSD
+#     Node4 - OSD
+#     Node5 - OSD, RBD Mirror
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    fsid: 97901760-9328-11ee-8807-fa163ece848d
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    registry-url: registry.redhat.io
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy 3 cluster for mirror failback test
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+        ceph-rbd3:
+          config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                  - ceph-common
+              copy_admin_keyring: true
+      desc: Configure the client system
+      destroy-cluster: false
+      module: test_client.py
+      name: Test to configure client
+      abort-on-fail: true
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd3:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd3:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: true
+      name: test to configure snapshot based mirroring
+      module: test_configure_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            stop_rbd_mirror_on_primary: true
+            poolname: pool_failback
+            mirrormode: snapshot
+            mode: image
+            imagesize: 1G
+            image-count: 10
+            io-total: 100M
+      polarion-id: CEPH-83573332
+      desc: Configures user specified mirrored images with snapshot schedule
+
+  - test:
+      name: Test to remove site-b cluster for failback
+      module: test_cephadm_ansible.py
+      clusters:
+        ceph-rbd2:
+          config:
+            playbook: cephadm-purge-cluster.yml
+            extra-vars:
+              ceph_origin: rhcs
+              fsid: 97901760-9328-11ee-8807-fa163ece848d
+              ireallymeanit: 'yes'
+      polarion-id: CEPH-83574414
+      desc: purge the ceph from site-b secondary clusters
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd3:
+          config:
+            poolname: pool_failback
+            io-total: 100M
+      desc: Test to verify rbd mirroring failback
+      module: rbd_mirror_reconfigure_secondary_cluster.py
+      polarion-id: CEPH-9477
+      name: Reconfigure mirror with newly created cluster as secondary

--- a/tests/rbd_mirror/rbd_mirror_reconfigure_secondary_cluster.py
+++ b/tests/rbd_mirror/rbd_mirror_reconfigure_secondary_cluster.py
@@ -1,0 +1,154 @@
+"""Test case covered -
+    CEPH-9477- Secondary cluster permanent failure,
+    Recreate the secondary cluster and Re-establish mirror with newly created cluster as secondary.
+
+    Pre-requisites :
+    1. Cluster must be up and running with capacity to create pool
+    (At least with 64 pgs)
+    2. We need atleast one client node with ceph-common package,
+    conf and keyring files
+
+    Test case flows:
+    1) After site-b failure, bring up new cluster for secondary
+    2) Create a pool with same name as secondary pool
+    3) Perform the mirroring bootstrap for cluster peers
+    4) copy and import bootstrap token to peer cluster
+    5) verify peer cluster got added successfully after failover
+    6) verify all the images from primary mirrored to secondary
+"""
+import ast
+import datetime
+import time
+
+from tests.rbd.rbd_utils import Rbd
+from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(**kw):
+    """
+    Verification of rbd mirroring failover scenario on secondary site,
+    This module configures the mirroring to newly created cluster.
+
+    Args:
+        kw: test data
+        Example::
+            config:
+                poolname: pool_failback
+    Returns:
+        int: The return value - 0 for success, 1 for failure
+    """
+    try:
+        log.info(
+            "Running test recreate secondary cluster in case of permanent failover"
+        )
+
+        config = kw.get("config")
+        poolname = config.get("poolname")
+
+        mirror3 = rbdmirror.RbdMirror(
+            kw.get("ceph_cluster_dict").get("ceph-rbd3"), config
+        )
+
+        mirror1 = rbdmirror.RbdMirror(
+            kw.get("ceph_cluster_dict").get("ceph-rbd1"), config
+        )
+
+        rbd1, _, rbd3 = [
+            Rbd(**kw, req_cname=cluster_name)
+            for cluster_name in kw["ceph_cluster_dict"].keys()
+        ]
+
+        kw["peer_mode"] = kw.get("peer_mode", "bootstrap")
+        kw["rbd_client"] = kw.get("rbd_client", "client.admin")
+        kw["failback"] = True
+
+        log.info("Re-establishing mirror with newly created cluster as secondary")
+
+        # remove the failed cluster from mirror peers
+        mirror1.peer_remove(poolname=poolname)
+
+        if not mirror1.mirror_info(poolname, "peers"):
+            log.error("Peers not removed successfully")
+            return 1
+
+        # For newly added cluster, creating pool and configuring two-way mirror
+        mirror3.create_pool(poolname=poolname)
+
+        # set custom_cluster_order according to the cluster to configure mirroring
+        # 0 indicates mirror1, 1 indicates mirror2 and 2 indicates mirror3
+        kw["custom_cluster_order"] = "0,2"
+
+        mirror1.config_mirror(
+            mirror3,
+            poolname=poolname,
+            mode="image",
+            start_rbd_mirror_primary=True,
+            **kw,
+        )
+
+        mirror1_peers = ast.literal_eval(mirror1.mirror_info(poolname, "peers"))
+        if mirror1_peers and "ceph-rbd3" in mirror1_peers[0]["site_name"]:
+            log.info("New secondary cluster added as peer")
+        else:
+            log.error("Error while configuring peers to new secondary cluster")
+            return 1
+
+        mirror3_peers = ast.literal_eval(mirror3.mirror_info(poolname, "peers"))
+        if mirror3_peers and "ceph-rbd1" in mirror3_peers[0]["site_name"]:
+            log.info("New secondary cluster has primary as peer")
+        else:
+            log.error("Error while configuring peers to new secondary cluster")
+            return 1
+
+        # Schedeluing the snapshots for image reflection
+        mirror1.mirror_snapshot_schedule_add(poolname=poolname)
+
+        # wait till image gets reflected to secondary
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=300)
+        while end_time > datetime.datetime.now():
+            mirror3_image_list = rbd3.list_images(poolname)
+            mirror1_image_list = rbd1.list_images(poolname)
+            if set(mirror3_image_list) == set(mirror1_image_list):
+                log.info(
+                    "After failback, primary cluster images successfuly mirrored to new secondary cluster"
+                )
+                break
+            time.sleep(60)
+            for imagename in mirror1_image_list:
+                mirror1.verify_snapshot_schedule(imagespec=f"{poolname}/{imagename}")
+        else:
+            log.error(
+                "After failback, primary cluster images are not successfuly mirrored to new secondary cluster"
+            )
+            return 1
+
+        for image in mirror1_image_list:
+            image_info = rbd3.image_info(pool_name=poolname, image_name=image)
+            if image_info.get("mirroring"):
+                if (
+                    not image_info["mirroring"]["primary"]
+                    and image_info["mirroring"]["state"] == "enabled"
+                    and image_info["mirroring"]["mode"] == "snapshot"
+                ):
+                    log.info(
+                        f"Mirroring configured successfully for image\
+                            {image} in the new secondary cluster"
+                    )
+                else:
+                    log.error(
+                        f"Mirroring configuration failed for image\
+                            {image} in the new secondary cluster"
+                    )
+                    return 1
+        return 0
+
+    except Exception as e:
+        log.exception(e)
+        return 1
+
+    finally:
+        if not kw.get("config").get("do_not_cleanup_pool"):
+            mirror3.clean_up(peercluster=mirror1, pools=[poolname])

--- a/tests/rbd_mirror/rbd_mirror_utils.py
+++ b/tests/rbd_mirror/rbd_mirror_utils.py
@@ -225,6 +225,10 @@ class RbdMirror:
         self.enable_mirroring(mirror_level="pool", specs=poolname, mode=mode)
         peer_cluster.enable_mirroring(mirror_level="pool", specs=poolname, mode=mode)
 
+        if kw.get("start_rbd_mirror_primary"):
+            time.sleep(60)
+            self.change_service_state(None, "start")
+
         if self.ceph_version >= 4:
             if peer_mode == "bootstrap":
                 self.bootstrap_peers(
@@ -893,8 +897,11 @@ class RbdMirror:
         """
         self.exec_cmd(cmd=f"rbd mirror image resync {imagespec}")
 
-    def random_string(self):
-        temp_str = "".join([random.choice(string.ascii_letters) for _ in range(10)])
+    def random_string(self, **kw):
+        length = 10
+        if kw.get("len"):
+            length = kw["len"]
+        temp_str = "".join([random.choice(string.ascii_letters) for _ in range(length)])
         return temp_str
 
     def delete_pool(self, poolname):
@@ -1414,7 +1421,7 @@ def create_mirrored_images_with_user_specified(**kw):
         number_of_images = config.get("image-count")
 
         for i in range(0, number_of_images):
-            imagename = "test_mirror_image" + mirror1.random_string()
+            imagename = "test_mirror_image" + mirror1.random_string(len=3)
             imagespec = poolname + "/" + imagename
 
             mirror1.create_image(imagespec=imagespec, size=imagesize)


### PR DESCRIPTION
Automation of test case - CEPH-9477- Secondary cluster permanent failure,
    Recreate the secondary cluster and Re-establish mirror with newly created cluster as secondary.

    Test case flows:
    1) After site-b failure, bring up new cluster for secondary
    2) Create a pool with same name as secondary pool
    3) Perform the mirroring bootstrap for cluster peers
    4) copy and import bootstrap token to peer cluster
    5) verify peer cluster got added successfully after failover
    6) verify all the images from secondary mirrored to primary

Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CDUII5/ 

Note: After reconfiguring newly created cluster as primary one of the mirrored images is always not reflecting proper image status in the new secondary cluster. Debugging this issue to see if this could be a product bug, however the PR is ready to be reviewed and merged.
There will not be any change in code whether its a product bug or not.
