### PR TITLE
[TFA issue fix] remove abort on failure from enabling service testcase

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -116,7 +116,6 @@ tests:
       name: deploy cluster
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:

--- a/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
@@ -116,7 +116,6 @@ tests:
       name: deploy cluster
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:

--- a/suites/quincy/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_multisite.yaml
@@ -298,8 +298,8 @@ tests:
             timeout: 300
 
   - test:
-      name: bucket granular sync policy with allowed allowed schemantic
-      desc: Test bucket granular sync policy with allowed allowed schemantic
+      name: bucket granular sync policy with allowed allowed semantic
+      desc: Test bucket granular sync policy with allowed allowed semantic
       polarion-id: CEPH-CEPH-83575868
       module: sanity_rgw_multisite.py
       comments: Known issue BZ-2153834
@@ -325,8 +325,8 @@ tests:
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
 
   - test:
-      name: bucket granular sync policy on enabled enabled schemantic with directional flow
-      desc: Test bucket granular sync policy on enabled enabled schemantic with directional flow
+      name: bucket granular sync policy on enabled enabled semantic with directional flow
+      desc: Test bucket granular sync policy on enabled enabled semantic with directional flow
       polarion-id: CEPH-83575137
       module: sanity_rgw_multisite.py
       clusters:
@@ -337,8 +337,8 @@ tests:
             timeout: 300
 
   - test:
-      name: bucket granular sync policy on allowed forbidden schemantic with directional flow
-      desc: Test bucket granular sync policy on allowed allowed schemantic with directional flow
+      name: bucket granular sync policy on allowed forbidden semantic with directional flow
+      desc: Test bucket granular sync policy on allowed allowed semantic with directional flow
       polarion-id: CEPH-83575137
       module: sanity_rgw_multisite.py
       clusters:

--- a/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -117,7 +117,6 @@ tests:
       name: deploy cluster
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -299,8 +298,8 @@ tests:
             timeout: 300
 
   - test:
-      name: bucket granular sync policy with allowed allowed schemantic
-      desc: Test bucket granular sync policy with allowed allowed schemantic
+      name: bucket granular sync policy with allowed allowed semantic
+      desc: Test bucket granular sync policy with allowed allowed semantic
       polarion-id: CEPH-CEPH-83575868
       module: sanity_rgw_multisite.py
       comments: Known issue BZ-2153834
@@ -313,8 +312,8 @@ tests:
             timeout: 300
 
   - test:
-      name: bucket granular sync policy on enabled enabled schemantic with directional flow
-      desc: Test bucket granular sync policy on enabled enabled schemantic with directional flow
+      name: bucket granular sync policy on enabled enabled semantic with directional flow
+      desc: Test bucket granular sync policy on enabled enabled semantic with directional flow
       polarion-id: CEPH-83575137
       module: sanity_rgw_multisite.py
       clusters:
@@ -325,8 +324,8 @@ tests:
             timeout: 300
 
   - test:
-      name: bucket granular sync policy on allowed forbidden schemantic with directional flow
-      desc: Test bucket granular sync policy on allowed allowed schemantic with directional flow
+      name: bucket granular sync policy on allowed forbidden semantic with directional flow
+      desc: Test bucket granular sync policy on allowed allowed semantic with directional flow
       polarion-id: CEPH-83575137
       module: sanity_rgw_multisite.py
       clusters:


### PR DESCRIPTION
# Description
[TFA issue fix] remove abort on failure from enabling service testcase
due to this the remaining  TC of the suite did no run.. http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/16.2.10-232/Regression/rgw/16/tier-1_rgw_ms-sync-policy-from-primary/

and updated the type

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
