### PR TITLE
[fix] segregate nvmeof testsuites with tiers from polarion

### DIFF
--- a/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
@@ -1,0 +1,133 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+##  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  #  Configure Ceph NVMeoF gateway
+  #  Configure Initiators
+  #  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool application enable rbd rbd
+          - config:
+              command: shell
+              args:
+                - rbd create -s 1G image1
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  label: nvmeof-gw
+              pos_args:
+                - rbd
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy nvmeof gateway
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5001
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 5001
+            node: node10
+      desc: E2E-Test NVMEoF Gateway on dedicated node and Run IOs on targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Basic E2ETest Ceph NVMEoF GW sanity test on dedicated node
+      polarion-id: CEPH-83575441

--- a/suites/reef/nvmeof/tier-1_nvmeof_vmware_esx_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_vmware_esx_sanity.yaml
@@ -45,12 +45,12 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  #  Configure Initiators
+  #  Run IO on NVMe Targets
   - test:
       abort-on-fail: true
       config:
@@ -81,7 +81,7 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
@@ -176,7 +176,7 @@ tests:
            service_name: nvmeof.nvmeof_pool
            verify: true
       desc: Remove nvmeof service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       module: test_orch.py
       name: Delete nvmeof gateway
 
@@ -198,6 +198,6 @@ tests:
               args:
                 - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
       desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-2_2-nvmeof-gw_1-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-2_2-nvmeof-gw_1-sub_ns.yaml
@@ -1,5 +1,6 @@
 # Test suite to scale with 2 GWs having 1 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
@@ -54,7 +55,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -90,7 +91,7 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
@@ -206,7 +207,7 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
       desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
+      destroy-cluster: false
       module: test_nvme_cli.py
       name: Delete NVMeOF targets
       polarion-id: CEPH-83575783
@@ -220,7 +221,7 @@ tests:
            service_name: nvmeof.nvmeof_pool
            verify: true
       desc: Remove nvmeof service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       module: test_orch.py
       name: Delete nvmeof gateway
 
@@ -242,6 +243,6 @@ tests:
               args:
                 - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
       desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-2_nvmeof_e2e_fips.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_e2e_fips.yaml
@@ -1,0 +1,99 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+##  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5001
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 5001
+            node: node10
+      desc: E2E-Test NVMEoF Gateway collocated and Run IOs on targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Basic E2ETest Ceph NVMEoF GW sanity test with collocation-FIPS
+      polarion-id: CEPH-83577610

--- a/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -269,63 +269,12 @@ tests:
         rep_pool_config:
           pool: rbd
         initiator_node: node10
-        operation: CEPH-83576084
-      desc: Delete-recreate bdev in loop and rediscover namespace
-      destroy-cluster: false
-      module: test_ceph_nvmeof_neg_tests.py
-      name: Delete-recreate bdev namespace
-      polarion-id: CEPH-83576084
-
-  - test:
-      abort-on-fail: true
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        initiator_node: node10
         operation: CEPH-83575467
       desc: Perform restart and validate the gateway entities
       destroy-cluster: false
       module: test_ceph_nvmeof_neg_tests.py
       name: Perform restart of NVMeOF gateway
       polarion-id: CEPH-83575467
-
-  - test:
-      abort-on-fail: true
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        initiator_node: node10
-        operation: CEPH-83576085
-      desc: Perform map and unmap NVMe namespaces in loop
-      destroy-cluster: false
-      module: test_ceph_nvmeof_neg_tests.py
-      name: Map-Unmap NVMe namespaces continuously
-      polarion-id: CEPH-83576085
-
-  - test:
-      abort-on-fail: true
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        initiator_node: node10
-        operation: CEPH-83576087
-      desc: Perform reboot on initiator node and validate the namespaces.
-      destroy-cluster: false
-      module: test_ceph_nvmeof_neg_tests.py
-      name: Reboot client node and check NVMe namespaces
-      polarion-id: CEPH-83576087
 
   - test:
       abort-on-fail: false
@@ -360,38 +309,3 @@ tests:
       module: test_ceph_nvmeof_neg_tests.py
       name: Validate Host accessibility to NVMe namespaces
       polarion-id: CEPH-83575455
-
-  - test:
-      abort-on-fail: false
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        initiator_node: node10
-        operation: CEPH-83575814
-      desc: Perform cluster operations when  IO operations between NVMeOF target NVMe-OF initiator are in progress.
-      destroy-cluster: false
-      module: test_ceph_nvmeof_neg_tests.py
-      name: Perform cluster operations when  IO operations are in progress.
-      polarion-id: CEPH-83575814
-
-# Reboot GW node
-  - test:
-      abort-on-fail: true
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        initiator_node: node10
-        operation: CEPH-83576093
-      desc: Perform reboot on GW node and validate the namespaces.
-      destroy-cluster: false
-      module: test_ceph_nvmeof_neg_tests.py
-      name: Reboot GW node and check NVMe namespaces
-      polarion-id: CEPH-83576093

--- a/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -1,5 +1,6 @@
 # Basic Ceph-NvmeoF sanity Test suite
-# cluster configuration file: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 # Set up the cluster
@@ -43,7 +44,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -64,9 +65,9 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-#  Configure Ceph NVMeoF gateway
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  #  Configure Ceph NVMeoF gateway
+  #  Configure Initiators
+  #  Run IO on NVMe Targets
   - test:
       abort-on-fail: true
       config:
@@ -93,7 +94,7 @@ tests:
               pos_args:
                 - rbd
       desc: NVMeoF Gateway deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy nvmeof gateway
@@ -157,7 +158,7 @@ tests:
               args:
                 name: bdev1
       desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
+      destroy-cluster: false
       module: test_nvme_cli.py
       name: Manage nvmeof gateway entities
       polarion-id: CEPH-83575783
@@ -171,7 +172,7 @@ tests:
            service_name: nvmeof.rbd
            verify: true
       desc: NVMeoF Gateway deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_orch.py
       name: Delete nvmeof gateway
 
@@ -190,72 +191,6 @@ tests:
                 - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
       desc: NVMeoF Gateway deployment using cephadm
       do-not-skip-tc: true
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: Delete nvmeof gateway pre-reqs
-
-  - test:
-      abort-on-fail: true
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        install: true                           # Run SPDK with all pre-requisites
-        cleanup:
-          - subsystems
-          - initiators
-          - pool
-          - gateway
-        subsystems:                             # Configure subsystems with all sub-entities
-          - nqn: nqn.2016-06.io.spdk:cnode1
-            serial: 1
-            bdevs:
-              count: 1
-              size: 10G
-            listener_port: 5001
-            allow_host: "*"
-        initiators:                             # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
-            node: node10
-      desc: E2E-Test NVMEoF Gateway on dedicated node and Run IOs on targets
-      destroy-cluster: false
-      module: test_ceph_nvmeof_gateway.py
-      name: Basic E2ETest Ceph NVMEoF GW sanity test on dedicated node
-      polarion-id: CEPH-83575441
-
-  - test:
-      abort-on-fail: true
-      config:
-        gw_node: node6
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        install: true                           # Run SPDK with all pre-requisites
-        cleanup:
-          - subsystems
-          - initiators
-          - pool
-          - gateway
-        subsystems:                             # Configure subsystems with all sub-entities
-          - nqn: nqn.2016-06.io.spdk:cnode1
-            serial: 1
-            bdevs:
-              count: 1
-              size: 10G
-            listener_port: 5001
-            allow_host: "*"
-        initiators:                             # Configure Initiators with all pre-req
-          - subnqn: nqn.2016-06.io.spdk:cnode1
-            listener_port: 5001
-            node: node10
-      desc: E2E-Test NVMEoF Gateway collocated and Run IOs on targets
-      destroy-cluster: false
-      module: test_ceph_nvmeof_gateway.py
-      name: Basic E2ETest Ceph NVMEoF GW sanity test with collocation-FIPS
-      polarion-id: CEPH-83577610

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_16-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_16-sub_ns.yaml
@@ -1,9 +1,10 @@
-# Test suite to scale with 2 GWs having 4 subsystem with 400 namespaces
+# Test suite to scale with 2 GWs having 16 subsystems with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale : 4 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale: 16 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
@@ -54,7 +55,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -72,7 +73,7 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-43573754
+      polarion-id: CEPH-83573758
 
   - test:
       abort-on-fail: true
