### PR TITLE
[TFA issue fix] s3cmd download from primary

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -485,12 +485,12 @@ tests:
       polarion-id: CEPH-83575433
 
   - test:
-      name: S3CMD object download on tertiary
+      name: S3CMD object download on primary
       desc: S3CMD object download or GET
       polarion-id: CEPH-83575477
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-ter:
+        ceph-pri:
           config:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml


### PR DESCRIPTION
# Description
pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-2LBVLK/S3CMD_object_download_on_primary_0.log

issue:
radosgw-admin --tenant tenant --uid johnj.467 --display-name "johnj.467" --access_key 541P2LR0oBZX7J1MH6BP --secret HRho5H0hCW09D3OOYCohTZ3B8FPYJIhO4U777NQQ user create --cluster ceph'
 b'Please run the command on master zone. Performing this operation on non-master zone leads to inconsistent metadata between zones Are you sure you want to go ahead? (requires --yes-i-really-mean-it)'
 failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-140/Regression/rgw/37/tier-2_rgw_3_way_multisite/S3CMD_object_download_on_tertiary_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
