### PR TITLE
CEPH-83573252: Tier-3 test to verify hard limit for PG log trimming

### DIFF
--- a/suites/pacific/rados/tier-3_rados-recovery_tests.yaml
+++ b/suites/pacific/rados/tier-3_rados-recovery_tests.yaml
@@ -103,6 +103,20 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Limit PG log size
+      polarion-id: CEPH-83573252
+      module: test_pg_log_limit.py
+      desc: Verify PG log growth limit using pglog_hardlimit flag
+
   - test:
         name: Testing async recovery
         desc: Testing async recovery

--- a/suites/quincy/rados/tier-3_rados-recovery_tests.yaml
+++ b/suites/quincy/rados/tier-3_rados-recovery_tests.yaml
@@ -103,6 +103,20 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Limit PG log size
+      polarion-id: CEPH-83573252
+      module: test_pg_log_limit.py
+      desc: Verify PG log growth limit using pglog_hardlimit flag
+
   - test:
         name: Testing async recovery
         desc: Testing async recovery

--- a/suites/reef/rados/tier-3_rados-recovery_tests.yaml
+++ b/suites/reef/rados/tier-3_rados-recovery_tests.yaml
@@ -103,6 +103,20 @@ tests:
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Limit PG log size
+      polarion-id: CEPH-83573252
+      module: test_pg_log_limit.py
+      desc: Verify PG log growth limit using pglog_hardlimit flag
+
   - test:
         name: Testing async recovery
         desc: Testing async recovery

--- a/tests/rados/test_osdmap_trim.py
+++ b/tests/rados/test_osdmap_trim.py
@@ -80,7 +80,7 @@ def run(ceph_cluster, **kw):
         bench_cfg = {
             "pool_name": _pool_name,
             "byte_size": "10KB",
-            "duration": 600,
+            "rados_write_duration": 600,
             "background": True,
         }
         rados_obj.bench_write(**bench_cfg)

