### PR TITLE
Adding test for snap and clone operations with snapshot mirroring

### DIFF
--- a/ceph/rbd/initial_config.py
+++ b/ceph/rbd/initial_config.py
@@ -184,6 +184,9 @@ def update_config(**kw):
                             {"mirrormode": rep_pool_config["mirrormode"]}
                         )
 
+                    if rep_pool_config.get("way"):
+                        rep_pool_config[pool].update({"way": rep_pool_config["way"]})
+
     if not kw.get("config").get("rep-pool-only"):
         pool_types.append("ec_pool_config")
         if not config.get("ec_pool_config"):
@@ -302,6 +305,8 @@ def update_config(**kw):
                         ec_pool_config[pool].update(
                             {"ec_profile": ec_pool_config["ec_profile"]}
                         )
+                    if ec_pool_config.get("way"):
+                        ec_pool_config[pool].update({"way": ec_pool_config["way"]})
     return pool_types
 
 
@@ -494,6 +499,7 @@ def initial_mirror_config(**kw):
                     ec_pgp_num:
                     mode: <pool/image>
                     mirrormode: <journal/snapshot>
+                    way: "one-way"
                 ec_pool_config:
                     ec-pool-k-m: 2,1
                     num_pools:
@@ -512,6 +518,7 @@ def initial_mirror_config(**kw):
                     ec_pgp_num:
                     mode: <pool/image>
                     mirrormode: <journal/snapshot>
+                    way: "one-way"
         Advanced configuration <specifying only detailed pool and image configuration>:
             config:
                 do_not_create_image: True  # if not set then images will be created by default

--- a/ceph/rbd/utils.py
+++ b/ceph/rbd/utils.py
@@ -63,7 +63,8 @@ def get_md5sum_rbd_image(**kw):
             "source-image-or-snap-spec": kw.get("image_spec"),
             "path-name": kw.get("file_path"),
         }
