### PR TITLE
Integration of tests for remote site downloads at archive and active …

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -307,3 +307,96 @@ tests:
       module: sanity_rgw_multisite.py
       name: test no bilogs are generated at archive zone
       comments: bug-2169298
+
+# configuring vault agent on all the sites
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-sec:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-arc:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.sec}"
+            timeout: 120
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.pri}"
+            timeout: 120
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.arc}"
+            timeout: 120
+      desc: Setting vault configs for sse-s3 on multisite
+      module: exec.py
+      name: set sse-s3 vault configs on multisite
+
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
+            timeout: 30
+      desc: test multipart download at remote site
+      polarion-id: CEPH-11357
+      module: sanity_rgw_multisite.py
+      name: test multipart download at remote site
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+            timeout: 30
+      desc: test multipart+encrypt object access at the archive site
+      polarion-id: CEPH-83573390
+      module: sanity_rgw_multisite.py
+      name: test multipart+encrypt object access at the archive site


### PR DESCRIPTION
Test encrypted+multipart download at remote site(active/archive)

Jira ticket : https://issues.redhat.com/browse/RHCEPHQE-12557

Polarian:

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-11357
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573390
Bugs:

https://bugzilla.redhat.com/show_bug.cgi?id=2237838
https://bugzilla.redhat.com/show_bug.cgi?id=2162337
Passed logs:

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RKP9JO

ceph-qe-scripts PR : https://github.com/red-hat-storage/ceph-qe-scripts/pull/536

test runs :
- rh-reef-weekly-rgw and
- ibm-reef-weekly-rgw
