### PR TITLE
[tfa-fix] Add fix for replace OSD test case failure

### DIFF
--- a/tests/cephadm/test_replace_osd.py
+++ b/tests/cephadm/test_replace_osd.py
@@ -1,4 +1,4 @@
-import json
+import ast
 
 from ceph.utils import get_nodes_by_ids
 from ceph.waiter import WaitUntil
@@ -17,7 +17,7 @@ def verify_osd_state(cephadm, osd_id, state):
     timeout, interval = 60, 2
     for w in WaitUntil(timeout=timeout, interval=interval):
         out = cephadm.ceph.osd.tree(**kw)
-        data = json.loads(out[0])
+        data = ast.literal_eval(out)
         for node in data.get("nodes"):
             _id = node.get("id")
             _type = node.get("type")


### PR DESCRIPTION
# Description

This fix is for the failure observed in TFA for "tier-2-osd-scenarios" suite.
The error observed was :
`json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)`
