### PR TITLE
[TFA] Fix IndexError

### DIFF
--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -147,7 +147,11 @@ def run(ceph_cluster, **kwargs):
 
     # Get the Tools repo file name
     out = installer.get_dir_list(dir_path=YUM_REPO_DIR)
-    file_name = [repo for repo in out if "Tools" in repo][0]
+    build_type = "ibm" if config.get("ibm_build") else "rh"
+    if build_type == "rh":
+        file_name = [repo for repo in out if "Tools" in repo][0]
+    elif build_type == "ibm":
+        file_name = [repo for repo in out if "IBM" in repo][0]
 
     try:
         # Validate if requied packages are installed


### PR DESCRIPTION
# Description

Problem:
The suites/reef/smoke/build.yaml test test_package_validation.py is failing with error "IndexError: list index out of range" while getting the name of the repo file.

Reason for failure:
The test fails only in IBM ceph clusters at https://github.com/red-hat-storage/cephci/blob/master/tests/cephadm/test_package_validation.py#L150 because the repo name for IBM Ceph does not contain the pattern "Tools" (IBM-CEPH-7.1-202401192122.ci.0-rhel9.repo  lab-extras.repo  redhat.repo), so it passes on RH ceph cluster and fails on IBM ceph cluster.

Solution:
Add a check for the type of deployment (IBM/RHCS) and accordingly add a check for the pattern ("Tools"/"IBM").

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
