### PR TITLE
[TFA] Fix the IndexError

### DIFF
--- a/tests/cephadm/test_package_validation.py
+++ b/tests/cephadm/test_package_validation.py
@@ -1,3 +1,4 @@
+from cli.exceptions import ResourceNotFoundError
 from cli.utilities.containers import Container
 from cli.utilities.packages import Package, PackageError, ReposError, Rpm
 from cli.utilities.utils import get_custom_repo_url
@@ -149,9 +150,13 @@ def run(ceph_cluster, **kwargs):
     out = installer.get_dir_list(dir_path=YUM_REPO_DIR)
     build_type = "ibm" if config.get("ibm_build") else "rh"
     if build_type == "rh":
-        file_name = [repo for repo in out if "Tools" in repo][0]
+        _files = [repo for repo in out if "Tools" in repo or "RHCEPH" in repo]
     elif build_type == "ibm":
-        file_name = [repo for repo in out if "IBM" in repo][0]
+        _files = [repo for repo in out if "IBM" in repo]
+    # Raise error if expected repository is not added
+    if not _files:
+        raise ResourceNotFoundError("Expected repository not added to node")
+    file_name = _files[0]
 
     try:
         # Validate if requied packages are installed


### PR DESCRIPTION
# Description

Problem: The suites/reef/smoke/build.yaml test test_package_validation.py is failing with error "IndexError: list index out of range" while getting the name of the repo file.

Reason for failure:
The test fails on the RHCS Pacific ceph clusters at https://github.com/red-hat-storage/cephci/blob/master/tests/cephadm/test_package_validation.py#L152 because the repo name for Pacific Ceph does not contain the pattern "Tools" (RHCEPH-5.3-RHEL-8-20240130.0.repo), so it passes on RHCS Quincy/Reef ceph cluster and fails on RHCS Pacific ceph cluster.

Solution:
Add a check for the pattern ("Tools"/"RHCEPH") for RHCS deployement.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
