### PR TITLE
Automation of the CEPH-83575431 - CEPH-83575431 - Verification of ceph-bluestore-tool rescue procedure

### DIFF
--- a/suites/reef/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/reef/rados/tier-2_rados_test_bluestore.yaml
@@ -139,3 +139,9 @@ tests:
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+  - test:
+      name: Bluestore rescue
+      desc: Bluestore resuce verification
+      polarion-id: CEPH-8
+      module: test_osd_bluestore_rescue.py

--- a/tests/rados/test_osd_bluestore_rescue.py
+++ b/tests/rados/test_osd_bluestore_rescue.py
@@ -1,0 +1,83 @@
+"""
+The program verifies the Bluestore rescue procedure
+"""
+
+import random
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.rados_scrub import RadosScrubber
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    scrub_object = RadosScrubber(node=cephadm)
+    rados_object = RadosOrchestrator(node=cephadm)
+    ceph_nodes = kw.get("ceph_nodes")
+    osd_list = []
+    try:
+        # setting the noout flag
+        scrub_object.set_osd_flags("set", "noout")
+
+        for node in ceph_nodes:
+            if node.role == "osd":
+                node_osds = rados_object.collect_osd_daemon_ids(node)
+                # Pick a single OSD from the host OSDs list
+                node_osds = random.sample(node_osds, 1)
+                osd_list = osd_list + node_osds
+        log.info(f"The number of OSDs in the cluster are-{len(osd_list)}")
+        osd_id = random.choice(osd_list)
+        log.info(f"The tests are performing on the {osd_id} OSD ")
+        osd_node = rados_object.fetch_host_node(
+            daemon_type="osd", daemon_id=str(osd_id)
+        )
+        if not rados_object.change_osd_state(action="stop", target=osd_id):
+            log.error(f" Failed to stop the OSD : {osd_id}")
+            return 1
+
+        cmd_base = f"cephadm shell --name osd.{osd_id} --"
+        cmd_bluestore_export = (
+            f"{cmd_base}  ceph-bluestore-tool bluefs-export --path "
+            f"/var/lib/ceph/osd/ceph-{osd_id} --out-dir  /tmp/bluefs_export_osd.{osd_id}"
+        )
+        output = osd_node.exec_command(sudo=True, cmd=cmd_bluestore_export)
+        log.info(f"The blue store export output is -{output}")
+        if "Segmentation fault" in output:
+            log.error("The output contain the Segmentation fault")
+            return 1
+
+        cmd_bluestore_recover = (
+            f"{cmd_base}  ceph-bluestore-tool -l /proc/self/fd/1 --log-level 5 --path "
+            f"/var/lib/ceph/osd/ceph-{osd_id} fsck --debug_bluefs=5/5 --bluefs_replay_recovery=true"
+        )
+        osd_node.exec_command(sudo=True, cmd=cmd_bluestore_recover)
+        osd_status_falg = False
+        time_end = time.time() + 60 * 4
+        while time.time() < time_end:
+            osd_status, status_desc = rados_object.get_daemon_status(
+                daemon_type="osd", daemon_id=osd_id
+            )
+            if osd_status == 1 or status_desc == "running":
+                log.info(f"OSD-{osd_id} is up and running")
+                osd_status_falg = True
+                break
+            log.info(f"osd-{osd_id} is not up and running")
+            time.sleep(10)
+        if not osd_status_falg:
+            log.error(f"The OSD-{osd_id} is not up after the bluestore recovery")
+            return 1
+        log.info(f"The OSD-{osd_id} is up and running after the bluestore recovery")
+    except Exception as er:
+        log.error(f"Exception hit while command execution. {er}")
+        return 1
+    finally:
+        if not rados_object.change_osd_state(action="start", target=osd_id):
+            log.error(f" Failed to stop the OSD : {osd_id}")
+            return 1
+    return 0


### PR DESCRIPTION
# Description
  Automation of the CEPH-83575431 - CEPH-83575431 - Verification of ceph-bluestore-tool rescue procedure

Test execution steps:
1. Set noout flag on the cluster
2. Stop  an OSD
3. Login into the stopped container
4. Verify the Export of the bluefs data scenario and check the output data.
5. Recover the OSD using the bluestore fsck command

Polarion link: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575431

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>



<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
