### PR TITLE
fixing ingress deployment failure by using loopback address as vip

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_ingress_with_ssl.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ingress_with_ssl.yaml
@@ -163,7 +163,26 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 10.0.211.172/22
+                    virtual_ip: 127.1.1.100/8
+                    virtual_interface_networks:
+                      # rhos-d network id's
+                      - '10.0.208.0/22'  # provider_net_cci_12
+                      - '10.0.204.0/22'  # provider_net_cci_11
+                      - '10.0.108.0/22'  # provider_net_cci_9
+                      - '10.0.104.0/22'  # provider_net_cci_8
+                      - '10.0.100.0/22'  # provider_net_cci_7
+                      - '10.0.96.0/22'  # provider_net_cci_6
+                      - '10.0.152.0/22'  # provider_net_cci_5
+                      - '10.0.148.0/22'  # provider_net_cci_4
+                      # rhos-01 network id's
+                      - '10.0.195.0/24'  # shared_net_12
+                      - '10.0.194.0/24'  # shared_net_11
+                      - '10.0.192.0/24'  # shared_net_9
+                      - '10.0.191.0/24'  # shared_net_8
+                      - '10.0.190.0/24'  # shared_net_7
+                      - '10.0.189.0/24'  # shared_net_6
+                      - '10.0.188.0/24'  # shared_net_5
+                      - '10.0.201.0/24'  # shared_net_4
                     frontend_port: 443
                     monitor_port: 1967
                     ssl_cert: create-cert
@@ -189,6 +208,25 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 10.0.209.108/22
+                    virtual_ip: 127.1.1.200/8
+                    virtual_interface_networks:
+                      # rhos-d network id's
+                      - '10.0.208.0/22'  # provider_net_cci_12
+                      - '10.0.204.0/22'  # provider_net_cci_11
+                      - '10.0.108.0/22'  # provider_net_cci_9
+                      - '10.0.104.0/22'  # provider_net_cci_8
+                      - '10.0.100.0/22'  # provider_net_cci_7
+                      - '10.0.96.0/22'  # provider_net_cci_6
+                      - '10.0.152.0/22'  # provider_net_cci_5
+                      - '10.0.148.0/22'  # provider_net_cci_4
+                      # rhos-01 network id's
+                      - '10.0.195.0/24'  # shared_net_12
+                      - '10.0.194.0/24'  # shared_net_11
+                      - '10.0.192.0/24'  # shared_net_9
+                      - '10.0.191.0/24'  # shared_net_8
+                      - '10.0.190.0/24'  # shared_net_7
+                      - '10.0.189.0/24'  # shared_net_6
+                      - '10.0.188.0/24'  # shared_net_5
+                      - '10.0.201.0/24'  # shared_net_4
                     frontend_port: 8083
                     monitor_port: 1967

--- a/suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_s3tests.yaml
@@ -205,7 +205,26 @@ tests:
                       - node5
                   spec:
                     backend_service: rgw.my-rgw
-                    virtual_ip: 10.0.211.172/22
+                    virtual_ip: 127.1.1.100/8
+                    virtual_interface_networks:
+                      # rhos-d network id's
+                      - '10.0.208.0/22'  # provider_net_cci_12
+                      - '10.0.204.0/22'  # provider_net_cci_11
+                      - '10.0.108.0/22'  # provider_net_cci_9
+                      - '10.0.104.0/22'  # provider_net_cci_8
+                      - '10.0.100.0/22'  # provider_net_cci_7
+                      - '10.0.96.0/22'  # provider_net_cci_6
+                      - '10.0.152.0/22'  # provider_net_cci_5
+                      - '10.0.148.0/22'  # provider_net_cci_4
+                      # rhos-01 network id's
+                      - '10.0.195.0/24'  # shared_net_12
+                      - '10.0.194.0/24'  # shared_net_11
+                      - '10.0.192.0/24'  # shared_net_9
+                      - '10.0.191.0/24'  # shared_net_8
+                      - '10.0.190.0/24'  # shared_net_7
+                      - '10.0.189.0/24'  # shared_net_6
+                      - '10.0.188.0/24'  # shared_net_5
+                      - '10.0.201.0/24'  # shared_net_4
                     frontend_port: 443
                     monitor_port: 1967
                     ssl_cert: create-cert

--- a/suites/reef/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -163,7 +163,26 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 10.0.211.172/22
+                    virtual_ip: 127.1.1.100/8
+                    virtual_interface_networks:
+                      # rhos-d network id's
+                      - '10.0.208.0/22'  # provider_net_cci_12
+                      - '10.0.204.0/22'  # provider_net_cci_11
+                      - '10.0.108.0/22'  # provider_net_cci_9
+                      - '10.0.104.0/22'  # provider_net_cci_8
+                      - '10.0.100.0/22'  # provider_net_cci_7
+                      - '10.0.96.0/22'  # provider_net_cci_6
+                      - '10.0.152.0/22'  # provider_net_cci_5
+                      - '10.0.148.0/22'  # provider_net_cci_4
+                      # rhos-01 network id's
+                      - '10.0.195.0/24'  # shared_net_12
+                      - '10.0.194.0/24'  # shared_net_11
+                      - '10.0.192.0/24'  # shared_net_9
+                      - '10.0.191.0/24'  # shared_net_8
+                      - '10.0.190.0/24'  # shared_net_7
+                      - '10.0.189.0/24'  # shared_net_6
+                      - '10.0.188.0/24'  # shared_net_5
+                      - '10.0.201.0/24'  # shared_net_4
                     frontend_port: 443
                     monitor_port: 1967
                     ssl_cert: create-cert
