### PR TITLE
[NFS-Ganesha][Setup][Core-Dump]addition

### DIFF
--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -627,8 +627,12 @@ def check_coredump_generated(node, coredump_path, created_after):
     cmd = f"ls -Art {coredump_path} | tail -n 1"
     file_name, _ = node.exec_command(cmd=cmd, sudo=True)
 
+    # If the path is empty / not created, return False as no coredump has been generated
+    if file_name == "":
+        return False
+
     # Get the file creation time
-    cmd = f"stat -c '%w' {file_name}"
+    cmd = f"stat -c '%w' {coredump_path}/{file_name}"
     created_time, _ = node.exec_command(cmd=cmd, sudo=True)
 
     # Remove timezone and fractional seconds from time
@@ -638,8 +642,8 @@ def check_coredump_generated(node, coredump_path, created_after):
 
     # Verify if the file is created after the given time
     if created_time > created_after:
-        return False
-    return True
+        return True
+    return False
 
 
 def create_files(client, mount_point, file_count):

--- a/tests/nfs/nfs_client_permission_export.py
+++ b/tests/nfs/nfs_client_permission_export.py
@@ -48,6 +48,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export with client permission

--- a/tests/nfs/nfs_edit_export_config_with_1client_access.py
+++ b/tests/nfs/nfs_edit_export_config_with_1client_access.py
@@ -66,6 +66,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export

--- a/tests/nfs/nfs_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_edit_export_config_with_ro.py
@@ -66,6 +66,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export

--- a/tests/nfs/nfs_file_append.py
+++ b/tests/nfs/nfs_file_append.py
@@ -47,6 +47,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create files from client 1

--- a/tests/nfs/nfs_file_truncate.py
+++ b/tests/nfs/nfs_file_truncate.py
@@ -45,6 +45,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create files from dd on client 1

--- a/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_client_permission.py
@@ -76,6 +76,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export

--- a/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
+++ b/tests/nfs/nfs_ha_failover_edit_export_config_with_ro.py
@@ -77,6 +77,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export

--- a/tests/nfs/nfs_ha_failover_with_untar.py
+++ b/tests/nfs/nfs_ha_failover_with_untar.py
@@ -56,6 +56,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         sleep(3)

--- a/tests/nfs/nfs_ha_readdir_operation.py
+++ b/tests/nfs/nfs_ha_readdir_operation.py
@@ -85,6 +85,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_hard_links_delete_file.py
+++ b/tests/nfs/nfs_hard_links_delete_file.py
@@ -46,6 +46,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_hard_links_server_reboot.py
+++ b/tests/nfs/nfs_hard_links_server_reboot.py
@@ -47,6 +47,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_hard_symbolic_links_rename.py
+++ b/tests/nfs/nfs_hard_symbolic_links_rename.py
@@ -46,6 +46,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_rootsquash_using_conf.py
+++ b/tests/nfs/nfs_rootsquash_using_conf.py
@@ -74,6 +74,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export

--- a/tests/nfs/nfs_spec_storage.py
+++ b/tests/nfs/nfs_spec_storage.py
@@ -42,6 +42,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         log.info(f"Run SPECstorage with {benchmark} benchmark")

--- a/tests/nfs/nfs_verify_bonnie.py
+++ b/tests/nfs/nfs_verify_bonnie.py
@@ -45,6 +45,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Install bonnie++ on clients

--- a/tests/nfs/nfs_verify_failover_with_file_ops.py
+++ b/tests/nfs/nfs_verify_failover_with_file_ops.py
@@ -78,6 +78,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_failover_with_io.py
+++ b/tests/nfs/nfs_verify_failover_with_io.py
@@ -56,6 +56,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         # Trigger smallfile IO

--- a/tests/nfs/nfs_verify_file_lock.py
+++ b/tests/nfs/nfs_verify_file_lock.py
@@ -58,6 +58,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")

--- a/tests/nfs/nfs_verify_file_lock_ha.py
+++ b/tests/nfs/nfs_verify_file_lock_ha.py
@@ -67,6 +67,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
     except Exception as e:
         log.error(f"Failed to setup nfs cluster {e}")

--- a/tests/nfs/nfs_verify_file_lock_root_squash.py
+++ b/tests/nfs/nfs_verify_file_lock_root_squash.py
@@ -87,6 +87,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export

--- a/tests/nfs/nfs_verify_file_modification.py
+++ b/tests/nfs/nfs_verify_file_modification.py
@@ -72,6 +72,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_operations.py
+++ b/tests/nfs/nfs_verify_file_operations.py
@@ -59,6 +59,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_ops_hard_links.py
+++ b/tests/nfs/nfs_verify_file_ops_hard_links.py
@@ -59,6 +59,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_file_ops_soft_links.py
+++ b/tests/nfs/nfs_verify_file_ops_soft_links.py
@@ -86,6 +86,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create oprtaions on each client

