### PR TITLE
[tfa-fix] Add fix for handling ibm repo URL

### DIFF
--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -215,6 +215,9 @@ def get_custom_repo_url(base_url, cloud_type="openstack"):
     if not base_url.endswith("/"):
         base_url += "/"
 
+    if base_url.endswith("x86_64/"):
+        return base_url
+
     if cloud_type == "ibmc":
         base_url += "Tools"
     else:


### PR DESCRIPTION
# Description

IBM package URLs end with `x86_64` and by default cephci is appending `compose/Tools/x86_64/os/` to the URL without validation.

Adding a check in `get_custom_repo_url` function for checking if URL ends with `x86_64`