### PR TITLE
Configuring multiple zones without replication

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_multisite_scenarios.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_scenarios.yaml
@@ -1,0 +1,283 @@
+# Test suite for testing multi-site deployment scenarios. configuring multiple zones without replication
+#
+# This suite deploys a single realm (India) spanning across two RHCS clusters.
+# It has a zonegroup (shared) which also spans across the clusters. There
+# exists a
+# master zone - pri
+# secondary zone - sec
+
+# The deployment is evaluated by disabling sync and running IOs across the environments.
+# This particular yaml runs the tests on the primary and verifies no objects syncs on the
+# secondary site and vice versa
+---
+
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83575222
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: get shared realm info on primary
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: get shared realm info on secondary
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+
+  # Disable multisite sync between primary and secondary zones and test replication doesn't happen
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            role: rgw
+            sudo: True
+            commands:
+              - "yum install -y jq"
+              - "radosgw-admin zonegroup get --rgw-zonegroup=shared > /tmp/zonegroup_shared_backup.json"
+              - "jq -r '.zones[].log_meta=false | .zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_shared_backup.json > /tmp/zonegroup_shared.json"
+              - "radosgw-admin zonegroup set --rgw-zonegroup=shared --infile=/tmp/zonegroup_shared.json"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "sleep 20"
+      desc: Disabling multisite sync between primary and secondary zones
+      module: exec.py
+      name: disable multisite sync between zones
+      polarion-id: CEPH-83581229
+
+  - test:
+      name: Test the byte ranges with get object on primary zone and check multisite replication doesn't happen
+      desc: Test the byte ranges with get_object on primary zone and check multisite replication doesn't happen
+      polarion-id: CEPH-83572691
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            test-version: v2
+            script-name: test_byte_range.py
+            config-file-name: ../configs/test_byte_range.yaml
+            multisite-replication-disabled: True
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 500
+
+  - test:
+      name: Test the byte ranges with get object on secondary zone and check multisite replication doesn't happen
+      desc: Test the byte ranges with get_object on secondary zone and check multisite replication doesn't happen
+      polarion-id: CEPH-83572691
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            test-version: v2
+            script-name: test_byte_range.py
+            config-file-name: ../configs/test_byte_range.yaml
+            multisite-replication-disabled: True
+            verify-io-on-site: ["ceph-pri"]
+            timeout: 500


### PR DESCRIPTION
This PR tests multisite scenario of configuring multiple zones without replication
refer this doc: https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/6/html-single/object_gateway_guide/index#configuring-multiple-zones-without-replication_rgw

polarion id: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581229

pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/multiple_zones_without_replication/cephci-run-F7NG0P/

updated pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/multiple_zones_without_replication/cephci-run-0LYWML/

sample pass log for f"io_info_{os.path.basename(config_file_name)}": http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/multiple_zones_without_replication/cephci-run-6S0N4B/

sample logs for failure scenarios if verify io fails:
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/multiple_zones_without_replication/cephci-run-2F2JGC/
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/multiple_zones_without_replication/cephci-run-UYY4P8/

test_byte_range.py testcase is added for creating users, buckets and objects. because it doesnot have sync status check, does not delete users and buckets, populates io_info file and works fine on both sites.

one issue seen with log file not being created after running test.
PR raised for this isssue: https://github.com/red-hat-storage/ceph-qe-scripts/pull/524

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
