### PR TITLE
Add new snapshot schedule and retention workflow for rentention count with n and multifs

### DIFF
--- a/suites/quincy/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
+++ b/suites/quincy/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
@@ -1,0 +1,248 @@
+---
+#===============================================================================================
+# Tier-level: 2
+# Test-Suite: tier-2_cephfs_test-snapshot-clone.yaml
+# Conf file : conf/pacific/cephfs/tier_0_fs.yaml
+# Test-Case Covered:
+#	CEPH-83573499 Remove the original volume after cloning and verify the data is accessible from cloned volume
+#	CEPH-83573501 Create a Cloned Volume using a snapshot
+#	CEPH-83573504 Verify the status of cloning operation
+#	CEPH-83573502 Interrupt the cloning operation in-between and observe the behavior.
+#	CEPH-83573520 Validate the max snapshot that can be created under a root FS sub volume level.
+#	              Increase by 50 at a time until it reaches the max limit.
+#	CEPH-83573521 Remove a subvolume group by retaining the snapshot : ceph fs subvolume rm <vol_n...
+#	CEPH-83573415 Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
+#	CEPH-83573418 Create a Snapshot, reboot the node and rollback the snapshot
+#	CEPH-83573420 Try writing the data to snap directory
+#   CEPH-83573524	Ensure the subvolume attributes are retained post clone operations
+#   CEPH-11319		Create first snap add more data to original then create a second snap.
+#                   Rollback 1st snap do data validation. Rollback 2nd snap and do data validation.
+#                   Perform cross platform rollback i.e. take snap on kernel mount and perform rollback using fuse mount
+#   CEPH-83573255	Try renaming the snapshot directory and rollbackCreate a FS and
+#                   create 10 directories and mount them on kernel client and fuse client(5 mounts each)
+#                   Add data (~ 100 GB). Create a Snapshot and verify the content in snap directory.
+#                   Try modifying the snapshot name.
+#   CEPH-83573522	Verify the retained snapshot details with "ceph fs info" command
+#   CEPH-83574724   Create Clone of subvolume which is completely filled with data till disk quota exceeded
+#   CEPH-83575038   verify CRUD operation on metadata of subvolume's snapshot
+#   CEPH-83574681 Cancel the subvolume snapshot clonning
+#   CEPH-83579271 Snap schedule and retention testing
+#  CEPH-83581235 Snap schedule and retention testing on multi fs setup
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: ~
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: Concurrent-clone-test
+      module: snapshot_clone.clone_threads.py
+      polarion-id: CEPH-83574592
+      desc: Concurrent-clone-test
+      abort-on-fail: false
+  - test:
+      name: Clone_status
+      module: snapshot_clone.clone_status.py
+      polarion-id: CEPH-83573501
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Clone_cancel_status
+      module: snapshot_clone.clone_cancel_status.py
+      polarion-id: CEPH-83573502
+      desc: Checks the clone status and states of the clone process
+      abort-on-fail: false
+  - test:
+      name: Retain_Snapshots
+      module: snapshot_clone.retain_snapshots.py
+      polarion-id: CEPH-83573521
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: snapshot_flag
+      module: snapshot_clone.snapshot_flag.py
+      polarion-id: CEPH-83573415
+      desc: Test to validate the cli - ceph fs set <fs_name> allow_new_snaps true
+      abort-on-fail: false
+  - test:
+        name: Remove_Subvolume_clone
+        module: snapshot_clone.clone_remove_subvol.py
+        polarion-id: CEPH-83573499
+        desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+        abort-on-fail: false
+  - test:
+      name: Test Max Snapshot limit
+      module: snapshot_clone.max_snapshot_limit.py
+      polarion-id: CEPH-83573520
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: Snapshot reboot
+      module: snapshot_clone.snapshot_reboot.py
+      polarion-id: CEPH-83573418
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: Snapshot write
+      module: snapshot_clone.snapshot_write.py
+      polarion-id: CEPH-83573420
+      desc: Try writing the data to snap directory
+      abort-on-fail: false
+  - test:
+      name: Clone_attributes
+      module: snapshot_clone.clone_attributes.py
+      polarion-id: CEPH-83573524
+      desc: Retains the snapshots after deletig the subvolume
+      abort-on-fail: false
+  - test:
+      name: cross_platform_snaps
+      module: snapshot_clone.cross_platform_snaps.py
+      polarion-id: CEPH-11319
+      desc: Clone a subvolume and remove the orginal volume and verify the contents in subvolume
+      abort-on-fail: false
+  - test:
+      name: rename snap directory
+      module: snapshot_clone.rename_snap_dir.py
+      polarion-id: CEPH-83573255
+      desc: Validate the max snapshot that can be created under a root FS sub volume level.Increase by 50 at a time until it reaches the max limit.
+      abort-on-fail: false
+  - test:
+      name: subvolume_info_retain
+      module: snapshot_clone.subvolume_info_retain.py
+      polarion-id: CEPH-83573522
+      desc: Create a Snapshot, reboot the node and rollback the snapshot
+      abort-on-fail: false
+  - test:
+      name: subvolume_full_vol
+      module: snapshot_clone.clone_subvolume_full_vol.py
+      polarion-id: CEPH-83574724
+      desc: Clone a subvolume with full data in the subvolume
+      abort-on-fail: false
+  - test:
+      name: snapshot_metadata
+      module: snapshot_clone.snapshot_metadata.py
+      polarion-id: CEPH-83575038
+      desc: verify CRUD operation on metadata of subvolume's snapshot
+      abort-on-fail: false
+  - test:
+      name: cancel the subvolume snapshot clonning
+      module: snapshot_clone.clone_cancel_in_progress.py
+      polarion-id: CEPH-83574681
+      desc: Try to cancel the snapshot while clonning is operating
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_test
+      module: snapshot_clone.snap_schedule.py
+      polarion-id: CEPH-83575569
+      desc: snap_schedule_test
+      abort-on-fail: false
+  - test:
+      name: snap_schedule_retention_vol_subvol
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83579271
+      desc: snap schedule and retention functional test on vol and subvol
+      abort-on-fail: false
+      config:
+        test_name : functional
+  - test:
+      name: snap_sched_multi_fs
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83581235
+      desc: snap schedule and retention functional test on multi-fs setup
+      abort-on-fail: false
+      config:
+        test_name : systemic

