### PR TITLE
Add -ve test workflow for snap schedule suite

### DIFF
--- a/suites/reef/cephfs/tier-4_cephfs_recovery.yaml
+++ b/suites/reef/cephfs/tier-4_cephfs_recovery.yaml
@@ -200,13 +200,13 @@ tests:
       polarion-id: CEPH-11267
       name: "Cephfs Scrubing"
   - test:
-      name: snap_retention_service_restart
+      name: snap_sched_retention_negative_test
       module: snapshot_clone.snap_schedule_retention_vol_subvol.py
       polarion-id: CEPH-83575627
-      desc: Verify Snapshot retention works even after service restarts
+      desc: Verify Snapshot schedule and retention works with service restart and non-existent path
       abort-on-fail: false
       config:
-        test_name : snap_retention_service_restart
+        test_name : negative
   - test:
       name: Move data and meta_data pool to different root level bucket in OSD tree.
       module: cephfs_generic.test_data_migrate_bw_buckets.py


### PR DESCRIPTION
# Description
Test Description:
Workflow7 - snap_sched_non_existing_path: Verify Snapshot schedule can be created for non-existing path.
    After the start-time is hit for the
    schedule, the snap-schedule module should have deactivated the schedule without throwing a traceback error.
    The snap-scheule module should continue to remain responsive and a log message should be seen in the logs
    about deactivating the schedule

Jira: https://issues.redhat.com/browse/RHCEPHQE-12381?filter=-1

Logs: 
logs with fix to comment: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-R01JHM

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EHGBOM
Test suite : suites/reef/cephfs/tier-4_cephfs_recovery.yaml
Added as below,
  - test:
      name: snap_sched_retention_negative_test
      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
      polarion-id: CEPH-83575627
      desc: Verify Snapshot schedule and retention works with service restart and non-existent path
      abort-on-fail: false
      config:
        test_name : negative


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
