### PR TITLE
[tfa-fix] Rename test_osd_memory_target for cephadm and fix json error

### DIFF
--- a/suites/pacific/cephadm/tier-2-osd-scenarios.yaml
+++ b/suites/pacific/cephadm/tier-2-osd-scenarios.yaml
@@ -138,7 +138,7 @@ tests:
   - test:
       name: Test OSD Memory Target
       desc: Set OSD Memory Target on OSD and Host
-      module: test_osd_memory_target.py
+      module: test_osd_memory_target_cephadm.py
       config:
         hosts:
             - node3

--- a/suites/quincy/cephadm/tier-2-osd-scenarios.yaml
+++ b/suites/quincy/cephadm/tier-2-osd-scenarios.yaml
@@ -138,7 +138,7 @@ tests:
   - test:
       name: Test OSD Memory Target
       desc: Set OSD Memory Target on OSD and Host
-      module: test_osd_memory_target.py
+      module: test_osd_memory_target_cephadm.py
       config:
         hosts:
             - node3

--- a/suites/reef/cephadm/tier2-osd-scenarios.yaml
+++ b/suites/reef/cephadm/tier2-osd-scenarios.yaml
@@ -138,7 +138,7 @@ tests:
   - test:
       name: Test OSD Memory Target
       desc: Set OSD Memory Target on OSD and Host
-      module: test_osd_memory_target.py
+      module: test_osd_memory_target_cephadm.py
       config:
         hosts:
             - node2

--- a/tests/cephadm/test_osd_memory_target_cephadm.py
+++ b/tests/cephadm/test_osd_memory_target_cephadm.py
@@ -38,7 +38,7 @@ def run(ceph_cluster, **kw):
     log.info(f"Memory target is set on host '{hostname}' : '{value}'")
 
     # Verify that the option is set in ceph config dump
-    kw = {"format": "json-pretty"}
+    kw = {"format": "json"}
     out = cephadm.ceph.config.dump(**kw)
     data = json.loads(out[0])
     found = False
@@ -56,7 +56,7 @@ def run(ceph_cluster, **kw):
 
     # Verify osd memory target for osd on the host matches the host level value
     out = cephadm.ceph.osd.tree(**kw)
-    data = json.loads(out[0])
+    data = json.loads(out)
     for item in data["nodes"]:
         if item.get("type") == "host" and item.get("name") == hostname:
             osd_list = item["children"]


### PR DESCRIPTION
# Description

### Problem:

Test suite `tier-2-osd-scenarios` failed for the test `test_osd_memory_target.py`.

### Reason for Failure:

There exist two files of the same name under different directories such as :

- `tests/rados/test_osd_memory_target.py` : https://github.com/red-hat-storage/cephci/blob/0c60bf9638cee697fe179cfe7b9f322cac5ff80d/tests/rados/test_osd_memory_target.py
- `tests/cephadm/test_osd_memory_target.py` : https://github.com/red-hat-storage/cephci/blob/0c60bf9638cee697fe179cfe7b9f322cac5ff80d/tests/cephadm/test_osd_memory_target.py

Both test files differ in contents. 

The suite `tier-2-osd-scenarios` must use the file under `cephadm` directory but it is instead using the file under the `rados` directory.

Also, when using the correct test file, the test fails with error :  `JSONDecodeError: Expecting property name enclosed in double quotes`

### Solution:

Rename `tests/cephadm/test_osd_memory_target.py` to `tests/cephadm/test_osd_memory_target_cephadm.py` and update all suite files which use this test.
Also, fix json decode error.