--- a/tests/rados/test_pg_log_limit.py
+++ b/tests/rados/test_pg_log_limit.py
@@ -1,0 +1,154 @@
+"""
+Module to test hard limit for pg log trimming
+Bugzilla:
+ - https://bugzilla.redhat.com/show_bug.cgi?id=1608060
+ - https://bugzilla.redhat.com/show_bug.cgi?id=1644409
+"""
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83573252
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1608060
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1644409
+    1. Create a replicated pool with default config
+    2. Check the default value of osd config parameter 'osd_max_pg_log_entries'
+        should default to 10K
+    3. Set the OSD level flag 'pglog_hardlimit'
+    4. Set OSD config parameter 'osd_pg_max_log_entries' to 5000
+    5. Trigger sequential I/Os followed by OSD restart untill PG log size reaches 5000
+    6. Trigger background IOPS on the created pool and monitor PG log size growth and trimming
+    7. Ensure pg log does not increase beyond value set in 'osd_max_pg_log_entries', i.e. 5000
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    pg_trim_log_list = []
+    _pool_name = "test-pg-log-limit"
+
+    try:
+        # create pool with given config
+        log.info("Creating a replicated pool with default config")
+        assert rados_obj.create_pool(pool_name=_pool_name)
+
+        # set OSD log level to 10 to capture pg log trimming
+        assert mon_obj.set_config(section="osd", name="debug_osd", value="10/10")
+
+        def_value = mon_obj.get_config(section="osd", param="osd_max_pg_log_entries")
+        log.info(f"Default value of parameter osd_max_pg_log_entries: {def_value}")
+        assert int(def_value) == 10000
+
+        # set pglog_hardlimit flag and 5000 value for 'osd_max_pg_log_entries'
+        out, _ = cephadm.shell(args=["ceph osd set pglog_hardlimit"])
+        assert mon_obj.set_config(
+            section="osd", name="osd_max_pg_log_entries", value="5000"
+        )
+
+        pg_id = rados_obj.get_pgid(pool_name=_pool_name)[0]
+        primary_osd = rados_obj.get_pg_acting_set(pg_num=pg_id)[0]
+        log.info(f"Primary OSD for pg {pg_id}: {primary_osd}")
+        osd_host = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=primary_osd)
+
+        # PG log stats before test commences
+        pg_query = rados_obj.run_ceph_command(cmd=f"ceph pg {pg_id} query")
+        init_log_size = pg_query["info"]["stats"]["log_size"]
+        log.info(f"Log size of pg {pg_id} before I/Os: {init_log_size}")
+
+        # rados bench config for foreground I/Os
+        fore_bench_cfg = {
+            "pool_name": _pool_name,
+            "byte_size": "10KB",
+            "rados_write_duration": 90,
+        }
+
+        # while loop to decide start time of capturing OSD logs
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=900)
+        while datetime.datetime.now() < endtime:
+            curr_pg_query = rados_obj.run_ceph_command(cmd=f"ceph pg {pg_id} query")
+            curr_log_size = curr_pg_query["info"]["stats"]["log_size"]
+            if int(curr_log_size) >= 5000:
+                log.info(
+                    f"PG log size is now greater than or equal to 5000: {curr_log_size}"
+                )
+                log.info("Fetching machine time to determine OSD log start time")
+                init_time, _ = osd_host.exec_command(
+                    cmd="date '+%Y-%m-%d %H:%M:%S'", sudo=True
+                )
+                break
+            log.info(f"PG log is increasing but currently below 5000: {curr_log_size}")
+            log.info("Triggering bench IOPS for 90 secs followed by recovery")
+            rados_obj.bench_write(**fore_bench_cfg)
+            rados_obj.change_osd_state(action="restart", target=primary_osd)
+        else:
+            log.error("PG logs could not increase beyond 5000 within timeout 900 secs")
+            raise Exception("PG logs could not increase beyond 9000 within timeout.")
+
+        """ Now that PG log count has reached 5K, we trigger background IOPS for a
+        duration of 120 secs and observe the trimming of these log beyond 9500."""
+        # initiate background iops on the pool
+        back_bench_cfg = {
+            "pool_name": _pool_name,
+            "byte_size": "11KB",
+            "rados_write_duration": 120,
+            "background": True,
+        }
+        rados_obj.bench_write(**back_bench_cfg)
+
+        # while loop to monitor PG log growth and to ascertain trimming of pg logs
+        endtime = datetime.datetime.now() + datetime.timedelta(seconds=140)
+        while datetime.datetime.now() < endtime:
+            curr_pg_query = rados_obj.run_ceph_command(cmd=f"ceph pg {pg_id} query")
+            curr_log_size = curr_pg_query["info"]["stats"]["log_size"]
+            # Trimming of pg log is not absolute and immediate, therefore
+            # to avoid false failures, a margin of 150 has been provided on top
+            # of set limit of 5000. PG log growth beyond 5150 would suggest
+            # irregular trimming.
+            if int(curr_log_size) >= 5150:
+                error_msg = (
+                    f"Excepted trimming of PG log did not take place."
+                    f"\n Current value of PG log: {curr_log_size}, ideally should"
+                    f"have been below 5150."
+                )
+                log.error(error_msg)
+                raise Exception(error_msg)
+            log.info(f"Current PG log size: {curr_log_size}")
+            time.sleep(8)
+
+        end_time, _ = osd_host.exec_command(cmd="date '+%Y-%m-%d %H:%M:%S'", sudo=True)
+        osd_logs = rados_obj.get_journalctl_log(
+            start_time=init_time,
+            end_time=end_time,
+            daemon_type="osd",
+            daemon_id=primary_osd,
+        )
+
+        for line in osd_logs.splitlines():
+            if f"pg[{pg_id}(" in line and "calc_trim_to_aggressive" in line:
+                pg_trim_log_list.append(line)
+
+        pg_trim_log = "\n".join(pg_trim_log_list)
+        log.info(
+            f"\n ==========================================================================="
+            f"\n PG log trimming entries in OSD.{primary_osd} log: \n {pg_trim_log}"
+            f"\n ==========================================================================="
+        )
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        mon_obj.remove_config(section="osd", name="debug_osd")
+        mon_obj.remove_config(section="osd", name="osd_max_pg_log_entries")
+        rados_obj.detete_pool(pool=_pool_name)
+    return 0


### PR DESCRIPTION
[CEPH-83573252](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573252): Tier-3 test to verify hard limit for pg log trimming

Jira: [RHCEPHQE-12592](https://issues.redhat.com/browse/RHCEPHQE-12592)

> Previously, the `osd_max_pg_log_entries` option did not set a hard limit for the placement group (PG) log length. Consequently, during recovery and backfill, the log could grow significantly and consume a lot of memory, in some cases even all of it. With this update, a hard limit is set on the number of log entries in the PG log even during recovery and backfill.
A corner case, where it might be hard to limit the PG log length, is on erasure-coded pools, when the rollback information on some of replicas is too old for some reason.
A flag called pglog_hardlimit has been introduced. It is off by default. This flag enables the feature that limits the length of the pg log. Users should run 'ceph osd set pglog_hardlimit' after a complete upgrade is over. Once all the OSDs have this flag set, the length of the pg log will be capped by a hard limit. This flag should not be unset.

Test module added:
- `tests/rados/test_pg_log_limit.py`

Test module modified:
- `tests/rados/test_osdmap_trim.py` introduced in #3305 had a minor config mismatch, where `rados_write_duration` was misspelt as `duration`, so the value sent here was ignore and test ran with default value of 200 seconds. This is now being rectified with this PR

Test suites modified:
- `suites/pacific/rados/tier-3_rados-recovery_tests.yaml`
- `suites/quincy/rados/tier-3_rados-recovery_tests.yaml`
- `suites/reef/rados/tier-3_rados-recovery_tests.yaml`

Logs - 
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EYP6A8/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MJPRY4
Reef:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>