### PR TITLE
CEPH-83575297: Tier-2 test to deploy cluster and test replica-1 pools

### DIFF
--- a/ceph/rados/crushtool_workflows.py
+++ b/ceph/rados/crushtool_workflows.py
@@ -670,6 +670,23 @@ class CrushToolWorkflows:
         log.info(f"Successfully set rules with name {rule_name} on the cluster")
         return True
 
+    def remove_device_class(self, osd_list: list) -> bool:
+        """
+        Method to remove the device class of one or more OSDs
+        Args:
+            osd_list: List of OSD IDs
+        Returns:
+            True -> device class removed successfully
+            False -> device class removal failed
+        """
+        device_rm_cmd = "ceph osd crush rm-device-class "
+        _cmd = device_rm_cmd + " ".join(osd_list)
+        out, err = self.client.exec_command(cmd=_cmd, sudo=True)
+        log.info(err)
+        if "done removing class of osd" in err or "belongs to no class" in err:
+            return True
+        return False
+
 
 class OsdToolWorkflows:
     """

--- a/conf/quincy/rados/11-node-replica1-cluster.yaml
+++ b/conf/quincy/rados/11-node-replica1-cluster.yaml
@@ -1,0 +1,84 @@
+# Rados test configuration for replica-1 pool
+# Deployment for all the ceph daemons , with 5 mon's, 3 mgr's, and 6 OSD daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - alertmanager
+          - crash
+      node3:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node4:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node5:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node6:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - crash
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - mon
+          - rgw
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node9:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node10:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node11:
+        role:
+          - mon
+          - rgw
+          - node-exporter
+          - crash

--- a/conf/reef/rados/11-node-replica1-cluster.yaml
+++ b/conf/reef/rados/11-node-replica1-cluster.yaml
@@ -1,0 +1,84 @@
+# Rados test configuration for replica-1 pool
+# Deployment for all the ceph daemons , with 5 mon's, 3 mgr's, and 6 OSD daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+        role:
+          - _admin
+          - mon
+          - mgr
+          - installer
+          - node-exporter
+          - alertmanager
+          - grafana
+          - prometheus
+          - crash
+      node2:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - alertmanager
+          - crash
+      node3:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node4:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node5:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node6:
+        role:
+          - mon
+          - mgr
+          - mds
+          - node-exporter
+          - crash
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - mon
+          - rgw
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node9:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node10:
+        role:
+          - osd
+          - node-exporter
+          - crash
+        no-of-volumes: 1
+        disk-size: 50
+      node11:
+        role:
+          - mon
+          - rgw
+          - node-exporter
+          - crash

--- a/suites/quincy/rados/tier-2_rados_test-replica1.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-replica1.yaml
@@ -1,0 +1,112 @@
+# Suite contains tests for replica-1 non-resilient pool
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83575297
+      desc: Test replica-1 non-resilient pools

--- a/suites/reef/rados/tier-2_rados_test-replica1.yaml
+++ b/suites/reef/rados/tier-2_rados_test-replica1.yaml
@@ -1,0 +1,112 @@
+# Suite contains tests for replica-1 non-resilient pool
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83575297
+      desc: Test replica-1 non-resilient pools

--- a/tests/rados/test_replica1.py
+++ b/tests/rados/test_replica1.py
@@ -1,0 +1,172 @@
+""" Test module to verify replica-1 non-resilient pool functionalities"""
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.crushtool_workflows import CrushToolWorkflows
+from tests.rados.monitor_configurations import MonConfigMethods
+from tests.rbd.rbd_utils import Rbd
+from utility.log import Log
+from utility.utils import generate_unique_id
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83575297
+    1. Deploy ceph cluster with one OSD per host
+    2. Remove the crush device for all OSDs
+    3. Set unique device class for few OSDs and replicated device
+    class for all others.
+    4. Divide the hosts into different zones
+    5. Create unique crush rule for each unique device class
+    6. Set MON Config mon_allow_pool_size_one to true
+    7. Create replia-1 pool for each zone device class OSD
+    8. Ensure proper health warning is generated.
+    9. Perform scrubbing, deep-scrubbing and repair on replica-1 pools
+    10. Create RBD images on replica-1 pool
+    11. Enable compression of replica-1 pool
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    crush_obj = CrushToolWorkflows(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    rbd_obj = Rbd(**kw)
+    repli_pools = []
+    zone_unique = generate_unique_id(length=4)
+
+    log.info("Running test case to verify replica-1 non-resilient pool")
+
+    try:
+        # Fetch all the OSDs on the cluster
+        out, _ = cephadm.shell(args=["ceph osd ls"])
+        osd_list = out.strip().split("\n")
+        log.debug(f"List of OSDs: {osd_list}")
+
+        # remove the device class for all the OSDs
+        assert crush_obj.remove_device_class(osd_list=osd_list)
+
+        # divide OSDs into different device classes(zones) and their respective
+        # hosts into unique zones
+        for osd_id in osd_list:
+            if int(osd_id) % 2 == 0:
+                zone_name = f"zone{osd_id}-{zone_unique}"
+                cephadm.shell(
+                    [f"ceph osd crush set-device-class zone{osd_id} {osd_id}"]
+                )
+                cephadm.shell([f"ceph osd crush add-bucket {zone_name} zone"])
+                cephadm.shell([f"ceph osd crush move {zone_name} root=default"])
+                osd_node = rados_obj.fetch_host_node(
+                    daemon_type="osd", daemon_id=osd_id
+                )
+                cephadm.shell(
+                    [f"ceph osd crush move {osd_node.hostname} zone={zone_name}"]
+                )
+
+        # divide OSDs into different device classes(replicated)
+        replicated_osd = " ".join(
+            [osd_id for osd_id in osd_list if int(osd_id) % 2 != 0]
+        )
+        cephadm.shell([f"ceph osd crush set-device-class replicated {replicated_osd}"])
+
+        # generate replicated crush rule to append cluster crush rule
+        rule_name = "general-replicated"
+        zone_rules = """        id 111
+        type replicated
+        step take default class replicated
+        step chooseleaf firstn 0 type host
+        step emit"""
+        assert crush_obj.add_crush_rule(rule_name=rule_name, rules=zone_rules)
+
+        # generate zone level crush rules to append cluster crush rule
+        for osd_id in osd_list:
+            if int(osd_id) % 2 == 0:
+                rule_name = f"zone{osd_id}"
+                zone_rules = f"""        id 5{osd_id}
+                type replicated
+                step take default class zone{osd_id}
+                step chooseleaf firstn 0 type host
+                step emit"""
+                assert crush_obj.add_crush_rule(rule_name=rule_name, rules=zone_rules)
+
+        # set general replicated crush rule to all existing pools
+        pool_list = rados_obj.list_pools()
+        log.debug(f"List of pools in the cluster: {pool_list}")
+        for pool in pool_list:
+            rados_obj.set_pool_property(
+                pool=pool, props="crush_rule", value="general-replicated"
+            )
+
+        # set mon mon_allow_pool_size_one true
+        assert mon_obj.set_config(
+            section="mon", name="mon_allow_pool_size_one", value=True
+        )
+
+        # create replica-1 pools for each zone device class osd
+        for osd_id in osd_list:
+            if int(osd_id) % 2 == 0:
+                pool_cfg = {
+                    "pool_name": f"replica1_zone{osd_id}",
+                    "pg_num": 1,
+                    "pgp_num": 1,
+                    "crush_rule": f"zone{osd_id}",
+                    "disable_pg_autoscale": True,
+                }
+                assert rados_obj.create_pool(**pool_cfg)
+
+                # set pool size to 1
+                out, _ = cephadm.shell(
+                    [
+                        f"ceph osd pool set {pool_cfg['pool_name']} size 1 --yes-i-really-mean-it"
+                    ]
+                )
+                log.info(out)
+                repli_pools.append(pool_cfg["pool_name"])
+
+        # check ceph status to confirm replica pools have been created.
+        health_detail, _ = cephadm.shell(["ceph health detail"])
+        assert "pool(s) have no replicas configured" in health_detail
+
+        # print the pool detail for each replica-1 pool
+        for _pool in repli_pools:
+            pool_detail = rados_obj.get_pool_details(pool=_pool)
+            log.info(f"{_pool} Pool details: ")
+            log.info(pool_detail)
+
+        # perform scrub, deep-scrub and repairs on the replica1 pool pg
+        for _pool in repli_pools:
+            pg_id = rados_obj.get_pgid(pool_name=_pool)[0]
+            # trigger repair
+            cephadm.shell([f"ceph pg repair {pg_id}"])
+            rados_obj.run_scrub(pool=_pool)
+            rados_obj.run_deep_scrub(pool=_pool)
+
+        # ensure acting set of each replica1 pool has only one OSD
+        for _pool in repli_pools:
+            pg_acting_set = rados_obj.get_pg_acting_set(pool_name=_pool)
+            assert len(pg_acting_set) == 1
+            log.info(f"Acting set of {_pool}: {pg_acting_set}")
+
+        # create and map rbd images
+        for _pool in repli_pools:
+            if rbd_obj.create_image(
+                pool_name=_pool, image_name=f"img-{_pool}", size="4M"
+            ):
+                raise Exception(f"RBD image creation failed on pool: {_pool}")
+            log.info(f"RBD image creation success on pool: {_pool}")
+
+        # enable compression and compression ratios for each replica 1 pool
+        compress_cfg = {
+            "compression_algorithm": "snappy",
+            "compression_mode": "force",
+            "compression_required_ratio": 0.5,
+        }
+        for _pool in repli_pools:
+            assert rados_obj.pool_inline_compression(pool_name=_pool, **compress_cfg)
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    return 0


### PR DESCRIPTION
[CEPH-83575297](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575297): Tier-2 test to deploy cluster and test replica-1 pools
We have a requirement to provide non-resilient, non-replicating storage pools in Ceph for applications that are self-replicating and insure resiliency themselves at a higher layer (e.g. Mongo, Cassandra, etc). The requirement applies to ODF and RHCS, with different potential customers (Morgan Stanley, OpenStack edge, etc).

Conf files added:
- conf/quincy/rados/11-node-replica1-cluster.yaml
- conf/reef/rados/11-node-replica1-cluster.yaml

Test Suites added:
- suites/quincy/rados/tier-2_rados_test-replica1.yaml
- suites/reef/rados/tier-2_rados_test-replica1.yaml

Tests added:
- tests/rados/test_replica1.py

Logs -
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TX7TBI/
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2LI1QX/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
