### PR TITLE
Added modules to test CIDR blocklisting of Clients

### DIFF
--- a/conf/pacific/rados/6-node-cluster-4-clients.yaml
+++ b/conf/pacific/rados/6-node-cluster-4-clients.yaml
@@ -1,0 +1,83 @@
+# Test Suite to test CIDR blocklisting of clients
+# Deployment for all the ceph daemons , with 3 mon's, 3 mgr's, 15 OSD daemons & 6 Client nodes
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_12
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        networks:
+          - provider_net_cci_12
+        role:
+          - mon
+          - mgr
+          - mds
+          - rgw
+      node3:
+        networks:
+          - provider_net_cci_12
+        role:
+          - osd
+        no-of-volumes: 5
+        disk-size: 25
+      node4:
+        networks:
+          - provider_net_cci_12
+        role:
+          - osd
+        no-of-volumes: 5
+        disk-size: 25
+      node5:
+        role:
+          - osd
+        no-of-volumes: 5
+        disk-size: 25
+      node6:
+        networks:
+          - provider_net_cci_12
+        role:
+          - mon
+          - mgr
+          - mds
+          - rgw
+      node7:
+        image-name:
+          openstack: RHEL-8.9.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
+        networks:
+          - provider_net_cci_13
+        role:
+          - client
+      node8:
+        image-name:
+          openstack: RHEL-8.9.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
+        networks:
+          - provider_net_cci_13
+        role:
+          - client
+      node9:
+        image-name:
+          openstack: RHEL-8.9.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
+        networks:
+          - provider_net_cci_10
+        role:
+          - client
+      node10:
+        image-name:
+          openstack: RHEL-8.9.0-x86_64-ga-latest
+          ibmc: rhel-87-server-released
+        networks:
+          - provider_net_cci_10
+        role:
+          - client

--- a/conf/pacific/rados/test-confs/pool-configurations.yaml
+++ b/conf/pacific/rados/test-confs/pool-configurations.yaml
@@ -4,7 +4,7 @@ replicated:
     pool_type: replicated
     pool_name: re_pool_10
     pg_num: 64
-    size: 4
+    size: 3
     disable_pg_autoscale: true
   sample-pool-2:
     pool_type: replicated
@@ -14,7 +14,7 @@ replicated:
     pool_type: replicated
     pool_name: re_pool_30
     pg_num: 128
-    size: 2
+    size: 3
 erasure:
   sample-pool-1:
     pool_name: ec_pool_10

--- a/conf/quincy/rados/6-node-cluster-4-clients.yaml
+++ b/conf/quincy/rados/6-node-cluster-4-clients.yaml
@@ -1,0 +1,86 @@
+# Test Suite to test CIDR blocklisting of clients
+# Deployment for all the ceph daemons , with 3 mon's, 3 mgr's, 15 OSD daemons & 6 Client nodes
+# This is Openstack only test suite.
+
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        networks:
+          - provider_net_cci_12
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - alertmanager
+          - grafana
+          - prometheus
+      node2:
+        networks:
+          - provider_net_cci_12
+        role:
+          - mon
+          - mgr
+          - mds
+          - rgw
+      node3:
+        networks:
+          - provider_net_cci_12
+        role:
+          - osd
+        no-of-volumes: 5
+        disk-size: 25
+      node4:
+        networks:
+          - provider_net_cci_12
+        role:
+          - osd
+        no-of-volumes: 5
+        disk-size: 25
+      node5:
+        role:
+          - osd
+        no-of-volumes: 5
+        disk-size: 25
+      node6:
+        networks:
+          - provider_net_cci_12
+        role:
+          - mon
+          - mgr
+          - mds
+          - rgw
+      node7:
+        image-name:
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
+        networks:
+          - provider_net_cci_13
+        role:
+          - client
+      node8:
+        image-name:
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
+        networks:
+          - provider_net_cci_13
+        role:
+          - client
+      node9:
+        image-name:
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
+        networks:
+          - provider_net_cci_10
+        role:
+          - client
+      node10:
+        image-name:
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
+        networks:
+          - provider_net_cci_10
+        role:
+          - client
+

--- a/conf/quincy/rados/test-confs/pool-configurations.yaml
+++ b/conf/quincy/rados/test-confs/pool-configurations.yaml
@@ -4,7 +4,7 @@ replicated:
     pool_type: replicated
     pool_name: re_pool_10
     pg_num: 64
-    size: 4
+    size: 3
     disable_pg_autoscale: true
   sample-pool-2:
     pool_type: replicated
