### PR TITLE
Using rbd config instead of rbd image-meta to set journal delay

### DIFF
--- a/ceph/rbd/workflows/journal_mirror_ops.py
+++ b/ceph/rbd/workflows/journal_mirror_ops.py
@@ -31,27 +31,27 @@ def config_mirroring_delay(**kw):
     operation = kw.get("operation")
     if kw.get("delay_per_image"):
         if operation == "set":
-            _, err = rbd.image_meta.set(
+            _, err = rbd.config.image.set(
                 pool=pool,
                 image=image,
-                key="conf_rbd_mirroring_replay_delay",
+                key="rbd_mirroring_replay_delay",
                 value=delay,
             )
         elif operation == "remove":
-            out, err = rbd.image_meta.remove(
-                pool=pool, image=image, key="conf_rbd_mirroring_replay_delay"
+            out, err = rbd.config.image.remove(
+                pool=pool, image=image, key="rbd_mirroring_replay_delay"
             )
             if not err:
                 return out
         elif operation == "get":
-            out, err = rbd.image_meta.get(
-                pool=pool, image=image, key="conf_rbd_mirroring_replay_delay"
+            out, err = rbd.config.image.get(
+                pool=pool, image=image, key="rbd_mirroring_replay_delay"
             )
             if not err:
                 return out
         if err:
             log.error(
-                f"Performing operation {operation} conf_rbd_mirroring_replay_delay failed for {pool}/{image}"
+                f"Performing operation {operation} rbd_mirroring_replay_delay failed for {pool}/{image}"
             )
             return 1
     else:

--- a/cli/rbd/config/config.py
+++ b/cli/rbd/config/config.py
@@ -1,0 +1,15 @@
+from cli import Cli
+
+from .image import Image
+
+
+class Config(Cli):
+    """Base class for all rbd config commands.
+    This module provides CLI interface to manage rbd config and
+    objects with wrapper for sub-commands.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Config, self).__init__(nodes)
+        self.base_cmd = base_cmd + " config"
+        self.image = Image(nodes, self.base_cmd)

--- a/cli/rbd/config/image.py
+++ b/cli/rbd/config/image.py
@@ -1,0 +1,138 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Image(Cli):
+    """
+    This module provides CLI interface to manage rbd config image commands for images in pool.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Image, self).__init__(nodes)
+        self.base_cmd = base_cmd + " image"
+
+    def get(self, **kw):
+        """
+        Get image config value for given key.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    key(str)   : image meta key
+                    See rbd help image-meta get for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        key = kw_copy.pop("key", "")
+        cmd = f"{self.base_cmd} get {image_spec} {key} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def list(self, **kw):
+        """
+        List image config values.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    See rbd help image-meta get for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} list {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def ls(self, **kw):
+        """
+        List image config values.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    See rbd help image-meta get for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} ls {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def remove(self, **kw):
+        """
+        Remove image config value for given key.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    key(str)   : image meta key
+                    See rbd help image-meta get for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        key = kw_copy.pop("key", "")
+        cmd = f"{self.base_cmd} remove {image_spec} {key} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def rm(self, **kw):
+        """
+        Remove image config value for given key.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    key(str)   : image meta key
+                    See rbd help image-meta get for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        key = kw_copy.pop("key", "")
+        cmd = f"{self.base_cmd} rm {image_spec} {key} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def set(self, **kw):
+        """
+        Set image config value for given key.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str)  : name of the pool
+                    image(str) : name of the image
+                    namespace(str) : name of the namespace
+                    image-spec(str) : <pool>/<image>
+                    key(str)   : image meta key
+                    value(str) : image meta value
+                    See rbd help image-meta get for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        key = kw_copy.pop("key", "")
+        value = kw_copy.pop("value", "")
+        cmd = f"{self.base_cmd} set {image_spec} {key} {value} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from cli import Cli
 from cli.utilities.utils import build_cmd_from_args
 
+from .config.config import Config
 from .device import Device
 from .feature import Feature
 from .image_meta import Image_meta
@@ -21,6 +22,7 @@ class Rbd(Cli):
         self.snap = Snap(nodes, self.base_cmd)
         self.feature = Feature(nodes, self.base_cmd)
         self.image_meta = Image_meta(nodes, self.base_cmd)
+        self.config = Config(nodes, self.base_cmd)
 
     def create(self, **kw):
         """


### PR DESCRIPTION
PR to fix the pipeline automation issue http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-180/Weekly/rbd/17/tier-3_journal_mirroring_regression/Test_delayed_replication_on_journal_mirrored_clusters_0.log and also to use rbd config to set journal delay instead of rbd image-meta.

This was the comment given by dev.
`You shouldn't be setting anything with rbd image-meta command
For fine-grained (e.g. per-image) configuration, rbd config commands should be used`

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-C4HU8Q/