--- a/suites/quincy/cephfs/tier-3_cephfs_scale.yaml
+++ b/suites/quincy/cephfs/tier-3_cephfs_scale.yaml
@@ -12,6 +12,7 @@
 #                  snapshots and capture the time taken
 #  CEPH-83575584 - Validate the max snapshot that can be created under a root FS sub volume.
 #  CEPH-83575629 - Validate the max clones can be created from single snapshot of subvolume.
+#  CEPH-83581234 - Snap schedule retention count validation using n
 #=======================================================================================================================
 tests:
   -
@@ -164,3 +165,11 @@ tests:
       module: cephfs_scale.max_clones_from_snap.py
       name: "Clone scale testing"
       polarion-id: "CEPH-83575629"
+  - test:
+      name: snap_retention_count_validate
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      desc: snap retention count validate with n usage on vol and subvol
+      abort-on-fail: false
+      config:
+        test_name : longevity
+      polarion-id: "CEPH-83581234"

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -83,9 +83,11 @@ def run(ceph_cluster, **kw):
         snap_util = SnapUtils(ceph_cluster)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
+        installer_node = ceph_cluster.get_ceph_object("installer")
         build = config.get("build", config.get("rhbuild"))
         fs_util_v1.prepare_clients(clients, build)
         fs_util_v1.auth_list(clients)
+        multi_fs = 0
         log.info("checking Pre-requisites")
         if len(clients) < 1:
             log.info(
@@ -123,7 +125,10 @@ def run(ceph_cluster, **kw):
             "snap_retention_service_restart",
             "snap_sched_non_existing_path",
         ]
-        test_longevity = ["snap_sched_validate", "snap_sched_count_validate"]
+        test_longevity = [
+            "snap_retention_count_validate_vol",
+            "snap_retention_count_validate_subvol",
+        ]
         test_systemic = ["snap_sched_multi_fs"]
         test_name_all = test_functional + test_negative + test_longevity + test_systemic
 
@@ -149,12 +154,40 @@ def run(ceph_cluster, **kw):
             "fs_util": fs_util_v1,
             "snap_util": snap_util,
             "client": client1,