@@ -104,7 +105,7 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
@@ -120,7 +121,7 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subsystems: 4
+                subsystems: 16
                 max-namespaces: 400
                 ana-reporting: ""
                 port: 4420
@@ -128,7 +129,7 @@ tests:
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target with 4 subsystems
+      desc: Configure NVMeOF target with 16 subsystems
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
@@ -145,12 +146,12 @@ tests:
           - config:
               command: create_listener
               args:
-                subsystems: 4
+                subsystems: 16
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target with 4 subsystems
+      desc: Configure NVMeOF target with 16 subsystems
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
@@ -167,7 +168,7 @@ tests:
           - config:
               command: add_namespace
               args:
-                subsystems: 4
+                subsystems: 16
                 namespaces: 400
                 image_size: 1T
                 pool: rbd
@@ -179,8 +180,8 @@ tests:
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 400 namespaces on 4 subsystems with IO
+      desc: Scale to 400 namespaces on 16 subsystems with IO
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Scale to 400 namespaces on 4 subsystems with IO
-      polarion-id: CEPH-83581630
+      name: Scale to 400 namespaces on 16 subsystems with IO
+      polarion-id: CEPH-83581632

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_2-sub_ns.yaml
@@ -1,14 +1,15 @@
-# Test module to scale Single GW components - scale factor being 1 subsystem and 256 namespaces
+# Test suite to scale with 2 GWs having 2 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
-  #  Single ceph-nvmeof GW colocated with osd on node5, node 6 is nvmeof initiators
+  #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 500 namespaces,  500 RBD images of 1TB size each
+     # Scale : 2 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
      # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write followed by a read
+     # io type combination : For volumes listed on an initiator a write
      # io runtime is 10 seconds per volume/ image
   # Check ceph health and rbd image usage at end of test
 tests:
@@ -54,12 +55,26 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-23573752
+
   - test:
       abort-on-fail: true
       config:
@@ -90,27 +105,36 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-##  Test cases to be executed
   - test:
       abort-on-fail: true
       config:
-        command: add
-        id: client.1
-        nodes:
-          - node10
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Setup client on NVMEoF gateway
+        node: node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              command: create_subsystem
+              args:
+                subsystems: 2
+                max-namespaces: 400
+                enable-ha: ""
+                ana-reporting: ""
+                port: 4420
+                pool: nvmeof_pool
+                hostnqn: "*"
+          - config:
+              command: get_subsystems
+      desc: Configure NVMeOF target with 2 subsystems
       destroy-cluster: false
-      module: test_client.py
-      name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Configure NVMeOF GW-1
+      polarion-id: CEPH-83581625
 
   - test:
       abort-on-fail: true
@@ -121,91 +145,44 @@ tests:
         rep-pool-only: true
         steps:
           - config:
-              command: create_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-                serial_num: 1
-                max_ns: 500
-          - config:
               command: create_listener
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subsystems: 2
                 port: 4420
                 pool: nvmeof_pool
           - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-                hostnqn: "*"
+              command: get_subsystems
+      desc: Configure NVMeOF target with 2 subsystems
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Configure NVMeOF GW-2
+      polarion-id: CEPH-83581627
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
           - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 500
+                subsystems: 2
+                namespaces: 400
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
-            subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
-            node: node10
+            node: node6
         run_io:
-          - node: node10
+          - node: node6
             io_type: write
-      desc: test with 1 subsystem and 500 namespaces in Single GW
+      desc: Scale to 400 namespaces on 2 subsystems with IO
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 500 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576686
-
-  - test:
-      abort-on-fail: false
-      config:
-        node: node5
-        steps:
-          - config:
-              command: delete_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-      desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
-      module: test_nvme_cli.py
-      name: Delete NVMeOF targets
-      polarion-id: CEPH-83575783
-
-  - test:
-      abort-on-fail: false
-      config:
-         command: remove
-         service: nvmeof
-         args:
-           service_name: nvmeof.nvmeof_pool
-           verify: true
-      desc: Remove nvmeof service on GW node
-      destroy-clster: false
-      module: test_orch.py
-      name: Delete nvmeof gateway
-
-  - test:
-      abort-on-fail: false
-      config:
-        verify_cluster_health: true
-        steps:
-          - config:
-              command: shell
-              args:
-                - ceph config set mon mon_allow_pool_delete true
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
-          - config:
-              command: shell
-              args:
-                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
-      desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
-      module: test_cephadm.py
-      name: Delete NVMeOF pools
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 400 namespaces on 2 subsystems with IO
+      polarion-id: CEPH-83581629

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_4-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_4-sub_ns.yaml
@@ -1,9 +1,10 @@
-# Test suite to scale with 2 GWs having 16 subsystems with 400 namespaces
+# Test suite to scale with 2 GWs having 4 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale: 16 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale : 4 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
@@ -54,7 +55,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -72,7 +73,7 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
+      polarion-id: CEPH-43573754
 
   - test:
       abort-on-fail: true
@@ -104,7 +105,7 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
@@ -120,7 +121,7 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subsystems: 16
+                subsystems: 4
                 max-namespaces: 400
                 ana-reporting: ""
                 port: 4420
@@ -128,7 +129,7 @@ tests:
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target with 16 subsystems
+      desc: Configure NVMeOF target with 4 subsystems
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
@@ -145,12 +146,12 @@ tests:
           - config:
               command: create_listener
               args:
-                subsystems: 16
+                subsystems: 4
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target with 16 subsystems
+      desc: Configure NVMeOF target with 4 subsystems
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
@@ -167,7 +168,7 @@ tests:
           - config:
               command: add_namespace
               args:
-                subsystems: 16
+                subsystems: 4
                 namespaces: 400
                 image_size: 1T
                 pool: rbd
@@ -179,8 +180,8 @@ tests:
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 400 namespaces on 16 subsystems with IO
+      desc: Scale to 400 namespaces on 4 subsystems with IO
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Scale to 400 namespaces on 16 subsystems with IO
-      polarion-id: CEPH-83581632
+      name: Scale to 400 namespaces on 4 subsystems with IO
+      polarion-id: CEPH-83581630

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_8-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_8-sub_ns.yaml
@@ -1,9 +1,10 @@
-# Test suite to scale with 2 GWs having 2 subsystem with 400 namespaces
+# Test suite to scale with 2 GWs having 8 subsystem with 400 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
   #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale : 2 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale : 8 subsystem, 400 namespaces,  400 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
