### PR TITLE
Integrating the rgw-restore-index tool test

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -593,3 +593,18 @@ tests:
       polarion-id: CEPH-83575917
       module: sanity_rgw_multisite.py
       name: Upload 5000 objects via s3cmd to test full sync at archive
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            extra-pkgs:
+              - yum install -y jq
+            script-name: test_rgw_restore_index_tool.py
+            config-file-name: test_rgw_restore_index_versioned_buckets.yaml
+            run-on-haproxy: true
+            monitor-consistency-bucket-stats: true
+            timeout: 300
+      desc: test rgw restore index tool on versioned bucket
+      polarion-id: CEPH-83575473
+      module: sanity_rgw_multisite.py
+      name: test rgw restore index tool on versioned bucket


### PR DESCRIPTION
test rgw restore index tool

This would address the manual verification of many Bugzillas over the different product releases.

https://bugzilla.redhat.com/show_bug.cgi?id=2247138
https://bugzilla.redhat.com/show_bug.cgi?id=2240992
https://bugzilla.redhat.com/show_bug.cgi?id=2182385

JIRA ticket https://issues.redhat.com/browse/RHCEPHQE-12036

[POLARIAN test case : CEPH-83575473](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575473)

passed logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2W9H4N