### PR TITLE
CEPH-83581346: Test to verify prometheus metric metadata post upgrade

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -62,8 +62,34 @@ class Api:
 
         return response.status_code, response.json()
 
-    def get(self):
-        pass
+    def get(self, data=None, header=None, verify=DEFAULT_VERIFY, check_sc=False):
+        """Get method for request
+
+        Args:
+            data (dict): Request payload
+            header (dict): Request header
+            verify (bool): Request URL verifier
+            check_sc (bool): Check for status code validation
+        """
+        LOG.info(f"Request URL - {self.url}")
+        LOG.info(f"Request VERIFY - {verify}")
+        LOG.info("Request METHOD - GET")
+
+        params = {"url": self.url, "verify": verify}
+
+        if data:
+            params["data"] = json.dumps(data)
+            LOG.debug(f"Request DATA - {data}")
+
+        if header:
+            params["headers"] = header
+            LOG.info(f"Request HEADER - {header}")
+
+        response = requests.get(**params)
+        if check_sc:
+            return self._response(response)
+
+        return response
 
     def post(self, data=None, header=None, verify=DEFAULT_VERIFY, check_sc=False):
         """Post method for request

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1862,7 +1862,7 @@ class RadosOrchestrator:
         )
 
         export_cmd = (
-            f"export pool_name={pool_name} obj_name={obj_name} END={int(obj_size/2)}"
+            f"export pool_name={pool_name} obj_name={obj_name} END={int(obj_size / 2)}"
         )
         inst_run_cmd = f"{export_cmd}; export offset=1048576; {loop_cmd}"
         client_run_cmd = f"{export_cmd}; export offset=0; {loop_cmd}"
@@ -3092,3 +3092,24 @@ class RadosOrchestrator:
             return False
         log.info(f"IP/CIDR : {ip} removed from blocklist successfully")
         return True
+
+    def get_daemon_metadata(self, daemon_type: str, daemon_id: str = None):
+        """
+        Method to fetch the metadata for any daemon
+        If daemon id is not provided, return complete output of
+        ceph <daemon_type> metadata
+        Returns:
+            metadata (List) -> If daemon_id is not provided
+            metadata (Dict) -> If daemon_id is provided
+            None if metadata is not found
+        """
+        base_cmd = f"ceph {daemon_type} metadata"
+        if not daemon_id:
+            return self.run_ceph_command(cmd=base_cmd, client_exec=True)
+
+        out = self.run_ceph_command(cmd=f"{base_cmd} {daemon_id}", client_exec=True)
+        if out is None:
+            log.error(
+                f"Metadata info for the input daemon: {daemon_type} {daemon_id} not found"
+            )
+        return out

--- a/conf/pacific/rados/7-node-cluster.yaml
+++ b/conf/pacific/rados/7-node-cluster.yaml
@@ -19,6 +19,7 @@ globals:
           - mon
           - mgr
           - mds
+          - nfs
           - rgw
           - node-exporter
           - alertmanager
@@ -49,6 +50,7 @@ globals:
           - mon
           - mgr
           - mds
+          - nfs
           - rgw
           - node-exporter
           - crash

--- a/conf/quincy/rados/7-node-cluster.yaml
+++ b/conf/quincy/rados/7-node-cluster.yaml
@@ -19,6 +19,7 @@ globals:
           - mon
           - mgr
           - mds
+          - nfs
           - rgw
           - node-exporter
           - alertmanager
@@ -49,6 +50,7 @@ globals:
           - mon
           - mgr
           - mds
+          - nfs
           - rgw
           - node-exporter
           - crash

--- a/conf/reef/rados/7-node-cluster.yaml
+++ b/conf/reef/rados/7-node-cluster.yaml
@@ -19,6 +19,7 @@ globals:
           - mon
           - mgr
           - mds
+          - nfs
           - rgw
           - node-exporter
           - alertmanager
@@ -49,6 +50,7 @@ globals:
           - mon
           - mgr
           - mds
+          - nfs
           - rgw
           - node-exporter
           - crash

--- a/suites/quincy/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-brownfield.yaml
@@ -1,0 +1,201 @@
+# Suite contains tests to be run after upgrade [brownfield deployment]
+# Use cluster-conf file: conf/quincy/rados/7-node-cluster.yaml
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                rhcs-version: 5.3
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      abort-on-fail: true
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: prometheus metadata
+      module: test_brownfield.py
+      desc: Fetch and verify ceph version for various daemons post upgrade
+      polarion-id: CEPH-83581346
+      config:
+       prometheus_metrics:
+         daemons:
+           - mon
+           - osd
+           - mgr

--- a/suites/reef/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/reef/rados/tier-2_rados_test-brownfield.yaml
@@ -1,0 +1,208 @@
+# Suite contains tests to be run after upgrade [brownfield deployment]
+# Use cluster-conf file: conf/reef/rados/7-node-cluster.yaml
+
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                rhcs-version: 6.1
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+      abort-on-fail: true
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Upgrade cluster to latest 7.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_cephadm_upgrade.py
+      polarion-id: CEPH-83573791
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  # Running basic rbd and rgw tests after upgrade
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+          script-name: test_multitenant_user_access.py
+          config-file-name: test_multitenant_access.yaml
+          timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: prometheus metadata
+      module: test_brownfield.py
+      desc: Fetch and verify ceph version for various daemons post upgrade
+      polarion-id: CEPH-83581346
+      config:
+       prometheus_metrics:
+         daemons:
+           - mon
+           - osd
+           - mgr

--- a/tests/rados/test_brownfield.py
+++ b/tests/rados/test_brownfield.py
@@ -1,0 +1,99 @@
+"""
+This file contains various tests/ validations related to brownfield deployment.
+Tests included:
+1. Verification of upgraded version as reported by prometheus
+
+"""
+
+
+import json
+
+from api import Api
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+HEADER = {
+    "Accept": "application/vnd.ceph.api.v1.0+json",
+    "Content-Type": "application/json",
+}
+
+
+def run(ceph_cluster, **kw):
+    """
+    Performs various validation tests for brownfield deployment
+    Returns:
+        1 -> Fail, 0 -> Pass
+
+    Current coverage:
+        - CEPH-83581346: Prometheus metrics verification
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    prom_node = ceph_cluster.get_nodes(role="prometheus")[0]
+
+    if config.get("prometheus_metrics"):
+        doc = """
+        # CEPH-83581346
+        # BZ - 2008524
+        Post cluster upgrade -
+        1. Fetch ceph version from installer node
+        2. Get daemon metadata metrics from Prometheus API
+        3. Check whether cluster upgraded version is correctly reflected
+        in prometheus output
+        """
+        log.info(doc)
+        out, _ = cephadm.shell(["ceph version"])
+        ceph_version = out.strip()
+        log.info(f"Ceph version: {ceph_version}")
+
+        # Get prometheus api host
+        url, _ = cephadm.shell(["ceph dashboard get-prometheus-api-host"])
+        log.info(f"Promethues api host: {url}")
+        url = f"http://{prom_node.ip_address}:9095"
+
+        daemon_list = config["prometheus_metrics"].get("daemons", ["mon", "mgr", "osd"])
+        for daemon in daemon_list:
+            log.info(
+                f"Verification start for Ceph version from Prometheus metric for {daemon}"
+            )
+            api_obj = Api(url=url, api=f"api/v1/query?query=ceph_{daemon}_metadata")
+            response = api_obj.get(header=HEADER)
+            metadata_dict = response.json()
+
+            metric_list = metadata_dict["data"]["result"]
+            log.info(f"Metric list for {daemon}:")
+            log.info(json.dumps(response.json(), indent=4, sort_keys=False))
+
+            # begin comparison of prometheus metadata with local metadata from the cluster
+            log.info(
+                "Begin comparison of prometheus metadata with local metadata from the cluster"
+            )
+            for metric in metric_list:
+                data = metric["metric"]
+                daemon_name = data["ceph_daemon"]
+                log.info(f"comparison begun for {daemon_name}")
+                _daemon_id = ".".join(daemon_name.split(".")[1:])
+                local_metadata = rados_obj.get_daemon_metadata(
+                    daemon_type=daemon, daemon_id=_daemon_id
+                )
+                log.info(
+                    f"Cluster fetched metadata for {daemon_name}: \n {local_metadata}"
+                )
+                if (
+                    local_metadata["ceph_version"] != data["ceph_version"]
+                    or data["ceph_version"] != ceph_version
+                ):
+                    log.error(
+                        f"(Version mismatch between prometheus metric and local metadata for {daemon_name}"
+                    )
+                    return 1
+            log.info(
+                f"Verification complete for {daemon}, prometheus report"
+                f" correct upgraded version for all {daemon} daemons"
+            )
+        return 0


### PR DESCRIPTION
[CEPH-83581346](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581346): Tier-2 test to verify ceph version for various daemons post upgrade as reported by Prometheus metrics through prometheus API

Test modules added/modified:
- `api/__init__.py`
- `get_daemon_metadata` in `ceph/rados/core_workflows.py`

Test cases added:
- tests/rados/test_brownfield.py

Test suites added:
- `suites/quincy/rados/tier-2_rados_test-brownfield.yaml`
- `suites/reef/rados/tier-2_rados_test-brownfield.yaml`

Steps:
Post cluster upgrade -
1. Fetch ceph version from installer node
2. Get daemon metadata metrics from Prometheus API
3. Check whether cluster upgraded version is correctly reflected in Prometheus output

Logs:
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L0WJ0B/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WGELXV/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0UUH6Q
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XBSSM8