### PR TITLE
[TFA] issue fix for swift_enabling_versioning_on_a_bucket_that_is_S3_…

### DIFF
--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -45,17 +45,13 @@ tests:
               args:
                 all-available-devices: true
           - config:
-              command: apply_spec
-              service: orch
-              specs:
-                - service_type: rgw
-                  service_id: rgw.ssl
-                  placement:
-                    nodes:
-                      - node5
-                  spec:
-                    ssl: true
-                    rgw_frontend_ssl_certificate: create-cert
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py

--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -45,17 +45,13 @@ tests:
               args:
                 all-available-devices: true
           - config:
-              command: apply_spec
-              service: orch
-              specs:
-                - service_type: rgw
-                  service_id: rgw.ssl
-                  placement:
-                    nodes:
-                      - node5
-                  spec:
-                    ssl: true
-                    rgw_frontend_ssl_certificate: create-cert
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: RHCS cluster deployment using cephadm.
       destroy-cluster: false
       module: test_cephadm.py


### PR DESCRIPTION
…versioned

# Description
issue is same as that of : https://github.com/red-hat-storage/cephci/pull/3284

in this test s3cmd is used, since the cluster had ssl init, s3cmd failed
log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-793M03/test_swift_enable_version_on_conatainer_of_different_user_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
