### PR TITLE
[tfa-fix] Add fix for RGW failure in apply spec suite

### DIFF
--- a/suites/pacific/cephadm/tier-1_cephadm-clients.yaml
+++ b/suites/pacific/cephadm/tier-1_cephadm-clients.yaml
@@ -134,6 +134,7 @@ tests:
                 data_devices:
                   all: "true"                         # boolean as string
                 encrypted: "true"                     # boolean as string
+                unmanaged: "true"
         - config:
             command: shell
             args:                 # sleep to get all services deployed
@@ -171,3 +172,39 @@ tests:
           client_group: clients
           fsid: f64f341c-655d-11eb-8778-fa163e914bcc
           keyring_dest: /etc/ceph/custom_name_ceph.keyring
+  - test:
+      name: Deploy OSD with limit filter spec
+      desc: Deploy OSD with limit filter spec
+      module: test_cephadm.py
+      config:
+        steps:                          # Deploy OSD with limit filter
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: osd
+                  service_id: small_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+                - service_type: osd
+                  service_id: big_db
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      size: '11GB:16GB'
+                      limit: 2
+          - config:
+              command: shell
+              args:                 # sleep to get all services deployed
+                - sleep
+                - "300"
+  - test:
+      name: Verify OSD deployed with limit filter spec
+      desc: Verify OSD deployed with limit filter spec
+      polarion-id: CEPH-83575588
+      module: test_osd_limit_filter.py

--- a/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
+++ b/suites/pacific/cephadm/tier-1_service_apply_spec.yaml
@@ -105,8 +105,8 @@ tests:
                     - node3
       abort-on-fail: true
   - test:
-      name: Service deployment with spec
-      desc: Add services using spec file.
+      name: MON stack Service deployment with spec
+      desc: Add MON stack services using spec file.
       module: test_cephadm.py
       polarion-id: CEPH-83574727
       config:
@@ -151,7 +151,6 @@ tests:
                     data_devices:
                       all: "true"                         # boolean as string
                     encrypted: "true"                     # boolean as string
-                    unmanaged: "true"
           - config:
               command: shell
               args:                 # sleep to get all services deployed
@@ -184,7 +183,7 @@ tests:
               command: shell
               args:              # sleep to get all services deployed
                 - sleep
-                - "120"
+                - "300"
   - test:
       name: NFS Service deployment with spec
       desc: Add NFS services using spec file
@@ -225,7 +224,7 @@ tests:
               command: shell
               args:              # sleep to get all services deployed
                 - sleep
-                - "120"
+                - "300"
   - test:
       name: RGW Service deployment with spec
       desc: Add RGW services using spec file
@@ -268,56 +267,7 @@ tests:
               command: shell
               args:              # sleep to get all services deployed
                 - sleep
-                - "120"
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        node: node5
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Configure the RGW,RBD client system
-      destroy-cluster: false
-      module: test_client.py
-      name: configure client
-  - test:
-      name: Deploy OSD with limit filter spec
-      desc: Deploy OSD with limit filter spec
-      module: test_cephadm.py
-      config:
-        steps:                          # Deploy OSD with limit filter
-          - config:
-              command: apply_spec
-              service: orch
-              specs:
-                - service_type: osd
-                  service_id: small_db
-                  placement:
-                    label: osd
-                  spec:
-                    data_devices:
-                      size: '11GB:16GB'
-                      limit: 2
-                - service_type: osd
-                  service_id: big_db
-                  placement:
-                    label: osd
-                  spec:
-                    data_devices:
-                      size: '11GB:16GB'
-                      limit: 2
-          - config:
-              command: shell
-              args:                 # sleep to get all services deployed
-                - sleep
                 - "300"
-  - test:
-      name: Verify OSD deployed with limit filter spec
-      desc: Verify OSD deployed with limit filter spec
-      polarion-id: CEPH-83575588
-      module: test_osd_limit_filter.py
   - test:
       name: test_remove_service
       desc: Perform removal of RBD mirroring service from the cluster


### PR DESCRIPTION
# Description

Previously, due to a change made for addition of the OSD Limit Filter test case to the `tier-1_service_apply_spec.yaml` suite, there was a change in default OSD deployment where "unmanaged" flag was marked as true. This was causing the MDS and RGW deployments to misbehave.
The OSD Limit-Filter test case has now been moved to `tier-1_cephadm-clients.yaml` and the default OSD deployment does not have the unmanaged flag.
This also includes addition of timeouts for MDS and RGW deployment to address the RGW deployment failure in the `tier-1_service_apply_spec.yaml` suite.