--- a/tests/nfs/nfs_verify_hard_links_inode.py
+++ b/tests/nfs/nfs_verify_hard_links_inode.py
@@ -46,6 +46,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
+++ b/tests/nfs/nfs_verify_multi_depth_dir_and_permissions.py
@@ -44,6 +44,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create multi depth dirs under nfs share

--- a/tests/nfs/nfs_verify_multi_node_cluster.py
+++ b/tests/nfs/nfs_verify_multi_node_cluster.py
@@ -49,6 +49,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
         # Perform file creation on client 1
         for i in range(100):

--- a/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
+++ b/tests/nfs/nfs_verify_multiple_parallel_io_and_lookups.py
@@ -48,6 +48,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Linux untar on client 1

--- a/tests/nfs/nfs_verify_nfs_ha.py
+++ b/tests/nfs/nfs_verify_nfs_ha.py
@@ -52,6 +52,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
         log.info("Successfully setup NFS HA cluster")
     except Exception as e:

--- a/tests/nfs/nfs_verify_nfs_kill_process_failover.py
+++ b/tests/nfs/nfs_verify_nfs_kill_process_failover.py
@@ -54,6 +54,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
         log.info("Successfully setup NFS HA cluster")
 

--- a/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
+++ b/tests/nfs/nfs_verify_parallel_rm_write_lookup.py
@@ -60,6 +60,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         operations = []

--- a/tests/nfs/nfs_verify_pynfs.py
+++ b/tests/nfs/nfs_verify_pynfs.py
@@ -44,6 +44,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create a file on Client 1

--- a/tests/nfs/nfs_verify_pynfs_ha.py
+++ b/tests/nfs/nfs_verify_pynfs_ha.py
@@ -55,6 +55,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create a file on Client 1

--- a/tests/nfs/nfs_verify_read_write_operations.py
+++ b/tests/nfs/nfs_verify_read_write_operations.py
@@ -44,6 +44,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         if operation == "verify_permission":

--- a/tests/nfs/nfs_verify_readdir_ops.py
+++ b/tests/nfs/nfs_verify_readdir_ops.py
@@ -47,6 +47,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Linux untar on client 1

--- a/tests/nfs/nfs_verify_setuid_bit.py
+++ b/tests/nfs/nfs_verify_setuid_bit.py
@@ -107,6 +107,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export with squash permission

--- a/tests/nfs/nfs_verify_stress.py
+++ b/tests/nfs/nfs_verify_stress.py
@@ -58,6 +58,7 @@ def run(ceph_cluster, **kw):
             fs,
             ha,
             vip,
+            ceph_cluster=ceph_cluster,
         )
         log.info("Successfully setup NFS cluster")
 

--- a/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
+++ b/tests/nfs/nfs_verify_symbolic_links_file_other_file_system.py
@@ -46,6 +46,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file in local file system

--- a/tests/nfs/nfs_verify_symbolic_links_permissions.py
+++ b/tests/nfs/nfs_verify_symbolic_links_permissions.py
@@ -46,6 +46,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file

--- a/tests/nfs/nfs_verify_symbolic_links_users.py
+++ b/tests/nfs/nfs_verify_symbolic_links_users.py
@@ -46,6 +46,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create file

--- a/tests/nfs/test_export_readonly.py
+++ b/tests/nfs/test_export_readonly.py
@@ -48,6 +48,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export with RO permission

--- a/tests/nfs/test_export_rootsquash.py
+++ b/tests/nfs/test_export_rootsquash.py
@@ -67,6 +67,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create export with squash permission

--- a/tests/nfs/test_file_ops_copy.py
+++ b/tests/nfs/test_file_ops_copy.py
@@ -94,6 +94,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
         # Create files and dirs from client 1 and copy files and dirs from client 2
         client1 = clients[0]

--- a/tests/nfs/test_file_ops_renames.py
+++ b/tests/nfs/test_file_ops_renames.py
@@ -92,6 +92,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         # Create files from Client 1 and perform lookups and rename from client 2 and client 3

--- a/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
+++ b/tests/nfs/test_nfs_rootsquash_file_access_from_multiple_clients.py
@@ -49,6 +49,7 @@ def run(ceph_cluster, **kw):
             fs_name,
             nfs_export,
             fs_name,
+            ceph_cluster=ceph_cluster,
         )
 
         Ceph(clients[0]).nfs.export.create(


### PR DESCRIPTION
[NFS-Ganesha][Setup][Core-Dump]addition

Problem:

To add coredump feature, the node details are required in the methods defined under nfs_operations. But currently, the node ips alone are being passed to these methods, hence any operations on nodes won't be possible with current implementation


Solution:
Pass the ceph_cluster variable to the setup_nfs_cluster method. This will enable the node specific and other related operations to be carried out, thus resolving the problem.

The current pr is specific to the tests and all the existing tests are modified in passing the ceph_cluster variable to the setup_nfs_cluster method