### PR TITLE
New Automation to add BZ 2247187 client evict defer workflow

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-clients.yaml
@@ -345,4 +345,16 @@ tests:
       module: clients.verify_root_squash_in_caps.py
       name: verify root_squash cap works in multiFS
       polarion-id: "CEPH-83573868"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client eviction is deferred if OSD was laggy"
+      module: cephfs_bugs.test_defer_client_evict_on_laggy_osd.py
+      name: Client eviction deferred if OSD is laggy
+      polarion-id: "CEPH-83581592"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client is blocklisted if session metadata is bloated"
+      module: cephfs_bugs.test_client_blocklist_large_session_metadata.py
+      name: Verify Client is blocklisted if session metadata is bloated
+      polarion-id: "CEPH-83581613"
 

--- a/suites/reef/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test-clients.yaml
@@ -354,6 +354,16 @@ tests:
       module: clients.verify_root_squash_in_caps.py
       name: verify root_squash cap works in multiFS
       polarion-id: "CEPH-83573868"
-
-
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client eviction is deferred if OSD was laggy"
+      module: cephfs_bugs.test_defer_client_evict_on_laggy_osd.py
+      name: Client eviction deferred if OSD is laggy
+      polarion-id: "CEPH-83581592"
+  - test:
+      abort-on-fail: false
+      desc: "Verify Client is blocklisted if session metadata is bloated"
+      module: cephfs_bugs.test_client_blocklist_large_session_metadata.py
+      name: Verify Client is blocklisted if session metadata is bloated
+      polarion-id: "CEPH-83581613"
 

