### PR TITLE
[TFA] Fix rgw sanity failure and remove ISCSI test case

### DIFF
--- a/conf/quincy/cephadm/tier-2_10node_cephadm_scale.yaml
+++ b/conf/quincy/cephadm/tier-2_10node_cephadm_scale.yaml
@@ -24,7 +24,6 @@ globals:
           - node-exporter
           - alertmanager
           - crash
-          - rgw
         no-of-volumes: 4
         disk-size: 15
       node3:
@@ -33,7 +32,6 @@ globals:
           - osd
           - node-exporter
           - crash
-          - rgw
           - mds
         no-of-volumes: 4
         disk-size: 15
@@ -49,7 +47,6 @@ globals:
           - node-exporter
           - alertmanager
           - crash
-          - rgw
         no-of-volumes: 4
         disk-size: 15
       node6:
@@ -58,7 +55,6 @@ globals:
           - osd
           - node-exporter
           - crash
-          - rgw
           - mds
         no-of-volumes: 4
         disk-size: 15

--- a/suites/quincy/cephadm/tier-2-cluster-elasticity.yaml
+++ b/suites/quincy/cephadm/tier-2-cluster-elasticity.yaml
@@ -529,28 +529,6 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Apply ISCSI Service
-      desc: Apply ISCSI target service on iscsi role nodes
-      module: test_iscsi.py
-      polarion-id: CEPH-83573756
-      config:
-        command: apply
-        service: iscsi
-        base_cmd_args:            # arguments to ceph orch
-          verbose: true
-        pos_args:
-          - iscsi                 # name of the pool
-          - api_user              # name of the API user
-          - api_pass              # password of the api_user.
-        args:
-          placement:
-            nodes:
-              - node7
-              - node8           # either label or node.
-      destroy-cluster: false
-      abort-on-fail: true
-
-  - test:
       name: Setup destination node for SNMP traps
       desc: Install snmptrapd tool and install CEPH MIB on destination node
       module: snmp_destination.py
@@ -745,27 +723,6 @@ tests:
               - node10
             limit: 2
             sep: ";"
-      destroy-cluster: false
-      abort-on-fail: true
-
-  - test:
-      name: Scale down ISCSI Service
-      desc: Scale down ISCSI target service to 1 node
-      module: test_iscsi.py
-      polarion-id: CEPH-83573756
-      config:
-        command: apply
-        service: iscsi
-        base_cmd_args:            # arguments to ceph orch
-          verbose: true
-        pos_args:
-          - iscsi                 # name of the pool
-          - api_user              # name of the API user
-          - api_pass              # password of the api_user.
-        args:
-          placement:
-            nodes:
-              - node7
       destroy-cluster: false
       abort-on-fail: true
 


### PR DESCRIPTION
# Description

Problem:
The tier-2-cluster-elasticity.yaml tests ([sanity_rgw.py] was failing with error - ERROR: Could not connect to the endpoint URL: "[http://10.0.210.163:80/bucket1](http://10.0.210.163/bucket1)"'

Reason for failure:
```
# ceph orch host ls
HOST                                         ADDR          LABELS                                                STATUS
ceph-saya-tfa-iq33ea-nvu88h-node1-installer  10.0.209.144  _admin
ceph-saya-tfa-iq33ea-nvu88h-node2            10.0.210.163  crash rgw osd mds mgr alertmanager mon node-exporter
ceph-saya-tfa-iq33ea-nvu88h-node3            10.0.211.88   crash rgw osd mds mon node-exporter
ceph-saya-tfa-iq33ea-nvu88h-node7            10.0.208.41   crash rgw osd mds mgr alertmanager mon node-exporter
ceph-saya-tfa-iq33ea-nvu88h-node8            10.0.207.129  crash rgw osd mds mon node-exporter
5 hosts in cluster 
```

```
# ceph orch ls | grep rgw
rgw.myrgw                  ?:80             2/2  2m ago     26m  ceph-saya-tfa-iq33ea-nvu88h-node7;ceph-saya-tfa-iq33ea-nvu88h-node8;count:2 
```

The "--rgw-node" being passed to the command "sudo venv/bin/python ~/rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_multitenant_user_access.py -c rgw-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/configs/test_multitenant_access.yaml --rgw-node 10.0.210.163"  should have rgw service up and running for the endpoint to be present.

The node with IP "10.0.210.163" has label "rgw", but no rgw service deployed on it.
As per the bootstrap test, the rgw service is deployed only on node7 and node8.

Solution:
(1) Fix the conf (conf/quincy/cephadm/tier-2_10node_cephadm_scale.yaml) and remove the label "rgw" from node2, node3, node5 and node6.
As a result, the command will be default pick the ip address of node7 which will have rgw service up and running.

(2) Also, as iscsi is not supported on quincy, removing the iscsi test case [test_iscsi.py] from the suite tier-2-cluster-elasticity.yaml

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