+            "installer_node": installer_node,
         }
         for test_case_name in test_list:
             log.info(
                 f"\n\n                                   ============ {test_case_name} ============ \n"
             )
             snap_test_params.update({"test_case": test_case_name})
+            if "multi_fs" in test_case_name:
+                log.info("Verify that setup has atleast 2 Ceph FS")
+                total_fs = fs_util_v1.get_fs_details(client1)
+                if len(total_fs) == 1:
+                    log.info("We need atleast two ceph FS to perform this test")
+                    for i in range(1, 3):
+                        out, rc = client1.exec_command(
+                            sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
+                        )
+                        daemon_ls_before = json.loads(out)
+                        daemon_count_before = len(daemon_ls_before)
+                        client1.exec_command(
+                            sudo=True,
+                            cmd=f"ceph fs volume create cephfs_{i}",
+                            check_ec=False,
+                        )
+                        fs_util_v1.wait_for_mds_process(client1, f"cephfs_{i}")
+                        out_after, rc = client1.exec_command(
+                            sudo=True, cmd="ceph orch ps --daemon_type mds -f json"
+                        )
+                        daemon_ls_after = json.loads(out_after)
+                        daemon_count_after = len(daemon_ls_after)
+                        assert daemon_count_after > daemon_count_before, (
+                            f"daemon count not increased after creating FS,daemon count before : {daemon_count_before}"
+                            f"after:{daemon_count_after}"
+                        )
+                        multi_fs = 1
             cleanup_params = run_snap_test(snap_test_params)
             snap_test_params["export_created"] = cleanup_params["export_created"]
             if cleanup_params["test_status"] == 1:
@@ -179,6 +212,18 @@ def run(ceph_cluster, **kw):
             cmd=f"ceph nfs cluster delete {nfs_name}",
             check_ec=False,
         )
+        if int(multi_fs) == 1:
+            client1.exec_command(
+                sudo=True,
+                cmd="ceph config set mon mon_allow_pool_delete true",
+                check_ec=False,
+            )
+            [fs_util_v1.remove_fs(client1, f"cephfs_{i}") for i in range(1, 3)]
+            client1.exec_command(
+                sudo=True,
+                cmd="ceph config set mon mon_allow_pool_delete false",
+                check_ec=False,
+            )
 
 
 def run_snap_test(snap_test_params):
@@ -198,6 +243,7 @@ def run_snap_test(snap_test_params):
         snap_test_params["fs_util"].create_subvolumegroup(
             snap_test_params["client"], **subvolumegroup
         )
+        time.sleep(30)
         snap_test_params["fs_util"].create_subvolume(
             snap_test_params["client"], **subvolume
         )
@@ -214,6 +260,10 @@ def run_snap_test(snap_test_params):
         post_test_params = snap_retention_test(snap_test_params)
     elif "snap_retention_service_restart" in test_case_name:
         post_test_params = snap_retention_service_restart(snap_test_params)
+    elif "snap_retention_count_validate" in test_case_name:
+        post_test_params = snap_retention_count_validate(snap_test_params)
+    elif "snap_sched_multi_fs" in test_case_name:
+        post_test_params = snap_sched_multi_fs(snap_test_params)
     # Cleanup subvolume and group
     if "subvol" in snap_test_params.get("test_case"):
         cmd = f"ceph fs subvolume rm {snap_test_params['fs_name']} {snap_test_params['subvol_name']} "
@@ -420,6 +470,362 @@ def snap_retention_test(snap_test_params):
     return post_test_params
 
 