--- a/tests/cephfs/cephfs_bugs/test_client_blocklist_large_session_metadata.py
+++ b/tests/cephfs/cephfs_bugs/test_client_blocklist_large_session_metadata.py
@@ -1,0 +1,225 @@
+import secrets
+import string
+import time
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    try:
+        """
+         CEPH-83581613 - Client is blocklisted if session metadata is bloated/large.
+
+        Steps:
+        1. Set ceph config as "client client inject fixed oldest tid true"
+        2. Set ceph config as "mds mds_max_completed_requests max_requests" , max_requests = 10000
+        3. Create files with count > max_requests asynchronously
+        4. Create 10 files synchronously
+        5. Wait for "failing to advance oldest client" in Ceph Status
+        6. Set config as "mds mds_session_metadata_threshold 5000"
+        7. Create more files synchronously with limit of 100000, until Client is blocklisted.
+           IO error occurs on client mount.
+        8. Verify MDS perf counters mds_sessions and mdthresh_evicted are incremented
+        9. Set ceph config as "client client inject fixed oldest tid false"
+        Cleanup:
+        1. Umount subvolume, Remove subvolume
+
+        """
+        tc = "CEPH-83581613"
+        log.info("Running cephfs %s test case" % (tc))
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        mds_nodes = ceph_cluster.get_ceph_objects("mds")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        client1 = clients[0]
+        fs_name = "cephfs"
+        log.info("Enable ceph logging for ceph client")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config set client log_to_file true",
+        )
+        log.info("Set client config client inject fixed oldest tid to true")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd='ceph config set client "client inject fixed oldest tid" true',
+        )
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd='ceph config get client "client inject fixed oldest tid"',
+        )
+        log.info(out)
+        if "true" not in out.strip():
+            log.error("client config could not be set to inject fixed oldest tid")
+            return 1
+        log.info("Set mds config mds_max_completed_requests 10000")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mds mds_max_completed_requests 10000",
+        )
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config get mds mds_max_completed_requests",
+        )
+        log.info(out)
+        if "10000" not in out.strip():
+            log.error("mds_max_completed_requests could not be set 10000")
+            return 1
+        mds = fs_util.get_active_mdss(clients[0], fs_name)[0]
+        for mds_node in mds_nodes:
+            log.info(mds_node.node.hostname)
+            if mds_node.node.hostname in mds:
+                log.info("Get the mdthresh_evicted ceph mds perf cntr value")
+                mds_daemon = f"mds.{mds}"
+                out, rc = mds_node.exec_command(
+                    sudo=True,
+                    cmd=f"cephadm shell ceph daemon {mds_daemon} perf dump | grep mdthresh_evicted",
+                )
+                mds_perf_out = out.strip().split("\n")
+        mdthresh_evicted_before = mds_perf_out[0].split(":")[1]
+        log.info(f"mdthresh_evicted_before:{mdthresh_evicted_before}")
+        subvolume = {
+            "vol_name": fs_name,
+            "subvol_name": "subvol_client_blocklist",
+        }
+        log.info("Create subvolume")
+        fs_util.create_subvolume(clients[0], **subvolume)
+        subvol_path, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume getpath {fs_name} subvol_client_blocklist",
+        )
+        fuse_mount_dir = "/mnt/fuse_" + "".join(
+            secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
+        )
+        log.info("Perform fuse mount of subvolume")
+        fs_util.fuse_mount(
+            [client1],
+            fuse_mount_dir,
+            extra_params=f" -r {subvol_path.strip()}  --client_fs {fs_name}",
+        )
+
+        log.info("Create files with count > 10000 asynchronously")
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 10 "
+            f"--files 10050 --top {fuse_mount_dir}",
+            long_running=True,
+        )
+        time.sleep(10)
+        log.info("Verify failing to advance oldest client message in ceph status")
+        out, _ = client1.exec_command(sudo=True, cmd="ceph status")
+        out = out.strip()
+        log.info(f"Ceph status : {out}")
+        if "failing to advance oldest client" not in out:
+            log.error("failing to advance oldest client was not found in ceph status")
+            return 1
+
+        log.info("Get mds_session_metadata_threshold default")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config get mds mds_session_metadata_threshold",
+        )
+        mds_session_metadata_threshold_default = out.strip()
+        log.info(
+            f"mds_session_metadata_threshold_default:{mds_session_metadata_threshold_default}"
+        )
+        log.info("Set mds_session_metadata_threshold to 5000")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mds mds_session_metadata_threshold 5000",
+        )
+
+        log.info("Create more files synchronously with limit of 100000")
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 20 --file-size 10 "
+            f"--files 5000 --top {fuse_mount_dir}",
+            long_running=True,
+        )
+
+        time.sleep(10)
+        log.info("Verify Client session is blocklisted by accessing mountpoint")
+        try:
+            client1.exec_command(
+                sudo=True,
+                cmd=f"mkdir {fuse_mount_dir}/newdir;ls {fuse_mount_dir}",
+                check_ec=True,
+            )
+        except Exception as ex:
+            log.info(f"ex:{ex}")
+            if "cannot create directory" in str(
+                ex
+            ) and "transport endpoint shutdown" in str(ex):
+                log.info(
+                    "Verified that Client is blocklisted, IO error occurs on client"
+                )
+            else:
+                log.error("Client is not blocklisted")
+                # return 1
+
+        log.info(
+            f"Verify ceph mds perf cntr mdthresh_evicted is incremented from {mdthresh_evicted_before}"
+        )
+        for mds_node in mds_nodes:
+            if mds_node.node.hostname in mds:
+                log.info("Get the mdthresh_evicted ceph mds perf cntr value")
+                mds_daemon = f"mds.{mds}"
+                try:
+                    out, rc = mds_node.exec_command(
+                        sudo=True,
+                        cmd=f"cephadm shell ceph daemon {mds_daemon} perf dump | grep mdthresh_evicted",
+                    )
+                    log.info(f"mds_out:{out}")
+                    mds_perf_out = out.strip().split("\n")
+                    log.info(f"mds_perf_out:{mds_perf_out}")
+                except Exception as ex:
+                    log.info(ex)
+        mdthresh_evicted_after = mds_perf_out[0].split(":")[1]
+        if mdthresh_evicted_after > mdthresh_evicted_before:
+            log.info(
+                f"mdthresh_evicted perf counter has incremented to {mdthresh_evicted_after}"
+            )
+        else:
+            log.error(
+                f"mdthresh_evicted has not incremented : {mdthresh_evicted_after}"
+            )
+
+        out_client, _ = client1.exec_command(
+            sudo=True, cmd='grep "I was blocklisted" /var/log/ceph/*'
+        )
+        if out_client.strip():
+            log.info("Client blocklisted message is logged in client debug log")
+        else:
+            log.error("Client blocklisted message is not logged in client debug log")
+
+        return 0
+
+    except CommandFailed as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Peforming Cleanup")
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph config set mds mds_session_metadata_threshold {mds_session_metadata_threshold_default}",
+        )
+        client1.exec_command(
+            sudo=True,
+            cmd='ceph config set client "client inject fixed oldest tid" false',
+        )
+        mds_session_metadata_threshold_default = out.strip()
+        client1.exec_command(sudo=True, cmd=f"umount {fuse_mount_dir}", check_ec=False)
+        client1.exec_command(sudo=True, cmd=f"rm -rf {fuse_mount_dir}", check_ec=False)
+        fs_util.remove_subvolume(clients[0], **subvolume)

