### PR TITLE
Scale subsystems on 2 nvmeof GWs

### DIFF
--- a/suites/reef/nvmeof/tier-2_2-nvmeof-gw_16-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_2-nvmeof-gw_16-sub_ns.yaml
@@ -1,14 +1,14 @@
-# Test suite to scale with 2 GWs having 1 subsystem with 400 namespaces
+# Test suite to scale with 2 GWs having 16 subsystems with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale: 16 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
      # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write followed by a read
+     # io type combination : For volumes listed on an initiator a write
      # io runtime is 10 seconds per volume/ image
   # Check ceph health and rbd image usage at end of test
 tests:
@@ -58,8 +58,22 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
   - test:
       abort-on-fail: true
       config:
@@ -95,23 +109,6 @@ tests:
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-##  Test cases to be executed
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        nodes:
-          - node6
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Setup client on NVMEoF gateway
-      destroy-cluster: false
-      module: test_client.py
-      name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
-
   - test:
       abort-on-fail: true
       config:
@@ -123,27 +120,19 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-                serial_num: 1
+                subsystems: 16
                 max-namespaces: 400
                 ana-reporting: ""
-          - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 port: 4420
                 pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 16 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
+      polarion-id: CEPH-83581625
 
   - test:
       abort-on-fail: true
@@ -156,15 +145,16 @@ tests:
           - config:
               command: create_listener
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subsystems: 16
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 16 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
+      polarion-id: CEPH-83581627
 
   - test:
       abort-on-fail: true
@@ -177,71 +167,20 @@ tests:
           - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 400
+                subsystems: 16
+                namespaces: 400
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
-            subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
             node: node6
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 1 subsystem with 400 namespaces with IO
+      desc: Scale to 400 namespaces on 16 subsystems with IO
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 1 subsystem with 400 namespaces
-
-  - test:
-      abort-on-fail: false
-      config:
-        node: node4
-        steps:
-          - config:
-              command: delete_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-      desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
-      module: test_nvme_cli.py
-      name: Delete NVMeOF targets
-      polarion-id: CEPH-83575783
-
-  - test:
-      abort-on-fail: false
-      config:
-         command: remove
-         service: nvmeof
-         args:
-           service_name: nvmeof.nvmeof_pool
-           verify: true
-      desc: Remove nvmeof service on GW node
-      destroy-clster: false
-      module: test_orch.py
-      name: Delete nvmeof gateway
-
-  - test:
-      abort-on-fail: false
-      config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: shell
-              args:
-                - ceph config set mon mon_allow_pool_delete true
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
-      desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
-      module: test_cephadm.py
-      name: Delete NVMeOF pools
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 400 namespaces on 16 subsystems with IO
+      polarion-id: CEPH-83581632

--- a/suites/reef/nvmeof/tier-2_2-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_2-nvmeof-gw_2-sub_ns.yaml
@@ -1,14 +1,14 @@
-# Test suite to scale with 2 GWs having 1 subsystem with 400 namespaces
+# Test suite to scale with 2 GWs having 2 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale : 2 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
      # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write followed by a read
+     # io type combination : For volumes listed on an initiator a write
      # io runtime is 10 seconds per volume/ image
   # Check ceph health and rbd image usage at end of test
 tests:
@@ -58,8 +58,22 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-23573752
+
   - test:
       abort-on-fail: true
       config:
@@ -95,23 +109,6 @@ tests:
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-##  Test cases to be executed
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        nodes:
-          - node6
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Setup client on NVMEoF gateway
-      destroy-cluster: false
-      module: test_client.py
-      name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
-
   - test:
       abort-on-fail: true
       config:
@@ -123,27 +120,20 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-                serial_num: 1
+                subsystems: 2
                 max-namespaces: 400
+                enable-ha: ""
                 ana-reporting: ""
-          - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 port: 4420
                 pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 2 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
+      polarion-id: CEPH-83581625
 
   - test:
       abort-on-fail: true
@@ -156,15 +146,16 @@ tests:
           - config:
               command: create_listener
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subsystems: 2
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 2 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
+      polarion-id: CEPH-83581627
 
   - test:
       abort-on-fail: true
