### PR TITLE
[TFA][DMFG][Cephadm][Quincy]Fix bootstrap-along-with-spec-file

### DIFF
--- a/suites/quincy/cephadm/tier-2-bootstrap-along-with-spec-file.yaml
+++ b/suites/quincy/cephadm/tier-2-bootstrap-along-with-spec-file.yaml
@@ -26,10 +26,13 @@ tests:
             spec:
               - service_type: host
                 hostname: node1
+                addr: node1
               - service_type: host
                 hostname: node2
+                addr: node2
               - service_type: host
                 hostname: node3
+                addr: node3
               - service_type: mon
                 placement:
                   hosts:


### PR DESCRIPTION
[TFA][DMFG][Cephadm][Quincy]Fix bootstrap-along-with-spec-file

Fix for quincy cephadm suite "suites/reef/cephadm/tier-2-bootstrap-along-with-spec-file.yaml"