### PR TITLE
[test-fix] Add fix for cephadm log spam failure

### DIFF
--- a/suites/reef/cephadm/tier1-service-apply-spec.yaml
+++ b/suites/reef/cephadm/tier1-service-apply-spec.yaml
@@ -263,3 +263,17 @@ tests:
       config:
         nodes:
           - node2
+  - test:
+      name: Verify spam not present in cephadm log file
+      desc: Verify spam logs 'DEBUG sestatus' not present in cephadm.log file (customer_bz)
+      polarion-id: CEPH-83575589
+      module: test_cephadm_log_spam.py
+      config:
+        type: file
+  - test:
+      name: Verify spam not present under cephadm logs command
+      desc: Verify spam logs 'Detected' not present under cephadm logs command (customer_bz)
+      polarion-id: CEPH-83575598
+      module: test_cephadm_log_spam.py
+      config:
+        type: command


### PR DESCRIPTION
# Description

Before the bug fix, the spam logs would be printed in cephadm logs every time the devices get refreshed. So if the command `ceph orch device ls --refresh` was ran repeatedly, the spam logs would keep getting filled without the devices actually changing.

With the bug fix, the logs would be triggered only once if the devices have changed.

The change here is to first run the device refresh command to populate the logs and get the count of those logs. Then running the device refresh command again and comparing the count of logs.