### PR TITLE
[Tier-2] cephci Integration of polarion testcase: CEPH-11150

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
@@ -191,3 +191,13 @@ tests:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
         timeout: 500
+
+  - test:
+      name: Test rgw get bucket website with users of same and different tenant
+      desc: Test rgw get bucket website with users of same and different tenant
+      polarion-id: CEPH-11150
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_with_tenant_user.py
+        config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml
+        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -154,3 +154,13 @@ tests:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
         timeout: 500
+
+  - test:
+      name: Test rgw get bucket website with users of same and different tenant
+      desc: Test rgw get bucket website with users of same and different tenant
+      polarion-id: CEPH-11150
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_with_tenant_user.py
+        config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml
+        timeout: 500


### PR DESCRIPTION
# Description

[Tier-2] cephci Integration of polarion testcase: CEPH-11150

depends on : https://github.com/red-hat-storage/ceph-qe-scripts/pull/551

log:
pacific: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-E8PZ3F/Test_rgw_get_bucket_website_with_users_of_same_and_different_tenant_0.log
quincy: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-RJ926B/Test_rgw_get_bucket_website_with_users_of_same_and_different_tenant_0.log
Reef: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-129BE1/Test_rgw_get_bucket_website_with_users_of_same_and_different_tenant_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