@@ -14,7 +14,7 @@ replicated:
     pool_type: replicated
     pool_name: re_pool_30
     pg_num: 128
-    size: 2
+    size: 3
 erasure:
   sample-pool-1:
     pool_name: ec_pool_10

--- a/conf/reef/rados/6-node-cluster-4-clients.yaml
+++ b/conf/reef/rados/6-node-cluster-4-clients.yaml
@@ -51,49 +51,33 @@ globals:
           - rgw
       node7:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
-          ibmc: rhel-87-server-released
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         networks:
-          - provider_net_cci_8
+          - provider_net_cci_13
         role:
           - client
       node8:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
-          ibmc: rhel-87-server-released
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         networks:
-          - provider_net_cci_8
+          - provider_net_cci_13
         role:
           - client
       node9:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
-          ibmc: rhel-87-server-released
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         networks:
-          - provider_net_cci_9
+          - provider_net_cci_10
         role:
           - client
       node10:
         image-name:
-          openstack: RHEL-7.9-x86_64-ga-latest
-          ibmc: rhel-server-79-x86-64-kvm
-        networks:
-          - provider_net_cci_9
-        role:
-          - client
-      node11:
-        image-name:
-          openstack: RHEL-9.1.0-x86_64-ga-latest
+          openstack: RHEL-9.3.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - provider_net_cci_7
-        role:
-          - client
-      node12:
-        image-name:
-          openstack: RHEL-9.1.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
-        networks:
-          - provider_net_cci_7
+          - provider_net_cci_10
         role:
           - client

--- a/conf/reef/rados/test-confs/pool-configurations.yaml
+++ b/conf/reef/rados/test-confs/pool-configurations.yaml
@@ -4,7 +4,7 @@ replicated:
     pool_type: replicated
     pool_name: re_pool_10
     pg_num: 64
-    size: 4
+    size: 3
     disable_pg_autoscale: true
   sample-pool-2:
     pool_type: replicated
@@ -14,7 +14,7 @@ replicated:
     pool_type: replicated
     pool_name: re_pool_30
     pg_num: 128
-    size: 2
+    size: 3
 erasure:
   sample-pool-1:
     pool_name: ec_pool_10

--- a/suites/pacific/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/pacific/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,0 +1,172 @@
+# Suite contains tests related to CIDR blocklisting of ceph clients
+# This is Openstack only test suite.
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+
+  - test:
+      name: Configure clients
+      desc: Configures multiple client nodes on cluster
+      module: test_parallel.py
+      parallel:
+        - test:
+            name: Configure client 1
+            desc: Configures client.1 admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.1                      # client Id (<type>.<Id>)
+              nodes:
+                  - node8:
+                      release: 5
+                  - node7:
+                      release: 5
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+        - test:
+            name: Configure client 2
+            desc: Configures client.2 admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.2                     # client Id (<type>.<Id>)
+              nodes:
+                - node9:
+                    release: 5
+                - node10:
+                    release: 5
+                - node11:
+                    release: 5
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps: # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+        - test:
+            name: Configure client 3
+            desc: Configures client admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.3                      # client Id (<type>.<Id>)
+              node: node12                       # client node
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: CIDR Blocklisting.
+      module: test_cidr_blocklisting.py
+      polarion-id: CEPH-83575008
+      config:
+        pool_configs:
+          pool-1:
+            type: replicated
+            conf: sample-pool-1
+          pool-2:
+            type: replicated
+            conf: sample-pool-2
+        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+      desc: CIDR Blocklisting of ceph rbd clients

--- a/suites/quincy/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/quincy/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,4 +1,6 @@
 # Suite contains tests related to CIDR blocklisting of ceph clients
+# This is Openstack only test suite.
+
 tests:
   - test:
       name: setup install pre-requisistes
@@ -95,9 +97,9 @@ tests:
               id: client.1                      # client Id (<type>.<Id>)
               nodes:
                   - node8:
-                      release: 5
+                      release: 6
                   - node7:
-                      release: 5
+                      release: 6
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node
@@ -116,11 +118,11 @@ tests:
               id: client.2                     # client Id (<type>.<Id>)
               nodes:
                 - node9:
-                    release: 5
+                    release: 6
                 - node10:
-                    release: 4
+                    release: 6
                 - node11:
