### PR TITLE
Adding ceph-common installation

### DIFF
--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_ha_disconnect.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirror_ha_disconnect.py
@@ -293,9 +293,6 @@ def run(ceph_cluster, **kw):
                     break
             else:
                 break
-        import pdb
-
-        pdb.set_trace()
         fs_mirroring_utils.validate_snapshot_sync_status(
             cephfs_mirror_node,
             source_fs,

--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirroring_configure_cephfs_mirroring_ha_on_4_nodes.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirroring_configure_cephfs_mirroring_ha_on_4_nodes.py
@@ -78,6 +78,8 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd=f"ceph orch apply cephfs-mirror --placement='4 {ha_nodes}'",
         )
+        for node in cephfs_mirror_node:
+            node.exec_command(sudo=True, cmd="yum install -y ceph-common --nogpgcheck")
         fs_util_ceph1.validate_services(source_clients[0], "cephfs-mirror")
 
         fs_mirroring_utils.deploy_cephfs_mirroring(

--- a/tests/cephfs/cephfs_recovery/fs_scrub.py
+++ b/tests/cephfs/cephfs_recovery/fs_scrub.py
@@ -98,9 +98,14 @@ def run(ceph_cluster, **kw):
         if "PAUSED" not in status["status"]:
             log.error(f"Expected status is PAUSED but actual output {status}")
             return 1
-        if status["scrubs"][scrub_tag]["tag"] != scrub_tag:
-            log.error(f"Expected scrub tag is {scrub_tag} but actual output {status}")
-            return 1
+        if status["scrubs"].get(scrub_tag):
+            if status["scrubs"][scrub_tag]["tag"] != scrub_tag:
+                log.error(
+                    f"Expected scrub tag is {scrub_tag} but actual output {status}"
+                )
+                return 1
+        else:
+            log.info("Scrub activity has been completed successfully")
         out, rc = client1.exec_command(
             sudo=True, cmd=f"ceph tell mds.{default_fs}:0 scrub resume --format json"
         )
@@ -116,9 +121,14 @@ def run(ceph_cluster, **kw):
         )
         status = json.loads(out)
         log.info(f"Scrub Resumed : \n {status}")
-        if status["scrubs"][scrub_tag]["tag"] != scrub_tag:
-            log.error(f"Expected scrub tag is {scrub_tag} but actual output {status}")
-            return 1
+        if status["scrubs"].get(scrub_tag):
+            if status["scrubs"][scrub_tag]["tag"] != scrub_tag:
+                log.error(
+                    f"Expected scrub tag is {scrub_tag} but actual output {status}"
+                )
+                return 1
+        else:
+            log.info("Scrub activity has been completed successfully")
         out, rc = client1.exec_command(
             sudo=True, cmd=f"ceph tell mds.{default_fs}:0 scrub abort --format json"
         )
@@ -135,9 +145,14 @@ def run(ceph_cluster, **kw):
         )
         status = json.loads(out)
         log.info(f"Scrub Aborted : \n {status}")
-        if status["scrubs"][scrub_tag]["tag"] != scrub_tag:
-            log.error(f"Expected scrub tag is {scrub_tag} but actual output {status}")
-            return 1
+        if status["scrubs"].get(scrub_tag):
+            if status["scrubs"][scrub_tag]["tag"] != scrub_tag:
+                log.error(
+                    f"Expected scrub tag is {scrub_tag} but actual output {status}"
+                )
+                return 1
+        else:
+            log.info("Scrub activity has been completed successfully")
         out, rc = client1.exec_command(
             sudo=True, cmd=f"ceph tell mds.{default_fs}:0 scrub resume --format json"
         )

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -178,6 +178,19 @@ class FsUtils(object):
 
         return list(set(filtered_list))
 
+    def get_fsid(self, client):
+        """
+        Returns the FSID of the cluster
+        Args:
+            client:
+
+        Returns:
+
+        """
+        out, rc = client.exec_command(sudo=True, cmd="ceph fsid -f json")
+        output = json.loads(out)
+        return output.get("fsid", "")
+
     def enable_mds_logs(self, client, fs_name="cephfs", validate=True):
         """
 
@@ -3202,7 +3215,7 @@ os.system('sudo systemctl start  network')
         if spec_frontend_port not in status_ports:
             raise CommandFailed(f"The frontend port{port} is not matching")
 
-    def get_ceph_health_status(self, client, validate=True):
+    def get_ceph_health_status(self, client, validate=True, status=["HEALTH_OK"]):
         """
         Validate if the Ceph Health is OK or in ERROR State.
         Args:
@@ -3214,7 +3227,7 @@ os.system('sudo systemctl start  network')
         log.info(out)
         health_status = json.loads(out)["health"]["status"]
 
-        if health_status != "HEALTH_OK":
+        if health_status not in status:
             raise CommandFailed(f"Ceph Cluster is in {health_status} State")
         log.info("Ceph Cluster is Healthy")
 

