### PR TITLE
[TFA]moving large object upload tests to other suite which doesnot configure network delay

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_test-quota-management.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-quota-management.yaml
@@ -86,7 +86,6 @@ tests:
       module: sanity_rgw.py
       name: test user quota max objects
       polarion-id: CEPH-83575330
-      comments: known issue (bz-2129931)
 
   - test:
       config:

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -365,17 +365,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             timeout: 300
   - test:
-      name: test sharding on primary
-      desc: test_Mbuckets_with_Nobjects_sharding on primary
-      polarion-id: CEPH-83573597
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-            timeout: 300
-  - test:
       name: test Mbuckets on primary
       desc: test_Mbuckets on primary
       polarion-id: CEPH-83575435
@@ -386,17 +375,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
-  - test:
-      name: LargeObjGet_GC on primary
-      desc: test_LargeObjGet_GC on primary
-      polarion-id: CEPH-83574416
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_LargeObjGet_GC.py
-            config-file-name: test_LargeObjGet_GC.yaml
             timeout: 300
 
   - test:

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -337,17 +337,6 @@ tests:
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets.yaml
             timeout: 300
-  - test:
-      name: LargeObjGet_GC test
-      desc: test_LargeObjGet_GC on secondary
-      polarion-id: CEPH-83574416
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_LargeObjGet_GC.py
-            config-file-name: test_LargeObjGet_GC.yaml
-            timeout: 300
 
   - test:
       name: create tenanted user

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -814,6 +814,7 @@ tests:
       module: test_s3.py
       name: execute s3tests
       polarion-id: CEPH-83575225
+      comments: Known issue - Ceph tracker 55614
 
   # Encryption tests
 

--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -550,6 +550,7 @@ tests:
       desc: test mdlog trimming on primary
       polarion-id: CEPH-10544 #CEPH-10722, CEPH-10547
       module: sanity_rgw_multisite.py
+      comments: Known issue BZ-2230359
       clusters:
         ceph-pri:
           config:

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
@@ -422,6 +422,18 @@ tests:
             timeout: 300
 
   - test:
+      name: test sharding on primary
+      desc: test_Mbuckets_with_Nobjects_sharding on primary
+      polarion-id: CEPH-83573597
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
+            timeout: 300
+
+  - test:
       name: LargeObjGet_GC test
       desc: test_LargeObjGet_GC on secondary
       polarion-id: CEPH-83574416

--- a/suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml
@@ -165,6 +165,7 @@ tests:
       module: test_s3.py
       name: execute s3tests
       polarion-id: CEPH-10361
+      comments: Known issue - Ceph tracker 55614
 
   - test:
       name: Deploy RGW Ingress daemon

--- a/suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml
@@ -127,7 +127,6 @@ tests:
       module: sanity_rgw.py
       name: test user quota max objects
       polarion-id: CEPH-83575330
-      comments: known issue (bz-2129931)
 
   - test:
       config:

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -296,7 +296,6 @@ tests:
       module: sanity_rgw.py
       name: test user quota max objects (single site)
       polarion-id: CEPH-83575330
-      comments: known issue (bz-2129931)
 
   - test:
       clusters:


### PR DESCRIPTION
the issue of large object upload failures is because of network delay configured on the cluster.
so moving those tests to other suite where network delay is not configured.
also updating comments for product bz's for some tests.

jira ticket: https://issues.redhat.com/browse/RHCEPHQE-11963

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
