### PR TITLE
integrating test sts aswi creds expire while object copy is in progress

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
@@ -195,3 +195,24 @@ tests:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
         timeout: 500
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+        rule: root netem delay 20ms 2ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+      polarion-id: CEPH-83575222
+
+  - test:
+      name: STS aswi Tests to test creds expire while copy object in progress
+      desc: STS aswi Tests to test creds expire while copy object in progress
+      polarion-id: CEPH-83581390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_creds_expire_copy_in_progress.yaml
+        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
@@ -195,3 +195,24 @@ tests:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
         timeout: 500
+
+  - test:
+      abort-on-fail: true
+      config:
+        roles:
+          - rgw
+        rule: root netem delay 20ms 2ms distribution normal
+      desc: Configuring network traffic delay
+      module: configure-tc.py
+      name: apply-net-qos
+      polarion-id: CEPH-83575222
+
+  - test:
+      name: STS aswi Tests to test creds expire while copy object in progress
+      desc: STS aswi Tests to test creds expire while copy object in progress
+      polarion-id: CEPH-83581390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_creds_expire_copy_in_progress.yaml
+        timeout: 500


### PR DESCRIPTION
this PR is to automate testing of sts aswi creds expire while object copy is in progress
hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2214981
polarion id: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581390

ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/544

pass logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_sts_hotfix_bz/5_3_test_sts_aswi_creds_expire_large_object_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_sts_hotfix_bz/7_1_test_sts_aswi_creds_expire_large_object_upload.console.log
http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_sts_hotfix_bz/5_3_test_sts_aswi.console.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
