### PR TITLE
integrating bucket lc reverse transition testcase

### DIFF
--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -203,6 +203,16 @@ tests:
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
         timeout: 500
 
+  - test:
+      name: Test bucket lc reverse transition
+      desc: Test bucket lc reverse transition
+      polarion-id: CEPH-83573373
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_reverse_transition.yaml
+        timeout: 300
+
   # swift container operation
   - test:
       name: test swift enable version on conatainer of different user

--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -203,6 +203,16 @@ tests:
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
         timeout: 500
 
+  - test:
+      name: Test bucket lc reverse transition
+      desc: Test bucket lc reverse transition
+      polarion-id: CEPH-83573373
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_reverse_transition.yaml
+        timeout: 300
+
   # swift container operation
   - test:
       name: swift enabling versioning on a bucket that is S3 versioned


### PR DESCRIPTION
ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/539

This PR automates testing of lc reverse transiton.
the rules are of

transition to cold after 4 days
transition to glacier after 10 days
transition back to cold after 16 days
polarion id: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573373

pass logs on pacific, quincy and reef: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_lc_reverse_transition/

pas log for changes in reusables and test_lc_rule_conflict_exp_days.yaml:
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_lc_reverse_transition/reef_test_lc_rule_conflict_exp_days.verbose.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
