### PR TITLE
[SuiteFix] Fix tier-0-nfs-ganesha suite

### DIFF
--- a/suites/reef/nfs/tier0-nfs-ganesha.yaml
+++ b/suites/reef/nfs/tier0-nfs-ganesha.yaml
@@ -289,15 +289,16 @@ tests:
         nfs_version: 4.1
         clients: 2
 
-  - test:
-      name: Nfs access file from  with root-squash enabled
-      module: nfs_verify_file_access_with_rootsquash.py
-      desc: Test NFS file access with root-squash enabled
-      polarion-id:
-      abort-on-fail: false
-      config:
-        nfs_version: 4.1
-        clients: 4
+# ToDo: Needs to revisit the test steps. Moving it out of ci runs till test steps verified
+#  - test:
+#      name: Nfs access file from  with root-squash enabled
+#      module: nfs_verify_file_access_with_rootsquash.py
+#      desc: Test NFS file access with root-squash enabled
+#      polarion-id:
+#      abort-on-fail: false
+#      config:
+#        nfs_version: 4.1
+#        clients: 4
 
   - test:
       name: Nfs Verify setuid bit set on a file


### PR DESCRIPTION
# Description

The Nfs access file from with root-squash enabled fails with permission denied issue. The tests steps needs to revisit and commenting the same test until the fix is ready, to avoid known failures in ci

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
