### PR TITLE
Integration of RGW-LC improvements and LC expiration at archive zone

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_5_3GA_to_7x_latest.yaml
@@ -422,7 +422,7 @@ tests:
       desc: rgw-ms, upgrade next site(primary)
       module: test_cephadm_upgrade.py
       name: rgw-ms, upgrade next site(primary)
-      polarion-id: CEPH-83574647
+      polarion-id: CEPH-83582415
       clusters:
         ceph-pri:
           config:

--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -407,3 +407,54 @@ tests:
       polarion-id: CEPH-83573390
       module: sanity_rgw_multisite.py
       name: test multipart+encrypt object access at the archive site
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_lifecycle_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_current_expiration.yaml
+            timeout: 300
+      desc: Test LC on archive for current versions
+      polarion-id: CEPH-83575394
+      module: sanity_rgw_multisite.py
+      name: Test LC on archive for current versions
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_lifecycle_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_newer_noncurrent_expiration.yaml
+            timeout: 300
+      desc: Test LC on archive for newer-noncurrent versions
+      polarion-id: CEPH-83575919
+      module: sanity_rgw_multisite.py
+      name: Test LC on archive for newer-noncurrent versions
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_lifecycle_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_noncurrent_expiration.yaml
+            timeout: 300
+      desc: Test LC on archive for non-current versions
+      polarion-id: CEPH-83575394
+      module: sanity_rgw_multisite.py
+      name: Test LC on archive for non-current versions
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_lifecycle_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_objects_size_noncurrent.yaml
+            timeout: 300
+      desc: Test LC on archive for objects size expiration
+      polarion-id: CEPH-83582000
+      module: sanity_rgw_multisite.py
+      name: Test LC on archive for objects size expiration

--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -411,7 +411,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_current_expiration.yaml
             timeout: 300
@@ -424,7 +423,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_newer_noncurrent_expiration.yaml
             timeout: 300
@@ -432,12 +430,12 @@ tests:
       polarion-id: CEPH-83575919
       module: sanity_rgw_multisite.py
       name: Test LC on archive for newer-noncurrent versions
+      comments: new in 7.1, fails since code yet not present
 
   - test:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_noncurrent_expiration.yaml
             timeout: 300
@@ -450,7 +448,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_objects_size_noncurrent.yaml
             timeout: 300
@@ -458,3 +455,4 @@ tests:
       polarion-id: CEPH-83582000
       module: sanity_rgw_multisite.py
       name: Test LC on archive for objects size expiration
+      comments : new in 7.1, fails since code yet not present


### PR DESCRIPTION
ceph-qe-scripts: https://github.com/red-hat-storage/ceph-qe-scripts/pull/541

This PR automates LC at the archive zone when LC is applied from an active(primary) site:

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575394
It also automates new features coming in rhcs-7.1 related to LC improvements.
a) Newer-non-current versions, which would fail as of now
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575919
b) LC expiration based on object size, which will also fail
Polarian test case yet to be created.
passed logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RJXE48

Test LC on archive for current versions --> passed
Test LC on archive for newer-noncurrent versions --> expected to fail
Test LC on archive for non-current versions -- > passed
Test LC on archive for objects size expiration -- > expected to fail


**Note**: I added a commit that corrects the polarian test case of a previous pr ( it was incorrectly updated as a polarian requirement.)