### PR TITLE
Enabling zlib compression on the multisite+archive

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -346,6 +346,8 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_auth agent"
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "radosgw-admin zone placement modify --rgw-zone secondary --placement-id default-placement  --compression zlib"
+              - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.sec}"
             timeout: 120
         ceph-pri:
@@ -358,6 +360,8 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_auth agent"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "radosgw-admin zone placement modify --rgw-zone primary --placement-id default-placement  --compression zlib"
+              - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.pri}"
             timeout: 120
         ceph-arc:
@@ -370,11 +374,14 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_auth agent"
               - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.arc} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "radosgw-admin zone placement modify --rgw-zone archive --placement-id default-placement  --compression zlib"
+              - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.arc}"
             timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
-      name: set sse-s3 vault configs on multisite
+      name: sse-s3 vault configs, and zlib compression
+      polarian-id: CEPH-83575916
 
 
   - test:


### PR DESCRIPTION
ceph-qe-scripts: https://github.com/red-hat-storage/ceph-qe-scripts/pull/542

[rgw-ms][compression-encryption][usage]: Encrypted multipart uploads cause an inconsistency in size obtained via bucket stats.

bugs for 6.1z4 : https://bugzilla.redhat.com/show_bug.cgi?id=2247742
bugs for 7.0: https://bugzilla.redhat.com/show_bug.cgi?id=2236643

logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Y5JXGB

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575916