### PR TITLE
[Tier-1] Automate - Ceph 83575814

### DIFF
--- a/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_functional_Regression.yaml
@@ -361,6 +361,23 @@ tests:
       name: Validate Host accessibility to NVMe namespaces
       polarion-id: CEPH-83575455
 
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83575814
+      desc: Perform cluster operations when  IO operations between NVMeOF target NVMe-OF initiator are in progress.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Perform cluster operations when  IO operations are in progress.
+      polarion-id: CEPH-83575814
+
 # Reboot GW node
   - test:
       abort-on-fail: true

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -17,8 +17,8 @@ LOG = Log(__name__)
 def configure_subsystems(rbd, pool, gw, config):
     """Configure Ceph-NVMEoF Subsystems."""
     sub_nqn = config["nqn"]
-    max_ns = config.get("max_ns", 32)
-    gw.create_subsystem(sub_nqn, config["serial"], max_ns)
+    max_ns = {"max-namespaces": config.get("max_ns", 32)}
+    gw.create_subsystem(sub_nqn, config["serial"], **max_ns)
 
     cfg = {"gateway-name": config.pop("gateway-name"), "traddr": gw.node.ip_address}
     gw.create_listener(sub_nqn, config["listener_port"], **cfg)

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -21,8 +21,8 @@ LOG = Log(__name__)
 def configure_subsystems(rbd, pool, gw, config):
     """Configure Ceph-NVMEoF Subsystems."""
     sub_nqn = config["nqn"]
-    max_ns = config.get("max_ns", 32)
-    gw.create_subsystem(sub_nqn, config["serial"], max_ns)
+    max_ns = {"max-namespaces": config.get("max_ns", 32)}
+    gw.create_subsystem(sub_nqn, config["serial"], **max_ns)
 
     cfg = {"gateway-name": config.pop("gateway-name"), "traddr": gw.node.ip_address}
     gw.create_listener(sub_nqn, config["listener_port"], **cfg)


### PR DESCRIPTION
# Description

- Automates [RHCEPHQE-12506](https://issues.redhat.com/browse/RHCEPHQE-12506)
CEPH-83575814 - Perform Cluster operations when write and read operations on the NVMe-oF target using the NVMe-oF initiator In Progress.
- It also fixes issue related to parameters passing that was found in test_ceph_nvmeof_data_integrity.py
```
2024-01-10 22:17:09,356 (cephci.test_ceph_nvmeof_data_integrity) [ERROR] - cephci.cephci.ceph.parallel.py:93 - Exception in parallel execution
Traceback (most recent call last):
  File "/Users/chebrolubalasaiharika/Desktop/code/cephci/ceph/parallel.py", line 88, in __exit__
    for result in self:
  File "/Users/chebrolubalasaiharika/Desktop/code/cephci/ceph/parallel.py", line 106, in __next__
    resurrect_traceback(result)
  File "/Users/chebrolubalasaiharika/Desktop/code/cephci/ceph/parallel.py", line 35, in resurrect_traceback
    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
  File "/Users/chebrolubalasaiharika/Desktop/code/cephci/ceph/parallel.py", line 22, in capture_traceback
    return func(*args, **kwargs)
  File "/Users/chebrolubalasaiharika/Desktop/code/cephci/tests/nvmeof/test_ceph_nvmeof_data_integrity.py", line 21, in configure_subsystems
    gw.create_subsystem(sub_nqn, config["serial"], max_ns)
TypeError: create_subsystem() takes 3 positional arguments but 4 were given
```
- It also fixes the unsupported argument --max_ns for create_subsystem nvme command
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