-        if kw.get("rbd").export(**export_spec):
+        out, err = kw.get("rbd").export(**export_spec)
+        if "100% complete...done" not in out + err:
             log.error(f"Export failed for image {kw.get('image_spec')}")
             return None
     return exec_cmd(
@@ -104,6 +105,45 @@ def check_data_integrity(**kw):
         log.error("md5sum values don't match")
         return 1
     return 0
+
+
+# def check_data_integrity_for_multiple_images(**kw):
+#     """
+#     Check data integrity for multiple images in multiple pools
+#     kw: {
+#         "pool_type":<>,
+#         "rbd":<>,
+#         "sec_obj":<>,
+#         "client":<>,
+#         "sec_client":<>,
+#         <multipool and multiimage config>
+#     }
+#     """
+#     pdb.set_trace()
+#     pool_type = kw.get("pool_type")
+#     rbd = kw.get("rbd")
+#     sec_rbd = kw.get("sec_obj")
+#     client = kw.get("client")
+#     sec_client = kw.get("sec_client")
+#     config = deepcopy(kw.get("config").get(pool_type))
+#     for pool, pool_config in getdict(config).items():
+#         multi_image_config = getdict(pool_config)
+#         multi_image_config.pop("test_config", {})
+#         for image in multi_image_config.keys():
+#             image_spec = f"{pool}/{image}"
+#             data_integrity_spec = {
+#                 "first": {"image_spec": image_spec, "rbd": rbd, "client": client},
+#                 "second": {
+#                     "image_spec": image_spec,
+#                     "rbd": sec_rbd,
+#                     "client": sec_client,
+#                 },
+#             }
+#             rc = check_data_integrity(**data_integrity_spec)
+#             if rc:
+#                 log.error(f"Data integrity check failed for {image_spec}")
+#                 return 1
+#     return 0
 
 
 def exec_cmd(node, cmd, **kw):

--- a/ceph/rbd/workflows/snap_clone_operations.py
+++ b/ceph/rbd/workflows/snap_clone_operations.py
@@ -1,0 +1,460 @@
+import json
+
+from ceph.rbd.utils import get_md5sum_rbd_image, random_string
+from ceph.rbd.workflows.snap_scheduling import (
+    run_io_verify_snap_schedule_single_image,
+    verify_snapshot_schedule,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def snap_list(**kw):
+    """
+    List all snapshots for an image
+    kw: {
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    out, err = rbd.snap.ls(pool=pool, image=image, all=True, format="json")
+    if err:
+        log.error(f"Snapshot listing failed for image {pool}/{image}")
+        return False
+    snaps = json.loads(out)
+    return snaps
+
+
+def snap_exists(**kw):
+    """
+    List snapshots for an image and verify if given
+    snapshot is present
+    kw: {
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "snap_name": <>,
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    snap_name = kw.get("snap_name")
+    snaps = snap_list(rbd=rbd, pool=pool, image=image)
+    if not snaps:
+        log.error(f"Error while listing snapshots for image {pool}/{image}")
+        return False
+    snap_exists = [snap for snap in snaps if snap["name"] == snap_name]
+    if not snap_exists:
+        log.error(f"Snapshot {snap_name} not present for image {pool}/{image}")
+        return False
+    return True
+
+
+def get_user_defined_snaps(**kw):
+    """
+    Fetch all user defined snapshots for an image
+    kw: {
+        "rbd": <>,
+        "pool": <>,
+        "image": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    snaps = snap_list(rbd=rbd, pool=pool, image=image)
+    if not snaps:
+        log.error(f"Error while listing snapshots for image {pool}/{image}")
+        return None
+    user_defined_snaps = [
+        snap for snap in snaps if snap.get("namespace", {}).get("type") == "user"
+    ]
+    if not user_defined_snaps:
+        log.error(f"User defined snapshots are not present for image {pool}/{image}")
+        return None
+    return user_defined_snaps
+
+
+def snap_create_list_and_verify(**kw):
+    """
+    Create snapshots for all the images and verify
+    kw: {
+        "rbd":<>,
+        "sec_obj":<>,
+        "is_secondary":<True/False>,
+        "pool": <>,
+        "image": <>,
+        <multipool and multiimage config>
+    }
+    """
+    rbd = kw.get("rbd")
+    sec_rbd = kw.get("sec_obj")
+    is_secondary = kw.get("is_secondary")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    image_config = kw.get("image_config")
+    snap_name = f"snap_{random_string(len=5)}"
+    out, err = rbd.snap.create(pool=pool, image=image, snap=snap_name)
+    if (
+        is_secondary
+        and "failed to create snapshot: (30) Read-only file system" in out + err
+    ):
+        log.info(
+            f"Snapshot creation failed as expected in secondary cluster for {pool}/{image}"
+        )
+    elif not is_secondary and "100% complete...done" in out + err:
+        log.info(f"Snapshot creation successful in primary cluster for {pool}/{image}")
+        if not snap_exists(rbd=rbd, pool=pool, image=image, snap_name=snap_name):
+            log.error(
+                f"Snapshot {snap_name} does not exist in snap ls for {pool}/{image} for primary cluster"
+            )
+            return 1
+        for interval in image_config.get("snap_schedule_intervals"):
+            out = verify_snapshot_schedule(rbd, pool, image, interval)
+            if out:
+                log.error(f"Snapshot verification failed for image {pool}/{image}")
+                return 1
+        if sec_rbd and not snap_exists(
+            rbd=sec_rbd, pool=pool, image=image, snap_name=snap_name
+        ):
+            log.error(
+                f"Snapshot {snap_name} does not exist in snap ls for {pool}/{image} for secondary cluster"
+            )
+            return 1
+    else:
+        log.error(f"Snapshot creation did not behave as expected for {pool}/{image}")
+        return 1
+    return 0
+
+
+def clone_ops(**kw):
+    """
+    Protect snapshots, create clones, unprotect snapshots, flatten clones and verify
+    kw:{
+        "pool": <>,
+        "image": <>,
+        "rbd": <>,
+        "is_secondary": <True/False>,
+        "pri_rbd": <>,
+        "image_config": <>,
+        <multipool and multiimage config>,
+        "operations": {
+            "protect_snap": <True/False>,
+            "create_clone": <True/False>,
+            "num_clones_per_snap": <>,
+            "unprotect_snap": <True/False>,
+            "flatten_clone": <True/False>
+        }
+    }
+    """
+    rbd = kw.get("rbd")
+    is_secondary = kw.get("is_secondary")
+    pri_rbd = kw.get("pri_rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    image_config = kw.get("image_config")
+    user_defined_snaps = get_user_defined_snaps(rbd=rbd, pool=pool, image=image)
+    operations = kw.get("operations")
+    num_clones_per_snap = operations.pop("num_clones_per_snap", 1)
+    if operations.get("protect_snap"):
+        log.info(
+            f"Performing snapshot protect for all user snapshots in {pool}/{image}"
+        )
+        for snap in user_defined_snaps:
+            _, err = rbd.snap.protect(pool=pool, image=image, snap=snap["name"])
+            if err:
+                if is_secondary and "Read-only file system" in err:
+                    log.info(
+                        f"Snapshot protection failed as expected for {pool}/{image} with error {err}"
+                    )
+                    if pri_rbd and snap["protected"] == "false":
+                        _, err = pri_rbd.snap.protect(
+                            pool=pool, image=image, snap=snap["name"]
+                        )
+                        if err:
+                            log.error(
+                                f"Error while protecting snap {snap['name']} at primary"
+                            )
+                        for interval in image_config.get("snap_schedule_intervals"):
+                            out = verify_snapshot_schedule(
+                                pri_rbd, pool, image, interval
+                            )
+                            if out:
+                                log.error(
+                                    f"Snapshot verification failed for image {pool}/{image}"
+                                )
+                elif not is_secondary:
+                    log.error(
+                        f"Snapshot protection failed for {pool}/{image}@{snap['name']} with error {err}"
+                    )
+                    return 1
+            elif is_secondary and not err:
+                log.error(f"Snapshot protect did not fail for {pool}/{image}")
+                return 1
+
+    if operations.get("create_clone"):
+        log.info(
+            f"Creating {num_clones_per_snap} number of clones per snapshot for each user\
+                    defined snapshot for {pool}/{image}"
+        )
+        for snap in user_defined_snaps:
+            clone_spec = {
+                "source-snap-spec": f"{pool}/{image}@{snap['name']}",
+                "dest-image-spec": f"{pool}/clone_{random_string(len=5)}",
+            }
+            _, err = rbd.clone(**clone_spec)
+            if err:
+                log.error(
+                    f"Clone creation failed for {pool}/{image}@{snap['name']} with error {err}"
+                )
+                return 1
+
+    if operations.get("flatten_clone"):
+        log.info(
+            f"Performing flatten operations for all clones of all user snapshots in {pool}/{image}"
+        )
+        for snap in user_defined_snaps:
+            out, err = rbd.children(
+                pool=pool, image=image, snap=snap["name"], format="json"
+            )
+            if err:
+                log.error(
+                    f"Fetching children failed for snap {pool}/{image}@{snap['name']} with error {err}"
+                )
+                return 1
+            clones = json.loads(out)
+            for clone in clones:
+                _, err = rbd.flatten(pool=clone["pool"], image=clone["image"])
+                if "100% complete...done" not in out + err:
+                    log.error(
+                        f"Flatten clone failed for {clone['pool']}/{clone['image']} with error {err}"
+                    )
+                    return 1
+
+    if operations.get("unprotect_snap"):
+        log.info(
+            f"Performing snapshot unprotect for all user snapshots in {pool}/{image}"
+        )
+        for snap in user_defined_snaps:
+            _, err = rbd.snap.unprotect(pool=pool, image=image, snap=snap["name"])
+            if err:
+                if is_secondary and "Read-only file system" in err:
+                    log.info(
+                        f"Snapshot unprotect failed as expected for {pool}/{image} with error {err}"
+                    )
+                elif not is_secondary:
+                    log.error(
+                        f"Snapshot unprotect failed for {pool}/{image}@{snap['name']} with error {err}"
+                    )
+                    return 1
+            elif is_secondary and not err:
+                log.error(f"Snapshot unprotect did not fail for {pool}/{image}")
+                return 1
+    return 0
+
+
+def test_snap_rollback(**kw):
+    """
+    Test snapshot rollback functionality for the user defined snapshot for an image
+    kw:{
+        "pool": <>,
+        "image": <>,
+        "image_config": <>,
+        "rbd": <>,
+        "client": <>,
+        "is_secondary": <True/False>,
+        "mount_path": <>,
+        <multipool and multiimage config>
+    }
+    """
+    rbd = kw.get("rbd")
+    is_secondary = kw.get("is_secondary")
+    client = kw.get("client")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    image_config = kw.get("image_config")
+    user_defined_snap = get_user_defined_snaps(rbd=rbd, pool=pool, image=image)[0]
+    if is_secondary:
+        _, err = rbd.snap.rollback(
+            pool=pool, image=image, snap=user_defined_snap["name"]
+        )
+        if err and "Read-only file system" in err:
+            log.info(
+                f"Snap rollback failed as expected for {pool}/{image}@{user_defined_snap['name']} with error {err}"
+            )
+        else:
+            log.error(
+                f"Snap rollback did not fail as expected for {pool}/{image}@{user_defined_snap['name']}"
+            )
+            return 1
+    else:
+        md5_sum_before_io = get_md5sum_rbd_image(
+            image_spec=f"{pool}/{image}",
+            rbd=rbd,
+            client=client,
+            file_path=f"/tmp/{random_string(len=3)}",
+        )
+        log.info(f"md5sum before IO: {md5_sum_before_io}")
+        rc = run_io_verify_snap_schedule_single_image(
+            rbd=rbd,
+            client=client,
+            pool=pool,
+            image=image,
+            image_config=image_config,
+            mount_path=kw.get("mount_path"),
+            skip_mkfs=True,
+        )
+        if rc:
+            log.error(
+                f"Run IO and verify snap schedule failed for image {pool}/{image}"
+            )
+            return 1
+
+        md5_sum_before_rollback = get_md5sum_rbd_image(
+            image_spec=f"{pool}/{image}",
+            rbd=rbd,
+            client=client,
+            file_path=f"/tmp/{random_string(len=3)}",
+        )
+        log.info(f"md5sum before rollback: {md5_sum_before_rollback}")
+
+        out, err = rbd.snap.rollback(
+            pool=pool, image=image, snap=user_defined_snap["name"]
+        )
+        if err and "100% complete" not in out + err:
+            log.error(
+                f"Snapshot rollback failed for {pool}/{image}@{user_defined_snap['name']} with error {out+err}"
+            )
+            return 1
+        md5_sum_after_rollback = get_md5sum_rbd_image(
+            image_spec=f"{pool}/{image}",
+            rbd=rbd,
+            client=client,
+            file_path=f"/tmp/{random_string(len=3)}",
+        )
+        log.info(f"md5sum after rollback: {md5_sum_after_rollback}")
+
+        if (
+            not md5_sum_before_io == md5_sum_after_rollback
+            and md5_sum_before_rollback != md5_sum_after_rollback
+        ):
+            log.error(
+                f"Rollback operation did not happen as expected for image {pool}/{image}"
+            )
+            return 1
+    return 0
+
+
+def remove_snap_and_verify(**kw):
+    """
+    Remove a user defined snapshot for the given images and verify
+    kw:{
+        "pool": <>,
+        "image": <>,
+        "rbd": <>,
+        "is_secondary": <True/False>,
+        <multipool and multiimage config>
+    }
+    """
+    rbd = kw.get("rbd")
+    is_secondary = kw.get("is_secondary")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    user_defined_snap = get_user_defined_snaps(rbd=rbd, pool=pool, image=image)[0]
+    if not is_secondary and user_defined_snap["protected"] == "true":
+        _, err = rbd.snap.unprotect(
+            pool=pool, image=image, snap=user_defined_snap["name"]
+        )
+        if err:
+            log.error(
+                f"Error while unprotecting snapshot {user_defined_snap['name']}: {err}"
+            )
+            return 1
+    out, err = rbd.snap.rm(pool=pool, image=image, snap=user_defined_snap["name"])
+    if is_secondary:
+        if err and "Read-only file system" in err:
+            log.info(
+                f"Snap remove failed as expected for {pool}/{image}@{user_defined_snap['name']} with error {err}"
+            )
+        else:
+            log.error(
+                f"Snap remove did not fail as expected for {pool}/{image}@{user_defined_snap['name']}"
+            )
+            return 1
+    else:
+        if err and "100% complete...done" not in out + err:
+            log.error(
+                f"Snapshot remove failed for {pool}/{image}@{user_defined_snap['name']} with error {err}"
+            )
+            return 1
+    if not is_secondary:
+        if snap_exists(
+            rbd=rbd, pool=pool, image=image, snap_name=user_defined_snap["name"]
+        ):
+            log.error(
+                f"Snapshot {pool}/{image}@{user_defined_snap['name']} exists even after removal"
+            )
+            return 1
+    return 0
+
+
+def purge_snap_and_verify(**kw):
+    """
+    Purge all snapshots for the given images and verify
+    kw: {
+        "pool": <>,
+        "image": <>,
+        "rbd": <>,
+        "is_secondary": <True/False>,
+        <multipool and multiimage config>
+    }
+    """
+    rbd = kw.get("rbd")
+    is_secondary = kw.get("is_secondary")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    if is_secondary:
+        _, err = rbd.snap.purge(pool=pool, image=image)
+        if err and "Read-only file system" in err:
+            log.info(
+                f"Snap purge failed as expected for {pool}/{image} with error {err}"
+            )
+        else:
+            log.error(f"Snap purge did not fail as expected for {pool}/{image}")
+            return 1
+    else:
+        snaps = snap_list(rbd=rbd, pool=pool, image=image)
+        for snap in snaps:
+            if snap["protected"] == "true":
+                _, err = rbd.snap.unprotect(pool=pool, image=image, snap=snap["name"])
+                if err:
+                    log.error(
+                        f"Error while unprotecting snapshot {snap['name']}: {err}"
+                    )
+                    return 1
+        if not snaps:
+            log.error(f"Error while listing snapshots for image {pool}/{image}")
+            return 1
+        elif not len(snaps) >= 1:
+            snap_name = f"snap_{random_string(len=5)}"
+            out, err = rbd.snap.create(pool=pool, image=image, snap=snap_name)
+            if "100% complete...done" not in out + err:
+                log.error(
+                    f"Snapshot creation failed for {pool}/{image}@{snap_name} with error {err}"
+                )
+                return 1
+        out, err = rbd.snap.purge(pool=pool, image=image)
+        if err and "100% complete...done" not in out + err:
+            log.error(f"Snap purge failed for {pool}/{image} with error {err}")
+            return 1
+        snaps = get_user_defined_snaps(rbd=rbd, pool=pool, image=image)
+        if snaps:
+            log.error(f"Snapshot purge did not delete all snaps for {pool}/{image}")
+            return 1
+    return 0

--- a/suites/pacific/rbd/tier-3_snap_mirroring_regression.yaml
+++ b/suites/pacific/rbd/tier-3_snap_mirroring_regression.yaml
@@ -1,9 +1,9 @@
 #===============================================================================================
 # Tier-level: 3
-# Test-Suite: tier-3_cluster_operations_with_snap_mirroring.yaml
+# Test-Suite: tier-3_snap_mirroring_regression.yaml
 #
 # Cluster Configuration:
-#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
+#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
 #    No of Clusters : 2
 #    Node 2 must to be a client node
 #===============================================================================================
@@ -167,7 +167,6 @@ tests:
       clusters:
         ceph-rbd1:
           config:
-            rep-pool-only: true
             rep_pool_config:
               num_pools: 1
               num_images: 1
@@ -194,7 +193,6 @@ tests:
               io_size: 200M
         ceph-rbd2:
           config:
-            rep-pool-only: true
             rep_pool_config:
               num_pools: 1
               num_images: 1
@@ -219,3 +217,127 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with snap and clone operations
+      name: Test snap and clone operations on snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_snap_clone_op.py
+      polarion-id: CEPH-83574861
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+        ceph-rbd2:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+
+  - test:
+      abort-on-fail: True
+      desc: Verify one way snapshot mirroring with snap and clone operations
+      name: Test snap and clone operations on one way snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_snap_clone_op.py
+      polarion-id: CEPH-83574862
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+              way: "one-way"
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+              way: "one-way"
+        ceph-rbd2:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+              way: "one-way"
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+              way: "one-way"

--- a/suites/quincy/rbd/tier-3_snap_mirroring_regression.yaml
+++ b/suites/quincy/rbd/tier-3_snap_mirroring_regression.yaml
@@ -1,9 +1,9 @@
 #===============================================================================================
 # Tier-level: 3
-# Test-Suite: tier-3_cluster_operations_with_snap_mirroring.yaml
+# Test-Suite: tier-3_snap_mirroring_regression.yaml
 #
 # Cluster Configuration:
-#    cephci/conf/reef/rbd/5-node-2-clusters.yaml
+#    cephci/conf/quincy/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
 #    Node 2 must to be a client node
 #===============================================================================================
@@ -167,7 +167,6 @@ tests:
       clusters:
         ceph-rbd1:
           config:
-            rep-pool-only: true
             rep_pool_config:
               num_pools: 1
               num_images: 1
@@ -194,7 +193,6 @@ tests:
               io_size: 200M
         ceph-rbd2:
           config:
-            rep-pool-only: true
             rep_pool_config:
               num_pools: 1
               num_images: 1
@@ -219,3 +217,127 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with snap and clone operations
+      name: Test snap and clone operations on snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_snap_clone_op.py
+      polarion-id: CEPH-83574861
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+        ceph-rbd2:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+
+  - test:
+      abort-on-fail: True
+      desc: Verify one way snapshot mirroring with snap and clone operations
+      name: Test snap and clone operations on one way snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_snap_clone_op.py
+      polarion-id: CEPH-83574862
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+              way: "one-way"
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+              way: "one-way"
+        ceph-rbd2:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+              way: "one-way"
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+              way: "one-way"

--- a/suites/reef/rbd/tier-3_snap_mirroring_regression.yaml
+++ b/suites/reef/rbd/tier-3_snap_mirroring_regression.yaml
@@ -1,9 +1,9 @@
 #===============================================================================================
 # Tier-level: 3
-# Test-Suite: tier-3_cluster_operations_with_snap_mirroring.yaml
+# Test-Suite: tier-3_snap_mirroring_regression.yaml
 #
 # Cluster Configuration:
-#    cephci/conf/pacific/rbd/tier-1_rbd_mirror.yaml
+#    cephci/conf/reef/rbd/5-node-2-clusters.yaml
 #    No of Clusters : 2
 #    Node 2 must to be a client node
 #===============================================================================================
@@ -167,7 +167,6 @@ tests:
       clusters:
         ceph-rbd1:
           config:
-            rep-pool-only: true
             rep_pool_config:
               num_pools: 1
               num_images: 1
@@ -194,7 +193,6 @@ tests:
               io_size: 200M
         ceph-rbd2:
           config:
-            rep-pool-only: true
             rep_pool_config:
               num_pools: 1
               num_images: 1
@@ -219,3 +217,127 @@ tests:
               snap_schedule_intervals:
                 - 1m
               io_size: 200M
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with snap and clone operations
+      name: Test snap and clone operations on snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_snap_clone_op.py
+      polarion-id: CEPH-83574861
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+        ceph-rbd2:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+
+  - test:
+      abort-on-fail: True
+      desc: Verify one way snapshot mirroring with snap and clone operations
+      name: Test snap and clone operations on one way snapshot mirrored clusters
+      module: test_rbd_snap_mirroring_with_snap_clone_op.py
+      polarion-id: CEPH-83574862
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+              way: "one-way"
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+              way: "one-way"
+        ceph-rbd2:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+              way: "one-way"
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 2G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals:
+                - 1m
+              io_size: 200M
+              way: "one-way"

--- a/tests/rbd_mirror/test_rbd_snap_mirroring_with_cluster_op.py
+++ b/tests/rbd_mirror/test_rbd_snap_mirroring_with_cluster_op.py
@@ -23,7 +23,7 @@ def test_snap_mirror_cluster_ops(
     rbd_obj, sec_obj, client_node, sec_client, pool_type, **kw
 ):
     """
-    Test the immutable object cache with cluster operations.
+    Test the snap mirroring with cluster operations.
 
     Args:
         rbd_obj: RBD object
@@ -283,22 +283,6 @@ def run(**kw):
 
         pool_types = list(mirror_obj.values())[0].get("pool_types")
         for pool_type in pool_types:
-            # rc = toggle_rbd_mirror_daemon_status_and_verify(
-            #     client=client,
-            #     rbd=rbd,
-            #     is_secondary=False,
-            #     pool_type=pool_type,
-            #     **kw,
-            # )
-
-            # rc = toggle_rbd_mirror_daemon_status_and_verify(
-            #     client=sec_client,
-            #     rbd=sec_rbd,
-            #     is_secondary=True,
-            #     pool_type=pool_type,
-            #     **kw,
-            # )
-
             rc = test_snap_mirror_cluster_ops(
                 rbd, sec_rbd, client, sec_client, pool_type, **kw
             )

--- a/tests/rbd_mirror/test_rbd_snap_mirroring_with_snap_clone_op.py
+++ b/tests/rbd_mirror/test_rbd_snap_mirroring_with_snap_clone_op.py
@@ -1,0 +1,364 @@
+from copy import deepcopy
+
+from ceph.rbd.initial_config import initial_mirror_config, random_string
+from ceph.rbd.utils import check_data_integrity, getdict
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.snap_clone_operations import (
+    clone_ops,
+    purge_snap_and_verify,
+    remove_snap_and_verify,
+    snap_create_list_and_verify,
+    test_snap_rollback,
+)
+from ceph.rbd.workflows.snap_scheduling import run_io_verify_snap_schedule_single_image
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_snap_mirror_snap_clone_ops(
+    rbd_obj, sec_obj, client_node, sec_client, pool_type, **kw
+):
+    """
+    Test the snapshot mirroring with snap and clone operations.
+
+    Args:
+        rbd_obj: RBD object
+        sec_obj: Secondary RBD object
+        client_node: RBD client node
+        sec_client: Secondary client node
+        pool_type: rep_pool_config/ec_pool_config
+        **kw: test data
+
+    Returns:
+        int: The return value. 0 for success, 1 for failure.
+    """
+    try:
+        log.info(
+            f"Running snap and clone operations while testing snap mirroring for pool type {pool_type}"
+        )
+
+        config = deepcopy(kw.get("config").get(pool_type))
+        for pool, pool_config in getdict(config).items():
+            multi_image_config = getdict(pool_config)
+            multi_image_config.pop("test_config", {})
+            for image, image_config in multi_image_config.items():
+                image_spec = f"{pool}/{image}"
+                mount_path = f"/tmp/mnt_{random_string(len=5)}"
+                rc = run_io_verify_snap_schedule_single_image(
+                    rbd=rbd_obj,
+                    client=client_node,
+                    pool=pool,
+                    image=image,
+                    image_config=image_config,
+                    mount_path=f"{mount_path}/file_00",
+                    skip_mkfs=False,
+                )
+                if rc:
+                    log.error(
+                        f"Run IO and verify snap schedule failed for image {pool}/{image}"
+                    )
+                    return 1
+
+                data_integrity_spec = {
+                    "first": {
+                        "image_spec": image_spec,
+                        "rbd": rbd_obj,
+                        "client": client_node,
+                        "file_path": f"/tmp/{random_string(len=3)}",
+                    },
+                    "second": {
+                        "image_spec": image_spec,
+                        "rbd": sec_obj,
+                        "client": sec_client,
+                        "file_path": f"/tmp/{random_string(len=3)}",
+                    },
+                }
+                rc = check_data_integrity(**data_integrity_spec)
+                if rc:
+                    log.error(f"Data integrity check failed for {image_spec}")
+                    return 1
+
+                log.info(f"Perform snapshot operations for image for {image_spec}")
+
+                log.info(
+                    f"Create snapshots, list and verify for image {image_spec} for primary cluster"
+                )
+
+                rc = snap_create_list_and_verify(
+                    pool=pool,
+                    image=image,
+                    image_config=image_config,
+                    rbd=rbd_obj,
+                    sec_obj=sec_obj,
+                    is_secondary=False,
+                    **kw,
+                )
+                if rc:
+                    log.error(
+                        f"Snapshot creation, listing and verification failed for {image_spec} in primary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Create snapshots, list and verify for image {image_spec} for secondary cluster"
+                )
+
+                rc = snap_create_list_and_verify(
+                    pool=pool, image=image, rbd=sec_obj, is_secondary=True, **kw
+                )
+                if rc:
+                    log.error(
+                        f"Snapshot creation, listing and verification failed for {image_spec} in secondary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Creating clones and performing clone operations for primary cluster for {image_spec}"
+                )
+                clone_ops_conf = {
+                    "pool": pool,
+                    "image": image,
+                    "rbd": rbd_obj,
+                    "is_secondary": False,
+                    "operations": {
+                        "protect_snap": True,
+                        "create_clone": True,
+                        "num_clones_per_snap": 1,
+                        "unprotect_snap": True,
+                        "flatten_clone": True,
+                    },
+                    **kw,
+                }
+                rc = clone_ops(**clone_ops_conf)
+                if rc:
+                    log.error(
+                        f"Clone operations failed for {image_spec} in primary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Creating clones and performing clone operations for secondary cluster for {image_spec}"
+                )
+                clone_ops_conf["rbd"] = sec_obj
+                clone_ops_conf["is_secondary"] = True
+                clone_ops_conf["pri_rbd"] = rbd_obj
+                clone_ops_conf["image_config"] = image_config
+                rc = clone_ops(**clone_ops_conf)
+                if rc:
+                    log.error(
+                        f"Clone operations did not work as expected for {image_spec} in secondary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Testing snap rollback functionality for {image_spec} in primary cluster"
+                )
+                snap_rollback_conf = {
+                    "pool": pool,
+                    "image": image,
+                    "image_config": image_config,
+                    "rbd": rbd_obj,
+                    "client": client_node,
+                    "is_secondary": False,
+                    "mount_path": f"{mount_path}/file_01",
+                    **kw,
+                }
+                rc = test_snap_rollback(**snap_rollback_conf)
+                if rc:
+                    log.error(
+                        f"Snap rollback failed for pool type {image_spec} in primary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Testing snap rollback functionality for {image_spec} in secondary cluster"
+                )
+                snap_rollback_conf["rbd"] = sec_obj
+                snap_rollback_conf["client"] = sec_client
+                snap_rollback_conf["is_secondary"] = True
+                rc = test_snap_rollback(**snap_rollback_conf)
+                if rc:
+                    log.error(
+                        f"Snap rollback did not work as expected for pool type {image_spec} in secondary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Remove a user defined snap from secondary cluster for {image_spec}"
+                )
+                rc = remove_snap_and_verify(
+                    pool=pool, image=image, rbd=sec_obj, is_secondary=True, **kw
+                )
+                if rc:
+                    log.error(
+                        f"Snapshot removal did not work as expected for {image_spec} in secondary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Remove a user defined snap from primary cluster for {image_spec}"
+                )
+                rc = remove_snap_and_verify(
+                    pool=pool, image=image, rbd=rbd_obj, is_secondary=False, **kw
+                )
+                if rc:
+                    log.error(
+                        f"Snapshot removal failed for {image_spec} in primary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Testing purge snapshots functionality for {image_spec} in secondary cluster"
+                )
+
+                log.info(
+                    f"Create snapshots, for image {image_spec} to test purge cluster"
+                )
+
+                rc = snap_create_list_and_verify(
+                    pool=pool,
+                    image=image,
+                    image_config=image_config,
+                    rbd=rbd_obj,
+                    sec_obj=sec_obj,
+                    is_secondary=False,
+                    **kw,
+                )
+                if rc:
+                    log.error(f"Snapshot creation failed for {image_spec}")
+                    return 1
+
+                rc = purge_snap_and_verify(
+                    pool=pool, image=image, rbd=sec_obj, is_secondary=True, **kw
+                )
+                if rc:
+                    log.error(
+                        f"Snapshot purge did not work as expected for {image_spec} in secondary cluster"
+                    )
+                    return 1
+
+                log.info(
+                    f"Testing purge snapshots functionality for {image_spec} in primary cluster"
+                )
+                rc = purge_snap_and_verify(
+                    pool=pool, image=image, rbd=rbd_obj, is_secondary=False, **kw
+                )
+                if rc:
+                    log.error(
+                        f"Snapshot purge failed for {image_spec} in primary cluster"
+                    )
+                    return 1
+    except Exception as err:
+        log.error(err)
+        return 1
+    return 0
+
+
+def run(**kw):
+    """CEPH-83574861 - Configure two-way rbd-mirror (replicated and ec pool) on
+    Stand alone CEPH cluster on image with snapshot based mirroring and perform snapshot,
+    clone and mirror snapshot schedule operations from primary and secondary clusters.
+    Pre-requisites :
+    We need atleast one client node with ceph-common, fio and rbd-nbd packages,
+    conf and keyring files in both clusters with snapshot based RBD mirroring
+    enabled between the clusters.
+    kw:
+        clusters:
+            ceph-rbd1:
+            config:
+                rep_pool_config:
+                num_pools: 1
+                num_images: 5
+                size: 10G
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals: #one value for each level specified above
+                    - 5m
+                io_percentage: 30 #percentage of space in each image to be filled
+                ec_pool_config:
+                num_pools: 1
+                num_images: 5
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals:
+                    - 5m
+                io_size: 200M
+            ceph-rbd2:
+            config:
+                rep_pool_config:
+                num_pools: 1
+                num_images: 5
+                size: 10G
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals: #one value for each level specified above
+                    - 5m
+                io_percentage: 30 #percentage of space in each image to be filled
+                ec_pool_config:
+                num_pools: 1
+                num_images: 5
+                mode: image # compulsory argument if mirroring needs to be setup
+                mirrormode: snapshot
+                snap_schedule_levels:
+                    - image
+                snap_schedule_intervals:
+                    - 5m
+                io_size: 200M
+    Test Case Flow
+    1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
+    2. Create pools and images as specified, enable snapshot based mirroring for all these images
+    3. Schedule snapshots for each of these images and run IOs on each of the images
+    4. Perform the operations like add snapshots - remove snapshots - list snapshots - rollback
+        snapshots - purge snapshots
+    5. Try snapshot creation/deletion from secondary cluster
+    6. Perform Clone Operations like protect snapshot,  clone the snapshot,  unprotect snapshot,
+        flatten clone
+    7. Try above operation from secondary
+    8. Perform snap schedule operations like, add/list/status/remove from both primary and secondary
+        clusters
+    """
+    pool_types = ["rep_pool_config", "ec_pool_config"]
+    log.info("Running snap and clone operations on snapshot based mirroring clusters")
+
+    try:
+        kw.get("config", {})["do_not_run_io"] = True
+        mirror_obj = initial_mirror_config(**kw)
+        mirror_obj.pop("output", [])
+
+        for val in mirror_obj.values():
+            if not val.get("is_secondary", False):
+                rbd = val.get("rbd")
+                client = val.get("client")
+            else:
+                sec_rbd = val.get("rbd")
+                sec_client = val.get("client")
+        log.info("Initial configuration complete")
+
+        pool_types = list(mirror_obj.values())[0].get("pool_types")
+        for pool_type in pool_types:
+            log.info(
+                f"Running snap and clone operations on snap based mirroring for {pool_type}"
+            )
+            rc = test_snap_mirror_snap_clone_ops(
+                rbd, sec_rbd, client, sec_client, pool_type, **kw
+            )
+            if rc:
+                log.error(
+                    f"Snap and clone operations on snapshot based mirroring clusters failed for {pool_type}"
+                )
+                return 1
+    except Exception as e:
+        log.error(
+            f"Testing snap and clone operations on snap mirroring clusters failed with error {str(e)}"
+        )
+        return 1
+    finally:
+        cleanup(pool_types=pool_types, multi_cluster_obj=mirror_obj, **kw)
+    return 0


### PR DESCRIPTION
Automation of CEPH-83574861 - Configure two-way rbd-mirror (replicated and ec pool) on Stand alone CEPH cluster on image with snapshot based mirroring and perform snapshot, clone and mirror snapshot schedule operations from primary and secondary clusters.

Test Case Flow
    1. Bootstrap two CEPH clusters and setup snapshot based mirroring in between these clusters
    2. Create pools and images as specified, enable snapshot based mirroring for all these images
    3. Schedule snapshots for each of these images and run IOs on each of the images
    4. Perform the operations like add snapshots - remove snapshots - list snapshots - rollback
        snapshots - purge snapshots
    5. Try snapshot creation/deletion from secondary cluster
    6. Perform Clone Operations like protect snapshot,  clone the snapshot,  unprotect snapshot,
        flatten clone
    7. Try above operation from secondary
    8. Perform snap schedule operations like, add/list/status/remove from both primary and secondary
        clusters

Automation of CEPH-83574862 - Configure one-way rbd-mirror (replicated pool) on Stand alone CEPH cluster on image with snapshot based mirroring and perform clone operations from primary and secondary clusters.

Test Case Flow 2
    1. Bootstrap two CEPH clusters and setup one way snapshot based mirroring in between these clusters
    2. Create pools and images as specified, enable snapshot based mirroring for all these images
    3. Schedule snapshots for each of these images and run IOs on each of the images
    4. Perform the operations like add snapshots - remove snapshots - list snapshots - rollback
        snapshots - purge snapshots
    5. Try snapshot creation/deletion from secondary cluster
    6. Perform Clone Operations like protect snapshot,  clone the snapshot,  unprotect snapshot,
        flatten clone
    7. Try above operation from secondary
    8. Perform snap schedule operations like, add/list/status/remove from both primary and secondary
        clusters

Success Logs for - CEPH-83574861 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KAKOPL/
