### PR TITLE
Object lock with no overwrite , tracks BZ BZ 1890843

### DIFF
--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -715,6 +715,16 @@ tests:
         timeout: 500
 
   - test:
+      name: object lock no overwrite
+      desc: object lock no overwrite
+      polarion-id: CEPH-83574059
+      module: sanity_rgw.py
+      config:
+        script-name: test_object_lock_no_overwrite.py
+        config-file-name: test_object_lock_no_overwrite.yaml
+        timeout: 500
+
+  - test:
       name: Test user modify with placement id
       desc: Test user modify with placement id
       polarion-id: CEPH-83575880

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -93,3 +93,15 @@ tests:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_incomplete_multipart.yaml
         timeout: 300
+
+  # Object lock no overwrite
+  - test:
+      name: object lock no overwrite
+      desc: object lock no overwrite
+      polarion-id: CEPH-83574059
+      module: sanity_rgw.py
+      comments: known issue (bz-1890843)
+      config:
+        script-name: test_object_lock_no_overwrite.py
+        config-file-name: test_object_lock_no_overwrite.yaml
+        timeout: 500


### PR DESCRIPTION
Description:
- Create bucket with bucket lock enabled
- Upload key1 with 2 minutes of retention time , and try deletion before retention time passes
- Delete key1 post retention time expiry
- Upload key with 2 minutes retention in GOVERNANCE mode
- Extend retention time to 3 minutes, and try deletion before retnetion period 
- Delete key2 with bypass-governance-retention option

Pass log : http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-5IFHXH/