### PR TITLE
[feat] Automate testcases for qos of namespace

### DIFF
--- a/ceph/nvmegw_cli/namespace.py
+++ b/ceph/nvmegw_cli/namespace.py
@@ -1,3 +1,5 @@
+import re
+
 from ceph.nvmegw_cli import NVMeGWCLI
 
 
@@ -7,16 +9,29 @@ class Namespace(NVMeGWCLI):
         self.name = "namespace"
 
     def set_qos(self, **kwargs):
+        """Set QoS for namespace."""
+        subsystem = kwargs.get("args", {}).get("subsystem")
+        _, namespaces = self.list(args={"subsystem": subsystem})
+
+        pattern = r"\│\s*(\d+)\s*│"
+        nsid = [int(match) for match in re.findall(pattern, namespaces)]
+
+        kwargs.setdefault("args", {}).update({"nsid": nsid[0]})
+
         return self.run_nvme_cli("set_qos", **kwargs)
 
     def add(self, **kwargs):
+        """Adds namespace for subsystem."""
         return self.run_nvme_cli("add", **kwargs)
 
     def delete(self, **kwargs):
+        """Deletes  namespace."""
         return self.run_nvme_cli("del", **kwargs)
 
     def list(self, **kwargs):
+        """Lists namespaces under subsystem."""
         return self.run_nvme_cli("list", **kwargs)
 
     def resize(self, **kwargs):
+        """Resize namespaces under subsystem."""
         return self.run_nvme_cli("resize", **kwargs)

--- a/suites/reef/nvmeof/tier-1_nvmeof_qos.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_qos.yaml
@@ -1,0 +1,269 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+#  Configure Ceph NVMeoF gateway
+#  Configure Initiators
+#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool application enable rbd rbd
+          - config:
+              command: shell
+              args:
+                - rbd create -s 1G image1
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  label: nvmeof-gw
+              pos_args:
+                - rbd
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-clster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node6
+        pool: rbd
+        port: 5500
+        steps:
+          - config:
+              service: version          # CLI Version
+              command: version
+              base_cmd_args:
+                format: json
+                output: log
+          - config:
+              service: gateway
+              command: version         # gateway Version
+              base_cmd_args:
+                format: json
+                output: log
+          - config:
+              service: gateway
+              command: info             # gateway info
+          - config:
+              service: log_level
+              command: get
+              base_cmd_args:
+                format: json
+                output: stdio
+          - config:
+              service: log_level
+              command: set
+              base_cmd_args:
+                format: json
+                output: stdio
+              args:
+                level: error
+                print: error
+          - config:
+              service: log_level
+              command: disable
+              base_cmd_args:
+                format: json
+                output: stdio
+          - config:
+              service: subsystem
+              command: add              # Subsystem add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                serial-number: 1
+          - config:
+              service: subsystem
+              command: list             # Subsystem list
+              base_cmd_args:
+                format: json
+          - config:
+              service: connection
+              command: list             # Subsystem connection list
+              base_cmd_args:
+                format: json
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+          - config:
+              service: listener
+              command: add                # Listener add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                gateway-name: node6
+                trsvcid: 5001
+                traddr: node6
+              base_cmd_args:
+                format: json
+          - config:
+              service: listener
+              command: list               # Listener list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+          - config:
+              service: listener
+              command: delete             # listener del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                gateway-name: node6
+                trsvcid: 5001
+                traddr: node6
+          - config:
+              service: host
+              command: add              # add Host access
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                host: "*"
+          - config:
+              service: host
+              command: list             # List access hosts
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+          - config:
+              service: host
+              command: delete           # access host del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                host: "*"
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                rbd-image: image1
+                rbd-pool: rbd
+                nsid: 1
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                rw-ios-per-second: 10
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 1
+          - config:
+              service: subsystem
+              command: delete           # subsystem delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+      desc: Manage NVMeoF Subsystem entities
+      destroy-clster: false
+      module: test_nvme_cli.py
+      name: Manage nvmeof gateway entities
+      polarion-id: CEPH-83581750
+
+# Clean-up
+  - test:
+      abort-on-fail: true
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.rbd
+           verify: true
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-clster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: NVMeoF Gateway deployment using cephadm
+      do-not-skip-tc: true
+      destroy-clster: false
+      module: test_cephadm.py
+      name: Delete nvmeof gateway pre-reqs

--- a/suites/reef/nvmeof/tier-4_nvmeof_neg_tests.yaml
+++ b/suites/reef/nvmeof/tier-4_nvmeof_neg_tests.yaml
@@ -1,0 +1,100 @@
+# Basic Ceph-NVMeOF Regression Test suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_functional.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+          - node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83581753
+      desc: set QoS for namespace in subsystem with invalid values and args
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: set QoS for namespace in subsystem with invalid values and args.
+      polarion-id: CEPH-83581753
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node10
+        operation: CEPH-83581945
+      desc: set QoS for namespace in subsystem without mandatory values and args
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: set QoS for namespace in subsystem without mandatory values and args.
+      polarion-id: CEPH-83581945


### PR DESCRIPTION
# Description

Automate negative testcases to set qos for namespace
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581753
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581945

logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-8FJI5W/

[RHCEPHQE-12853](https://issues.redhat.com//browse/RHCEPHQE-12853) Automate to set QoS for a namespace in subsystem
Log: http://magna002.ceph.redhat.com/ceph-qe-logs/Harika/cephci-run-PHRDID/Manage_nvmeof_gateway_entities_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
