### PR TITLE
Deployment of Pluto environment in cephci

### DIFF
--- a/suites/reef/baremetal/pluto/pluto_conf.yaml
+++ b/suites/reef/baremetal/pluto/pluto_conf.yaml
@@ -1,0 +1,145 @@
+globals:
+  -
+    ceph-cluster:
+      name: ceph-pri
+      networks:
+        public: ['10.0.0.0/12']
+      nodes:
+        -
+          hostname: pluto001.ceph.redhat.com
+          ip: 10.8.129.101
+          root_password: r
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: pluto002.ceph.redhat.com
+          ip: 10.8.129.102
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: pluto003.ceph.redhat.com
+          ip: 10.8.129.103
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+            - rgw
+            - client
+          volumes:
+            - /dev/sdb
+            - /dev/sda
+            - /dev/sdd
+
+
+  -
+    ceph-cluster:
+      name: ceph-sec
+      networks:
+        public: ['10.0.0.0/12']
+      nodes:
+        -
+          hostname: pluto004.ceph.redhat.com
+          ip: 10.8.129.104
+          root_password: r
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: pluto005.ceph.redhat.com
+          ip: 10.8.129.105
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sda
+        -
+          hostname: pluto006.ceph.redhat.com
+          ip: 10.8.129.106
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+            - rgw
+            - client
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sda
+
+  -
+    ceph-cluster:
+      name: ceph-arc
+      networks:
+        public: ['10.0.0.0/12']
+      nodes:
+        -
+          hostname: pluto007.ceph.redhat.com
+          ip: 10.8.129.107
+          root_password: r
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: pluto008.ceph.redhat.com
+          ip: 10.8.129.108
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+            - rgw
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+        -
+          hostname: pluto010.ceph.redhat.com
+          ip: 10.8.129.110
+          root_password: r
+          role:
+            - mon
+            - mgr
+            - osd
+            - rgw
+            - client
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd

