### PR TITLE
[TFA-fix] s3cmd bucket creation failure

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw.yaml
+++ b/suites/pacific/rgw/tier-1_rgw.yaml
@@ -47,17 +47,13 @@ tests:
               args:
                 all-available-devices: true
           - config:
-              command: apply_spec
-              service: orch
-              specs:
-                - service_type: rgw
-                  service_id: rgw.ssl
-                  placement:
-                    nodes:
-                      - node5
-                  spec:
-                    ssl: true
-                    rgw_frontend_ssl_certificate: create-cert
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: bootstrap and deployment services with label placements.
       destroy-cluster: false
       polarion-id: CEPH-83573777


### PR DESCRIPTION
# Description

S3cmd execution is not supported with rgw ssl, so issue seen

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-F8NDFZ/S3CMD_small_and_multipart_object_download_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
