### PR TITLE
Remove client label from gateway node

### DIFF
--- a/conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
@@ -33,7 +33,6 @@ globals:
         disk-size: 20
       node6:
         role:
-          - client
           - nvmeof-gw
       node7:
         id: node10


### PR DESCRIPTION
Fix issues in sanity test suites.
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/Live/reef/18.2.0-128/tier-0_nvmeof_sanity/

Test results:

```

/home/sunilkumar/workspace/venv/bin/python3 run.py --log-level debug --osp-cred /home/sunilkumar/osp.yaml --instances-name 3sunilkumar --rhbuild 7.0 --build released --platform rhel-9 --global-conf conf/reef/nvmeof/ceph_nvmeof_sanity.yaml --suite suites/reef/nvmeof/tier-0_nvmeof_sanity.yaml --inventory conf/inventory/rhel-9.3-server-x86_64-large.yaml --custom-config nvmeof_cli_image=registry.redhat.io/rhceph/ceph-nvmeof-cli-rhel9:latest --store

All test logs located here: /tmp/cephci-run-R87KVD

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:05:42.360031                   Pass                             
deploy cluster                   RHCS cluster deployment using cephadm                          0:12:06.657307                   Pass                             
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:01:16.499509                   Pass                             
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:02:25.819973                   Pass                             
Manage nvmeof gateway entities   Manage NVMeoF Subsystem entities                               0:00:49.877916                   Failed                           
Delete nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:25.669328                   Pass                             
Delete nvmeof gateway pre-reqs   NVMeoF Gateway deployment using cephadm                        0:00:25.359702                   Pass                             
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway on dedicated node and Run IOs on tar   0:16:07.147518                   Pass                             
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway collocated and Run IOs on targets      0:17:08.431574                   Pass   ```