+def snap_retention_count_validate(snap_test_params):
+    """
+    1. Read mds_max_snaps_per_dir default value(100), verify with no retention field, max scheduled snap count retained
+       is this default value - 1 i.e., 99 , perform snap cleanup(remove retention value and delete sched snaps)
+    2. Add retention count as 5n, verify only 5 snapshots are retained, perform snap cleanup
+    3. Enable mgr debug logs, Note default value for mds_max_snaps_per_dir, Set mds_max_snaps_per_dir as 8, verify 8
+       scheduled snaps are retained, try manual snap creation in same path, verify error, but no
+       traceback or exception in mgr logs,perform snap clean up, set back default mds_max_snaps_per_dir value
+    """
+    client = snap_test_params["client"]
+    installer_node = snap_test_params["installer_node"]
+    snap_util = snap_test_params["snap_util"]
+    fs_util = snap_test_params["fs_util"]
+    snap_util.enable_snap_schedule(client)
+    snap_test_params["validate"] = True
+    snap_test_params["path"] = "/"
+    sched_list = ["1M"]
+
+    test_fail = 0
+    mnt_list = ["kernel", "fuse", "nfs"]
+    mnt_paths = {}
+    post_test_params = {}
+    if "subvol" in snap_test_params.get("test_case"):
+        log.info(
+            "BZ 2254477 - Need to wait for 10mins for snapshot rotation issue to be gone"
+        )
+        time.sleep(600)
+        cmd = f"ceph fs subvolume getpath {snap_test_params['fs_name']} {snap_test_params.get('subvol_name')} "
+        cmd += f"{snap_test_params.get('group_name')}"
+        subvol_path, rc = snap_test_params["client"].exec_command(
+            sudo=True,
+            cmd=cmd,
+        )
+        snap_test_params["path"] = f"{subvol_path.strip()}/.."
+
+    out, rc = client.exec_command(
+        sudo=True, cmd="ceph config get mds mds_max_snaps_per_dir"
+    )
+    default_retention = int(out.strip()) - 1
+    time.sleep(60)
+    log.info(
+        f"Test to verify that max scheduled snaps retained is mds_max_snaps_per_dir default {default_retention}"
+    )
+    snap_test_params["sched"] = sched_list[0]
+    snap_test_params["start_time"] = get_iso_time(client)
+    snap_util.create_snap_schedule(snap_test_params)
+
+    snap_test_params["retention"] = default_retention
+    duration_min = int(default_retention)
+    for mnt_type in mnt_list:
+        path, post_test_params["export_created"] = fs_util.mount_ceph(
+            mnt_type, snap_test_params
+        )
+        mnt_paths[mnt_type] = path
+    snap_path = f"{mnt_paths['fuse']}"
+    io_path = f"{mnt_paths['kernel']}/"
+    if "subvol" in snap_test_params.get("test_case"):
+        snap_path = f"{mnt_paths['fuse']}{snap_test_params['path']}"
+        io_path = f"{mnt_paths['kernel']}{subvol_path.strip()}/"
+    log.info(f"add sched data params : {client} {io_path} {duration_min}")
+    dd_params = {
+        "bs": "10k",
+        "count": 10,
+    }
+    smallfile_params = {
+        "threads": 5,
+        "file-size": 1024,
+        "files": 5,
+    }
+    fs_util.run_ios_V1(
+        client,
+        io_path,
+        run_time=duration_min,
+        dd_params=dd_params,
+        smallfile_params=smallfile_params,
+    )
+    wait_retention_check = 60
+    log.info(
+        f"Wait for additional time {wait_retention_check}secs to validate retention"
+    )
+    time.sleep(wait_retention_check)
+    if snap_util.validate_snap_retention(client, snap_path, snap_test_params["path"]):
+        test_fail = 1
+        log.error(
+            f"max scheduled snaps retained is NOT mds_max_snaps_per_dir default {default_retention}"
+        )
+
+    log.info("Perform schedule snaps cleanup")
+    snap_util.sched_snap_cleanup(client, snap_path)
+    snap_util.remove_snap_schedule(client, snap_test_params["path"])
+
+    log.info(
+        "Verify if retention field is 5n, only 5 scheduled snapshots are retained,manual snap can be created"
+    )
+    snap_util.create_snap_schedule(snap_test_params)
+    snap_test_params["retention"] = "5n"
+    snap_util.create_snap_retention(snap_test_params)
+
+    duration_min = 5
+    log.info(f"add sched data params : {client} {io_path} {duration_min}")
+    fs_util.run_ios_V1(client, io_path, run_time=duration_min)
+    wait_retention_check = 60
+    log.info(
+        f"Wait for additional time {wait_retention_check}secs to validate retention"
+    )
+    time.sleep(wait_retention_check)
+    if snap_util.validate_snap_retention(
+        client, snap_path, snap_test_params["path"], ret_type="n"
+    ):
+        test_fail = 1
+        log.error("A check to verify only 5 scheduled snaps retained has failed")
+
+    log.info("Verify a manual snapshot can still be created")
+    if "subvol" in snap_test_params.get("test_case"):
+        snapshot = {
+            "vol_name": snap_test_params["fs_name"],
+            "subvol_name": snap_test_params["subvol_name"],
+            "snap_name": "manual_test_snap",
+            "group_name": snap_test_params["group_name"],
+        }
+        fs_util.create_snapshot(client, **snapshot)
+        log.info("Manual snapshot creation suceeded")
+    else:
+        cmd = f"mkdir {snap_path}/.snap/manual_test_snap"
+        out, rc = client.exec_command(sudo=True, cmd=cmd)
+        log.info("Manual snapshot creation suceeded")
+    snap_util.remove_snap_retention(
+        client, snap_test_params["path"], ret_val=snap_test_params["retention"]
+    )
+    log.info("Perform schedule snaps cleanup")
+    snap_util.sched_snap_cleanup(client, snap_path)
+    snap_util.remove_snap_schedule(client, snap_test_params["path"])
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"rmdir {snap_path}/.snap/manual_test_snap"
+    )
+    log.info("Verify retention when mds_max_snaps_per_dir set to non-default value - 8")
+
+    log.info("Enable mgr debug logs")
+    cmd = "ceph config set mgr log_to_file true"
+    out, rc = client.exec_command(sudo=True, cmd=cmd)
+    log.info("Note default value for mds_max_snaps_per_dir")
+    out, rc = client.exec_command(
+        sudo=True, cmd="ceph config get mds mds_max_snaps_per_dir"
+    )
+    default_retention = int(out.strip())
+    log.info(f"Default value for mds_max_snaps_per_dir : {default_retention}")
+    log.info("Set mds_max_snaps_per_dir as 8")
+    out, rc = client.exec_command(
+        sudo=True, cmd="ceph config set mds mds_max_snaps_per_dir 8"
+    )
+    snap_util.create_snap_schedule(snap_test_params)
+    log.info("Verify 8 scheduled snaps are retained")
+    duration_min = 8
+    log.info(f"add sched data params : {client} {io_path} {duration_min}")
+    fs_util.run_ios_V1(client, io_path, run_time=duration_min)
+    wait_retention_check = 60
+    log.info(
+        f"Wait for additional time {wait_retention_check}secs to validate retention"
+    )
+    time.sleep(wait_retention_check)
+    if snap_util.validate_snap_retention(client, snap_path, snap_test_params["path"]):
+        test_fail = 1
+        log.error("A check to verify only 8 scheduled snaps retained, has failed")
+    log.info("Note last entry in mgr logs")
+    log.info("Fetch the FSID of the ceph cluster")
+    out, _ = installer_node.exec_command(sudo=True, cmd="cephadm ls")
+    data = json.loads(out)
+    fsid = data[0]["fsid"]
+    cmd = f"cd /var/log/ceph/{fsid}/;ls *mgr*log"
+    out, _ = installer_node.exec_command(sudo=True, cmd=cmd)
+    mgr_file = out.strip()
+    cmd = f"cat /var/log/ceph/{fsid}/{mgr_file}|grep Traceback|wc -l"
+    traceback_before, _ = installer_node.exec_command(sudo=True, cmd=cmd)
+    cmd = f"cat /var/log/ceph/{fsid}/{mgr_file}|grep Exception|wc -l"
+    exception_before, _ = installer_node.exec_command(sudo=True, cmd=cmd)
+    log.info(
+        f"Traceback info before: {traceback_before},Exception info : {exception_before}"
+    )
+    log.info("Try manual snap creation")
+    try:
+        if "subvol" in snap_test_params.get("test_case"):
+            snapshot = {
+                "vol_name": snap_test_params["fs_name"],
+                "subvol_name": snap_test_params["subvol_name"],
+                "snap_name": "manual_test_snap1",
+                "group_name": snap_test_params["group_name"],
+            }
+            fs_util.create_snapshot(client, **snapshot)
+        else:
+            cmd = f"mkdir {snap_path}/.snap/manual_test_snap1"
+            out, rc = client.exec_command(sudo=True, cmd=cmd)
+    except Exception as e:
+        log.info(e)
+        if ("Too many links" in str(e)) or ("EMLINK" in str(e)):
+            log.info("Manual snap creation failed as max limit reached")
+        else:
+            test_fail = 1
+            log.error("Unexpected error during manual snap creation")
+    cmd = f"cat /var/log/ceph/{fsid}/{mgr_file}|grep Traceback|wc -l"
+    traceback_after, _ = installer_node.exec_command(sudo=True, cmd=cmd)
+    cmd = f"cat /var/log/ceph/{fsid}/{mgr_file}|grep Exception|wc -l"
+    exception_after, _ = installer_node.exec_command(sudo=True, cmd=cmd)
+
+    log.info("Verify no exception or traceback in mgr logs since last entry")
+    log.info(
+        f"Traceback info after: {traceback_after},Exception info after: {exception_after}"
+    )
+    if (int(traceback_after) != int(traceback_before)) or (
+        int(exception_after) != int(exception_before)
+    ):
+        log.error(
+            "There seems traceback/exception during snapshot create, its not expected"
+        )
+
+    log.info("Reset mds_max_snaps_per_dir to default")
+    out, rc = client.exec_command(
+        sudo=True, cmd=f"ceph config set mds mds_max_snaps_per_dir {default_retention}"
+    )
+
+    log.info(f"Performing test{snap_test_params['test_case']} cleanup")
+    snap_util.sched_snap_cleanup(client, snap_path)
+
+    post_test_params["test_status"] = test_fail
+    snap_util.remove_snap_schedule(client, snap_test_params["path"])
+    umount_all(mnt_paths, snap_test_params)
+    return post_test_params
+
+
+def snap_sched_multi_fs(snap_test_params):
+    snap_util = snap_test_params["snap_util"]
+    fs_util = snap_test_params["fs_util"]
+    client = snap_test_params["client"]
+    snap_util.enable_snap_schedule(client)
+    snap_test_params["path"] = "/"
+
+    snap_test_params["validate"] = True
+    sched_list = ["1M", "1h", "1d", "1w"]
+
+    test_fail = 0
+    mnt_list = ["kernel", "fuse", "nfs"]
+    mnt_paths = {}
+    post_test_params = {}
+    mnt_path_fs = []
+    log.info("Perform ceph fs ls to get the list")
+    total_fs = fs_util.get_fs_details(client)
+    log.info(total_fs)
+    log.info(
+        "Verify fs-name is prompted when snap-schedule is tried to create without fs-name"
+    )
+    exp_err_str = (
+        "filesystem argument is required when there is more than one file system"
+    )
+    try:
+        out, rc = client.exec_command(sudo=True, cmd="ceph fs snap-schedule add / 2M")
+        out, rc = client.exec_command(sudo=True, cmd="ceph fs snap-schedule remove /")
+        # test_fail = 1
+        log.error(
+            "BZ 2224060: snap-schedule create without fs-name passed but it was not expected"
+        )
+
+    except Exception as e:
+        log.info(e)
+        if exp_err_str in str(e):
+            log.info(
+                "fs-name is prompted when snap-schedule is tried to create without fs-name"
+            )
+        else:
+            test_fail = 1
+            log.error(
+                "snap-schedule create without fs-name failed for unexpected error"
+            )
+
+    log.info("Create snap-schedule on all ceph FS except first one in list")
+    fs_cnt = len(total_fs)
+    for i in range(1, fs_cnt):
+        snap_test_params["fs_name"] = total_fs[i]["name"]
+        snap_test_params["sched"] = sched_list[0]
+        snap_test_params["start_time"] = get_iso_time(client)
+
+        sched_list_tmp = re.split(r"(\d+)", sched_list[0])
+        duration_min = int(sched_list_tmp[1]) * 2
+        for mnt_type in mnt_list:
+            path, post_test_params["export_created"] = fs_util.mount_ceph(
+                mnt_type, snap_test_params
+            )
+            mnt_paths[mnt_type] = path
+            mnt_path_fs.append(path)
+        snap_path = f"{mnt_paths['fuse']}"
+        io_path = f"{mnt_paths['kernel']}/"
+
+        for sched_val in sched_list:
+            snap_test_params["sched"] = sched_val
+            snap_util.create_snap_schedule(snap_test_params)
+        log.info(f"add sched data params : {client} {io_path} {duration_min}")
+        fs_util.run_ios_V1(snap_test_params["client"], io_path, run_time=duration_min)
+        if snap_util.validate_snap_schedule(client, snap_path, sched_list[0]):
+            log.error("Snapshot schedule validation failed")
+            test_fail = 1
+
+    log.info(
+        "Verify fs-name is prompted when snap-schedule status is run without fs-name"
+    )
+
+    try:
+        out, rc = client.exec_command(sudo=True, cmd="ceph fs snap-schedule status /")
+        # test_fail = 1
+        log.error(
+            "BZ 2224060: snap-schedule status without fs-name passed but it was not expected"
+        )
+
+    except Exception as e:
+        log.info(e)
+        if exp_err_str in str(e):
+            log.info(
+                "fs-name is prompted when snap-schedule status is tried without fs-name"
+            )
+        else:
+            test_fail = 1
+            log.error(
+                "snap-schedule status without fs-name failed for unexpected error"
+            )
+
+    log.info("Verify snap-schedule remove without fs-name gives an error")
+    try:
+        out, rc = client.exec_command(sudo=True, cmd="ceph fs snap-schedule remove /")
+        test_fail = 1
+        log.error("snap-schedule remove without fs-name passed but it was not expected")
+
+    except Exception as e:
+        log.info(e)
+        if exp_err_str in str(e):
+            log.info(
+                "fs-name is prompted when snap-schedule remove is tried without fs-name"
+            )
+        else:
+            # test_fail = 1
+            log.error(
+                "BZ 2224060: snap-schedule remove without fs-name failed for unexpected error"
+            )
+
+    log.info("Verify snap-schedule remove with fs-name works")
+    for i in range(1, fs_cnt):
+        snap_util.remove_snap_schedule(
+            client, snap_test_params["path"], fs_name=total_fs[i]["name"]
+        )
+
+    snap_util.sched_snap_cleanup(client, snap_path)
+    log.info(mnt_path_fs)
+    for mnt_pt in mnt_path_fs:
+        cmd = f"rm -rf {mnt_pt}/*file*"
+        client.exec_command(sudo=True, cmd=cmd, timeout=1800)
+        client.exec_command(sudo=True, cmd=f"umount {mnt_pt}")
+    post_test_params["test_status"] = test_fail
+    return post_test_params
+
+
 def snap_retention_service_restart(snap_test_params):
     client = snap_test_params["client"]
     snap_util = snap_test_params["snap_util"]
