### PR TITLE
[tfa-fix] Add fix for ibm repo handling

### DIFF
--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -217,6 +217,8 @@ def get_custom_repo_url(base_url, cloud_type="openstack"):
 
     if cloud_type == "ibmc":
         base_url += "Tools"
+    elif base_url.endswith("x86_64/"):
+        return base_url
     else:
         base_url += "compose/Tools/x86_64/os/"
 

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -215,10 +215,11 @@ def get_custom_repo_url(base_url, cloud_type="openstack"):
     if not base_url.endswith("/"):
         base_url += "/"
 
+    if base_url.endswith("x86_64/"):
+        return base_url
+
     if cloud_type == "ibmc":
         base_url += "Tools"
-    elif base_url.endswith("x86_64/"):
-        return base_url
     else:
         base_url += "compose/Tools/x86_64/os/"
 


### PR DESCRIPTION
# Description


IBM package urls end with `x86_64` and by default cephci is appending "compose/Tools/x86_64/os/" to the url without the validation.

Adding an elif statement to `get_custom_repo_url` function which will check if url ends with x86_64