@@ -54,7 +55,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -72,7 +73,7 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-23573752
+      polarion-id: CEPH-83573758
 
   - test:
       abort-on-fail: true
@@ -104,7 +105,7 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
@@ -120,16 +121,15 @@ tests:
           - config:
               command: create_subsystem
               args:
-                subsystems: 2
+                subsystems: 8
                 max-namespaces: 400
-                enable-ha: ""
                 ana-reporting: ""
                 port: 4420
                 pool: nvmeof_pool
                 hostnqn: "*"
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target with 2 subsystems
+      desc: Configure NVMeOF target with 8 subsystems
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-1
@@ -146,12 +146,12 @@ tests:
           - config:
               command: create_listener
               args:
-                subsystems: 2
+                subsystems: 8
                 port: 4420
                 pool: nvmeof_pool
           - config:
               command: get_subsystems
-      desc: Configure NVMeOF target with 2 subsystems
+      desc: Configure NVMeOF target with 8 subsystems
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
       name: Configure NVMeOF GW-2
@@ -168,7 +168,7 @@ tests:
           - config:
               command: add_namespace
               args:
-                subsystems: 2
+                subsystems: 8
                 namespaces: 400
                 image_size: 1T
                 pool: rbd
@@ -180,8 +180,8 @@ tests:
         run_io:
           - node: node6
             io_type: write
-      desc: Scale to 400 namespaces on 2 subsystems with IO
+      desc: Scale to 400 namespaces on 8 subsystems with IO
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Scale to 400 namespaces on 2 subsystems with IO
-      polarion-id: CEPH-83581629
+      name: Scale to 400 namespaces on 8 subsystems with IO
+      polarion-id: CEPH-83581631

--- a/suites/reef/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
@@ -1,0 +1,101 @@
+# NVMeoTCP functional regression tests suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_functional.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+          - node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83576084
+      desc: Delete-recreate bdev in loop and rediscover namespace
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Delete-recreate bdev namespace
+      polarion-id: CEPH-83576084
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83575814
+      desc: Perform cluster operations when  IO operations between NVMeOF target NVMe-OF initiator are in progress.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Perform cluster operations when  IO operations are in progress.
+      polarion-id: CEPH-83575814

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -67,62 +68,66 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-#   Test IO Perf
+  # Test IO Perf
   - test:
-      name: libRBD VS NVMeoF - WriteNRead IOtype 4kb 10vols
-      description: WriteNRead IO-comparison on 10G-multi-volumes with 4kb blocksize
+      name: libRBD VS NVMeoF - WriteNRead IOtype 128k blocksize
+      description: WriteNRead IO comparison on 10G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
+        io_overrides:
+          bs: 128k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 2G
-                    count: 10
+                    size: 10G
+                    count: 1
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 2G
-                    count: 10
+                    size: 10G
+                    count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
-      description: ReadWrite IO-comparison on 10G-multi-volumes with 4k blocksize
+      name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
+      description: ReadWrite IOType comparison on 10G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
+        io_overrides:
+          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
-                count: 10
+                size: 10G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
-                count: 10
+                size: 10G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
-      description: Random WriteNRead IOType-comparison on 10G-multi-volumes with 4k blocksize
+      name: libRBD VS NVMeoF Random WriteNRead IOType 128k blocksize
+      description: Random WriteNRead IOType comparison on 10G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -130,24 +135,26 @@ tests:
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
+        io_overrides:
+          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
-                count: 10
+                size: 10G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
-                count: 10
+                size: 10G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
-      description: Random ReadWrite IOType-comparison on 10G-multi-volumes with 4k blocksize
+      name: libRBD VS NVMeoF Random ReadWrite IOType
+      description: Random ReadWrite IOType comparison on 10G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -155,15 +162,17 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: false
         delete_gateway: node6
+        io_overrides:
+          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
-                count: 10
+                size: 10G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
-                count: 10
+                size: 10G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -69,10 +70,10 @@ tests:
 
   # Test IO Perf
   - test:
-      name: libRBD VS NVMeoF - WriteNRead IOtype 128k blocksize
-      description: WriteNRead IO comparison on 10G image with 128kb-block-size
+      name: libRBD VS NVMeoF-WriteNRead IOtype 128kb-block-size multi volumes
+      description: WriteNRead IO-comparison on 10G-multi-volumes with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576118
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -85,22 +86,22 @@ tests:
         io_exec:
             -   proto: librbd
                 image:
-                    size: 10G
-                    count: 1
+                    size: 2G
+                    count: 10
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 10G
-                    count: 1
+                    size: 2G
+                    count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
-      description: ReadWrite IOType comparison on 10G image with 128kb-block-size
+      name: libRBD VS NVMeoF ReadWrite IOType 128kb-bs multi-volumes
+      description: ReadWrite IOType-comparison on 10G-multi-volumes with 128k-blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576118
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -112,21 +113,21 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random WriteNRead IOType 128k blocksize
-      description: Random WriteNRead IOType comparison on 10G image with 128kb-block-size
+      name: libRBD VS NVMeoF Random ReadNWrite IOType 128kb-bs multi volumes
+      description: Random ReadNWrite IOType-comparison on 128G multi volumes with 16kb-bs
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576118
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -139,21 +140,21 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadWrite IOType
-      description: Random ReadWrite IOType comparison on 10G image with 128kb-block-size
+      name: libRBD VS NVMeoF Random-ReadWrite IOType 128k-bs multi-volumes
+      description: Random ReadWrite IOType-comparison 10G-multi-volumes with 128k-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576118
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -166,12 +167,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -85,12 +86,12 @@ tests:
         io_exec:
             -   proto: librbd
                 image:
-                    size: 2G
+                    size: 25G
                     count: 10
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 2G
+                    size: 25G
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
@@ -112,12 +113,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
+                size: 25G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
+                size: 25G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
@@ -139,12 +140,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
+                size: 25G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
+                size: 25G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
@@ -166,12 +167,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
+                size: 25G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
+                size: 25G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -69,38 +70,38 @@ tests:
 
   # Test IO Perf
   - test:
-      name: libRBD VS NVMeoF-WriteNRead IOtype 16kb-block-size multi volumes
-      description: WriteNRead IO-comparison on 10G-multi-volumes with 16kb-block-size
+      name: libRBD VS NVMeoF - WriteNRead IOtype 128k blocksize
+      description: WriteNRead IO comparison on 40G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576117
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         io_overrides:
-          bs: 16k
+          bs: 128k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 25G
-                    count: 10
+                    size: 40G
+                    count: 1
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 25G
-                    count: 10
+                    size: 40G
+                    count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType 16kb-bs multi-volumes
-      description: ReadWrite IOType-comparison on 10G-multi-volumes with 16k-blocksize
+      name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
+      description: ReadWrite IOType comparison on 40G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576117
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -108,25 +109,25 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: true
         io_overrides:
-          bs: 16k
+          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
-                count: 10
+                size: 40G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
-                count: 10
+                size: 40G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadNWrite IOType 16kb-bs multi volumes
-      description: Random ReadNWrite IOType-comparison on 10G multi volumes with 16kb-bs
+      name: libRBD VS NVMeoF Random WriteNRead IOType 128k blocksize
+      description: Random WriteNRead IOType comparison on 40G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576117
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -135,25 +136,25 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: true
         io_overrides:
