### PR TITLE
TFA fixes for snap schedule tests

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -2728,7 +2728,10 @@ os.system('sudo systemctl start  network')
                     if smallfile_params.get(io_param):
                         io_params[io_param] = smallfile_params[io_param]
             dir_suffix = "".join(
-                [random.choice(string.ascii_letters) for _ in range(3)]
+                [
+                    random.choice(string.ascii_lowercase + string.digits)
+                    for _ in range(3)
+                ]
             )
             io_path = f"{mounting_dir}/{io_params['testdir_prefix']}_{dir_suffix}"
             client.exec_command(sudo=True, cmd=f"mkdir {io_path}")
@@ -3390,7 +3393,7 @@ os.system('sudo systemctl start  network')
                  export_created : 1, if export was created in module else 0
         """
         client = mount_params["client"]
-        fs_vol_path = "/"
+        fs_vol_path = mount_params.get("mnt_path", "/")
         mount_suffix = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(3))

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -1063,9 +1063,14 @@ def snap_retention_service_restart(snap_test_params):
     post_test_params["test_status"] = test_fail
     schedule_path = snap_test_params["path"]
     snap_util.remove_snap_retention(
-        client, snap_test_params["path"], ret_val=snap_test_params["retention"]
+        client,
+        snap_test_params["path"],
+        ret_val=snap_test_params["retention"],
+        fs_name=snap_test_params["fs_name"],
     )
-    snap_util.remove_snap_schedule(client, schedule_path)
+    snap_util.remove_snap_schedule(
+        client, schedule_path, fs_name=snap_test_params["fs_name"]
+    )
     snap_util.sched_snap_cleanup(client, snap_path)
     client.exec_command(sudo=True, cmd=f"umount {snap_path}")
     return post_test_params
@@ -1076,8 +1081,8 @@ def snap_retention_service_restart(snap_test_params):
 ####################
 def umount_all(mnt_paths, umount_params):
     cmd = f"rm -rf {mnt_paths['kernel']}/*file*"
-    if umount_params.get("subvol_name"):
-        cmd = f"rm -rf {mnt_paths['kernel']}{umount_params['path']}/*"
+    if "subvol" in umount_params.get("test_case"):
+        cmd = f"rm -rf {mnt_paths['kernel']}{umount_params['path']}/*file*"
     umount_params["client"].exec_command(sudo=True, cmd=cmd, timeout=1800)
     for mnt_type in mnt_paths:
         umount_params["client"].exec_command(


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/RHCEPHQE-13053

Fix description:
Failure mentioned in http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-196/Weekly/cephfs/21/tier-3_cephfs_scale/snap_retention_count_validate_0.log is due to random.choice method not generating effectively a random string of 3 chars in test case interval.
2024-02-04 21:08:40,946 (cephci.snapshot_clone.snap_schedule_retention_vol_subvol) [ERROR] - cephci.Weekly.cephfs.21.cephci.ceph.ceph.py:1600 - mkdir: cannot create directory â€˜/mnt/cephfs_kernel_ziq///smallfile_io_dir_iggâ€™: File exists
Adding more randomisation as fix.
 
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-196/Weekly/cephfs/21/tier-4_cephfs_recovery/snap_retention_service_restart_0.log - This failure is due remove snap schedule command run in multifs environment. With fix for relevant multifs support BZ in Quincy, error is seen now. So mentioning fs-name in snap-schedule is required. Made necessary changes to test code.
 
[http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-196/Regression/cephfs/33[…]-snapshot-clone/snap_schedule_retention_vol_subvol_0.log](http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-196/Regression/cephfs/33/tier-2_cephfs_test-snapshot-clone/snap_schedule_retention_vol_subvol_0.log) - This failure is due to error during cleanup of test files, as subvolume dirs exist in mnt_path. Added fix to cleanup files and dirs with specific pattern.

Logs with fixes:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7OIPF4/
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DETZDW