--- a/suites/reef/baremetal/pluto/pluto_suite.yaml
+++ b/suites/reef/baremetal/pluto/pluto_suite.yaml
@@ -1,0 +1,777 @@
+# run pre-requisites
+tests:
+   - test:
+       abort-on-fail: true
+       desc: Install software pre-requisites for cluster deployment.
+       module: install_prereq.py
+       name: setup pre-requisites
+#perform bootstrap
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: bootstrap
+                   service: cephadm
+                   args:
+                     registry-url: registry.redhat.io
+                     mon-ip: pluto001
+                     allow-fqdn-hostname: true
+                     orphan-initial-daemons: true
+                     initial-dashboard-password: admin@123
+                     dashboard-password-noupdate: true
+
+         ceph-sec:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: bootstrap
+                   service: cephadm
+                   args:
+                     registry-url: registry.redhat.io
+                     mon-ip: pluto004
+                     allow-fqdn-hostname: true
+                     orphan-initial-daemons: true
+                     initial-dashboard-password: admin@123
+                     dashboard-password-noupdate: true
+
+         ceph-arc:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: bootstrap
+                   service: cephadm
+                   args:
+                     registry-url: registry.redhat.io
+                     mon-ip: pluto007
+                     allow-fqdn-hostname: true
+                     orphan-initial-daemons: true
+                     initial-dashboard-password: admin@123
+                     dashboard-password-noupdate: true
+
+       desc: Bootstrap clusters using cephadm.
+       polarion-id: CEPH-83573386
+       destroy-cluster: false
+       module: test_cephadm.py
+       name: Bootstrap clusters
+
+#enable ptrace and set log to file
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             cephadm: true
+             commands:
+               - "ceph config set mgr mgr/cephadm/allow_ptrace true"
+               - "ceph config set global log_to_file true"
+               - "ceph config set global mon_cluster_log_to_file true"
+               - "ceph config set mgr mgr/cephadm/container_image_grafana registry-proxy.engineering.redhat.com/rh-osbs/grafana:9.4.7-1"
+         ceph-sec:
+           config:
+             cephadm: true
+             commands:
+               - "ceph config set mgr mgr/cephadm/allow_ptrace true"
+               - "ceph config set global log_to_file true"
+               - "ceph config set global mon_cluster_log_to_file true"
+               - "ceph config set mgr mgr/cephadm/container_image_grafana registry-proxy.engineering.redhat.com/rh-osbs/grafana:9.4.7-1"
+         ceph-arc:
+           config:
+             cephadm: true
+             commands:
+               - "ceph config set mgr mgr/cephadm/allow_ptrace true"
+               - "ceph config set global log_to_file true"
+               - "ceph config set global mon_cluster_log_to_file true"
+               - "ceph config set mgr mgr/cephadm/container_image_grafana registry-proxy.engineering.redhat.com/rh-osbs/grafana:9.4.7-1"
+       desc: setup debugging(ptrace) for containers
+       module: exec.py
+       name: setup debugging for containers
+       polarion-id: CEPH-10362
+
+# #deploy more mons and mgrs
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: add_hosts
+                   service: host
+                   args:
+                     attach_ip_address: true
+                     labels: apply-all-labels
+               - config:
+                   command: apply
+                   service: mgr
+                   args:
+                     placement:
+                       label: mgr
+               - config:
+                   command: apply
+                   service: mon
+                   args:
+                     placement:
+                       label: mon
+
+         ceph-sec:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: add_hosts
+                   service: host
+                   args:
+                     attach_ip_address: true
+                     labels: apply-all-labels
+               - config:
+                   command: apply
+                   service: mgr
+                   args:
+                     placement:
+                       label: mgr
+               - config:
+                   command: apply
+                   service: mon
+                   args:
+                     placement:
+                       label: mon
+         ceph-arc:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: add_hosts
+                   service: host
+                   args:
+                     attach_ip_address: true
+                     labels: apply-all-labels
+               - config:
+                   command: apply
+                   service: mgr
+                   args:
+                     placement:
+                       label: mgr
+               - config:
+                   command: apply
+                   service: mon
+                   args:
+                     placement:
+                       label: mon
+
+
+       desc: RHCS deploy more mons and mgrs.
+       polarion-id: CEPH-83575222
+       destroy-cluster: false
+       module: test_cephadm.py
+       name: deploy more mons and mgrs.
+
+# # deploy osds
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto001
+                     - "/dev/sdb"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto001
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto001
+                     - "/dev/sdd"
+
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto002
+                     - "/dev/sdb"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto002
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto002
+                     - "/dev/sdd"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto003
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto003
+                     - "/dev/sda"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto003
+                     - "/dev/sdb"
+
+         ceph-sec:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto004
+                     - "/dev/sdb"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto004
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto004
+                     - "/dev/sdd"
+
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto005
+                     - "/dev/sdb"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto005
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto005
+                     - "/dev/sda"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto006
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto006
+                     - "/dev/sda"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto006
+                     - "/dev/sdd"
+
+         ceph-arc:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto007
+                     - "/dev/sda"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto007
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto007
+                     - "/dev/sdd"
+
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto008
+                     - "/dev/sdb"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto008
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto008
+                     - "/dev/sda"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto010
+                     - "/dev/sdc"
+
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto010
+                     - "/dev/sdd"
+               - config:
+                   command: add
+                   service: osd
+                   pos_args:
+                     - pluto010
+                     - "/dev/sda"
+
+       desc: RHCS OSD deployment on single SSD
+       polarion-id: CEPH-83575222
+       destroy-cluster: false
+       module: test_daemon.py
+       name: Add OSD services on single SSD.
+
+# # deploy rgws
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: apply
+                   service: rgw
+                   pos_args:
+                     - india.pri.80
+                   args:
+                     port: 80
+                     placement:
+                       nodes:
+                         - pluto002
+                         - pluto003
+         ceph-sec:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: apply
+                   service: rgw
+                   pos_args:
+                     - india.sec.80
+                   args:
+                     port: 80
+                     placement:
+                       nodes:
+                         - pluto005
+                         - pluto006
+         ceph-arc:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: apply
+                   service: rgw
+                   pos_args:
+                     - india.arc.80
+                   args:
+                     port: 80
+                     placement:
+                       nodes:
+                         - pluto008
+                         - pluto010
+
+       desc: RHCS sync rgws deploy using cephadm.
+       polarion-id: CEPH-83575222
+       destroy-cluster: false
+       module: test_cephadm.py
+       name: sync rgws deploy using cephadm
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: apply_spec
+                   service: orch
+                   validate-spec-services: true
+                   specs:
+                     - service_type: prometheus
+                       placement:
+                         count: 1
+                         nodes:
+                           - pluto001
+                     - service_type: grafana
+                       placement:
+                         nodes:
+                           - pluto001
+                     - service_type: alertmanager
+                       placement:
+                         count: 1
+                     - service_type: node-exporter
+                       placement:
+                         host_pattern: "*"
+                     - service_type: crash
+                       placement:
+                         host_pattern: "*"
+         ceph-sec:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: apply_spec
+                   service: orch
+                   validate-spec-services: true
+                   specs:
+                     - service_type: prometheus
+                       placement:
+                         count: 1
+                         nodes:
+                           - pluto004
+                     - service_type: grafana
+                       placement:
+                         nodes:
+                           - pluto004
+                     - service_type: alertmanager
+                       placement:
+                         count: 1
+                     - service_type: node-exporter
+                       placement:
+                         host_pattern: "*"
+                     - service_type: crash
+                       placement:
+                         host_pattern: "*"
+         ceph-arc:
+           config:
+             verify_cluster_health: true
+             steps:
+               - config:
+                   command: apply_spec
+                   service: orch
+                   validate-spec-services: true
+                   specs:
+                     - service_type: prometheus
+                       placement:
+                         count: 1
+                         nodes:
+                           - pluto007
+                     - service_type: grafana
+                       placement:
+                         nodes:
+                           - pluto007
+                     - service_type: alertmanager
+                       placement:
+                         count: 1
+                     - service_type: node-exporter
+                       placement:
+                         host_pattern: "*"
+                     - service_type: crash
+                       placement:
+                         host_pattern: "*"
+       name: Monitoring Services deployment
+       desc: Add monitoring services using spec file.
+       module: test_cephadm.py
+       polarion-id: CEPH-83574727
+
+# #configure clients
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             command: add
+             id: client.pri
+             node: pluto003
+             install_packages:
+               - ceph-common
+             copy_admin_keyring: true
+         ceph-sec:
+           config:
+             command: add
+             id: client.sec
+             node: pluto006
+             install_packages:
+               - ceph-common
+             copy_admin_keyring: true
+         ceph-arc:
+           config:
+             command: add
+             id: client.arc
+             node: pluto010
+             install_packages:
+               - ceph-common
+             copy_admin_keyring: true
+       desc: Configure the sync RGW client system
+       polarion-id: CEPH-83573758
+       destroy-cluster: false
+       module: test_client.py
+       name: conf
+
+# # Setting up primary site in a multisite
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             cephadm: true
+             commands:
+               - "radosgw-admin realm create --rgw-realm india --default"
+               - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://pluto002:80,http://pluto003:80 --master --default"
+               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://pluto002:80,http://pluto003:80 --master --default"
+               - "radosgw-admin period update --rgw-realm india --commit"
+               - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key a123 --secret s123 --rgw-realm india --system"
+               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key a123 --secret s123"
+               - "radosgw-admin period update --rgw-realm india --commit"
+               - "ceph config set client.rgw.india.pri.80 rgw_realm india"
+               - "ceph config set client.rgw.india.pri.80 rgw_zonegroup shared"
+               - "ceph config set client.rgw.india.pri.80 rgw_zone primary"
+               - "ceph orch restart rgw.india.pri.80"
+               - "radosgw-admin zonegroup modify --rgw-realm india --rgw-zonegroup shared --endpoints http://pluto003:5000"
+               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --endpoints http://pluto003:5000"
+               - "radosgw-admin period update --rgw-realm india --commit"
+       desc: Setting up primary site in a multisite.
+       module: exec.py
+       name: Setting up primary site in a multisite
+       polarion-id: CEPH-10362
+
+# # configuring HAproxy on the port '5000'
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             haproxy_clients:
+               - pluto003
+             rgw_endpoints:
+               - "pluto002:80"
+               - "pluto003:80"
+         ceph-sec:
+           config:
+             haproxy_clients:
+               - pluto006
+             rgw_endpoints:
+               - "pluto005:80"
+               - "pluto006:80"
+         ceph-arc:
+           config:
+             haproxy_clients:
+               - plto010
+             rgw_endpoints:
+               - "pluto008:80"
+               - "plto010:80"
+       desc: "Configure HAproxy fpr sync rgws"
+       module: haproxy.py
+       name: "Configure HAproxy"
+       polarion-id: CEPH-83572703
+
+# #configuring the secondary zone and archive zone from the Primary's Haproxy.
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             cephadm: true
+             commands:
+               - "ceph orch restart rgw.india.pri.80"
+
+
+         ceph-sec:
+           config:
+             commands:
+               - "sleep 120"
+               - "radosgw-admin realm pull --rgw-realm india --url http://pluto003:5000  --access-key a123 --secret s123 --default"
+               - "radosgw-admin period pull --url http://pluto003:5000 --access-key a123 --secret s123"
+               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://pluto005:80,http://pluto006:80 --access-key a123 --secret s123"
+               - "radosgw-admin period update --rgw-realm india --commit"
+               - "ceph config set client.rgw.india.sec.80 rgw_realm india"
+               - "ceph config set client.rgw.india.sec.80 rgw_zonegroup shared"
+               - "ceph config set client.rgw.india.sec.80 rgw_zone secondary"
+               - "ceph orch restart rgw.india.sec.80"
+               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://pluto006:5000"
+               - "radosgw-admin period update --rgw-realm india --commit"
+
+         ceph-arc:
+           config:
+             commands:
+               - "sleep 120"
+               - "radosgw-admin realm pull --rgw-realm india --url http://pluto003:5000  --access-key a123 --secret s123 --default"
+               - "radosgw-admin period pull --url http://pluto003:5000 --access-key a123 --secret s123"
+               - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://pluto008:80,http://plto010:80 --access-key a123 --secret s123 --tier-type archive"
+               - "radosgw-admin period update --rgw-realm india --commit"
+               - "ceph config set client.rgw.india.arc.80 rgw_realm india"
+               - "ceph config set client.rgw.india.arc.80 rgw_zonegroup shared"
+               - "ceph config set client.rgw.india.arc.80 rgw_zone archive"
+               - "ceph orch restart rgw.india.arc.80"
+               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://plto010:5000"
+               - "radosgw-admin period update --rgw-realm india --commit"
+
+       desc: Setting up RGW multisite replication environment
+       module: exec.py
+       name: setup multisite
+       polarion-id: CEPH-10362
+
+# # configure vault agent on IO rgws
+
+   - test:
+       clusters:
+         ceph-pri:
+           config:
+             install:
+               - agent
+             run-on-rgw: true
+         ceph-sec:
+           config:
+             install:
+               - agent
+             run-on-rgw: true
+         ceph-arc:
+           config:
+             install:
+               - agent
+             run-on-rgw: true
+       desc: Setup and configure vault agent
+       destroy-cluster: false
+       module: install_vault.py
+       name: configure vault agent
+       polarion-id: CEPH-83575226
+
+   - test:
+       abort-on-fail: true
+       clusters:
+         ceph-pri:
+           config:
+             cephadm: true
+             commands:
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_require_ssl false"
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_sse_s3_backend vault"
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_sse_s3_vault_auth agent"
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_sse_s3_vault_prefix /v1/transit "
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_sse_s3_vault_secret_engine transit"
+               - "ceph config set client.rgw.india.pri.80 rgw_crypt_default_encryption_key 4YSmvJtBv0aZ7geVgAsdpRnLBEwWSWlMIGnRS8a9TSA="
+               - "ceph orch restart rgw.india.pri.80"
+             timeout: 120
+         ceph-sec:
+           config:
+             cephadm: true
+             commands:
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_require_ssl false"
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_sse_s3_backend vault"
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_sse_s3_vault_auth agent"
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_sse_s3_vault_prefix /v1/transit "
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_sse_s3_vault_secret_engine transit"
+               - "ceph config set client.rgw.india.sec.80 rgw_crypt_default_encryption_key 4YSmvJtBv0aZ7geVgAsdpRnLBEwWSWlMIGnRS8a9TSA="
+               - "ceph orch restart rgw.india.sec.80"
+             timeout: 120
+         ceph-arc:
+           config:
+             cephadm: true
+             commands:
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_require_ssl false"
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_sse_s3_backend vault"
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_sse_s3_vault_auth agent"
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_sse_s3_vault_prefix /v1/transit "
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_sse_s3_vault_secret_engine transit"
+               - "ceph config set client.rgw.india.arc.80 rgw_crypt_default_encryption_key 4YSmvJtBv0aZ7geVgAsdpRnLBEwWSWlMIGnRS8a9TSA="
+               - "ceph orch restart rgw.india.arc.80"
+             timeout: 120
+       desc: Setting vault configs for sse-s3 on multisite archive
+       module: exec.py
+       name: set sse-s3 vault configs on multisite
+   - test:
+       clusters:
+         ceph-pri:
+           config:
+             cephadm: true
+             commands:
+               - "ceph versions"
+               - "radosgw-admin sync status"
+               - "ceph -s"
+               - "radosgw-admin realm list"
+               - "radosgw-admin zonegroup list"
+               - "radosgw-admin zone list"
+               - "radosgw-admin user list"
+         ceph-sec:
+           config:
+             cephadm: true
+             commands:
+               - "ceph versions"
+               - "radosgw-admin sync status"
+               - "ceph -s"
+               - "radosgw-admin realm list"
+               - "radosgw-admin zonegroup list"
+               - "radosgw-admin zone list"
+               - "radosgw-admin user list"
+         ceph-arc:
+           config:
+             cephadm: true
+             commands:
+               - "ceph versions"
+               - "radosgw-admin sync status"
+               - "ceph -s"
+               - "radosgw-admin realm list"
+               - "radosgw-admin zonegroup list"
+               - "radosgw-admin zone list"
+               - "radosgw-admin user list"
+       desc: Retrieve the configured environment details
+       polarion-id: CEPH-83575227
+       module: exec.py
+       name: get shared realm info


### PR DESCRIPTION
Motive:
Deploying the different environments to perform manual or automation scale workloads per the recommended configs is a mundane and redundant task. 
Automating these deployments would be of great relief for any scale workload tests.

**1. cli.** - /usr/bin/python3 run.py --rhbuild 5.3 --platform rhel-9 --cluster-conf pluto/pluto_conf.yaml --suite pluto/pluto_suite.yaml --log-level DEBUG --build latest --cloud baremetal"

logs:
osd : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RNWE2M/Add_OSD_services_on_single_SSD._0.log
rgws: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C6ULRO
client, haproxy and multisite: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SQ2BOA
vault: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SQ2BOA