-          bs: 16k
+          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
-                count: 10
+                size: 40G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
-                count: 10
+                size: 40G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random-ReadWrite IOType 16k-bs multi-volumes
-      description: Random ReadWrite IOType-comparison 10G-multi-volumes with 16k-block-size
+      name: libRBD VS NVMeoF Random ReadWrite IOType
+      description: Random ReadWrite IOType comparison on 40G image with 128kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576117
+      polarion-id: CEPH-83576115
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -162,16 +163,16 @@ tests:
         do_not_delete_pool: false
         delete_gateway: node6
         io_overrides:
-          bs: 16k
+          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
-                count: 10
+                size: 40G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
-                count: 10
+                size: 40G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -69,38 +70,38 @@ tests:
 
   # Test IO Perf
   - test:
-      name: libRBD VS NVMeoF-WriteNRead IOtype 128kb-block-size multi volumes
-      description: WriteNRead IO-comparison on 10G-multi-volumes with 128kb-block-size
+      name: libRBD VS NVMeoF-WriteNRead IOtype 16kb-block-size multi volumes
+      description: WriteNRead IO-comparison on 10G-multi-volumes with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576118
+      polarion-id: CEPH-83576117
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         io_overrides:
-          bs: 128k
+          bs: 16k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 25G
+                    size: 2G
                     count: 10
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 25G
+                    size: 2G
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType 128kb-bs multi-volumes
-      description: ReadWrite IOType-comparison on 10G-multi-volumes with 128k-blocksize
+      name: libRBD VS NVMeoF ReadWrite IOType 16kb-bs multi-volumes
+      description: ReadWrite IOType-comparison on 10G-multi-volumes with 16k-blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576118
+      polarion-id: CEPH-83576117
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -108,25 +109,25 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: true
         io_overrides:
-          bs: 128k
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
+                size: 2G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
+                size: 2G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadNWrite IOType 128kb-bs multi volumes
-      description: Random ReadNWrite IOType-comparison on 128G multi volumes with 16kb-bs
+      name: libRBD VS NVMeoF Random ReadNWrite IOType 16kb-bs multi volumes
+      description: Random ReadNWrite IOType-comparison on 10G multi volumes with 16kb-bs
       module: test_io_perf.py
-      polarion-id: CEPH-83576118
+      polarion-id: CEPH-83576117
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -135,25 +136,25 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: true
         io_overrides:
-          bs: 128k
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
+                size: 2G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
+                size: 2G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random-ReadWrite IOType 128k-bs multi-volumes
-      description: Random ReadWrite IOType-comparison 10G-multi-volumes with 128k-block-size
+      name: libRBD VS NVMeoF Random-ReadWrite IOType 16k-bs multi-volumes
+      description: Random ReadWrite IOType-comparison 10G-multi-volumes with 16k-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576118
+      polarion-id: CEPH-83576117
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -162,16 +163,16 @@ tests:
         do_not_delete_pool: false
         delete_gateway: node6
         io_overrides:
-          bs: 128k
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
+                size: 2G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
+                size: 2G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -85,12 +86,12 @@ tests:
         io_exec:
             -   proto: librbd
                 image:
-                    size: 2G
+                    size: 25G
                     count: 10
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 2G
+                    size: 25G
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
@@ -112,12 +113,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
+                size: 25G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
+                size: 25G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
@@ -139,12 +140,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
+                size: 25G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
+                size: 25G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
@@ -166,12 +167,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 2G
+                size: 25G
                 count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 2G
+                size: 25G
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -55,6 +56,7 @@ tests:
         command: add
         id: client.1
         nodes:
+          - node6
           - node10
         install_packages:
           - ceph-common
@@ -66,62 +68,66 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-# Test IO Perf
+  # Test IO Perf
   - test:
-      name: libRBD-VS-NVMeoF WRITE-READ-IOtype 4kblocksize single-10G-vol
-      description: Write and Read IO comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF - WriteNRead IOtype
+      description: WriteNRead IO comparison on 50G image with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
+        io_overrides:
+          bs: 16k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 10G
+                    size: 50G
                     count: 1
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 10G
+                    size: 50G
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
-      description: Read-Write IOType comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
+      description: ReadWrite IOType comparison on 50G image with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
+        io_overrides:
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
+                size: 50G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
+                size: 50G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random-WRITE-READ-IOType 4kblocksize single-10G-vol
-      description: Random Read and Write IOType comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF Random WriteNRead IOType 16k blocksize
+      description: Random WriteNRead IOType comparison on 50G image with 16kb-blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -129,24 +135,26 @@ tests:
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
+        io_overrides:
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
+                size: 50G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
+                size: 50G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random-READWRITE-IOType 4kblocksize single-10G-vol
-      description: Random Read-Write IOType comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF Random ReadWrite IOType
+      description: Random ReadWrite IOType comparison on 50G image with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -154,15 +162,17 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: false
         delete_gateway: node6
+        io_overrides:
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
+                size: 50G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
+                size: 50G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -67,66 +68,62 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-  # Test IO Perf
+#   Test IO Perf
   - test:
-      name: libRBD VS NVMeoF - WriteNRead IOtype
-      description: WriteNRead IO comparison on 10G image with 16kb-block-size
+      name: libRBD VS NVMeoF - WriteNRead IOtype 4kb 10vols
+      description: WriteNRead IO-comparison on 10G-multi-volumes with 4kb blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
-        io_overrides:
-          bs: 16k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 10G
-                    count: 1
+                    size: 2G
+                    count: 10
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 10G
-                    count: 1
+                    size: 2G
+                    count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
-      description: ReadWrite IOType comparison on 10G image with 16kb-block-size
+      name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
+      description: ReadWrite IO-comparison on 10G-multi-volumes with 4k blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
-        io_overrides:
-          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random WriteNRead IOType 16k blocksize
-      description: Random WriteNRead IOType comparison on 10G image with 16kb-blocksize
+      name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
+      description: Random WriteNRead IOType-comparison on 10G-multi-volumes with 4k blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -134,26 +131,24 @@ tests:
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
-        io_overrides:
-          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadWrite IOType
-      description: Random ReadWrite IOType comparison on 10G image with 16kb-block-size
+      name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
+      description: Random ReadWrite IOType-comparison on 10G-multi-volumes with 4k blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -161,17 +156,15 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: false
         delete_gateway: node6
-        io_overrides:
-          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 10G
-                count: 1
+                size: 2G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -67,66 +68,62 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-  # Test IO Perf
+#   Test IO Perf
   - test:
-      name: libRBD VS NVMeoF - WriteNRead IOtype 128k blocksize
-      description: WriteNRead IO comparison on 40G image with 128kb-block-size
+      name: libRBD VS NVMeoF - WriteNRead IOtype 4kb 10vols
+      description: WriteNRead IO-comparison on 25G-multi-volumes with 4kb blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
-        io_overrides:
-          bs: 128k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 40G
-                    count: 1
+                    size: 25G
+                    count: 10
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 40G
-                    count: 1
+                    size: 25G
+                    count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
-      description: ReadWrite IOType comparison on 40G image with 128kb-block-size
+      name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
+      description: ReadWrite IO-comparison on 25G-multi-volumes with 4k blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
-        io_overrides:
-          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 40G
-                count: 1
+                size: 25G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 40G
-                count: 1
+                size: 25G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random WriteNRead IOType 128k blocksize
-      description: Random WriteNRead IOType comparison on 40G image with 128kb-block-size
+      name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
+      description: Random WriteNRead IOType-comparison on 25G-multi-volumes with 4k blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -134,26 +131,24 @@ tests:
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
-        io_overrides:
-          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 40G
-                count: 1
+                size: 25G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 40G
-                count: 1
+                size: 25G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadWrite IOType
-      description: Random ReadWrite IOType comparison on 40G image with 128kb-block-size
+      name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
+      description: Random ReadWrite IOType-comparison on 25G-multi-volumes with 4k blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576115
+      polarion-id: CEPH-83576116
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -161,17 +156,15 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: false
         delete_gateway: node6
