### PR TITLE
Address the IAM failures in s3tests suite

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -348,6 +348,11 @@ def create_s3_user(node: CephNode, user_prefix: str, data: Dict) -> None:
         "email": user_info["email"],
     }
 
+    if user_prefix == "iam":
+        log.info("Adding user-policy caps for IAM user")
+        cmd = f'radosgw-admin caps add --uid={uid} --caps="user-policy=*"'
+        out, err = node.exec_command(sudo=True, cmd=cmd)
+
 
 def create_s3_conf(
     cluster: Ceph,
@@ -380,6 +385,7 @@ def create_s3_conf(
     create_s3_user(node=rgw_node, user_prefix="main", data=data)
     create_s3_user(node=rgw_node, user_prefix="alt", data=data)
     create_s3_user(node=rgw_node, user_prefix="tenant", data=data)
+    create_s3_user(node=rgw_node, user_prefix="iam", data=data)
 
     if kms_keyid:
         data["main"]["kms_keyid"] = kms_keyid


### PR DESCRIPTION
Added the IAM section to tests the IAM tests as part of Ceph-reef  branch of s3tests suite.
There are still some STS failures which will be addressed as part of a further PR.

Pass log : http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-JY6RWN/