@@ -177,71 +168,20 @@ tests:
           - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 400
+                subsystems: 2
+                namespaces: 400
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
-            subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
             node: node6
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 1 subsystem with 400 namespaces with IO
+      desc: Scale to 400 namespaces on 2 subsystems with IO
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 1 subsystem with 400 namespaces
-
-  - test:
-      abort-on-fail: false
-      config:
-        node: node4
-        steps:
-          - config:
-              command: delete_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-      desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
-      module: test_nvme_cli.py
-      name: Delete NVMeOF targets
-      polarion-id: CEPH-83575783
-
-  - test:
-      abort-on-fail: false
-      config:
-         command: remove
-         service: nvmeof
-         args:
-           service_name: nvmeof.nvmeof_pool
-           verify: true
-      desc: Remove nvmeof service on GW node
-      destroy-clster: false
-      module: test_orch.py
-      name: Delete nvmeof gateway
-
-  - test:
-      abort-on-fail: false
-      config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: shell
-              args:
-                - ceph config set mon mon_allow_pool_delete true
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
-      desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
-      module: test_cephadm.py
-      name: Delete NVMeOF pools
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 400 namespaces on 2 subsystems with IO
+      polarion-id: CEPH-83581629

--- a/suites/reef/nvmeof/tier-2_2-nvmeof-gw_4-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_2-nvmeof-gw_4-sub_ns.yaml
@@ -1,14 +1,14 @@
-# Test suite to scale with 2 GWs having 1 subsystem with 400 namespaces
+# Test suite to scale with 2 GWs having 4 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale : 4 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
      # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write followed by a read
+     # io type combination : For volumes listed on an initiator a write
      # io runtime is 10 seconds per volume/ image
   # Check ceph health and rbd image usage at end of test
 tests:
@@ -58,8 +58,22 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-43573754
+
   - test:
       abort-on-fail: true
       config:
@@ -95,23 +109,6 @@ tests:
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-##  Test cases to be executed
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        nodes:
-          - node6
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Setup client on NVMEoF gateway
-      destroy-cluster: false
-      module: test_client.py
-      name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
-
   - test:
       abort-on-fail: true
       config:
@@ -123,27 +120,19 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-                serial_num: 1
+                subsystems: 4
                 max-namespaces: 400
                 ana-reporting: ""
-          - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 port: 4420
                 pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 4 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
+      polarion-id: CEPH-83581625
 
   - test:
       abort-on-fail: true
@@ -156,15 +145,16 @@ tests:
           - config:
               command: create_listener
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subsystems: 4
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 4 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
+      polarion-id: CEPH-83581627
 
   - test:
       abort-on-fail: true
@@ -177,71 +167,20 @@ tests:
           - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 400
+                subsystems: 4
+                namespaces: 400
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
-            subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
             node: node6
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 1 subsystem with 400 namespaces with IO
+      desc: Scale to 400 namespaces on 4 subsystems with IO
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 1 subsystem with 400 namespaces
-
-  - test:
-      abort-on-fail: false
-      config:
-        node: node4
-        steps:
-          - config:
-              command: delete_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-      desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
-      module: test_nvme_cli.py
-      name: Delete NVMeOF targets
-      polarion-id: CEPH-83575783
-
-  - test:
-      abort-on-fail: false
-      config:
-         command: remove
-         service: nvmeof
-         args:
-           service_name: nvmeof.nvmeof_pool
-           verify: true
-      desc: Remove nvmeof service on GW node
-      destroy-clster: false
-      module: test_orch.py
-      name: Delete nvmeof gateway
-
-  - test:
-      abort-on-fail: false
-      config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: shell
-              args:
-                - ceph config set mon mon_allow_pool_delete true
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
-      desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
-      module: test_cephadm.py
-      name: Delete NVMeOF pools
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 400 namespaces on 4 subsystems with IO
+      polarion-id: CEPH-83581630

