### PR TITLE
Adding test for scaled snap mirroring with upgrade

### DIFF
--- a/ceph/rbd/workflows/execute.py
+++ b/ceph/rbd/workflows/execute.py
@@ -1,0 +1,39 @@
+import importlib
+
+
+def execute(mod_file_name, args, test_name, results={}, raise_exception=False):
+    """
+    Executes the test specified and updates return
+    value to results dict.
+
+    It involves the following steps
+        - Importing of test module based on test
+        - Running the test module
+
+    Args:
+        test: The test module which needs to be executed
+        cluster: Ceph cluster participating in the test.
+        config:  The key/value pairs passed by the tester.
+        results: results in dictionary
+
+    Returns:
+        int: non-zero on failure, zero on pass
+    """
+    try:
+        test_mod = importlib.import_module(mod_file_name)
+
+        rc = test_mod.run(
+            ceph_cluster=args["ceph_cluster"],
+            ceph_nodes=args["ceph_nodes"],
+            config=args["config"],
+            test_data=args["test_data"],
+            ceph_cluster_dict=args["ceph_cluster_dict"],
+            clients=args["clients"],
+        )
+        if rc and raise_exception:
+            raise Exception(f"{mod_file_name} execution failed")
+        results.update({test_name: rc})
+    except Exception as e:
+        if raise_exception:
+            raise Exception(e)
+        results.update({test_name: 1})

--- a/ceph/rbd/workflows/krbd_io_handler.py
+++ b/ceph/rbd/workflows/krbd_io_handler.py
@@ -45,7 +45,7 @@ def krbd_io_handler(**kw):
     """
     client = kw.get("client")
     if kw.get("rbd_obj"):
-        rbd = kw.get("rbd")
+        rbd = kw.get("rbd_obj")
     else:
         rbd = Rbd(client)
     config = kw.get("config")

--- a/ceph/rbd/workflows/pool.py
+++ b/ceph/rbd/workflows/pool.py
@@ -90,7 +90,7 @@ def create_ecpool(
         0 if ec pool creation is successful
         1 if ec pool creation fails
     """
