### PR TITLE
[TFA] adding tenant user cretaion tc before tc bucket_policy_modify i…

### DIFF
--- a/suites/reef/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -384,19 +384,6 @@ tests:
             timeout: 300
 
   - test:
-      name: modify bucket policy on secondary
-      desc: test_bucket_policy_modify.yaml on secondary
-      polarion-id: CEPH-11633
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_policy_ops.py
-            config-file-name: test_bucket_policy_modify.yaml
-            verify-io-on-site: ["ceph-pri"]
-            timeout: 300
-
-  - test:
       name: enabling bucket versioning and uploading objects on secondary
       polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
       desc: test_versioning_objects_enable on secondary
@@ -432,4 +419,31 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            timeout: 300
+
+  - test:
+      name: create tenanted user
+      desc: create tenanted user
+      polarion-id: CEPH-83575199
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+
+  - test:
+      name: modify bucket policy on secondary
+      desc: test_bucket_policy_modify.yaml on secondary
+      polarion-id: CEPH-11633
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_bucket_policy_ops.py
+            config-file-name: test_bucket_policy_modify.yaml
+            verify-io-on-site: ["ceph-pri"]
             timeout: 300


### PR DESCRIPTION
…n secondary site

# Description
issue log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-131/Weekly/rgw/20/tier-2_ssl_rgw_ms_ecpool_test/modify_bucket_policy_on_secondary_0.log 
(cephci.sanity_rgw_multisite) [DEBUG] - cephci.Weekly.rgw.20.cephci.ceph.ceph.py:1524 - b"KeyError: 'tenant'"

testcase : modify_bucket_policy_on_secondary, since its runs on  secondary site and we don't have system tenant user created issue seen

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
