### PR TITLE
CEPH-10046: Tier-3 test to verify automatic periodic trimming of osdmaps

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -406,7 +406,7 @@ class RadosOrchestrator:
             kwargs: Any other param that needs to passed
                 - rados_write_duration -> duration of write operation (int)
                 - byte_size -> size of objects to be written (str)
-                    eg : 10KB, 4096
+                    eg : 10KB, default - 4096KB
                 - max_objs -> max number of objects to be written (int)
                 - verify_stats -> arg to control whether obj stats need to
                   be verified after write (bool) | default: True
@@ -1353,6 +1353,7 @@ class RadosOrchestrator:
             )
         except Exception as er:
             log.error(f"Exception hit while command execution. {er}")
+            raise
         return log_lines
 
     def set_mclock_profile(self, profile="balanced", osd="osd", reset=False):
@@ -3113,3 +3114,15 @@ class RadosOrchestrator:
                 f"Metadata info for the input daemon: {daemon_type} {daemon_id} not found"
             )
         return out
+
+    def get_osd_status(self, osd_id):
+        """
+        method to fetch the output of osd status command -
+        ceph tell osd.N status command
+        Args:
+            osd_id: ID of desired osd daemon
+        Returns:
+            dict output of ceph tell osd.N status command
+        """
+        base_cmd = f"ceph tell osd.{osd_id} status"
+        return self.run_ceph_command(cmd=base_cmd)

--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -4,6 +4,7 @@ Module to change pool attributes
 2. Snapshots
 """
 import datetime
+import random
 import time
 import traceback
 
@@ -334,11 +335,12 @@ class PoolFunctions:
         log.info(f"Completed deleting all objects from pool {pool_name}")
         return True
 
-    def create_pool_snap(self, pool_name: str):
+    def create_pool_snap(self, pool_name: str, count: int = 1):
         """
         Creates snapshots of the given pool
         Args:
             pool_name: name of the pool
