### PR TITLE
removing install_start_kafka present at the later test of the notification suite

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -235,9 +235,6 @@ tests:
       polarion-id: CEPH-83574417
       module: sanity_rgw.py
       config:
-        extra-pkgs:
-          - wget https://download.oracle.com/java/17/latest/jdk-17_linux-x64_bin.rpm
-        install_start_kafka: true
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml


### PR DESCRIPTION
This PR is to fix minor issue of removing unwanted install_start_kafka present at the later test of the notification suite which might have added by mistake

this observed while verifying a bz: https://bugzilla.redhat.com/show_bug.cgi?id=2252256#c6

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
