### PR TITLE
Adding test to perform cluster operations with snapshot mirroring

### DIFF
--- a/ceph/rbd/workflows/snap_scheduling.py
+++ b/ceph/rbd/workflows/snap_scheduling.py
@@ -1,6 +1,9 @@
 import json
 import time
+from copy import deepcopy
 
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.krbd_io_handler import krbd_io_handler
 from utility.log import Log
 
 log = Log(__name__)
@@ -90,3 +93,54 @@ def verify_snapshot_schedule(rbd, pool, image, interval="1m"):
             f"Snapshot verification failed for image {pool}/{image} with error {e}"
         )
         return 1
+
+
+def run_io_verify_snap_schedule(**kw):
+    """
+    Run IOs on the given image and verify snapshot schedule
+    """
+    pool_type = kw.get("pool_type")
+    rbd = kw.get("rbd")
+    client = kw.get("client")
+    config = deepcopy(kw.get("config").get(pool_type))
+    for pool, pool_config in getdict(config).items():
+        multi_image_config = getdict(pool_config)
+        multi_image_config.pop("test_config", {})
+        for image, image_config in multi_image_config.items():
+            image_spec = f"{pool}/{image}"
+
+            io_size = image_config.get(
+                "io_size", int(int(image_config["size"][:-1]) / 3)
+            )
+            io_config = {
+                "rbd_obj": rbd,
+                "client": client,
+                "size": image_config["size"],
+                "do_not_create_image": True,
+                "config": {
+                    "file_size": io_size,
+                    "file_path": [f"{kw['mount_path']}"],
+                    "get_time_taken": True,
+                    "image_spec": [image_spec],
+                    "operations": {
+                        "fs": "ext4",
+                        "io": True,
+                        "mount": True,
+                        "nounmap": False,
+                        "device_map": True,
+                    },
+                    "skip_mkfs": kw["skip_mkfs"],
+                },
+            }
+            krbd_io_handler(**io_config)
+            kw["io_config"] = io_config
+            for interval in image_config.get("snap_schedule_intervals"):
+                out = verify_snapshot_schedule(rbd, pool, image, interval)
+                if out:
+                    log.error(f"Snapshot verification failed for image {pool}/{image}")
+                    if kw.get("raise_exception"):
+                        raise Exception(
+                            f"Snapshot verification failed for image {pool}/{image}"
+                        )
+                    return 1
+    return 0

--- a/suites/pacific/rbd/tier-3_cluster_operations_with_snap_mirroring.yaml
+++ b/suites/pacific/rbd/tier-3_cluster_operations_with_snap_mirroring.yaml
@@ -1,0 +1,221 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_cluster_operations_with_snap_mirroring.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+                - fio
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                    - fio
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with cluster operations
+      name: Test cluster operations on snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_cluster_op.py
+      polarion-id: CEPH-83574896
+      clusters:
+        ceph-rbd1:
+          config:
+            rep-pool-only: true
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+        ceph-rbd2:
+          config:
+            rep-pool-only: true
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M

--- a/suites/quincy/rbd/tier-3_cluster_operations_with_snap_mirroring.yaml
+++ b/suites/quincy/rbd/tier-3_cluster_operations_with_snap_mirroring.yaml
@@ -1,0 +1,221 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_cluster_operations_with_snap_mirroring.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+                - fio
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                    - fio
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with cluster operations
+      name: Test cluster operations on snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_cluster_op.py
+      polarion-id: CEPH-83574896
+      clusters:
+        ceph-rbd1:
+          config:
+            rep-pool-only: true
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+        ceph-rbd2:
+          config:
+            rep-pool-only: true
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M

--- a/suites/reef/rbd/tier-3_cluster_operations_with_snap_mirroring.yaml
+++ b/suites/reef/rbd/tier-3_cluster_operations_with_snap_mirroring.yaml
@@ -1,0 +1,221 @@
+#===============================================================================================
+# Tier-level: 3
+# Test-Suite: tier-3_cluster_operations_with_snap_mirroring.yaml
+#
+# Cluster Configuration:
+#    cephci/conf/reef/rbd/5-node-2-clusters.yaml
+#    No of Clusters : 2
+#    Node 2 must to be a client node
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+      desc: RBD Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+  - test:
+        abort-on-fail: true
+        clusters:
+          ceph-rbd1:
+            config:
+              command: add
+              id: client.1
+              node: node2
+              install_packages:
+                - ceph-common
+                - fio
+              copy_admin_keyring: true
+          ceph-rbd2:
+            config:
+                command: add
+                id: client.1
+                node: node2
+                install_packages:
+                    - ceph-common
+                    - fio
+                copy_admin_keyring: true
+        desc: Configure the client system 1
+        destroy-cluster: false
+        module: test_client.py
+        name: configure client
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+        ceph-rbd2:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set mon mon_allow_pool_delete true"
+      desc: Enable mon_allow_pool_delete to True for deleting the pools
+      module: exec.py
+      name: configure mon_allow_pool_delete to True
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+        ceph-rbd2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      label: rbd-mirror
+      desc: RBD Mirror daemon deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy rbd-mirror daemon
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with cluster operations
+      name: Test cluster operations on snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_cluster_op.py
+      polarion-id: CEPH-83574896
+      clusters:
+        ceph-rbd1:
+          config:
+            rep-pool-only: true
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+        ceph-rbd2:
+          config:
+            rep-pool-only: true
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M