--- a/suites/reef/nvmeof/tier-2_2-nvmeof-gw_8-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_2-nvmeof-gw_8-sub_ns.yaml
@@ -1,14 +1,14 @@
-# Test suite to scale with 2 GWs having 1 subsystem with 400 namespaces
+# Test suite to scale with 2 GWs having 8 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale : 8 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
      # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write followed by a read
+     # io type combination : For volumes listed on an initiator a write
      # io runtime is 10 seconds per volume/ image
   # Check ceph health and rbd image usage at end of test
 tests:
@@ -58,8 +58,22 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
   - test:
       abort-on-fail: true
       config:
@@ -95,23 +109,6 @@ tests:
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-##  Test cases to be executed
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        nodes:
-          - node6
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Setup client on NVMEoF gateway
-      destroy-cluster: false
-      module: test_client.py
-      name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
-
   - test:
       abort-on-fail: true
       config:
@@ -123,27 +120,19 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-                serial_num: 1
+                subsystems: 8
                 max-namespaces: 400
                 ana-reporting: ""
-          - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 port: 4420
                 pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 8 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
+      polarion-id: CEPH-83581625
 
   - test:
       abort-on-fail: true
@@ -156,15 +145,16 @@ tests:
           - config:
               command: create_listener
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subsystems: 8
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target
+      desc: Configure NVMeOF target with 8 subsystems
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
+      module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
+      polarion-id: CEPH-83581627
 
   - test:
       abort-on-fail: true
@@ -177,71 +167,20 @@ tests:
           - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 400