-                    release: 5
+                    release: 6
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,0 +1,172 @@
+# Suite contains tests related to CIDR blocklisting of ceph clients
+# This is Openstack only test suite.
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+
+  - test:
+      name: Configure clients
+      desc: Configures multiple client nodes on cluster
+      module: test_parallel.py
+      parallel:
+        - test:
+            name: Configure client 1
+            desc: Configures client.1 admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.1                      # client Id (<type>.<Id>)
+              nodes:
+                  - node8:
+                      release: 6
+                  - node7:
+                      release: 6
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+        - test:
+            name: Configure client 2
+            desc: Configures client.2 admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.2                     # client Id (<type>.<Id>)
+              nodes:
+                - node9:
+                    release: 6
+                - node10:
+                    release: 6
+                - node11:
+                    release: 6
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps: # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+        - test:
+            name: Configure client 3
+            desc: Configures client admin node on cluster
+            module: test_client.py
+            polarion-id:
+            config:
+              command: add
+              id: client.3                      # client Id (<type>.<Id>)
+              node: node12                       # client node
+              install_packages:
+                - ceph-common
+              copy_admin_keyring: true          # Copy admin keyring to node
+              caps:                             # authorize client capabilities
+                mon: "allow *"
+                osd: "allow *"
+                mds: "allow *"
+                mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: CIDR Blocklisting.
+      module: test_cidr_blocklisting.py
+      polarion-id: CEPH-83575008
+      config:
+        pool_configs:
+          pool-1:
+            type: replicated
+            conf: sample-pool-1
+          pool-2:
+            type: replicated
+            conf: sample-pool-2
+        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+      desc: CIDR Blocklisting of ceph rbd clients

--- a/tests/rados/test_cidr_blocklisting.py
+++ b/tests/rados/test_cidr_blocklisting.py
@@ -1,3 +1,6 @@
+import random
+import time
+
 import yaml
 
 from ceph.ceph_admin import CephAdmin
@@ -18,17 +21,281 @@ def run(ceph_cluster, **kw):
     config = kw["config"]
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
-    # client_nodes = rados_obj.ceph_cluster.get_nodes(role="client")
+    client_nodes = rados_obj.ceph_cluster.get_nodes(role="client")
     pool_details = config["pool_configs"]
+    image_count = config.get("image_count", 2)
     pool_configs_path = config["pool_configs_path"]
     log.debug("Verifying CIDR Blocklisting of ceph clients")
 
     with open(pool_configs_path, "r") as fd:
         pool_conf = yaml.safe_load(fd)
 
+    pool_names = []
     for i in pool_details.values():
         pool = pool_conf[i["type"]][i["conf"]]
         pool.update({"app_name": "rbd"})
         create_given_pool(rados_obj, pool)
+        pool_names.append(pool["pool_name"])
 