-    cmd = f"ceph osd pool create {pool} {pg_num} {pgp_num} erasure --cluster {cluster}"
+    cmd = f"ceph osd pool create {pool} {pg_num} {pgp_num} erasure --cluster {cluster} "
     if profile != "use_default":
         cmd += profile
         if set_ec_profile(

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -68,8 +68,8 @@ def config_rbd_multi_pool(
             pool=pool_config.get("data_pool"),
             k_m=pool_config.get("ec-pool-k-m"),
             profile=pool_config.get("ec_profile", "use_default"),
-            pg_num=pool_config.get("ec_pg_num", 16),
-            pgp_num=pool_config.get("ec_pgp_num", 16),
+            pg_num=pool_config.get("ec_pg_num", 32),
+            pgp_num=pool_config.get("ec_pgp_num", 32),
             failure_domain=pool_config.get("failure_domain", ""),
             client=client,
             cluster=cluster,
@@ -101,7 +101,15 @@ def config_rbd_multi_pool(
                     {
                         k: v
                         for k, v in image_config_val.items()
-                        if k not in ["io_total", "test_config", "is_secondary"]
+                        if k
+                        not in [
+                            "io_total",
+                            "test_config",
+                            "is_secondary",
+                            "snap_schedule_levels",
+                            "snap_schedule_intervals",
+                            "io_size",
+                        ]
                     }
                 )
                 create_config.update({"cluster": cluster})

--- a/ceph/rbd/workflows/snap_scheduling.py
+++ b/ceph/rbd/workflows/snap_scheduling.py
@@ -1,0 +1,92 @@
+import json
+import time
+
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def add_snapshot_scheduling(rbd, **kw):
+    """
+    Add snapshot scheduling to an rbd mirror cluster
+    """
+    pool = kw.get("pool")
+    image = kw.get("image")
+    level = kw.get("level")
+    interval = kw.get("interval")
+
+    if level == "cluster":
+        out, err = rbd.mirror.snapshot.schedule.add_(interval=interval)
+    elif level == "pool":
+        out, err = rbd.mirror.snapshot.schedule.add_(pool=pool, interval=interval)
+    else:
+        out, err = rbd.mirror.snapshot.schedule.add_(
+            pool=pool, image=image, interval=interval
+        )
+
+    return out, err
+
+
+def verify_snapshot_schedule(rbd, pool, image, interval="1m"):
+    """
+    This will verify the snapshot roll overs on the image
+    snapshot based mirroring is enabled
+    Args:
+        pool: pool name
+        image: image name
+        interval : this is interval and specified in min
+    Returns:
+        0 if snapshot schedule is verified successfully
+        1 if fails
+    """
+    try:
+        status_spec = {"pool": pool, "image": image, "format": "json"}
+        out, err = rbd.mirror.snapshot.schedule.ls(**status_spec)
+        if err:
+            log.error(
+                f"Error while fetching snapshot schedule list for image {pool}/{image}"
+            )
+            return 1
+
+        schedule_list = json.loads(out)
+        schedule_present = [
+            schedule for schedule in schedule_list if schedule["interval"] == interval
+        ]
+        if not schedule_present:
+            log.error(
+                f"Snapshot schedule not listed for image {pool}/{image} at interval {interval}"
+            )
+            return 1
+
+        output, err = rbd.mirror.image.status(**status_spec)
+        if err:
+            log.error(
+                f"Error while fetching mirror image status for image {pool}/{image}"
+            )
+            return 1
+        json_dict = json.loads(output)
+        snapshot_ids = [i["id"] for i in json_dict.get("snapshots")]
+        log.info(f"snapshot_ids Before : {snapshot_ids}")
+        interval_int = int(interval[:-1])
+        time.sleep(interval_int * 120)
+        output, err = rbd.mirror.image.status(**status_spec)
+        if err:
+            log.error(
+                f"Error while fetching mirror image status for image {pool}/{image}"
+            )
+            return 1
+        json_dict = json.loads(output)
+        snapshot_ids_1 = [i["id"] for i in json_dict.get("snapshots")]
+        log.info(f"snapshot_ids After : {snapshot_ids_1}")
+        if snapshot_ids != snapshot_ids_1:
+            log.info(
+                f"Snapshot schedule verification successful for image {pool}/{image}"
+            )
+            return 0
+        log.error(f"Snapshot schedule verification failed for image {pool}/{image}")
+        return 1
+    except Exception as e:
+        log.error(
+            f"Snapshot verification failed for image {pool}/{image} with error {e}"
+        )
+        return 1

--- a/suites/pacific/rbd/tier-3_rbd_mirror_upgrade_scale.yaml
+++ b/suites/pacific/rbd/tier-3_rbd_mirror_upgrade_scale.yaml
@@ -1,0 +1,219 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_mirror_upgrade_scale.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/tier-1_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - rbd-nbd
+              - fio
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+                - ceph-common
+                - rbd-nbd
+                - fio
+            copy_admin_keyring: true
+      desc: Configure the client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with upgrade
+      name: Test upgrade on snapshot mirrored clusters
+      module: test_rbd_snapshot_mirroring_with_upgrade.py
+      polarion-id: CEPH-83574895
+      clusters:
+        ceph-rbd1:
+          config:
+            installed_version: "5.3"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-rbd2:
+          config:
+            installed_version: "5.3"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true

--- a/suites/quincy/rbd/tier-3_rbd_mirror_upgrade_scale.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_mirror_upgrade_scale.yaml
@@ -1,0 +1,219 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_mirror_upgrade_scale.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - rbd-nbd
+              - fio
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+                - ceph-common
+                - rbd-nbd
+                - fio
+            copy_admin_keyring: true
+      desc: Configure the client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with upgrade
+      name: Test upgrade on snapshot mirrored clusters
+      module: test_rbd_snapshot_mirroring_with_upgrade.py
+      polarion-id: CEPH-83574895
+      clusters:
+        ceph-rbd1:
+          config:
+            installed_version: "5.3"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-rbd2:
+          config:
+            installed_version: "5.3"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true

--- a/suites/reef/rbd/tier-3_rbd_mirror_upgrade_5xto7x_scale.yaml
+++ b/suites/reef/rbd/tier-3_rbd_mirror_upgrade_5xto7x_scale.yaml
@@ -1,0 +1,219 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_mirror_upgrade_scale.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/reef/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 5.3
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - rbd-nbd
+              - fio
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+                - ceph-common
+                - rbd-nbd
+                - fio
+            copy_admin_keyring: true
+      desc: Configure the client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with upgrade
+      name: Test upgrade on snapshot mirrored clusters
+      module: test_rbd_snapshot_mirroring_with_upgrade.py
+      polarion-id: CEPH-83574895
+      clusters:
+        ceph-rbd1:
+          config:
+            installed_version: "5.3"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-rbd2:
+          config:
+            installed_version: "5.3"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true

--- a/suites/reef/rbd/tier-3_rbd_mirror_upgrade_6xto7x_scale.yaml
+++ b/suites/reef/rbd/tier-3_rbd_mirror_upgrade_6xto7x_scale.yaml
@@ -1,0 +1,219 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_mirror_upgrade_scale.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/reef/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 6.1
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 6.1
+                    release: "rc"
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+              - ceph-common
+              - rbd-nbd
+              - fio
+            copy_admin_keyring: true
+        ceph-rbd2:
+          config:
+            command: add
+            id: client.1
+            node: node2
+            install_packages:
+                - ceph-common
+                - rbd-nbd
+                - fio
+            copy_admin_keyring: true
+      desc: Configure the client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with upgrade
+      name: Test upgrade on snapshot mirrored clusters
+      module: test_rbd_snapshot_mirroring_with_upgrade.py
+      polarion-id: CEPH-83574895
+      clusters:
+        ceph-rbd1:
+          config:
+            installed_version: "6.1"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-rbd2:
+          config:
+            installed_version: "6.1"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            command: start
+            service: upgrade
+            verify_cluster_health: true

--- a/tests/rbd_mirror/test_rbd_snapshot_mirroring_with_upgrade.py
+++ b/tests/rbd_mirror/test_rbd_snapshot_mirroring_with_upgrade.py
@@ -1,0 +1,249 @@
+from copy import deepcopy
+
+from ceph.parallel import parallel
+from ceph.rbd.initial_config import initial_mirror_config, random_string
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.execute import execute
+from ceph.rbd.workflows.krbd_io_handler import krbd_io_handler
+from ceph.rbd.workflows.snap_scheduling import verify_snapshot_schedule
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run_io_verify_snap_schedule(**kw):
+    """
+    Run IOs on the given image and verify snapshot schedule
+    """
+    pool_type = kw.get("pool_type")
+    rbd = kw.get("rbd")
+    client = kw.get("client")
+    config = deepcopy(kw.get("config").get(pool_type))
+    for pool, pool_config in getdict(config).items():
+        multi_image_config = getdict(pool_config)
+        multi_image_config.pop("test_config", {})
+        for image, image_config in multi_image_config.items():
+            image_spec = f"{pool}/{image}"
+
+            io_size = image_config.get(
+                "io_size", int(int(image_config["size"][:-1]) / 3)
+            )
+            io_config = {
+                "rbd_obj": rbd,
+                "client": client,
+                "size": image_config["size"],
+                "do_not_create_image": True,
+                "config": {
+                    "file_size": io_size,
+                    "file_path": [f"{kw['mount_path']}"],
+                    "get_time_taken": True,
+                    "image_spec": [image_spec],
+                    "operations": {
+                        "fs": "ext4",
+                        "io": True,
+                        "mount": True,
+                        "nounmap": False,
+                        "device_map": True,
+                    },
+                    "skip_mkfs": kw["skip_mkfs"],
+                },
+            }
+            krbd_io_handler(**io_config)
+            kw["io_config"] = io_config
+            for interval in image_config.get("snap_schedule_intervals"):
+                out = verify_snapshot_schedule(rbd, pool, image, interval)
+                if out:
+                    log.error(f"Snapshot verification failed for image {pool}/{image}")
+                    if kw.get("raise_exception"):
+                        raise Exception(
+                            f"Snapshot verification failed for image {pool}/{image}"
+                        )
+                    return 1
+    return 0
+
+
+def test_cluster_upgrade(**kw):
+    """
+    Upgrade cluster and run IOs in parallel while upgrading
+    """
+    try:
+        ceph_cluster = kw.get("ceph_cluster")
+        mon_node = ceph_cluster.get_nodes("installer")[0]
+        rc = ceph_cluster.check_health(
+            kw["config"]["installed_version"],
+            client=mon_node,
+            timeout=300,
+        )
+
+        if rc != 0:
+            log.error("Ceph health not OK")
+            return 1
+
+        client = kw.get("client")
+        client.exec_command(cmd="ceph osd set noout", sudo=True)
+        client.exec_command(cmd="ceph osd set noscrub", sudo=True)
+        client.exec_command(cmd="ceph osd set nodeep-scrub", sudo=True)
+
+        with parallel() as p:
+            p.spawn(
+                execute,
+                mod_file_name="tests.cephadm.test_cephadm_upgrade",
+                args=kw,
+                test_name="Upgrade cluster",
+                raise_exception=True,
+            )
+            for pool_type in kw.get("pool_types"):
+                mount_path = kw["mount_paths"][pool_type]
+                p.spawn(
+                    run_io_verify_snap_schedule,
+                    pool_type=pool_type,
+                    raise_exception=True,
+                    mount_path=f"{mount_path}/file_2",
+                    **kw,
+                )
+
+        client.exec_command(cmd="ceph osd unset noout", sudo=True)
+        client.exec_command(cmd="ceph osd unset noscrub", sudo=True)
+        client.exec_command(cmd="ceph osd unset nodeep-scrub", sudo=True)
+    except Exception as e:
+        log.error(f"Cluster upgrade failed with error {e}")
+        return 1
+    return 0
+
+
+def run(**kw):
+    """CEPH-83574895 - Configure two-way rbd-mirror on Stand alone
+    CEPH cluster on image (with replicated and ec pools)with snapshot
+    based mirroring and perform upgrade
+    Pre-requisites :
+    We need atleast one client node with ceph-common, fio and rbd-nbd packages,
+    conf and keyring files in both clusters with snapshot based RBD mirroring
+    enabled between the clusters.
+    kw:
+        clusters:
+            ceph-rbd1:
+            config:
+                rep_pool_config:
+                num_pools: 1
+                num_images: 5
+                size: 10G
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals: #one value for each level specified above
+                    - 5m
+                io_percentage: 30 #percentage of space in each image to be filled
+                ec_pool_config:
+                num_pools: 1
+                num_images: 5
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals:
+                    - 5m
+                io_percentage: 30
+                command: start
+                service: upgrade
+                verify_cluster_health: true
+            ceph-rbd2:
+            config:
+                rep_pool_config:
+                num_pools: 1
+                num_images: 5
+                size: 10G
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals: #one value for each level specified above
+                    - 5m
+                io_percentage: 30 #percentage of space in each image to be filled
+                ec_pool_config:
+                num_pools: 1
+                num_images: 5
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals:
+                    - 5m
+                io_percentage: 30
+                command: start
+                service: upgrade
+                verify_cluster_health: true
+    Test Case Flow
+    1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
+    2. Create pools and images as specified, enable snapshot based mirroring for all these images
+    3. Schedule snapshots for each of these images and run IOs on each of the images
+    4. Perform upgrades on both the clusters
+    5. Check data and run IOs again on the upgraded clusters
+    """
+    pool_types = ["rep_pool_config", "ec_pool_config"]
+    log.info("Running rbd mirror cluster upgrade with snapshot mirroring enabled")
+
+    try:
+        kw.get("config", {})["do_not_run_io"] = True
+        mirror_obj = initial_mirror_config(**kw)
+        mirror_obj.pop("output", [])
+
+        for val in mirror_obj.values():
+            if not val.get("is_secondary", False):
+                rbd = val.get("rbd")
+                client = val.get("client")
+        log.info("Initial configuration complete")
+
+        pool_types = list(mirror_obj.values())[0].get("pool_types")
+        log.info("Run IOs on images before upgrade")
+        mount_paths = {}
+        for pool_type in pool_types:
+            mount_path = f"/tmp/mnt_{random_string(len=5)}"
+            mount_paths[pool_type] = mount_path
+            rc = run_io_verify_snap_schedule(
+                pool_type=pool_type,
+                rbd=rbd,
+                client=client,
+                skip_mkfs=False,
+                mount_path=f"{mount_path}/file_1",
+                **kw,
+            )
+            if rc:
+                log.error(f"Run IOs before upgrade failed for pool type {pool_type}")
+                return 1
+
+        log.info("Upgrade cluster and run IOs in parallel")
+        rc = test_cluster_upgrade(
+            pool_types=pool_types,
+            rbd=rbd,
+            client=client,
+            skip_mkfs=True,
+            mount_paths=mount_paths,
+            **kw,
+        )
+        if rc:
+            log.error(f"Cluster upgrade failed for pool type {pool_type}")
+            return 1
+
+        log.info("Run IOs on images after upgrade")
+        for pool_type in pool_types:
+            rc = run_io_verify_snap_schedule(
+                pool_type=pool_type,
+                rbd=rbd,
+                client=client,
+                skip_mkfs=True,
+                mount_path=f"{mount_paths[pool_type]}/file_3",
+                **kw,
+            )
+            if rc:
+                log.error(f"Run IOs after upgrade failed for pool type {pool_type}")
+                return 1
+    except Exception as e:
+        log.error(
+            f"Rbd mirror cluster upgrade with snapshot mirroring enabled failed with error {str(e)}"
+        )
+        return 1
+    finally:
+        cleanup(pool_types=pool_types, multi_cluster_obj=mirror_obj, **kw)
+    return 0


### PR DESCRIPTION
Automation of test case - CEPH-83574895 - Configure two-way rbd-mirror on Stand alone CEPH cluster on image (with replicated and ec pools)with snapshot based mirroring and perform upgrade

Test Steps:
    1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
    2. Create pools and images as specified, enable snapshot based mirroring for all these images
    3. Schedule snapshots for each of these images and run IOs on each of the images
    4. Perform upgrades on both the clusters
    5. Check data and run IOs again on the upgraded clusters

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574895

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XRAIAD/