--- a/tests/cephfs/cephfs_bugs/test_defer_client_evict_on_laggy_osd.py
+++ b/tests/cephfs/cephfs_bugs/test_defer_client_evict_on_laggy_osd.py
@@ -1,0 +1,217 @@
+import json
+import secrets
+import string
+import traceback
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    try:
+        """
+         CEPH-83581592 - Defer eviction of client if OSD is laggy.
+
+        Steps:
+        1. ceph config set mds defer_client_eviction_on_laggy_osds false
+        2. Make OSD laggy: send SIGSTOP, wait 120 secs, send SIGCONT
+            a. grep the osds
+                dparmar:~$ pgrep ceph-osd -a
+                483404 /../ceph/build/bin/ceph-osd -i 0 -c /home/dparmar/CephRepo0/ceph/build/ceph.conf
+                484700 /../ceph/build/bin/ceph-osd -i 1 -c /home/dparmar/CephRepo0/ceph/build/ceph.conf
+                485987 /../ceph/build/bin/ceph-osd -i 2 -c /home/dparmar/CephRepo0/ceph/build/ceph.conf
+            b. send SIGSTOP(used to pause the process) to an OSD, let us pick first one
+                dparmar:~$ kill -SIGSTOP 483404
+            c. wait for 120 seconds
+            d. send SIGCONT to resume the paused OSD process
+                dparmar:~$ kill -SIGCONT 483404
+        3. Make client laggy by bringing down network interface, waiting for session_timeout + 30 secs and
+          bring up network interface
+        4. Wait for 6mins, the below mentioned lines should not be visible in mon log because some OSD(s) is/are laggy
+            Health check failed: 1 client(s) laggy due to laggy OSDs (MDS_CLIENTS_LAGGY)
+        Cleanup:
+        1. unmount the FS
+
+        """
+        tc = "CEPH-83581592"
+        log.info("Running cephfs %s test case" % (tc))
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        mon_node = ceph_cluster.get_ceph_objects("mon")[0]
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        client1 = clients[0]
+        fs_name = "cephfs"
+        file = "network_disconnect.sh"
+        osd_nodes = ceph_cluster.get_nodes("osd")
+
+        log.info("Enable ceph logging for mon daemon")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mon log_to_file true",
+        )
+        log.info("Set mds config defer_client_eviction_on_laggy_osds to false")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mds defer_client_eviction_on_laggy_osds false",
+        )
+        subvolume = {
+            "vol_name": fs_name,
+            "subvol_name": "subvol_osd_laggy",
+        }
+        log.info("Create subvolume")
+        fs_util.create_subvolume(clients[0], **subvolume)
+        subvol_path, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs subvolume getpath {fs_name} subvol_osd_laggy",
+        )
+        fuse_mount_dir = "/mnt/fuse_" + "".join(
+            secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
+        )
+        log.info("Perform fuse mount of subvolume")
+        fs_util.fuse_mount(
+            [client1],
+            fuse_mount_dir,
+            extra_params=f" -r {subvol_path.strip()}  --client_fs {fs_name}",
+        )
+        log.info("Run IO on subvolume")
+        client1.exec_command(
+            sudo=True,
+            cmd=f"python3 /home/cephuser/smallfile/smallfile_cli.py --operation create --threads 10 --file-size 4 "
+            f"--files 1000 --files-per-dir 10 --dirs-per-dir 2 --top "
+            f"{fuse_mount_dir}",
+            long_running=True,
+        )
+        log.info("Make OSD laggy")
+        mds_list = fs_util.get_active_mdss(clients[0], fs_name)
+        for mds in mds_list:
+            for osd_node in osd_nodes:
+                if osd_node.hostname in mds:
+                    log.info("Get the OSD daemon ID")
+                    out, rc = osd_node.exec_command(
+                        sudo=True,
+                        cmd="pgrep ceph-osd -a",
+                    )
+                    osd_list = out.split("\n")
+                    osd_ps_id = osd_list[0].split(" ")[0]
+                    log.info(
+                        f"Stop the OSD Daemon with ID {osd_ps_id}, wait for 120 secs and start"
+                    )
+                    out, rc = osd_node.exec_command(
+                        sudo=True,
+                        cmd=f"kill -SIGSTOP {osd_ps_id};sleep 120;kill -SIGCONT {osd_ps_id}",
+                    )
+        out, _ = client1.exec_command(sudo=True, cmd="ceph status")
+        out = out.strip()
+        log.info(f"Ceph status : {out}")
+
+        log.info("Get client session_timeout value")
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph fs dump | grep session_timeout"
+        )
+        out_list = out.split("\n")
+        for out in out_list:
+            if "session_timeout" in out:
+                session_timeout = out.split("\t")[1]
+
+        client1.upload_file(
+            sudo=True,
+            src="tests/cephfs/cephfs_bugs/network_disconnect.sh",
+            dst=f"/root/{file}",
+        )
+        nw_down_time = int(session_timeout) + 30
+        log.info(
+            f"Bring down Client network for {nw_down_time}secs to make client laggy"
+        )
+        out, _ = client1.exec_command(sudo=True, cmd="hostname -I | awk '{print $1}'")
+        client_ip_addr = out.strip()
+        log.info(f"{out},{client_ip_addr}")
+        client1.exec_command(
+            sudo=True,
+            cmd=f"bash /root/{file} {client_ip_addr} {nw_down_time}",
+        )
+        log.info(
+            "Verify if Client laggy due to OSD laggy message appears in ceph status or mon log"
+        )
+        unexp_str = '"client(s) laggy due to laggy OSDs"'
+        out, _ = mon_node.exec_command(sudo=True, cmd="cephadm ls")
+        data = json.loads(out)
+        fsid = data[0]["fsid"]
+        out_mon, _ = mon_node.exec_command(
+            sudo=True, cmd=f"cd /var/log/ceph/{fsid}/;ls *mon*log"
+        )
+        mon_file = out_mon.strip()
+        out, _ = mon_node.exec_command(
+            sudo=True,
+            check_ec=False,
+            cmd=f"cat /var/log/ceph/{fsid}/{mon_file}|grep {unexp_str}",
+        )
+        if out:
+            log.error(
+                f"Found unexpected Client laggy due to OSD laggy messages in mon log file : {out}"
+            )
+
+        out, _ = client1.exec_command(sudo=True, cmd="ceph status")
+        out = out.strip()
+        log.info(f"Ceph status : {out}")
+        if unexp_str in out.strip():
+            log.error(
+                "Found unexpected Client laggy due to OSD laggy messages in ceph status"
+            )
+
+        log.info("Verify if existing mountpoint is still accessible")
+        out, _ = client1.exec_command(
+            sudo=True, cmd=f"ls {fuse_mount_dir}|grep file_srcdir", check_ec=False
+        )
+        log.info(out)
+        if "file_srcdir" not in out:
+            log.error("Client mountpoint is NOT active, session could be evicted")
+            out, _ = client1.exec_command(
+                sudo=True, cmd="ceph tell mds.0 session ls --format json"
+            )
+            out = json.loads(out)
+            for session_item in out:
+                if client_ip_addr in session_item["entity"]["addr"]["addr"]:
+                    log.info(f"Client session details for debugging:{session_item}")
+            return 1
+
+        log.info("Verify client sessions were not evicted")
+        out, _ = client1.exec_command(
+            sudo=True, cmd="ceph tell mds.0 session ls --format json"
+        )
+        out = json.loads(out)
+        for session_item in out:
+            if client_ip_addr in session_item["entity"]["addr"]["addr"]:
+                if session_item["state"] == "open":
+                    log.info(
+                        f"Client session {session_item['id']} is open, not evicted, as expected"
+                    )
+                else:
+                    log.error(
+                        f"Client session {session_item['id']} is evicted:{session_item}"
+                    )
+                    return 1
+
+        return 0
+
+    except CommandFailed as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        client1.exec_command(
+            sudo=True,
+            cmd="ceph config set mds defer_client_eviction_on_laggy_osds true",
+        )
+        client1.exec_command(sudo=True, cmd=f"umount {fuse_mount_dir}", check_ec=False)
+        client1.exec_command(sudo=True, cmd=f"rm -rf {fuse_mount_dir}", check_ec=False)
+        fs_util.remove_subvolume(clients[0], **subvolume)


### PR DESCRIPTION
# Description
[BZ 2247187](https://bugzilla.redhat.com/show_bug.cgi?id=2247187) workflow : Defer client evict if OSD is laggy

Polarion TC : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581592

Jira ID : https://issues.redhat.com/browse/RHCEPHQE-12598

Test suite : suites/reef/cephfs/tier-2_cephfs_test-clients.yaml
- test:
      abort-on-fail: false
      desc: "Verify Client eviction is deferred if OSD was laggy"
      module: cephfs_bugs.test_defer_client_evict_on_laggy_osd.py
      name: Client eviction deferred if OSD is laggy
      polarion-id: "CEPH-83581592"

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UZFXJW

Added another BZ workflow BZ2238663 to the same PR.

Polarion TC : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581613
Jira ID : https://issues.redhat.com/browse/RHCEPHQE-12598
Test suite : suites/reef/cephfs/tier-2_cephfs_test-clients.yaml
- test:
      abort-on-fail: false
      desc: "Verify Client is blocklisted if session metadata is bloated"
      module: cephfs_bugs.test_client_blocklist_large_session_metadata.py
      name: Verify Client is blocklisted if session metadata is bloated
      polarion-id: "CEPH-83581613"

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5OHZJT

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
