### PR TITLE
[TestFix] Fix tier1-cephadm-ansible-wrapper-bootstrap-with-custom-ssh…

### DIFF
--- a/suites/quincy/cephadm/tier1-cephadm-ansible-wrapper-bootstrap-with-custom-ssh.yaml
+++ b/suites/quincy/cephadm/tier1-cephadm-ansible-wrapper-bootstrap-with-custom-ssh.yaml
@@ -24,6 +24,12 @@ tests:
             ssh_user: cephuser
 
   - test:
+      name: Delete cluster using cephadm rm-cluster command
+      desc:  Verify cluster purge via cephamd commands
+      polarion-id: CEPH-83573765
+      module: test_remove_cluster.py
+
+  - test:
       name: Bootstrap cluster using cephadm-ansible wrapper modules
       desc: Execute 'bootstrap-with-exisitng-keys.yaml' playbook
       polarion-id: CEPH-83575205


### PR DESCRIPTION
… suite

Problem:
The test bootstrap with exisitng keys is called immediately after the normal bootstrap causing the failure

Solution:
Remove/purge the cluster before triggering the second bootstrap test

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
