### PR TITLE
[TestFix] Fix tier2-verify-custom-container suite

### DIFF
--- a/cephci/utils/configure.py
+++ b/cephci/utils/configure.py
@@ -314,7 +314,10 @@ def add_images_to_private_registry(
 
     for image in images:
         img_reg = image.replace(f"{registry}/", "")
-        src_image = f"{registry}/{image}"
+        if registry not in img_reg:
+            src_image = f"{registry}/{img_reg}"
+        else:
+            src_image = img_reg
         dst_image = f"{node.hostname}:5000/{img_reg}"
         skopeo_cmd = generate_skopeo_copy_cmd(
             src_image,


### PR DESCRIPTION
Problem:
With the recent lib fix, the container image is appended with
an additional registry entry. E.g: docker://registry.redhat.io/registry.redhat.io/<image_name>
This causes the test suites to fail

Solution:
Append the registry path only if its missing

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