-        io_overrides:
-          bs: 128k
         io_exec:
           -   proto: librbd
               image:
-                size: 40G
-                count: 1
+                size: 25G
+                count: 10
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 40G
-                count: 1
+                size: 25G
+                count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -55,7 +56,6 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
           - node10
         install_packages:
           - ceph-common
@@ -67,12 +67,12 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-#   Test IO Perf
+# Test IO Perf
   - test:
-      name: libRBD VS NVMeoF - WriteNRead IOtype 4kb 10vols
-      description: WriteNRead IO-comparison on 25G-multi-volumes with 4kb blocksize
+      name: libRBD-VS-NVMeoF WRITE-READ-IOtype 4kblocksize single-10G-vol
+      description: Write and Read IO comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -83,22 +83,22 @@ tests:
         io_exec:
             -   proto: librbd
                 image:
-                    size: 25G
-                    count: 10
+                    size: 50G
+                    count: 1
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 25G
-                    count: 10
+                    size: 50G
+                    count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
-      description: ReadWrite IO-comparison on 25G-multi-volumes with 4k blocksize
+      name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
+      description: Read-Write IOType comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -108,21 +108,21 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
-                count: 10
+                size: 50G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
-                count: 10
+                size: 50G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
-      description: Random WriteNRead IOType-comparison on 25G-multi-volumes with 4k blocksize
+      name: libRBD VS NVMeoF Random-WRITE-READ-IOType 4kblocksize single-10G-vol
+      description: Random Read and Write IOType comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -133,21 +133,21 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
-                count: 10
+                size: 50G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
-                count: 10
+                size: 50G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
-      description: Random ReadWrite IOType-comparison on 25G-multi-volumes with 4k blocksize
+      name: libRBD VS NVMeoF Random-READWRITE-IOType 4kblocksize single-10G-vol
+      description: Random Read-Write IOType comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576116
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -158,12 +158,12 @@ tests:
         io_exec:
           -   proto: librbd
               image:
-                size: 25G
-                count: 10
+                size: 50G
+                count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 25G
-                count: 10
+                size: 50G
+                count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -55,6 +56,7 @@ tests:
         command: add
         id: client.1
         nodes:
+          - node6
           - node10
         install_packages:
           - ceph-common
@@ -66,62 +68,66 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-# Test IO Perf
+  # Test IO Perf
   - test:
-      name: libRBD-VS-NVMeoF WRITE-READ-IOtype 4kblocksize single-10G-vol
-      description: Write and Read IO comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF - WriteNRead IOtype
+      description: WriteNRead IO comparison on 10G image with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
+        io_overrides:
+          bs: 16k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 50G
+                    size: 10G
                     count: 1
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 50G
+                    size: 10G
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
-      description: Read-Write IOType comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
+      description: ReadWrite IOType comparison on 10G image with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
+        io_overrides:
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 50G
+                size: 10G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 50G
+                size: 10G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random-WRITE-READ-IOType 4kblocksize single-10G-vol
-      description: Random Read and Write IOType comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF Random WriteNRead IOType 16k blocksize
+      description: Random WriteNRead IOType comparison on 10G image with 16kb-blocksize
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -129,24 +135,26 @@ tests:
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
+        io_overrides:
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 50G
+                size: 10G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 50G
+                size: 10G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random-READWRITE-IOType 4kblocksize single-10G-vol
-      description: Random Read-Write IOType comparison on 10G image with 4kb-block-size
+      name: libRBD VS NVMeoF Random ReadWrite IOType
+      description: Random ReadWrite IOType comparison on 10G image with 16kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576113
+      polarion-id: CEPH-83576114
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -154,15 +162,17 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: false
         delete_gateway: node6
+        io_overrides:
+          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 50G
+                size: 10G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 50G
+                size: 10G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
@@ -1,5 +1,6 @@
 # Basic IO Perf comparison test LibRBD vs NVMeoF protocols
-# cluster configuration: conf/quincy/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
 
@@ -44,7 +45,7 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
@@ -55,7 +56,6 @@ tests:
         command: add
         id: client.1
         nodes:
-          - node6
           - node10
         install_packages:
           - ceph-common
@@ -67,66 +67,62 @@ tests:
       name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
-  # Test IO Perf
+# Test IO Perf
   - test:
-      name: libRBD VS NVMeoF - WriteNRead IOtype
-      description: WriteNRead IO comparison on 50G image with 16kb-block-size
+      name: libRBD-VS-NVMeoF WRITE-READ-IOtype 4kblocksize single-10G-vol
+      description: Write and Read IO comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
-        io_overrides:
-          bs: 16k
         rbd_pool: rbd
         do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
-                    size: 50G
+                    size: 10G
                     count: 1
                 node: node10             # client node
             -   proto: nvmeof
                 image:
-                    size: 50G
+                    size: 10G
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
                 install_gw: true
 
   - test:
-      name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
-      description: ReadWrite IOType comparison on 50G image with 16kb-block-size
+      name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
+      description: Read-Write IOType comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
-        io_overrides:
-          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 50G
+                size: 10G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 50G
+                size: 10G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random WriteNRead IOType 16k blocksize
-      description: Random WriteNRead IOType comparison on 50G image with 16kb-blocksize
+      name: libRBD VS NVMeoF Random-WRITE-READ-IOType 4kblocksize single-10G-vol
+      description: Random Read and Write IOType comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -134,26 +130,24 @@ tests:
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
         do_not_delete_pool: true
-        io_overrides:
-          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 50G
+                size: 10G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 50G
+                size: 10G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
 
   - test:
-      name: libRBD VS NVMeoF Random ReadWrite IOType
-      description: Random ReadWrite IOType comparison on 50G image with 16kb-block-size
+      name: libRBD VS NVMeoF Random-READWRITE-IOType 4kblocksize single-10G-vol
+      description: Random Read-Write IOType comparison on 10G image with 4kb-block-size
       module: test_io_perf.py
-      polarion-id: CEPH-83576114
+      polarion-id: CEPH-83576113
       config:
         iterations: 1               # number of iterations to find out average
         io_profiles:
@@ -161,17 +155,15 @@ tests:
         rbd_pool: rbd
         do_not_delete_pool: false
         delete_gateway: node6
-        io_overrides:
-          bs: 16k
         io_exec:
           -   proto: librbd
               image:
-                size: 50G
+                size: 10G
                 count: 1
               node: node10             # client node
           -   proto: nvmeof
               image:
-                size: 50G
+                size: 10G
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node

