### PR TITLE
[TFA] [Rados] Fix for verification of osd_memory_target value from ceph config dump

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -98,9 +98,9 @@ tests:
         osd_level: true
 
   - test:
-      name: osd_memory_target param set at Host level
+      name: osd_memory_target param set at host level
       module: test_osd_memory_target.py
-      desc: Verification of osd_memory_target parameter set at OSD level
+      desc: Verification of osd_memory_target parameter set at host level
       polarion-id: CEPH-83580881
       config:
         host_level: true

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -99,9 +99,9 @@ tests:
         osd_level: true
 
   - test:
-      name: osd_memory_target param set at Host level
+      name: osd_memory_target param set at host level
       module: test_osd_memory_target.py
-      desc: Verification of osd_memory_target parameter set at OSD level
+      desc: Verification of osd_memory_target parameter set at host level
       polarion-id: CEPH-83580881
       config:
         host_level: true

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -99,9 +99,9 @@ tests:
         osd_level: true
 
   - test:
-      name: osd_memory_target param set at Host level
+      name: osd_memory_target param set at host level
       module: test_osd_memory_target.py
-      desc: Verification of osd_memory_target parameter set at OSD level
+      desc: Verification of osd_memory_target parameter set at host level
       polarion-id: CEPH-83580881
       config:
         host_level: true


### PR DESCRIPTION
TFA fix for edge case where multiple entries listed in `ceph config dump` satisfy the conditional checks present in [verify_set_config](https://github.com/red-hat-storage/cephci/blob/e5d6e2176ebb0058631fe3d53fe5be100dc9a003/tests/rados/monitor_configurations.py#L266) method
The first match value from `ceph config dump` was being picked and compared with the input value set for the parameter, however, the actual set value was listed further below in the `ceph config dump` json output 
As the `for loop` is designed to exit if conditional checks match but the parameter value is different, the test failed without consider all the entries relevant to parameter being set.
Failure log:
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/16.2.10-232/Regression/rados/16/tier-2_rados_test-osd-rebalance/osd_memory_target_param_set_at_OSD_level_0.log

Modifying the [verify_set_config](https://github.com/red-hat-storage/cephci/blob/e5d6e2176ebb0058631fe3d53fe5be100dc9a003/tests/rados/monitor_configurations.py#L266) method would require extensive code change and may have repercussions on other tests utilizing this module.
As a workaround and quick-fix, all the required osd config parameters are being set and verified exclusively without the use of this method.

Test case modified:
`tests/rados/test_osd_memory_target.py`

Pass log:
Pacific: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N7NH8M/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5YWVBK

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