+    log.debug(
+        f"Pools created on the cluster for testing CIDR blocklisting : {pool_names}. "
+        f"Initializing the pools with RBD and creating images on the pools for testing"
+    )
+
+    try:
+        rbd_images = {}
+        img_count = 0
+        for pool_name in pool_names:
+            for _ in range(image_count):
+                img_count += 1
+                img_name = f"test_img_{pool_name}-{img_count}"
+                # Creating 25Gib Images on the pool
+                rados_obj.create_rbd_image(pool_name=pool_name, img_name=img_name)
+                if pool_name not in rbd_images:
+                    rbd_images[pool_name] = []
+                rbd_images[pool_name].extend([img_name])
+        log.debug(
+            "Completed creating images on the pools. Proceeding to mount them on clients"
+        )
+
+        # Proceeding to mount images
+        count = 0
+        for client in client_nodes:
+            log.debug(f"Client selected to mount is : {client.hostname}")
+            for pool_name in pool_names:
+                log.debug(
+                    f"Pool selected : {pool_name}. Images on the pool : {rbd_images[pool_name]}"
+                )
+                for img in rbd_images[pool_name]:
+                    count += 1
+                    mount_path = f"/tmp/rbd_mounts/path{count}/"
+                    out = rados_obj.mount_image_on_client(
+                        pool_name=pool_name,
+                        img_name=img,
+                        client_obj=client,
+                        mount_path=mount_path,
+                    )
+                    if not out:
+                        log.error(
+                            f"Failed to mount image : {img} on client : {client.hostname}"
+                        )
+                        raise Exception("Image not mounted error")
+                    log.info(f"Image {img} mounted on Client: {client.hostname}")
+        log.info("Completed mapping images onto all the clients")
+
+        # Proceeding to write data on to all Images from all clients
+        for client in client_nodes:
+            log.debug(f"Client selected to write IOs is : {client.hostname}")
+            for pool in pool_names:
+                for img in rbd_images[pool]:
+                    log.info(
+                        f"Proceeding to write data into pool : {pool} and image : {img}"
+                    )
+                    out, status = rados_obj.rbd_bench_write(
+                        client_obj=client, pool_name=pool, image_name=img
+                    )
+                    if not status:
+                        log.error(
+                            f"IOs could not be written on pool : {pool} and image : {img} "
+                        )
+                        raise Exception("IOs not written error")
+                    log.debug(f"Items written into pool : {out}")
+                    log.info("IO's written onto RBD image. ")
+        log.info(
+            "completed writing data into all the images on the pools"
+            "Sleeping for 60 seconds for the watchers to be updated..."
+        )
+
+        # Sleeping for 40 seconds and checking if clients are updated as watchers...
+        time.sleep(60)
+
+        for client in client_nodes:
+            log.debug(
+                f"Client selected to check if it's added as watcher : {client.hostname}"
+            )
+            for pool in pool_names:
+                for img in rbd_images[pool]:
+                    # Checking if the client has been added as a watcher
+                    watcher_clients = rados_obj.get_rbd_client_ips(
+                        pool_name=pool, image_name=img
+                    )
+                    if client.ip_address not in watcher_clients:
+                        log.error(
+                            f"Client : {client.hostname} not listed as watcher "
+                            f"for the image : {img} on pool : {pool}"
+                        )
+                        raise Exception("Client IP not listed as watcher error")
+        log.debug(
+            "Confirmed that all clients are listed as watchers on the pool/images created.."
+            "Proceeding to test blocklisting commands"
+        )
+
+        # Starting workflows to test various kinds of blocklisting...
+
+        log.info("------ Scenario 1: testing blocklisting of client IP --------")
+        test_client = random.choice(client_nodes)
+        test_pool = random.choice(pool_names)
+        test_image = random.choice(rbd_images[test_pool])
+        log.info(
+            f"Client selected to be blocklisted : {test_client.hostname}"
+            f"Testing single client block. IP : {test_client.ip_address}"
+        )
+        if not rados_obj.add_client_blocklisting(ip=test_client.ip_address):
+            log.error(f"Could not add IP {test_client.ip_address} in blocklist")
+            raise Exception("IP could not be blocklisted error")
+        time.sleep(10)
+
+        log.debug(
+            f"Client IP : {test_client.ip_address} blocklisted. testing IO access"
+        )
+        out, status = rados_obj.rbd_bench_write(
+            client_obj=test_client, pool_name=test_pool, image_name=test_image
+        )
+        if status:
+            log.error("Able to write into image from client after blocklisting it")
+            raise Exception("IOs working with Blocklist error")
+        log.debug(
+            f"Error msg displayed when IO's are attempted during blocklisting : \n{out}"
+        )
+        log.debug(
+            f"Tested working of blocklisting of clinet {test_client.hostname}. working as expected\n"
+            f"Testing if other non-blocklisted clients are still able to serve IO's "
+        )
+
+        for client in client_nodes:
+            if client.hostname != test_client.hostname:
+                log.debug(
+                    f"Testing IO access on : {client.hostname}, which is not blocklisted"
+                )
+                out, status = rados_obj.rbd_bench_write(
+                    client_obj=client, pool_name=test_pool, image_name=test_image
+                )
+                if not status:
+                    log.error(
+                        "UnAble to write into image from client after blocklisting peer client IP"
+                    )
+                    log.error(
+                        f"\nBlocklisted client details :\n Name : {test_client.hostname}\n "
+                        f"IP : {test_client.ip_address}\n Subnet : {test_client.subnet}"
+                        f"\n Test Client Details (non-blocklisted):\n Name : {client.hostname}\n "
+                        f"IP : {client.ip_address}\n Subnet : {client.subnet}"
+                    )
+                    raise Exception("IOs working with Blocklist error")
+                log.info(
+                    f"IO's working as expected on non-blocklisted client : {client.hostname}"
+                )
+        log.info(
+            "Tested IO access on all non-blocklisted clients. Working as expected.\n"
+        )
+        log.debug(
+            f"Proceeding to Removing the blocklisting from client ip : {test_client.ip_address}"
+        )
+
+        if not rados_obj.rm_client_blocklisting(ip=test_client.ip_address):
+            log.error(f"Could not remove IP {test_client.ip_address} from blocklist")
+            raise Exception("IP could not be removed from blocklisted error")
+        log.info("Completed testing of IP blocklisting")
+
+        log.info("---- Scenario 2: testing blocklisting of client CIDR -----")
+        test_client = random.choice(client_nodes)
+        test_pool = random.choice(pool_names)
+        test_image = random.choice(rbd_images[test_pool])
+        clients_blocked = get_all_clients_in_cidr(
+            cidr=test_client.subnet, clients=client_nodes
+        )
+
+        log.debug(
+            f"All the clients that would be blocklisted are : {[cli.hostname for cli in clients_blocked]}"
+        )
+
+        log.info(
+            f"Client CIDR selected to be blocklisted : {test_client.hostname}"
+            f"Testing CIDR level client blocklisting. IP : {test_client.subnet}"
+        )
+        if not rados_obj.add_client_blocklisting(cidr=test_client.subnet):
+            log.error(f"Could not add CIDR {test_client.subnet} in blocklist")
+            raise Exception("CIDR could not be blocklisted error")
+        time.sleep(10)
+
+        log.debug(
+            f"Client IP : {test_client.subnet} blocklisted. testing IO access on all clients belonging to that subnet"
+        )
+        for client in clients_blocked:
+            out, status = rados_obj.rbd_bench_write(
+                client_obj=client, pool_name=test_pool, image_name=test_image
+            )
+            if status:
+                log.error("Able to write into image from client after blocklisting it")
+                raise Exception("IOs working with Blocklist error")
+            log.debug(
+                f"Error msg displayed when IO's are attempted during blocklisting : \n{out}"
+            )
+
+        log.debug(
+            f"Tested working of blocklisting of clinet subnet {test_client.hostname}. working as expected"
+            f"Testing if other non-blocklisted clients from other subnets are still able to serve IO's "
+        )
+
+        for client in client_nodes:
+            if client.hostname not in [host.hostname for host in clients_blocked]:
+                log.debug(
+                    f"Testing IO access on : {client.hostname}, which is not blocklisted"
+                )
+                out, status = rados_obj.rbd_bench_write(
+                    client_obj=client, pool_name=test_pool, image_name=test_image
+                )
+                if not status:
+                    log.error(
+                        "UnAble to write into image from client after blocklisting peer client CIDR"
+                    )
+                    log.error(
+                        f"\nBlocklisted client details :\n Name : {test_client.hostname}\n "
+                        f"IP : {test_client.ip_address}\n Subnet : {test_client.subnet}"
+                        f"\n Test Client Details (non-blocklisted):\n Name : {client.hostname}\n "
+                        f"IP : {client.ip_address}\n Subnet : {client.subnet}"
+                    )
+                    raise Exception("IOs working with Blocklist error")
+                log.info(
+                    f"IO's working as expected on non-blocklisted client : {client.hostname}"
+                )
+        log.info(
+            "Tested IO access on all non-blocklisted clients. Working as expected."
+        )
+
+        log.debug(
+            f"Proceeding to Removing the blocklisting from client cidr : {test_client.ip_address}"
+        )
+
+        if not rados_obj.rm_client_blocklisting(cidr=test_client.subnet):
+            log.error(f"Could not remove CIDR {test_client.subnet} from blocklist")
+            raise Exception("CIDR could not be removed from blocklisted error")
+        log.info("Completed testing of CIDR blocklisting")
+
+    except Exception as err:
+        log.error(f"Hit Exception : {err} during execution. Failed...")
+        return 1
+    finally:
+        log.info("----------------- IN FINALLY BLOCK ------------------")
+        for pool in pool_names:
+            rados_obj.detete_pool(pool=pool)
+    log.info("Completed testing CIDR blocklisting of ceph clients. Pass!")
     return 0
+
+
+def get_all_clients_in_cidr(cidr, clients):
+    """
+    Method to get all the client objects that are present in the same CIDR sent
+    Args:
+        cidr: CIDR to be searched
+        clients: All client objects that are present on the cluster
+    Returns:
+        list of client objects that are present in the CIDR sent
+    """
+    log.debug(
+        f"CIDR sent : {cidr}. Iterating through all clients to select nodes belonging to cidr sent"
+    )
+    cidr_list = []
+    for client in clients:
+        if client.subnet == cidr:
+            cidr_list.append(client)
+    return cidr_list


### PR DESCRIPTION
Automation of test : 
CEPH-83575008 - Verify that CIDR blocklisting of the ceph client IP's is working as expected
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575008

Added test to verify blocklisting of Ceph clients via IP and CIDR notation of client Subnet.
Steps:
1. Create two RBD pools.
2. Create images and mount them on all clients.
3. Deployment includes 6 client nodes belonging to 3 different subnets.
4. Write data to images, and check if they have been added to watchers list.
5. Add single client IP to blocklist and verify IO capabilities.
6. Add the CIDR of the client, blocking all IO from all clients from that Subnet.