--- a/suites/reef/nvmeof/tier-3_nvmeof_namespace_limit.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_namespace_limit.yaml
@@ -1,19 +1,20 @@
-# Test module to scale Single GW components - scale factor being 1 subsystem and 256 namespaces with 4 scale steps
-# Test conf at conf/reef/nvmeof/ceph_nvmeof_scale_cluster.yaml
+# Test module to explore namespace scale limitations in Single subsystem
+# Test conf at conf/reef/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
-  #  Single ceph-nvmeof GW colocated with osd on node5, node 6,7,8 and 9 are nvmeof initiators
+  #  Single ceph-nvmeof GW colocated with osd on node5, node 6 and 7are nvmeof initiators
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1 subsystem, 256 namespaces,  256 RBD images of 500M size each
-     # Scale-2 : 2 subsystem, 512 namespaces, 512 RBD images of 500M size each
-     # Scale-3 : 3 subsystem, 512 namespaces, 512 RBD images of 500M size each
-     # Scale-4 : 4 subsystem, 1024 namespaces, 1024 RBD images of 500M size each
-  #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 4 initiator : 4 subsystems)
+     # Scale-1 : 1000 namespaces
+     # Scale-2 : 2000 namespaces
+     # Scale-3 : 3000 namespaces
+     # Scale-4 : 4000 namespaces
+     # Scale-5 : 5000 namespaces
+  #  nvmeof initiator - Each initiator/ client connects to same subsystem
   #  io test (no performance tests)
      # Tool : fio
-     # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write in first test followed by a read in next test
-     # io runtime is 10 seconds per volume/ image
-  # Check ceph health and rbd image usage at end of each test
+     # io is run IO only on newly added Namespace
+     # io type : write
+     # io runtime: 10 seconds
 tests:
 # Set up the cluster
   - test:
@@ -57,10 +58,12 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
+#  Configure Initiators
+#  Run IO on NVMe Targets
   - test:
       abort-on-fail: true
       config:
@@ -91,30 +94,26 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-  #  Test cases to be executed
+##  Test cases to be executed
   - test:
       abort-on-fail: true
       config:
         command: add
         id: client.1
         nodes:
-          - node6
-          - node7
-          - node8
-          - node9
+          - node10
         install_packages:
           - ceph-common
         copy_admin_keyring: true
-        nvmeof-scale: true
       desc: Setup client on NVMEoF gateway
       destroy-cluster: false
       module: test_client.py
-      name: configure Ceph client
+      name: configure Ceph client for NVMe tests
       polarion-id: CEPH-83573758
 
 #  Configure Initiators
@@ -132,7 +131,7 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
                 serial_num: 1
-                max_ns: 400
+                max_ns: 10000
           - config:
               command: create_listener
               args:
@@ -148,7 +147,7 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 256
+                end_count: 1000
                 image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode1
@@ -157,15 +156,15 @@ tests:
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
-            node: node6
+            node: node10
         run_io:
-          - node: node6
+          - node: node10
             io_type: write
-      desc: test with 1 subsystem and 256 namespaces in Single GW
+      desc: test namespace limitations with 1K namespaces
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576686
+      name: test 1k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
 
   - test:
       abort-on-fail: true
@@ -176,46 +175,23 @@ tests:
         rep-pool-only: true
         steps:
           - config:
-              command: create_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode2
-                serial_num: 2
-                max_ns: 400
-          - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode2
-                port: 5002
-                pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode2
-                hostnqn: "*"
-          - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 256
+                start_count: 1001
+                end_count: 2000
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode2
+                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
-        initiators:
-          subnqn: nqn.2016-06.io.spdk:cnode2
-          listener_port: 5002
-          node: node7
         run_io:
-          - node: node6
-            io_type: read
-          - node: node7
+          - node: node10
             io_type: write
-      desc: test with 1 subsystem and 256 namespaces in Single GW
+      desc: test namespace limitations with 2K namespaces
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576686
+      name: test 2k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
 
   - test:
       abort-on-fail: true
@@ -226,48 +202,23 @@ tests:
         rep-pool-only: true
         steps:
           - config:
-              command: create_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode3
-                serial_num: 3
-                max_ns: 400
-          - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode3
-                port: 5003
-                pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode3
-                hostnqn: "*"
-          - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 256
+                start_count: 2001
+                end_count: 3000
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode3
+                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
-        initiators:
-          subnqn: nqn.2016-06.io.spdk:cnode3
-          listener_port: 5003
-          node: node8
         run_io:
-          - node: node6
+          - node: node10
             io_type: write
-          - node: node7
-            io_type: read
-          - node: node8
-            io_type: write
-      desc: test with 1 subsystem and 256 namespaces in Single GW
+      desc: test namespace limitations with 3K namespaces
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576686
+      name: test 3k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
 
   - test:
       abort-on-fail: true
@@ -278,52 +229,65 @@ tests:
         rep-pool-only: true
         steps:
           - config:
-              command: create_subsystem
+              command: add_namespace
               args:
-                subnqn: nqn.2016-06.io.spdk:cnode4
-                serial_num: 4
-                max_ns: 400
+                start_count: 3001
+                end_count: 4000
+                image_size: 1T
+                pool: rbd
+                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
-              command: create_listener
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode4
-                port: 5004
-                pool: nvmeof_pool
-          - config:
-              command: add_host
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode4
-                hostnqn: "*"
+              command: get_subsystems
+        run_io:
+          - node: node10
+            io_type: write
+      desc: test namespace limitations with 4K namespaces
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_scale.py
+      name: test 4k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node5
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
           - config:
               command: add_namespace
               args:
-                start_count: 1
-                end_count: 256
+                start_count: 4001
+                end_count: 5000
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode4
+                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
-        initiators:
-          subnqn: nqn.2016-06.io.spdk:cnode4
-          listener_port: 5004
-          node: node9
         run_io:
-          - node: node6
-            io_type: read
-          - node: node7
+          - node: node10
             io_type: write
-          - node: node8
-            io_type: read
-          - node: node9
-            io_type: write
-          - node: node9
-            io_type: read
-      desc: test with 1 subsystem and 256 namespaces in Single GW
+      desc: test namespace limitations with 5K namespaces
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
-      polarion-id: CEPH-83576686
+      name: test 5k namespace with 1 subsystem in Single GW
+      polarion-id: CEPH-83576691
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node5
+        steps:
+          - config:
+              command: delete_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode1
+      desc: Manage NVMeoF Subsystem entities
+      destroy-cluster: false
+      module: test_nvme_cli.py
+      name: Delete NVMeOF targets
+      polarion-id: CEPH-83575783
 
   - test:
       abort-on-fail: false
@@ -334,7 +298,7 @@ tests:
            service_name: nvmeof.nvmeof_pool
            verify: true
       desc: Remove nvmeof service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       module: test_orch.py
       name: Delete nvmeof gateway
 
@@ -356,6 +320,6 @@ tests:
               args:
                 - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
       desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-3_nvmeof_restart_operations.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_restart_operations.yaml
@@ -1,0 +1,102 @@
+# NVMeoTCP functional regression tests suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_functional.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+          - node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83576087
+      desc: Perform reboot on initiator node and validate the namespaces.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Reboot client node and check NVMe namespaces
+      polarion-id: CEPH-83576087
+
+  # Reboot GW node
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83576093
+      desc: Perform reboot on GW node and validate the namespaces.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Reboot GW node and check NVMe namespaces
+      polarion-id: CEPH-83576093