@@ -488,7 +894,7 @@ def snap_retention_service_restart(snap_test_params):
 # HELPER ROUTINES
 ####################
 def umount_all(mnt_paths, umount_params):
-    cmd = f"rm -rf {mnt_paths['kernel']}/*"
+    cmd = f"rm -rf {mnt_paths['kernel']}/*file*"
     if umount_params.get("subvol_name"):
         cmd = f"rm -rf {mnt_paths['kernel']}{umount_params['path']}/*"
     umount_params["client"].exec_command(sudo=True, cmd=cmd, timeout=1800)


### PR DESCRIPTION
Workflows included:

Type - Longevity
Workflow6 - snap_sched_snapcount_validate: Verify Snapshot schedule and retention for default snapshot count 50, non-default value say '75' and
upto 'mds_max_snaps_per_dir' i.e., 100(default), 150(non-default). Add functionality supported with [BZ 2227807](https://bugzilla.redhat.com/show_bug.cgi?id=2227807)
 Coverage for both volume and subvolume is added

Type - Systemic
Workflow8 - snap_sched_multi_fs: Create multiFS(3), Create snap-schedules across all FS except first one from the list obtained
with ceph fs ls. Create snap-schedule with and without specifying FS name and validate behaviour, without
FS name it should generate error. Remove snap-schedule with and without FS name and validate behaviour.

Jira: https://issues.redhat.com/browse/RHCEPHQE-12049

Logs:

Latest logs for Workflow6 when volume and subvolume executions are run with timegap - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0Z1FEK

Workflow6 on Volume, Workflow8 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-84IHAU
Workflow 6 on subvolume : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XAQHUP

Workflow6 on volume and subvolume cant be run back-back because, the last step in workflows either on volume or subvolume causes snapshot rotation issue for which BZ will be raised today.
Due to this impact on system any snapshot schedule test on same cephfs can't be run immediately on same system.

Looking at possibilities to alignment this testcases until BZ is addressed.

Also both workflow 6 and 8 cant be run on reef as fix to support is still not available. Added to quincy for now, when fix is in 7.0, could be in z stream release, as part of BZ validation, will enable feature for reef too.


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