+                subsystems: 8
+                namespaces: 400
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
-            subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
             node: node6
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 1 subsystem with 400 namespaces with IO
+      desc: Scale to 400 namespaces on 8 subsystems with IO
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 1 subsystem with 400 namespaces
-
-  - test:
-      abort-on-fail: false
-      config:
-        node: node4
-        steps:
-          - config:
-              command: delete_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-      desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
-      module: test_nvme_cli.py
-      name: Delete NVMeOF targets
-      polarion-id: CEPH-83575783
-
-  - test:
-      abort-on-fail: false
-      config:
-         command: remove
-         service: nvmeof
-         args:
-           service_name: nvmeof.nvmeof_pool
-           verify: true
-      desc: Remove nvmeof service on GW node
-      destroy-clster: false
-      module: test_orch.py
-      name: Delete nvmeof gateway
-
-  - test:
-      abort-on-fail: false
-      config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: shell
-              args:
-                - ceph config set mon mon_allow_pool_delete true
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
-      desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
-      module: test_cephadm.py
-      name: Delete NVMeOF pools
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 400 namespaces on 8 subsystems with IO
+      polarion-id: CEPH-83581631

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
@@ -1,0 +1,265 @@
+from copy import deepcopy
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin import CephAdmin
+from ceph.ceph_admin.common import fetch_method
+from ceph.nvmeof.initiator import Initiator
+from ceph.nvmeof.nvmeof_gwcli import NVMeCLI, find_client_daemon_id
+from ceph.utils import get_node_by_id
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.retry import retry
+from utility.utils import generate_unique_id, run_fio
+
+LOG = Log(__name__)
+
+
+def initiators(ceph_cluster, gateway, config):
+    """Configure NVMe Initiators."""
+    client = get_node_by_id(ceph_cluster, config["node"])
+    initiator = Initiator(client)
+    initiator.disconnect_all()
+
+    connect_cmd_args = {
+        "transport": "tcp",
+        "traddr": gateway.ip_address,
+        "trsvcid": config["listener_port"],
+        "nqn": config["subnqn"],
+    }
+    LOG.debug(initiator.connect(**connect_cmd_args))
+
+
+@retry(Exception, tries=5, delay=10)
+def run_io(ceph_cluster, num, io):
+    """Run IO on newly added namespace."""
+    LOG.info(io)
+    client = get_node_by_id(ceph_cluster, io["node"])
+    initiator = Initiator(client)
+
+    targets = initiator.list_spdk_drives()
+    if not targets:
+        raise Exception(f"NVMe Targets not found on {client.hostname}")
+
+    device_path = next(
+        (device["DevicePath"] for device in targets if device["NameSpace"] == num), None
+    )
+    LOG.debug(device_path)
+
+    if device_path is None:
+        raise Exception("NVMe volume not found")
+    else:
+        io_args = {
+            "device_name": device_path,
+            "client_node": client,
+            "run_time": "10",
+            "long_running": True,
+            "io_type": io["io_type"],
+            "cmd_timeout": "notimeout",
+        }
+        result = run_fio(**io_args)
+        if result != 0:
+            raise Exception("FIO failure")
+
+
+def configure_subsystem(config, nvme_cli, ceph_cluster, node):
+    max_ns = config["args"].pop("max-namespaces")
+    pool_name = config["args"].pop("pool")
+    port = config["args"].pop("port")
+    hostnqn = config["args"].pop("hostnqn")
+
+    for num in range(1, config["args"].pop("subsystems") + 1):
+        config["args"].update(
+            {
+                "subnqn": f"nqn.2016-06.io.spdk:cnode{num}",
+                "serial_num": f"{num}",
+                "m": max_ns,
+            }
+        )
+
+        subsystem_func = fetch_method(nvme_cli, "create_subsystem")
+        subsystem_func(**config["args"])
+        config["args"].clear()
+
+        client_id = find_client_daemon_id(
+            ceph_cluster, pool_name, node_name=node.hostname
+        )
+        config["args"].update(
+            {
+                "subnqn": f"nqn.2016-06.io.spdk:cnode{num}",
+                "gateway-name": client_id,
+                "traddr": node.ip_address,
+                "port": port,
+            }
+        )
+
+        listener_func = fetch_method(nvme_cli, "create_listener")
+        listener_func(**config["args"])
+        config["args"].clear()
+
+        config["args"].update(
+            {
+                "subnqn": f"nqn.2016-06.io.spdk:cnode{num}",
+                "hostnqn": hostnqn,
+            }
+        )
+
+        host_access_func = fetch_method(nvme_cli, "add_host")
+        host_access_func(**config["args"])
+        config["args"].clear()
+
+
+def configure_listener(config, nvme_cli, ceph_cluster, node):
+    port = config["args"].pop("port")
+    pool_name = config["args"].pop("pool")
+
+    for num in range(1, config["args"].pop("subsystems") + 1):
+        client_id = find_client_daemon_id(
+            ceph_cluster, pool_name, node_name=node.hostname
+        )
+        config["args"].update(
+            {
+                "subnqn": f"nqn.2016-06.io.spdk:cnode{num}",
+                "gateway-name": client_id,
+                "traddr": node.ip_address,
+                "port": port,
+            }
+        )
+
+        listener_func = fetch_method(nvme_cli, "create_listener")
+        listener_func(**config["args"])
+        config["args"].clear()
+
+
+def configure_namespace(
+    config, nvme_cli, ceph_cluster, node, init_config, rbd_obj, io_param
+):
+    subsystems = config["args"].pop("subsystems")
+    namespaces = config["args"].pop("namespaces")
+    image_size = config["args"].pop("image_size")
+    pool = config["args"].pop("pool")
+    half_sub = int(subsystems / 2)
+    namespaces_sub = int(namespaces / subsystems)
+
+    LOG.info(half_sub)
+    LOG.info(namespaces_sub)
+
+    for sub_num in range(1, subsystems + 1):
+        init_config.update({"subnqn": f"nqn.2016-06.io.spdk:cnode{sub_num}"})
+        initiators(ceph_cluster, node, init_config)
+        name = generate_unique_id(length=4)
+        LOG.info(sub_num)
+        LOG.info(subsystems)
+
+        for num in range(1, namespaces_sub + 1):
+            rbd_obj.create_image(pool, f"{name}-image{num}", image_size)
+            LOG.info(num)
+            LOG.info(namespaces)
+            config["args"].clear()
+            config["args"].update(
+                {
+                    "name": f"{name}-bdev{num}",
+                    "image": f"{name}-image{num}",
+                    "pool": pool,
+                }
+            )
+
+            bdev_func = fetch_method(nvme_cli, "create_block_device")
+            bdev_func(**config["args"])
+            config["args"].clear()
+
+            config["args"].update(
+                {
+                    "bdev": f"{name}-bdev{num}",
+                    "subnqn": f"nqn.2016-06.io.spdk:cnode{sub_num}",
+                }
+            )
+            config["args"]["anagrpid"] = 1 if sub_num < half_sub + 1 else 2
+            namespace_func = fetch_method(nvme_cli, "add_namespace")
+            namespace_func(**config["args"])
+
+            for io in io_param:
+                run_io(ceph_cluster, num, io)
+
+            mem_usage, _ = node.exec_command(
+                cmd="ps -eo pid,ppid,cmd,comm,%mem,%cpu --sort=-%mem | head -20",
+                sudo=True,
+            )
+            LOG.info(mem_usage)
+            top_usage, _ = node.exec_command(cmd="top -b | head -n 20", sudo=True)
+            LOG.info(top_usage)
+
+
+def execute_and_log_results(node):
+    commands = [
+        "cephadm shell ceph df",
+        "cephadm shell rbd du",
+        "cephadm shell ceph -s",
+        "cephadm shell ceph health detail",
+        "cat /proc/meminfo",
+        "cat /proc/cpuinfo",
+        "ps -eo pid,ppid,cmd,comm,%mem,%cpu --sort=-%mem | head -20",
+        "top -b | head -n 20",
+    ]
+    for cmd in commands:
+        output, _ = node.installer.exec_command(cmd, sudo=True)
+        LOG.info(output)
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    LOG.info("Configure Ceph NVMeoF entities at scale over CLI.")
+    config = deepcopy(kwargs["config"])
+    node = get_node_by_id(ceph_cluster, config["node"])
+    rbd_pool = config.get("rbd_pool", "rbd_pool")
+    kwargs["config"].update(
+        {
+            "do_not_create_image": True,
+            "rep-pool-only": True,
+            "rep_pool_config": {"pool": rbd_pool},
+        }
+    )
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeCLI.CEPH_NVMECLI_IMAGE = value
+            break
+
+    nvme_cli = NVMeCLI(node, config.get("port", 5500))
+
+    try:
+        steps = config.get("steps", [])
+        init_config = config.get("initiators")
+        io = config.get("run_io")
+
+        for step in steps:
+            cfg = step["config"]
+            command = cfg.pop("command")
+
+            if command == "create_subsystem":
+                configure_subsystem(cfg, nvme_cli, ceph_cluster, node)
+            elif command == "create_listener":
+                configure_listener(cfg, nvme_cli, ceph_cluster, node)
+            elif command == "add_namespace":
+                configure_namespace(
+                    cfg, nvme_cli, ceph_cluster, node, init_config, rbd_obj, io
+                )
+            else:
+                func = fetch_method(nvme_cli, command)
+
+                if "args" not in cfg:
+                    cfg["args"] = {}
+
+                func(**cfg["args"])
+
+        instance = CephAdmin(cluster=ceph_cluster, **config)
+        execute_and_log_results(instance)
+
+    except BaseException as be:
+        LOG.error(be, exc_info=True)
+        instance = CephAdmin(cluster=ceph_cluster, **config)
+        execute_and_log_results(instance)
+
+        return 1
+
+    return 0


### PR DESCRIPTION
Scale testing
Constants - 2 GWs, 400 namesapces
variables - subsystems in 2,4,8 and 16 intervals

2 subsystems - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X0TZQH
8 subsystems - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NX1Q76/
16 subsystems - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L6DP3E
                          http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M4D3GR

scaling namespaces on 8 subsystems - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3GX5ZV
E2E 2GWs, 16 subsystems, 400 NS with 2 anagrpids - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QFPQJ1
E2E 2GWs, 2 subsystems, 400 NS with 2 anagrpids - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N4XB8M

Polarion test links

Configure GW-1 : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581625
Configure GW- 2 : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581627

Scale to 400 namespaces on 2 subsystems with IO : https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581629
Scale to 400 namespaces on 4 subsystems with IO: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581630
Scale to 400 namespaces on 8 subsystems with IO - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581631
Scale to 400 namespaces on 16 subsystems with IO - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581632




