### PR TITLE
TFA Fix- Moving the Blue store pinned tests to the baremetal

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_bluestore.yaml
@@ -134,33 +134,6 @@ tests:
         bluestore_cache: true
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
-  - test:
-      name:  Testing bluestore
-      desc: Testing bluestore pinned
-      module: test_bluestore_features.py
-      polarion-id: CEPH-83575438
-      config:
-          execution-time: 30
-          cache_trim_max_skip_pinned:
-            configurations:
-               pool-1:
-                 pool_type: replicated
-                 pool_name: blustore_pinned
-                 pg_num: 64
-                 pg_num_min: 32
-                 rados_write_duration: 300
-                 rados_read_duration: 150
-                 byte_size: 64MB
-               pool-2:
-                 pool_name: bluestore_ec_pool
-                 pool_type: erasure
-                 pg_num: 32
-                 k: 8
-                 m: 4
-                 plugin: jerasure
-                 rados_write_duration: 50
-                 rados_read_duration: 50
-          desc: Verification of the bluestore pinned tests
 
   - test:
       name: ceph-bluestore-tool utility

--- a/suites/quincy/rados/mero_4_node_rados_db_wal_conf.yaml
+++ b/suites/quincy/rados/mero_4_node_rados_db_wal_conf.yaml
@@ -94,8 +94,92 @@ tests:
       name: "configure client"
   -
     test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
       name: DB and WAL configuration
       desc: Add DB and WAL to the existing OSD
       module: test_osd_db_wal_configuration.py
       polarion-id: CEPH-83574885
       abort-on-fail: true
+  -
+    test:
+      name:  Testing bluestore
+      desc: Testing bluestore pinned
+      module: test_bluestore_features.py
+      polarion-id: CEPH-83575438
+      config:
+          execution-time: 30
+          cache_trim_max_skip_pinned:
+            configurations:
+               pool-1:
+                 pool_type: replicated
+                 pool_name: blustore_pinned
+                 pg_num: 64
+                 pg_num_min: 32
+                 rados_write_duration: 300
+                 rados_read_duration: 150
+                 byte_size: 64MB
+               pool-2:
+                 pool_name: bluestore_ec_pool
+                 pool_type: erasure
+                 pg_num: 32
+                 k: 8
+                 m: 4
+                 plugin: jerasure
+                 rados_write_duration: 50
+                 rados_read_duration: 50
+          desc: Verification of the bluestore pinned tests

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -135,34 +135,6 @@ tests:
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
   - test:
-      name:  Testing bluestore
-      desc: Testing bluestore pinned
-      module: test_bluestore_features.py
-      polarion-id: CEPH-83575438
-      config:
-          execution-time: 30
-          cache_trim_max_skip_pinned:
-            configurations:
-               pool-1:
-                 pool_type: replicated
-                 pool_name: blustore_pinned
-                 pg_num: 64
-                 pg_num_min: 32
-                 rados_write_duration: 300
-                 rados_read_duration: 150
-                 byte_size: 64MB
-               pool-2:
-                 pool_name: bluestore_ec_pool
-                 pool_type: erasure
-                 pg_num: 32
-                 k: 8
-                 m: 4
-                 plugin: jerasure
-                 rados_write_duration: 50
-                 rados_read_duration: 50
-          desc: Verification of the bluestore pinned tests
-
-  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692

--- a/suites/reef/rados/mero_4_node_rados_db_wal_conf.yaml
+++ b/suites/reef/rados/mero_4_node_rados_db_wal_conf.yaml
@@ -94,8 +94,92 @@ tests:
       name: "configure client"
   -
     test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
       name: DB and WAL configuration
       desc: Add DB and WAL to the existing OSD
       module: test_osd_db_wal_configuration.py
       polarion-id: CEPH-83574885
       abort-on-fail: true
+  -
+    test:
+      name:  Testing bluestore
+      desc: Testing bluestore pinned
+      module: test_bluestore_features.py
+      polarion-id: CEPH-83575438
+      config:
+          execution-time: 30
+          cache_trim_max_skip_pinned:
+            configurations:
+               pool-1:
+                 pool_type: replicated
+                 pool_name: blustore_pinned
+                 pg_num: 64
+                 pg_num_min: 32
+                 rados_write_duration: 300
+                 rados_read_duration: 150
+                 byte_size: 64MB
+               pool-2:
+                 pool_name: bluestore_ec_pool
+                 pool_type: erasure
+                 pg_num: 32
+                 k: 8
+                 m: 4
+                 plugin: jerasure
+                 rados_write_duration: 50
+                 rados_read_duration: 50
+          desc: Verification of the bluestore pinned tests

--- a/suites/reef/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/reef/rados/tier-2_rados_test_bluestore.yaml
@@ -135,34 +135,6 @@ tests:
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
   - test:
-      name:  Testing bluestore
-      desc: Testing bluestore pinned
-      module: test_bluestore_features.py
-      polarion-id: CEPH-83575438
-      config:
-          execution-time: 30
-          cache_trim_max_skip_pinned:
-            configurations:
-               pool-1:
-                 pool_type: replicated
-                 pool_name: blustore_pinned
-                 pg_num: 64
-                 pg_num_min: 32
-                 rados_write_duration: 300
-                 rados_read_duration: 150
-                 byte_size: 64MB
-               pool-2:
-                 pool_name: bluestore_ec_pool
-                 pool_type: erasure
-                 pg_num: 32
-                 k: 8
-                 m: 4
-                 plugin: jerasure
-                 rados_write_duration: 50
-                 rados_read_duration: 50
-          desc: Verification of the bluestore pinned tests
-
-  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692


### PR DESCRIPTION
**TFA Error:**

rc = test_mod.run(
File "/home/jenkins/ceph-builds/18.2.0-128/Weekly/rados/17/cephci/tests/rados/test_bluestore_features.py", line 94, in run
mem_growth = is_what_percent_mem(mem_list)
File "/home/jenkins/ceph-builds/18.2.0-128/Weekly/rados/17/cephci/tests/rados/test_bluestore_features.py", line 178, in is_what_percent_mem
min_mem = int(min(mem_list))
ValueError: invalid literal for int() with base 10: ''

**Root cause:**

The method "get_heap_dump" cannot able to get the OSD heap dump due to OSD getting flapped or down sometimes in the rhos-d environment.

Jira story- https://issues.redhat.com/browse/RHCEPHQE-12175

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
