### PR TITLE
Adding utilities for retrieving ceph version

### DIFF
--- a/suites/reef/baremetal/upgrade_suite_RH.yaml
+++ b/suites/reef/baremetal/upgrade_suite_RH.yaml
@@ -1,0 +1,27 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Validate the ceph version before upgrade"
+      module: validate_version.py
+      config:
+        env_type: "RH"
+      name: "Validate the ceph version before upgrade"
+  - test:
+      name: Upgrade ceph
+      desc: Upgrade cluster to latest version
+      module: cephadm.test_cephadm_upgrade.py
+      polarion-id: CEPH-83574638
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        benchmark:
+          type: rados                      # future-use
+          pool_per_client: true
+          pg_num: 128
+          duration: 10
+        verify_cluster_health: true
+      destroy-cluster: false

--- a/tests/misc_env/validate_version.py
+++ b/tests/misc_env/validate_version.py
@@ -1,0 +1,30 @@
+import traceback
+
+from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster, get_ceph_version_from_repo
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    try:
+        clients = ceph_cluster.get_ceph_objects("client")
+        config = kw.get("config")
+        log.info(kw.get("config"))
+        ceph_version_installed = get_ceph_version_from_cluster(clients[0])
+        ceph_version = get_ceph_version_from_repo(clients[0], config)
+        if ceph_version <= ceph_version_installed:
+            log.info(
+                f"Upgrade should not proceeded as installed versions is {ceph_version_installed} "
+                f"greater than or equal to latest Version i.e., {ceph_version}"
+            )
+            return 1
+        log.info(
+            f"Upgrade should be proceeded as installed versions is {ceph_version_installed} "
+            f"lesser than latest Version i.e., {ceph_version}"
+        )
+        return 0
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1

--- a/utility/validate_cluster_health.py
+++ b/utility/validate_cluster_health.py
@@ -1,0 +1,99 @@
+import json
+import pickle
+
+import paramiko
+import yaml
+from docopt import docopt
+
+from ceph.ceph import CommandFailed
+from utility.retry import retry
+
+doc = """
+Standard script to Check the cluster health state
+
+    Usage:
+        validate_cluster_health.py --conf <str> [--pickle]
+        validate_cluster_health.py (-h | --help)
+
+    Options:
+        -h --help          Shows the command usage
+        --conf <str>       conffile path if baremetal or pickle file path
+        --pickle           boolean
+    """
+
+
+@retry(CommandFailed, tries=3, delay=10)
+def get_cluster_status(client):
+    ssh_client = paramiko.SSHClient()
+    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_client.connect(client["ip"], username="root", password=client["root_password"])
+    stdin, stdout, stderr = ssh_client.exec_command("ceph -s -f json")
+    health_status = json.loads(stdout.read())["health"]["status"]
+    if health_status not in ["HEALTH_OK", "HEALTH_WARN"]:
+        raise CommandFailed("Health is not OK")
+    print("Cluster is in a Healthy state")
+    return health_status
+
+
+def load_cluster_config(config):
+    cluster_dict = None
+    with open(config, "rb") as f:
+        cluster_dict = pickle.load(f)
+
+    for _, cluster in cluster_dict.items():
+        for node in cluster:
+            node.reconnect()
+
+    return cluster_dict
+
+
+def load_cluster_from_file(config):
+    with open(config, "r") as file:
+        yaml_data = file.read()
+
+    parsed_data = yaml.safe_load(yaml_data)
+    return parsed_data
+
+
+def get_nodes_with_role(parsed_data, target_role="client"):
+    nodes_with_target_role = []
+
+    # Check if 'globals' key exists and is a list
+    if "globals" in parsed_data and isinstance(parsed_data["globals"], list):
+        for item in parsed_data["globals"]:
+            if isinstance(item, dict):
+                # Check if 'ceph-cluster' key exists and is a dictionary
+                ceph_cluster = item.get("ceph-cluster")
+                if ceph_cluster and isinstance(ceph_cluster, dict):
+                    # Check if 'nodes' key exists and is a list
+                    nodes = ceph_cluster.get("nodes")
+                    if nodes and isinstance(nodes, list):
+                        for node in nodes:
+                            # Check if 'role' key exists and contains the target role
+                            if "role" in node and target_role in node["role"]:
+                                nodes_with_target_role.append(node)
+
+    return nodes_with_target_role
+
+
+if __name__ == "__main__":
+    arguments = docopt(doc)
+    conf = arguments.get("--conf")
+
+    if arguments.get("--pickle"):
+        cluster_dict = load_cluster_config(conf)
+        client = cluster_dict.get("ceph").get_ceph_objects("client")[0]
+        client_dict = {"ip": client.ip_address, "root_password": client.root_password}
+    else:
+        parsed_data = load_cluster_from_file(conf)
+        client_nodes = get_nodes_with_role(parsed_data)
+        if not client_nodes:
+            raise ValueError("No nodes with the specified role found.")
+        client_dict = {
+            "ip": client_nodes[0].get("ip"),
+            "root_password": client_nodes[0].get("root_password"),
+        }
+    try:
+        get_cluster_status(client_dict)
+    except Exception as e:
+        print(e)


### PR DESCRIPTION
# Description
Adding utilities for retrieving ceph version

To add support for bare-metal upgrade. This functions will retrieve 
1. Ceph version from cluster installed. 
2. Ceph version from repo details given as part of run.py

Logs : 6.1 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9YKG4F
7.0 : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1GWLM0

**utility/validate_cluster_health.py** : 
This system includes a utility module designed for validating the health of the cluster. The module accepts either a configuration file or a pickle file as input to assess the cluster's health status. It is invoked within the baremetal pipeline following each suite execution. If the cluster is identified in a 'HEALTH_ERR' state, the entire job is terminated, leaving the setup in that state for debugging purposes. The module allows for a 30-minute waiting period, giving Ceph the opportunity to auto-recover during this time.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
