### PR TITLE
CEPH-83575455: Perform NVMeOF Initiator access failures

### DIFF
--- a/ceph/nvmeof/initiator.py
+++ b/ceph/nvmeof/initiator.py
@@ -7,3 +7,7 @@ class Initiator(NVMeCLI):
         super().__init__(node)
         self.node = node
         self.configure()
+
+    def nqn(self):
+        out, _ = self.node.exec_command(cmd="nvme show-hostnqn")
+        return out.strip()

--- a/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -344,6 +344,23 @@ tests:
       name: RBD operations shrink and expand on images
       polarion-id: CEPH-83575813
 
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83575455
+      desc: Validate Host accessibility via nvme-cli commands.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Validate Host accessibility to NVMe namespaces
+      polarion-id: CEPH-83575455
+
 # Reboot GW node
   - test:
       abort-on-fail: true


### PR DESCRIPTION
 Perform NVMeOF Initiator access failures to NVMe namespaces.

```All test logs located here: /tmp/cephci-run-CBUFGM

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate Host accessibility to   Validate Host accessibility via nvme-cli commands.             0:04:31.345055                   Pass    ```