--- a/suites/reef/nvmeof/tier-3_nvmeof_scale_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_scale_ns.yaml
@@ -1,14 +1,15 @@
-# Test suite to scale with 2 GWs having 8 subsystem with 400 namespaces
+# Test module to scale Single GW components - scale factor being 1 subsystem and 256 namespaces
 # Test config at conf/reef/nvmeof/ceph_nvmeof_subsystem_scale_cluster.yaml or conf/reef/nvmeof/octo-6-node-env.yaml for baremetal
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
-  #  2 ceph-nvmeof GWs colocated with osd on node4 and node5, node 6 is nvmeof initiator
+  #  Single ceph-nvmeof GW colocated with osd on node5, node 6 is nvmeof initiators
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale : 8 subsystem, 400 namespaces,  400 RBD images of 1TB size each
+     # Scale-1 : 1 subsystem, 500 namespaces,  500 RBD images of 1TB size each
   #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 1 initiator : 1 subsystem)
   #  io test (no performance tests)
      # Tool : fio
      # io is run on all nvme volumes listed on all initiators configured to that point
-     # io type combination : For volumes listed on an initiator a write
+     # io type combination : For volumes listed on an initiator a write followed by a read
      # io runtime is 10 seconds per volume/ image
   # Check ceph health and rbd image usage at end of test
 tests:
@@ -54,26 +55,12 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
-  - test:
-      abort-on-fail: true
-      config:
-        command: add
-        id: client.1
-        nodes:
-          - node6
-        install_packages:
-          - ceph-common
-        copy_admin_keyring: true
-      desc: Setup client on NVMEoF gateway
-      destroy-cluster: false
-      module: test_client.py
-      name: configure Ceph client for NVMe tests
-      polarion-id: CEPH-83573758
-
+#  Configure Initiators
+#  Run IO on NVMe Targets
   - test:
       abort-on-fail: true
       config:
@@ -104,35 +91,27 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
+##  Test cases to be executed
   - test:
       abort-on-fail: true
       config:
-        node: node4
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        steps:
-          - config:
-              command: create_subsystem
-              args:
-                subsystems: 8
-                max-namespaces: 400
-                ana-reporting: ""
-                port: 4420
-                pool: nvmeof_pool
-                hostnqn: "*"
-          - config:
-              command: get_subsystems
-      desc: Configure NVMeOF target with 8 subsystems
+        command: add
+        id: client.1
+        nodes:
+          - node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Configure NVMeOF GW-1
-      polarion-id: CEPH-83581625
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
 
   - test:
       abort-on-fail: true
@@ -143,44 +122,91 @@ tests:
         rep-pool-only: true
         steps:
           - config:
+              command: create_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode1
+                serial_num: 1
+                max_ns: 500
+          - config:
               command: create_listener
               args:
-                subsystems: 8
+                subnqn: nqn.2016-06.io.spdk:cnode1
                 port: 4420
                 pool: nvmeof_pool
           - config:
-              command: get_subsystems
-      desc: Configure NVMeOF target with 8 subsystems
-      destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Configure NVMeOF GW-2
-      polarion-id: CEPH-83581627
-
-  - test:
-      abort-on-fail: true
-      config:
-        node: node4
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        steps:
+              command: add_host
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode1
+                hostnqn: "*"
           - config:
               command: add_namespace
               args:
-                subsystems: 8
-                namespaces: 400
+                start_count: 1
+                end_count: 500
                 image_size: 1T
                 pool: rbd
+                subnqn: nqn.2016-06.io.spdk:cnode1
           - config:
               command: get_subsystems
         initiators:
+            subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
-            node: node6
+            node: node10
         run_io:
-          - node: node6
+          - node: node10
             io_type: write
-      desc: Scale to 400 namespaces on 8 subsystems with IO
+      desc: test with 1 subsystem and 500 namespaces in Single GW
       destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_sub_scale.py
-      name: Scale to 400 namespaces on 8 subsystems with IO
-      polarion-id: CEPH-83581631
+      module: test_ceph_nvmeof_gateway_scale.py
+      name: Scale to 500 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node5
+        steps:
+          - config:
+              command: delete_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode1
+      desc: Manage NVMeoF Subsystem entities
+      destroy-cluster: false
+      module: test_nvme_cli.py
+      name: Delete NVMeOF targets
+      polarion-id: CEPH-83575783
+
+  - test:
+      abort-on-fail: false
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.nvmeof_pool
+           verify: true
+      desc: Remove nvmeof service on GW node
+      destroy-cluster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: Delete nvmeof and rbd pool from ceph cluster
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-3_nvmeof_scale_sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_scale_sub_ns.yaml
@@ -1,19 +1,20 @@
-# Test module to explore namespace scale limitations in Single subsystem
-# Test conf at conf/reef/nvmeof/ceph_nvmeof_namespace_scale_cluster.yaml
+# Test module to scale Single GW components - scale factor being 1 subsystem and 256 namespaces with 4 scale steps
+# Test conf at conf/reef/nvmeof/ceph_nvmeof_scale_cluster.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 # Test attributes
-  #  Single ceph-nvmeof GW colocated with osd on node5, node 6 and 7are nvmeof initiators
+  #  Single ceph-nvmeof GW colocated with osd on node5, node 6,7,8 and 9 are nvmeof initiators
   #  nvmeof GW - at end of each scale step/ test below is the configuration
-     # Scale-1 : 1000 namespaces
-     # Scale-2 : 2000 namespaces
-     # Scale-3 : 3000 namespaces
-     # Scale-4 : 4000 namespaces
-     # Scale-5 : 5000 namespaces
-  #  nvmeof initiator - Each initiator/ client connects to same subsystem
+     # Scale-1 : 1 subsystem, 256 namespaces,  256 RBD images of 500M size each
+     # Scale-2 : 2 subsystem, 512 namespaces, 512 RBD images of 500M size each
+     # Scale-3 : 3 subsystem, 512 namespaces, 512 RBD images of 500M size each
+     # Scale-4 : 4 subsystem, 1024 namespaces, 1024 RBD images of 500M size each
+  #  nvmeof initiator - Each initiator/ client connects to a subsystem ( 4 initiator : 4 subsystems)
   #  io test (no performance tests)
      # Tool : fio
-     # io is run IO only on newly added Namespace
-     # io type : write
-     # io runtime: 10 seconds
+     # io is run on all nvme volumes listed on all initiators configured to that point
+     # io type combination : For volumes listed on an initiator a write in first test followed by a read in next test
+     # io runtime is 10 seconds per volume/ image
+  # Check ceph health and rbd image usage at end of each test
 tests:
 # Set up the cluster
   - test:
@@ -57,12 +58,10 @@ tests:
               args:
                 all-available-devices: true
       desc: RHCS cluster deployment using cephadm
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
 
-#  Configure Initiators
-#  Run IO on NVMe Targets
   - test:
       abort-on-fail: true
       config:
@@ -93,26 +92,30 @@ tests:
               args:
                 - rbd pool init rbd
       desc: deploy NVMeoF service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       do-not-skip-tc: true
       module: test_cephadm.py
       name: deploy NVMeoF service on GW node
 
-##  Test cases to be executed
+  #  Test cases to be executed
   - test:
       abort-on-fail: true
       config:
         command: add
         id: client.1
         nodes:
-          - node10
+          - node6
+          - node7
+          - node8
+          - node9
         install_packages:
           - ceph-common
         copy_admin_keyring: true
+        nvmeof-scale: true
       desc: Setup client on NVMEoF gateway
       destroy-cluster: false
       module: test_client.py
-      name: configure Ceph client for NVMe tests
+      name: configure Ceph client
       polarion-id: CEPH-83573758
 
 #  Configure Initiators
@@ -130,7 +133,7 @@ tests:
               args:
                 subnqn: nqn.2016-06.io.spdk:cnode1
                 serial_num: 1
-                max_ns: 10000
+                max_ns: 400
           - config:
               command: create_listener
               args:
@@ -146,7 +149,7 @@ tests:
               command: add_namespace
               args:
                 start_count: 1
-                end_count: 1000
+                end_count: 256
                 image_size: 1T
                 pool: rbd
                 subnqn: nqn.2016-06.io.spdk:cnode1
@@ -155,15 +158,15 @@ tests:
         initiators:
             subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 4420
-            node: node10
+            node: node6
         run_io:
-          - node: node10
+          - node: node6
             io_type: write
-      desc: test namespace limitations with 1K namespaces
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: test 1k namespace with 1 subsystem in Single GW
-      polarion-id: CEPH-83576691
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: true
@@ -174,23 +177,46 @@ tests:
         rep-pool-only: true
         steps:
           - config:
+              command: create_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode2
+                serial_num: 2
+                max_ns: 400
+          - config:
+              command: create_listener
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode2
+                port: 5002
+                pool: nvmeof_pool
+          - config:
+              command: add_host
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode2
+                hostnqn: "*"
+          - config:
               command: add_namespace
               args:
-                start_count: 1001
-                end_count: 2000
+                start_count: 1
+                end_count: 256
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subnqn: nqn.2016-06.io.spdk:cnode2
           - config:
               command: get_subsystems
+        initiators:
+          subnqn: nqn.2016-06.io.spdk:cnode2
+          listener_port: 5002
+          node: node7
         run_io:
-          - node: node10
+          - node: node6
+            io_type: read
+          - node: node7
             io_type: write
-      desc: test namespace limitations with 2K namespaces
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: test 2k namespace with 1 subsystem in Single GW
-      polarion-id: CEPH-83576691
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: true
@@ -201,23 +227,48 @@ tests:
         rep-pool-only: true
         steps:
           - config:
+              command: create_subsystem
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode3
+                serial_num: 3
+                max_ns: 400
+          - config:
+              command: create_listener
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode3
+                port: 5003
+                pool: nvmeof_pool
+          - config:
+              command: add_host
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode3
+                hostnqn: "*"
+          - config:
               command: add_namespace
               args:
-                start_count: 2001
-                end_count: 3000
+                start_count: 1
+                end_count: 256
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subnqn: nqn.2016-06.io.spdk:cnode3
           - config:
               command: get_subsystems
+        initiators:
+          subnqn: nqn.2016-06.io.spdk:cnode3
+          listener_port: 5003
+          node: node8
         run_io:
-          - node: node10
+          - node: node6
             io_type: write
-      desc: test namespace limitations with 3K namespaces
+          - node: node7
+            io_type: read
+          - node: node8
+            io_type: write
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: test 3k namespace with 1 subsystem in Single GW
-      polarion-id: CEPH-83576691
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: true
@@ -228,65 +279,52 @@ tests:
         rep-pool-only: true
         steps:
           - config:
-              command: add_namespace
+              command: create_subsystem
               args:
-                start_count: 3001
-                end_count: 4000
-                image_size: 1T
-                pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subnqn: nqn.2016-06.io.spdk:cnode4
+                serial_num: 4
+                max_ns: 400
           - config:
-              command: get_subsystems
-        run_io:
-          - node: node10
-            io_type: write
-      desc: test namespace limitations with 4K namespaces
-      destroy-cluster: false
-      module: test_ceph_nvmeof_gateway_scale.py
-      name: test 4k namespace with 1 subsystem in Single GW
-      polarion-id: CEPH-83576691
-
-  - test:
-      abort-on-fail: true
-      config:
-        node: node5
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        steps:
+              command: create_listener
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode4
+                port: 5004
+                pool: nvmeof_pool
+          - config:
+              command: add_host
+              args:
+                subnqn: nqn.2016-06.io.spdk:cnode4
+                hostnqn: "*"
           - config:
               command: add_namespace
               args:
-                start_count: 4001
-                end_count: 5000
+                start_count: 1
+                end_count: 256
                 image_size: 1T
                 pool: rbd
-                subnqn: nqn.2016-06.io.spdk:cnode1
+                subnqn: nqn.2016-06.io.spdk:cnode4
           - config:
               command: get_subsystems
+        initiators:
+          subnqn: nqn.2016-06.io.spdk:cnode4
+          listener_port: 5004
+          node: node9
         run_io:
-          - node: node10
+          - node: node6
+            io_type: read
+          - node: node7
             io_type: write
-      desc: test namespace limitations with 5K namespaces
+          - node: node8
+            io_type: read
+          - node: node9
+            io_type: write
+          - node: node9
+            io_type: read
+      desc: test with 1 subsystem and 256 namespaces in Single GW
       destroy-cluster: false
       module: test_ceph_nvmeof_gateway_scale.py
-      name: test 5k namespace with 1 subsystem in Single GW
-      polarion-id: CEPH-83576691
-
-  - test:
-      abort-on-fail: false
-      config:
-        node: node5
-        steps:
-          - config:
-              command: delete_subsystem
-              args:
-                subnqn: nqn.2016-06.io.spdk:cnode1
-      desc: Manage NVMeoF Subsystem entities
-      destroy-clster: false
-      module: test_nvme_cli.py
-      name: Delete NVMeOF targets
-      polarion-id: CEPH-83575783
+      name: Scale to 256 namespaces in single subsystem on NVMeOF GW
+      polarion-id: CEPH-83576686
 
   - test:
       abort-on-fail: false
@@ -297,7 +335,7 @@ tests:
            service_name: nvmeof.nvmeof_pool
            verify: true
       desc: Remove nvmeof service on GW node
-      destroy-clster: false
+      destroy-cluster: false
       module: test_orch.py
       name: Delete nvmeof gateway
 
@@ -319,6 +357,6 @@ tests:
               args:
                 - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
       desc: Delete nvmeof and rbd pool from ceph cluster
-      destroy-clster: false
+      destroy-cluster: false
       module: test_cephadm.py
       name: Delete NVMeOF pools

--- a/suites/reef/nvmeof/tier-4_nvmeof_namespace_operations.yaml
+++ b/suites/reef/nvmeof/tier-4_nvmeof_namespace_operations.yaml
@@ -1,0 +1,84 @@
+# NVMeoTCP functional regression tests suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_functional.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+          - node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83576085
+      desc: Perform map and unmap NVMe namespaces in loop
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Map-Unmap NVMe namespaces continuously
+      polarion-id: CEPH-83576085


### PR DESCRIPTION
Segregate nvmeof testsuites with tiers from polarion
 
e2e_fips.yaml: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-3ZOQ2A/

sanity: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-5S5OP2/

namespace_operations: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-TQ8FB0/

cluster_operations: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-KGH9S5/

gateway_operations: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-AYI3FI

bdev_operations: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-OIFY03/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