@@ -189,6 +208,25 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 10.0.209.108/22
+                    virtual_ip: 127.1.1.200/8
+                    virtual_interface_networks:
+                      # rhos-d network id's
+                      - '10.0.208.0/22'  # provider_net_cci_12
+                      - '10.0.204.0/22'  # provider_net_cci_11
+                      - '10.0.108.0/22'  # provider_net_cci_9
+                      - '10.0.104.0/22'  # provider_net_cci_8
+                      - '10.0.100.0/22'  # provider_net_cci_7
+                      - '10.0.96.0/22'  # provider_net_cci_6
+                      - '10.0.152.0/22'  # provider_net_cci_5
+                      - '10.0.148.0/22'  # provider_net_cci_4
+                      # rhos-01 network id's
+                      - '10.0.195.0/24'  # shared_net_12
+                      - '10.0.194.0/24'  # shared_net_11
+                      - '10.0.192.0/24'  # shared_net_9
+                      - '10.0.191.0/24'  # shared_net_8
+                      - '10.0.190.0/24'  # shared_net_7
+                      - '10.0.189.0/24'  # shared_net_6
+                      - '10.0.188.0/24'  # shared_net_5
+                      - '10.0.201.0/24'  # shared_net_4
                     frontend_port: 8083
                     monitor_port: 1967


### PR DESCRIPTION
fixing ingress deployment failure by using loopback address as vip and rhos-d and rhos-01 network ids as virtual_interface_networks, so that it pass in both rhos-d and rhos-01

tried many combinations with trail and error method, found below working solution without much changes..
 
as the virtual ip we provide is only restricted to the particular node, tried with both dummy network ip and loopback address. I tried with two hosts, but then 2/4 daemons were active. 
```
[cephuser@ceph-pri-hsm-6x-z98klm-node6 ~]$ ceph health detail
HEALTH_WARN Failed to place 2 daemon(s)
[WRN] CEPHADM_DAEMON_PLACE_FAIL: Failed to place 2 daemon(s)
    Failed while placing keepalived.ingress2.ceph-pri-hsm-6x-z98klm-node4.roffmy on ceph-pri-hsm-6x-z98klm-node4: Unable to identify interface for 127.0.0.200/8 on ceph-pri-hsm-6x-z98klm-node4
    Failed while placing keepalived.ingress2.ceph-pri-hsm-6x-z98klm-node5.gqxhos on ceph-pri-hsm-6x-z98klm-node5: Unable to identify interface for 127.0.0.200/8 on ceph-pri-hsm-6x-z98klm-node5
[cephuser@ceph-pri-hsm-6x-z98klm-node6 ~]$
```

then I used `virtual_interface_networks` to list the network ids of both rhos-d and rhos-01 in the spec file, 4/4 daemons were up with this change.

we can create dummy network interface and use that ip as well, but that requires some moe code changes..
```[root@ceph-pri-hsm-6x-z98klm-node4 ~]# sudo lsmod | grep dummy
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# sudo modprobe dummy
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# sudo lsmod | grep dummy
dummy                  16384  0
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# sudo ip link add eth10 type dummy
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# 
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# ip link show eth10
3: eth10: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether fa:b0:19:8a:17:c4 brd ff:ff:ff:ff:ff:ff
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# sudo ip addr add 192.168.100.199/24 brd + dev eth10 label eth10:0
[root@ceph-pri-hsm-6x-z98klm-node4 ~]# ifconfig -a eth10
eth10: flags=130<BROADCAST,NOARP>  mtu 1500
        ether fa:b0:19:8a:17:c4  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

[root@ceph-pri-hsm-6x-z98klm-node4 ~]# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether fa:16:3e:09:54:97 brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    altname ens3
    inet 10.0.209.5/22 brd 10.0.211.255 scope global dynamic noprefixroute eth0
       valid_lft 40637sec preferred_lft 40637sec
    inet6 2620:52:0:d0:f816:3eff:fe09:5497/64 scope global dynamic mngtmpaddr 
       valid_lft 2591853sec preferred_lft 604653sec
    inet6 fe80::f816:3eff:fe09:5497/64 scope link 
       valid_lft forever preferred_lft forever
3: eth10: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether fa:b0:19:8a:17:c4 brd ff:ff:ff:ff:ff:ff
    inet 192.168.100.199/24 brd 192.168.100.255 scope global eth10:0
       valid_lft forever preferred_lft forever
```

this method failed when the ip addresses of the hosts mentioned in ingress spec comes under two different subnets. anyhow the current vip address what we are specifying floating ip or fixed ip of a particular subnet also fails if the two hosts are under different subnets. but assuming the probability is less, so going ahead with this solution.


pass logs:

- pacific: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/fix_ingress_deployment_failure_PR/pass_log_5.3
- quincy: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/fix_ingress_deployment_failure_PR/cephci-run-TODKG1/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
