### PR TITLE
[tfa-fix] Add fix for IBM TFA issue which failed for repo addition

### DIFF
--- a/cli/ops/cephadm_ansible.py
+++ b/cli/ops/cephadm_ansible.py
@@ -126,7 +126,7 @@ def configure_cephadm_ansible_inventory(nodes):
     installer.exec_command(sudo=True, cmd=cmd)
 
 
-def exec_cephadm_preflight(node, build_type, repo=None):
+def exec_cephadm_preflight(node, build_type, ibm_build=False, repo=None):
     """Executes cephadm preflight playbook
 
     Args:
@@ -139,6 +139,11 @@ def exec_cephadm_preflight(node, build_type, repo=None):
 
     # Set custom repository
     if repo:
+        if ibm_build and repo.endswith(".repo") and "public.dhe.ibm.com" in repo:
+            if "rhel9" in repo:
+                repo = repo.replace(repo.split("/")[-1], "rhel9/x86_64/")
+            elif "rhel8" in repo:
+                repo = repo.replace(repo.split("/")[-1], "rhel8/x86_64/")
         extra_vars = {
             "ceph_origin": "custom",
             "gpgcheck": "no",

--- a/cli/utilities/configure.py
+++ b/cli/utilities/configure.py
@@ -340,7 +340,7 @@ def setup_installer_node(
     configure_cephadm_ansible_inventory(nodes)
 
     # Execute cephadm ansible preflight playbook
-    exec_cephadm_preflight(installer, build_type, tools_repo)
+    exec_cephadm_preflight(installer, build_type, ibm_build, tools_repo)
 
 
 def setup_client_node(installer, ansible_clients):

--- a/suites/quincy/cephadm/tier-2-permissive-mode-scenarios.yaml
+++ b/suites/quincy/cephadm/tier-2-permissive-mode-scenarios.yaml
@@ -19,7 +19,7 @@ tests:
       module: test_cephadm_ansible_bootstrap.py
       config:
         bootstrap:
-          playbook: cephadm-bootstrap.yaml
+          playbook: bootstrap-with-registry-details.yaml
           set_selinux: permissive  # permissive or enforcing
           module_args:
             mon_ip: node1

--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-registry-details.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-registry-details.yaml
@@ -8,6 +8,6 @@
       cephadm_bootstrap:
         image: "{{ image | default(False) }}"
         mon_ip: "{{ mon_ip }}"
-        registry_url: "{{ registry_url }}"
-        registry_username: "{{ registry_username }}"
-        registry_password: "{{ registry_password }}"
+        registry_url: "{{ registry_url | default() }}"
+        registry_username: "{{ registry_username | default() }}"
+        registry_password: "{{ registry_password | default() }}"


### PR DESCRIPTION
# Description

Problem:
1. Test suite "tier-2-permissive-mode-scenarios" failed for IBM deployments when providing the custom repo as a ".repo" URL instead of the baseurl.
2. When appropriate baseurl is provided, the suite fails to pull the ceph image during bootstrap.

Reason for Failure:
1. When the "baseurl" is provided with a ".repo" file , the preflight playbook add the ".repo" URL as the baseurl in the repo which is incorrect.
2. The bootstrap.yaml file provided for the cephadm-ansible deployment was missing the registry details.

Solution:
1. Made changes in the `exec_cephadm_preflight` function to convert the repo to use baseurl instead of ".repo" URL.
2. Changed the playbook within the suite to use `bootstrap-with-registry-details.yaml` instead of `cephhadm-bootstrap.yaml`