--- a/tests/cephfs/clients/client_mds_restriction.py
+++ b/tests/cephfs/clients/client_mds_restriction.py
@@ -1,12 +1,79 @@
+import json
 import secrets
 import string
+import time
 import traceback
 
+from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
-from tests.cephfs.subvolume_authorize import verify_mount_failure_on_root
 from utility.log import Log
 
 log = Log(__name__)
+
+
+def verify_mount_failure_on_root(
+    fs_util,
+    client,
+    kernel_mount_dir,
+    fuse_mount_dir,
+    client_name,
+    mon_node_ip,
+    **kwargs,
+):
+    """
+    Verify kernel & fuse mount on root directory fails for client.
+    :param client:
+    :param kernel_mount_dir:
+    :param kernel_mount_dir:
+    :param fuse_mount_dir:
+    :param client_name:
+    :param mon_node_ip:
+    **kwargs:
+        extra_params : we can include extra parameters for mount options such as fs_name
+    """
+    kernel_fs_para = f",fs={kwargs.get('fs_name', 'cephfs')}"
+    fuse_fs_para = f" --client_fs {kwargs.get('fs_name', 'cephfs')}"
+    try:
+        fs_util.kernel_mount(
+            client,
+            kernel_mount_dir,
+            mon_node_ip,
+            new_client_hostname=client_name,
+            extra_params=kernel_fs_para,
+        )
+    except AssertionError as e:
+        log.info(e)
+        log.info(f"Permissions set for {client_name} is working for kernel mount")
+    except CommandFailed as e:
+        log.info(e)
+        log.info("Error is expected as the client does not have permissions")
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    else:
+        log.error(f"Permissions set for {client_name} is not working for kernel mount")
+        return 1
+    try:
+        fs_util.fuse_mount(
+            client,
+            fuse_mount_dir,
+            new_client_hostname=client_name,
+            extra_params=fuse_fs_para,
+        )
+    except AssertionError as e:
+        log.info(e)
+        log.info(f"Permissions set for {client_name} is working for fuse mount")
+    except CommandFailed as e:
+        log.info(e)
+        log.info("Error is expected as the client does not have permissions")
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    else:
+        log.error(f"Permissions set for {client_name} is not working for fuse mount")
+        return 1
 
 
 def run(ceph_cluster, **kw):
@@ -45,10 +112,39 @@ def run(ceph_cluster, **kw):
         mount_points = []
         fs1 = "cephfs"
         fs2 = "cephfs-ec"
+        for fs in [fs1, fs2]:
+            result, rc = clients[0].exec_command(
+                sudo=True, cmd=f"ceph fs status {fs} --format json-pretty"
+            )
+            result_json = json.loads(result)
+            log.info(result_json)
+
+        mds_nodes = ceph_cluster.get_ceph_objects("mds")
+        mds_names_hostname = []
+        for mds in mds_nodes:
+            mds_names_hostname.append(mds.node.hostname)
+        if len(mds_names_hostname) > 2:
+            hosts_list1 = mds_names_hostname[-2:]
+        else:
+            hosts_list1 = mds_names_hostname
+
+        mds_hosts_1 = " ".join(hosts_list1)
+        log.info(f"MDS host list 1 {mds_hosts_1}")
+        clients[0].exec_command(
+            sudo=True,
+            cmd=f"ceph orch apply mds {fs2} --placement='2 {mds_hosts_1}'",
+        )
+        time.sleep(60)
+        fs_util.wait_for_mds_process(clients[0], fs2)
         log.info(f"Creating client authorized to {fs1}")
         fs_util.fs_client_authorize(client1, fs1, "client1", "/", "rw")
         log.info(f"Creating client authorized to {fs2}")
         fs_util.fs_client_authorize(client1, fs2, "client2", "/", "rw")
+        for client in clients:
+            command = (
+                "ceph auth get client.client1 -o /etc/ceph/ceph.client.client1.keyring"
+            )
+            client.exec_command(sudo=True, cmd=command)
         kernel_mount_dir = "/mnt/kernel" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )
@@ -58,14 +154,14 @@ def run(ceph_cluster, **kw):
         mount_points.extend([kernel_mount_dir, fuse_mount_dir])
         log.info(f"Mounting {fs1} with client1")
         fs_util.kernel_mount(
-            clients,
+            [client1],
             kernel_mount_dir,
             mon_node_ip,
             new_client_hostname="client1",
             extra_params=f",fs={fs1}",
         )
         fs_util.fuse_mount(
-            clients,
+            [client1],
             fuse_mount_dir,
             new_client_hostname="client1",
             extra_params=f" --client_fs {fs1}",
@@ -73,7 +169,7 @@ def run(ceph_cluster, **kw):
         log.info(f"Verifying mount failure for client1 for {fs2}")
         rc = verify_mount_failure_on_root(
             fs_util,
-            clients,
+            [client1],
             kernel_mount_dir + "_dir1",
             fuse_mount_dir + "_dir1",
             "client1",
@@ -92,21 +188,21 @@ def run(ceph_cluster, **kw):
         mount_points.extend([kernel_mount_dir, fuse_mount_dir])
         log.info(f"Mounting {fs2} with client2")
         fs_util.kernel_mount(
-            clients,
+            [client1],
             kernel_mount_dir,
             mon_node_ip,
             new_client_hostname="client2",
             extra_params=f",fs={fs2}",
         )
         fs_util.fuse_mount(
-            clients,
+            [client1],
             fuse_mount_dir,
             new_client_hostname="client2",
             extra_params=f" --client_fs {fs2}",
         )
         rc = verify_mount_failure_on_root(
             fs_util,
-            clients,
+            [client1],
             kernel_mount_dir + "_dir2",
             fuse_mount_dir + "_dir2",
             "client2",
@@ -127,6 +223,10 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up the system")
         for client in clients:
             for mount_point in mount_points:
-                client.exec_command(sudo=True, cmd=f"umount {mount_point}")
+                client.exec_command(
+                    sudo=True, cmd=f"umount {mount_point}", check_ec=False
+                )
         for num in range(1, 4):
-            client1.exec_command(sudo=True, cmd=f"ceph auth rm client.client{num}")
+            client1.exec_command(
+                sudo=True, cmd=f"ceph auth rm client.client{num}", check_ec=False
+            )

--- a/tests/cephfs/clients/mds_journal_value_conf_verification.py
+++ b/tests/cephfs/clients/mds_journal_value_conf_verification.py
@@ -84,7 +84,7 @@ def run(ceph_cluster, **kw):
             if output[0].rstrip() != target[1]:
                 raise CommandFailed(f"Failed to set {client_conf} to {value}")
 
-        fs_util.get_ceph_health_status(client1)
+        fs_util.get_ceph_health_status(client1, status=["HEALTH_WARN", "HEALTH_OK"])
         log.info("Successfully set all the client config values")
         return 0
     except Exception as e:

--- a/tests/cephfs/clients/mds_scrub_after_failover.py
+++ b/tests/cephfs/clients/mds_scrub_after_failover.py
@@ -51,6 +51,7 @@ def run(ceph_cluster, **kw):
             fs_name = fs["name"]
             # delete the file systems
             retry_remove_volume(client1, fs_name)
+            time.sleep(60)
         mds_nodes = ceph_cluster.get_ceph_objects("mds")
         print(len(mds_nodes))
         mds_names = []


### PR DESCRIPTION
# Description
Adding ceph-common installation
This PR has fixes for below failures



Mirror HA
Failed log : http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-170/Weekly/cephfs/16/tier-2_cephfs_mirror_ha/
Passed log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LIW6Z9 


Client suite :
Failed log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-170/Regression/cephfs/24/tier-2_cephfs_test-clients/
Passed log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PC10PM/

Added logs for adding mds logs from ceph cluster to magna002
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C5M54M 
```
amk@magna002:/ceph/cephci-jenkins/cephci-run-C5M54M$ ls -lrt
total 80860
-rw-rw-r-- 1 amk amk     1966 Dec 18 10:36 startup.log
-rw-rw-r-- 1 amk amk        0 Dec 18 10:36 setup_install_pre-requisistes_0.err
-rw-rw-r-- 1 amk amk      987 Dec 18 10:36 setup_install_pre-requisistes_0.log
-rw-rw-r-- 1 amk amk        0 Dec 18 10:36 cluster_deployment_0.err
-rw-rw-r-- 1 amk amk      973 Dec 18 10:36 cluster_deployment_0.log
-rw-rw-r-- 1 amk amk        0 Dec 18 10:36 configure_client_0.err
-rw-rw-r-- 1 amk amk      956 Dec 18 10:36 configure_client_0.log
-rw-rw-r-- 1 amk amk      313 Dec 18 10:36 cephfs_Scale_test_for_max_Snapshots_under_single_subvolume_0.err
-rw-rw-r-- 1 amk amk 37410434 Dec 18 10:38 ceph-mds.cephfs.ceph-mirror-amk-pwsavd-node4.xxssaw.log
-rw-rw-r-- 1 amk amk  2211302 Dec 18 10:38 ceph-mds.cephfs.ceph-mirror-amk-pwsavd-node6.xlqsfz.log
-rw-rw-r-- 1 amk amk 43095237 Dec 18 10:38 ceph-mds.cephfs.ceph-mirror-amk-pwsavd-node5.hjouso.log
-rw-rw-r-- 1 amk amk    67192 Dec 18 10:38 cephfs_Scale_test_for_max_Snapshots_under_single_subvolume_0.log
-rw-rw-r-- 1 amk amk     2266 Dec 18 10:38 xunit.xml
-rw-rw-r-- 1 amk amk        2 Dec 18 10:38 run_summary.json
-rw-rw-r-- 1 amk amk     6278 Dec 18 10:38 index.html
```


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
