### PR TITLE
[TFA] Enable sync between zones before testcase of Granular sync policy

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_multisite_scenarios.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_scenarios.yaml
@@ -243,7 +243,7 @@ tests:
             commands:
               - "yum install -y jq"
               - "radosgw-admin zonegroup get --rgw-zonegroup=shared > /tmp/zonegroup_shared_backup.json"
-              - "jq -r '.zones[].log_meta=false | .zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_shared_backup.json > /tmp/zonegroup_shared.json"
+              - "jq -r '.zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_shared_backup.json > /tmp/zonegroup_shared.json"
               - "radosgw-admin zonegroup set --rgw-zonegroup=shared --infile=/tmp/zonegroup_shared.json"
               - "radosgw-admin period update --rgw-realm india --commit"
               - "sleep 20"
@@ -281,6 +281,24 @@ tests:
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-pri"]
             timeout: 500
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            role: rgw
+            sudo: True
+            commands:
+              - "radosgw-admin zonegroup get --rgw-zonegroup=shared > /tmp/zonegroup_shared_backup.json"
+              - "jq -r '.zones[].log_data=true | .zones[].sync_from_all=true' /tmp/zonegroup_shared_backup.json > /tmp/zonegroup_shared.json"
+              - "radosgw-admin zonegroup set --rgw-zonegroup=shared --infile=/tmp/zonegroup_shared.json"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "sleep 20"
+      desc: enable multisite sync between primary and secondary zones
+      module: exec.py
+      name: enable multisite sync between zones
+      polarion-id: CEPH-83581229
 
   - test:
       name: bucket granular sync policy on enabled forbidden semantic with symmetrical and directional flow


### PR DESCRIPTION
# Description
 Enable sync between zones before testcase of Granular sync policy
 failure log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.1-7/Regression/rgw/40/tier-2_rgw_multisite_scenarios/bucket_granular_sync_policy_on_enabled_forbidden_semantic_with_symmetrical_and_directional_flow_0.log
 
pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-8B4C82/bucket_granular_sync_policy_on_enabled_forbidden_semantic_with_symmetrical_and_directional_flow_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
