### PR TITLE
[TestFix][TFA][DMFG] Fix tier-2-ceph-volume suite

### DIFF
--- a/cli/ceph/osd/pool.py
+++ b/cli/ceph/osd/pool.py
@@ -12,7 +12,7 @@ class Pool(Cli):
 
     def ls(self, **kw):
         """List pool details"""
-        cmd = f"{self.base_cmd} ls details{build_cmd_from_args(**kw)}"
+        cmd = f"{self.base_cmd} ls detail {build_cmd_from_args(**kw)}"
 
         out = self.execute(sudo=True, cmd=cmd)
         if isinstance(out, tuple):

--- a/tests/ceph_volume/test_ceph_volume_lvm_tags_after_osd_rm.py
+++ b/tests/ceph_volume/test_ceph_volume_lvm_tags_after_osd_rm.py
@@ -45,12 +45,12 @@ def run(ceph_cluster, **kw):
     if not out:
         raise RemoveOsdError("Failed to fetch the pools")
 
-    pools = loads(out[0])
+    pools = loads(out)
     pool_size = 2  # Update the pool size to 2
     for pool in pools:
         pool_name = pool.get("pool_name")
         out = CephAdm(osd_node).ceph.osd.pool.set(pool_name, "size", pool_size)
-        if not out:
+        if out:
             raise RemoveOsdError("Failed to update the pool size")
 
     # Perform osd remove


### PR DESCRIPTION
# Description
Problem: 
The tier-2-ceph-volume tests ([Validate lvm tags post osd rm command](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575103) and  [ceph volume fails to zap the lvm device](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575121) ) were failing while collecting the osd details. 

Reason for failure:
The command for getiing osd details is `cephadm shell ceph osd pool ls detail ` whereas the lib had `cephadm shell ceph osd pool ls details` causing the command to fail

Solution:
Fix the lib to execute the correct command to get osd details

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