--- a/tests/rbd_mirror/test_rbd_snap_mirroring_with_cluster_op.py
+++ b/tests/rbd_mirror/test_rbd_snap_mirroring_with_cluster_op.py
@@ -1,0 +1,317 @@
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.parallel import parallel
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.monitor_workflows import MonitorWorkflows
+from ceph.rbd.initial_config import initial_mirror_config, random_string
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.cluster_operations import (
+    check_health,
+    operation,
+    restart_ceph_target,
+    restart_osd,
+)
+from ceph.rbd.workflows.rbd_mirror import toggle_rbd_mirror_daemon_status_and_verify
+from ceph.rbd.workflows.snap_scheduling import run_io_verify_snap_schedule
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_snap_mirror_cluster_ops(
+    rbd_obj, sec_obj, client_node, sec_client, pool_type, **kw
+):
+    """
+    Test the immutable object cache with cluster operations.
+
+    Args:
+        rbd_obj: RBD object
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    config = kw.get("config")
+    ceph_cluster = kw.get("ceph_cluster")
+    admin_node = ceph_cluster.get_nodes(role="_admin")[0]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonitorWorkflows(node=cephadm)
+
+    try:
+        log.info("Running cluster operations while testing snap mirroring")
+
+        mount_path = f"/tmp/mnt_{random_string(len=5)}"
+
+        with parallel() as p:
+            log.info(
+                "Test to restart rbd mirror daemon on primary along with snap mirroring"
+            )
+            p.spawn(
+                toggle_rbd_mirror_daemon_status_and_verify,
+                client=client_node,
+                rbd=rbd_obj,
+                is_secondary=False,
+                pool_type=pool_type,
+                raise_exception=True,
+                **kw,
+            )
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=False,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_00",
+                **kw,
+            )
+
+        with parallel() as p:
+            log.info(
+                "Test to restart rbd mirror daemon on secondary along with snap mirroring"
+            )
+            p.spawn(
+                toggle_rbd_mirror_daemon_status_and_verify,
+                client=sec_client,
+                rbd=sec_obj,
+                is_secondary=True,
+                pool_type=pool_type,
+                raise_exception=True,
+                **kw,
+            )
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=False,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_01",
+                **kw,
+            )
+
+        with parallel() as p:
+            log.info("Test to restart mon service along with snap mirroring")
+            p.spawn(
+                operation,
+                rados_obj,
+                "restart_daemon_services",
+                daemon="mon",
+            )
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=False,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_1",
+                **kw,
+            )
+
+        with parallel() as p:
+            log.info("Test to restart osd service along with snap mirroring")
+            p.spawn(restart_osd, client_node=client_node)
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=True,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_2",
+                **kw,
+            )
+
+        with parallel() as p:
+            log.info("Test to restart ceph target service along with snap mirroring")
+            p.spawn(restart_ceph_target, admin_node=admin_node)
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=True,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_3",
+                **kw,
+            )
+
+        mon_host = ceph_cluster.get_nodes(role="mon")[0]
+        with parallel() as p:
+            log.info("Test to remove mon service along with snap mirroring")
+            cmd = f"ceph orch host label rm {mon_host.hostname} mon"
+            out, err = client_node.exec_command(cmd=cmd, sudo=True)
+
+            if err:
+                raise Exception(f"ceph mon remove command failed as {err}")
+
+            p.spawn(
+                operation,
+                mon_obj,
+                "remove_mon_service",
+                host=mon_host.hostname,
+            )
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=True,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_4",
+                **kw,
+            )
+
+        with parallel() as p:
+            log.info(
+                "Test to add the mon service back to the cluster with snap mirroring"
+            )
+            cmd = f"ceph orch host label add {mon_host.hostname} mon"
+            out, err = client_node.exec_command(cmd=cmd, sudo=True)
+
+            if err:
+                raise Exception(f"ceph mon add command failed as {err}")
+
+            time.sleep(10)
+            p.spawn(
+                operation,
+                mon_obj,
+                "check_mon_exists_on_host",
+                host=mon_host.hostname,
+            )
+            p.spawn(
+                run_io_verify_snap_schedule,
+                pool_type=pool_type,
+                rbd=rbd_obj,
+                client=client_node,
+                skip_mkfs=True,
+                raise_exception=True,
+                mount_path=f"{mount_path}/file_5",
+                **kw,
+            )
+
+        check_health(client_node)
+    except Exception as err:
+        log.error(err)
+        return 1
+
+    return 0
+
+
+def run(**kw):
+    """CEPH-83574895 - Configure two-way rbd-mirror on Stand alone
+    CEPH cluster on image (with replicated and ec pools)with snapshot
+    based mirroring and perform cluster operations
+    Pre-requisites :
+    We need atleast one client node with ceph-common, fio and rbd-nbd packages,
+    conf and keyring files in both clusters with snapshot based RBD mirroring
+    enabled between the clusters.
+    kw:
+        clusters:
+            ceph-rbd1:
+            config:
+                rep_pool_config:
+                num_pools: 1
+                num_images: 5
+                size: 10G
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals: #one value for each level specified above
+                    - 5m
+                io_percentage: 30 #percentage of space in each image to be filled
+                ec_pool_config:
+                num_pools: 1
+                num_images: 5
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals:
+                    - 5m
+                io_size: 200M
+            ceph-rbd2:
+            config:
+                rep_pool_config:
+                num_pools: 1
+                num_images: 5
+                size: 10G
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals: #one value for each level specified above
+                    - 5m
+                io_percentage: 30 #percentage of space in each image to be filled
+                ec_pool_config:
+                num_pools: 1
+                num_images: 5
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals:
+                    - 5m
+                io_size: 200M
+    Test Case Flow
+    1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
+    2. Create pools and images as specified, enable snapshot based mirroring for all these images
+    3. Schedule snapshots for each of these images and run IOs on each of the images
+    4. Perform cluster operations on both the clusters
+    5. Make sure that snapshot mirroring is not affected by any of the cluster operations
+    """
+    pool_types = ["rep_pool_config", "ec_pool_config"]
+    log.info("Running cluster operations on snapshot based mirroring clusters")
+
+    try:
+        kw.get("config", {})["do_not_run_io"] = True
+        mirror_obj = initial_mirror_config(**kw)
+        mirror_obj.pop("output", [])
+
+        for val in mirror_obj.values():
+            if not val.get("is_secondary", False):
+                rbd = val.get("rbd")
+                client = val.get("client")
+            else:
+                sec_rbd = val.get("rbd")
+                sec_client = val.get("client")
+        log.info("Initial configuration complete")
+
+        pool_types = list(mirror_obj.values())[0].get("pool_types")
+        for pool_type in pool_types:
+            # rc = toggle_rbd_mirror_daemon_status_and_verify(
+            #     client=client,
+            #     rbd=rbd,
+            #     is_secondary=False,
+            #     pool_type=pool_type,
+            #     **kw,
+            # )
+
+            # rc = toggle_rbd_mirror_daemon_status_and_verify(
+            #     client=sec_client,
+            #     rbd=sec_rbd,
+            #     is_secondary=True,
+            #     pool_type=pool_type,
+            #     **kw,
+            # )
+
+            rc = test_snap_mirror_cluster_ops(
+                rbd, sec_rbd, client, sec_client, pool_type, **kw
+            )
+            if rc:
+                log.error(
+                    "Cluster operations on snapshot based mirroring clusters failed"
+                )
+                return 1
+    except Exception as e:
+        log.error(
+            f"Testing cluster operations on snap mirroring clusters failed with error {str(e)}"
+        )
+        return 1
+    finally:
+        cleanup(pool_types=pool_types, multi_cluster_obj=mirror_obj, **kw)
+    return 0


### PR DESCRIPTION
Automation of test case - CEPH-83574895 - Configure two-way rbd-mirror on Stand alone CEPH cluster on image (with replicated and ec pools)with snapshot based mirroring and perform cluster operations
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83574896  

Test Steps:
1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
2. Create pools and images as specified, enable snapshot based mirroring for all these images
3. Schedule snapshots for each of these images and run IOs on each of the images
4. Perform cluster operations on both the clusters
5. Make sure that snapshot mirroring is not affected by any of the cluster operations

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6W8V7I/
