### PR TITLE
[TFA fix]: fixing jq installation failure in archive haproxy suite

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -598,7 +598,7 @@ tests:
         ceph-pri:
           config:
             extra-pkgs:
-              - yum install -y jq
+              - jq
             script-name: test_rgw_restore_index_tool.py
             config-file-name: test_rgw_restore_index_versioned_buckets.yaml
             run-on-haproxy: true


### PR DESCRIPTION
This PR fixes TFA failure for rgw-restore-bucket-index, which failed because of jq installation failure..
extra_pkg should be list of package names. but by mistake 'yum install -y jq' command is passed. fixing that issue in this PR.

failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-131/Weekly/rgw/20/tier-2_rgw_ms_archive_with_haproxy/test_rgw_restore_index_tool_on_versioned_bucket_0.log



# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