+            count: number of snaps to create (optional)
         Returns: Pass -> name of the snapshot created, Fail -> False
 
         """
@@ -356,12 +358,10 @@ class PoolFunctions:
                 return False
 
         # Creating snaps on the pool provided
-        cmd = "uuidgen"
-        out, err = self.rados_obj.node.shell([cmd])
-        uuid = out[0:5]
-        snap_name = f"{pool_name}-snap-{uuid}"
-        cmd = f"ceph osd pool mksnap {pool_name} {snap_name}"
-        self.rados_obj.node.shell([cmd], long_running=True)
+        for _ in range(count):
+            snap_name = f"{pool_name}-snap-{random.randint(0, 10000)}"
+            cmd = f"ceph osd pool mksnap {pool_name} {snap_name}"
+            self.rados_obj.node.shell([cmd], long_running=True)
 
         # Checking if snap was created successfully
         if not self.check_snap_exists(snap_name=snap_name, pool_name=pool_name):

--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -105,6 +105,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: Inconsistent object pg check
       desc: Inconsistent object pg check
       module: test_osd_inconsistency_pg.py
@@ -203,3 +210,9 @@ tests:
             obj_end: 5
             num_keys_obj: 10
         delete_pool: true
+
+  - test:
+      name: Automatic trimming of osdmaps
+      desc: check for periodic trimming of osdmaps
+      module: test_osdmap_trim.py
+      polarion-id: CEPH-10046

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -105,6 +105,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: Inconsistent object pg check
       desc: Inconsistent object pg check
       module: test_osd_inconsistency_pg.py
@@ -203,3 +210,9 @@ tests:
             obj_end: 5
             num_keys_obj: 10
         delete_pool: true
+
+  - test:
+      name: Automatic trimming of osdmaps
+      desc: check for periodic trimming of osdmaps
+      module: test_osdmap_trim.py
+      polarion-id: CEPH-10046

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -105,6 +105,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: Inconsistent object pg check
       desc: Inconsistent object pg check
       module: test_osd_inconsistency_pg.py
@@ -217,3 +224,9 @@ tests:
               pool_type: replicated
               pg_num: 16
         delete_pool: true
+
+  - test:
+      name: Automatic trimming of osdmaps
+      desc: check for periodic trimming of osdmaps
+      module: test_osdmap_trim.py
+      polarion-id: CEPH-10046

--- a/tests/rados/test_osdmap_trim.py
+++ b/tests/rados/test_osdmap_trim.py
@@ -1,0 +1,168 @@
+"""
+Method to create OSDMAPs and verify automatic trimming and logging in mon logs
+"""
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-10046
+    Automatic trimming of OSDMAP
+    1. Create a replicated pool with default config
+    2. Fetch the primary osd of first PG
+    3. Retrieve initial osdmap stats
+    4. Trigger background iops and create pool snapshots
+    5. Monitor trimming of osdmaps for 10 mins
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    mon_trim_log_list = []
+    _pool_name = "test-osdmap"
+    log.info("Running test case to verify trimming of OSDMAPs")
+
+    def manipulate_osdmaps(p_name):
+        # create and delete pool snaps to increase osdmaps
+        pool_obj.create_pool_snap(pool_name=p_name, count=50)
+        pool_obj.delete_pool_snap(pool_name=p_name)
+        time.sleep(10)
+
+    try:
+        # enable required log levels for OSD and MON
+        assert mon_obj.set_config(
+            section="osd", name="osd_beacon_report_interval", value="30"
+        )
+        assert mon_obj.set_config(section="mon", name="debug_paxos", value="10/10")
+        assert mon_obj.set_config(
+            section="mon", name="paxos_service_trim_min", value="100"
+        )
+        assert mon_obj.set_config(
+            section="mon", name="mon_min_osdmap_epochs", value="100"
+        )
+
+        # create pool with given config
+        log.info("Creating a replicated pool with default config")
+        assert rados_obj.create_pool(pool_name=_pool_name)
+
+        # fetch acting set and primary osd for the created pool
+        acting_set = rados_obj.get_pg_acting_set(pool_name=_pool_name)
+        primary_osd = acting_set[0]
+        log.info(f"Acting set for {_pool_name}: {acting_set}")
+
+        # fetch osdmap for the primary osd before starting the test
+        init_osdmap = rados_obj.get_osd_status(osd_id=primary_osd)
+        init_oldest_map = init_osdmap["oldest_map"]
+        init_newest_map = init_osdmap["newest_map"]
+        log.info(f"ceph osd status for {primary_osd}: \n {init_osdmap}")
+        log.info(f"Oldest map before test for {primary_osd}: \n {init_oldest_map}")
+        log.info(f"Newest map before test for {primary_osd}: \n {init_newest_map}")
+
+        status_report = rados_obj.run_ceph_command(cmd="ceph report", client_exec=True)
+        osdmap_first_committed = status_report["osdmap_first_committed"]
+        osdmap_last_committed = status_report["osdmap_last_committed"]
+
+        log.info(f"osdmap_first_committed from ceph report: {osdmap_first_committed}")
+        log.info(f"osdmap_last_committed from ceph report: {osdmap_last_committed}")
+
+        # initiate background iops on the pool
+        bench_cfg = {
+            "pool_name": _pool_name,
+            "byte_size": "10KB",
+            "duration": 600,
+            "background": True,
+        }
+        rados_obj.bench_write(**bench_cfg)
+
+        # fetch leader mon and record logging start time
+        leader_mon_daemon = rados_obj.run_ceph_command(cmd="ceph mon stat")["leader"]
+        mon_host = rados_obj.fetch_host_node(
+            daemon_type="mon", daemon_id=leader_mon_daemon
+        )
+        init_time, _ = mon_host.exec_command(cmd="date '+%Y-%m-%d %H:%M:%S'", sudo=True)
+
+        # call method to create and remove pool snaps
+        manipulate_osdmaps(p_name=_pool_name)
+        time.sleep(10)
+
+        # while loop to ascertain trimming of osdmaps
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=600)
+        while datetime.datetime.now() < endtime:
+            curr_osdmap = rados_obj.get_osd_status(osd_id=primary_osd)
+            curr_oldest_map = curr_osdmap["oldest_map"]
+            curr_status_report = rados_obj.run_ceph_command(
+                cmd="ceph report", client_exec=True
+            )
+            curr_osdmap_first_committed = curr_status_report["osdmap_first_committed"]
+            if (
+                curr_oldest_map > init_oldest_map
+                and curr_oldest_map == curr_osdmap_first_committed
+            ):
+                log.info(
+                    "Current 'oldest osd map' is greater than initial 'oldest osd map"
+                )
+                log.info(f"{curr_oldest_map} > {init_oldest_map}")
+                log.info(
+                    "Current 'oldest osd map' is equal to 'osdmap first committed' "
+                    "which signifies trimming has occured and completed."
+                )
+                log.info(f"{curr_oldest_map} == {curr_osdmap_first_committed}")
+                end_time, _ = mon_host.exec_command(
+                    cmd="date '+%Y-%m-%d %H:%M:%S'", sudo=True
+                )
+                break
+            else:
+                if datetime.datetime.now() >= endtime:
+                    log.error("osdmaps were not trimmed even once within timeout")
+                    raise Exception("osdmaps were not trimmed even once within timeout")
+                log.info("Trimming is yet to occur, creating more osdmaps")
+                manipulate_osdmaps(p_name=_pool_name)
+                time.sleep(10)
+
+        leader_mon_daemon = rados_obj.run_ceph_command(cmd="ceph mon stat")["leader"]
+        mon_logs = rados_obj.get_journalctl_log(
+            start_time=init_time,
+            end_time=end_time,
+            daemon_type="mon",
+            daemon_id=leader_mon_daemon,
+        )
+
+        for line in mon_logs.splitlines():
+            if "paxosservice(osdmap" in line and (
+                "maybe_trim trim" in line or "trim from" in line
+            ):
+                mon_trim_log_list.append(line)
+
+        mon_trim_log = "\n".join(mon_trim_log_list)
+
+        log.info(
+            f"\n ==========================================================================="
+            f"\n osdmap trimming entries in mon.{leader_mon_daemon} log: \n {mon_trim_log}"
+            f"\n ==========================================================================="
+        )
+        log.info("Automatic trimming of OSDMAPs has been verified")
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        log.info("*********** Execution of finally block starts ***********")
+        # remove all the modified configs
+        mon_obj.remove_config(section="osd", name="osd_beacon_report_interval")
+        mon_obj.remove_config(section="mon", name="debug_paxos")
+        mon_obj.remove_config(section="mon", name="paxos_service_trim_min")
+        mon_obj.remove_config(section="mon", name="mon_min_osdmap_epochs")
+        # Delete the created osd pool
+        rados_obj.detete_pool(pool=_pool_name)
+    return 0


### PR DESCRIPTION
[CEPH-10046](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-10046): Tier-3 test to verify automatic periodic trimming of osdmaps. OSDs should trim its osdmap cache periodically and this trimming can be tuned using several config parameters.

Jira: [RHCEPHQE-9945](https://issues.redhat.com/browse/RHCEPHQE-9945)

Test modules added:
- `get_osd_status` in `ceph/rados/core_workflows.py`

Test modules modified:
- `create_pool_snap` in `ceph/rados/pool_workflows.py`

Test suites modified:
- suites/pacific/rados/tier-2_rados_test_omap.yaml
- suites/quincy/rados/tier-2_rados_test_omap.yaml
- suites/reef/rados/tier-2_rados_test_omap.yaml

Logs -
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N69OT0
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-T5BQAR
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-V882QS

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
