### PR TITLE
RBD namespace in default pool tests

### DIFF
--- a/ceph/rbd/workflows/namespace.py
+++ b/ceph/rbd/workflows/namespace.py
@@ -1,0 +1,65 @@
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def create_namespace_and_verify(**kw):
+    """
+    Creates a namespace in a given pool
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool-name(str) : name of the pool in which namespace should be stored, default pool is rbd
+                namespace(str): namespace to created in the pool
+                See rbd help create for more supported keys
+    """
+    rbd = Rbd(kw["client"])
+
+    # verify if the pool exists, if pool is not passed then consider default pool name i.e rbd
+    pool_name = kw.get("pool-name", "rbd")
+    log.info(f"verifying if pool {pool_name} exists")
+    pool_init_kw = {}
+    pool_init_kw["pool-name"] = pool_name
+    (_, pool_stats_err) = rbd.pool.stats(**pool_init_kw)
+
+    # if pool does not exists, create a pool
+    if pool_stats_err:
+        log.error(
+            f"The pool where namespace is suppose to be created does not exist, creating the pool {pool_name}"
+        )
+        # TBD: Currently to use initial_rb_config methods to create a pool we need add an ability to not create image
+        return 1
+
+    # once successfully pool gets created, create a namespace
+    namespace_name = kw.get("namespace", None)
+    log.info(f"namespace {namespace_name} in {pool_name} is getting created")
+    ns_create_kw = {}
+    if namespace_name is None:
+        log.error("namespace name is a must for create namespace method")
+        return 1
+    _pool_name = kw.get("pool-name", None)
+    ns_create_kw["namespace"] = namespace_name
+    ns_create_kw["pool-name"] = _pool_name
+    (_, ns_create_err) = rbd.namespace.create(**ns_create_kw)
+    if not ns_create_err:
+        log.info(
+            f"SUCCESS: Namespace {namespace_name} got created in pool {pool_name} "
+        )
+    else:
+        log.error(
+            f"FAIL: Namespace {namespace_name} creation failed in pool {pool_name} with error {ns_create_err}"
+        )
+        return 1
+
+    # verify created namespace using namespace ls command
+    log.info(
+        f"created namespace {namespace_name} in pool {pool_name} is getting verified"
+    )
+    ns_verify_kw = {}
+    ns_verify_kw["pool-name"] = _pool_name
+    ns_ls_out = rbd.namespace.list(**ns_verify_kw)
+    if namespace_name in ns_ls_out[0]:
+        log.info(f"namespace {namespace_name} creation successfully verified")
+        return 0

--- a/cli/rbd/namespace.py
+++ b/cli/rbd/namespace.py
@@ -1,0 +1,72 @@
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+
+class Namespace(Cli):
+    def __init__(self, nodes, base_cmd):
+        super(Namespace, self).__init__(nodes)
+        self.base_cmd = base_cmd + " namespace"
+
+    def create(self, **kw):
+        """
+        Creates a namespace in a given pool, if pool is not given then create in default pool i.e rbd.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool-name(str) : name of the pool into which namespace should be stored,default pool is rbd
+                namespace(str): namespace to created in the pool
+                See rbd help create for more supported keys
+        """
+        pool_name = kw.get("pool-name", None)
+        namespace_name = kw.get("namespace", None)
+        ns_create_kw = {}
+        ns_create_kw["namespace"] = namespace_name
+        if pool_name is not None:
+            ns_create_kw["pool"] = pool_name
+        cmd = f"{self.base_cmd} create {build_cmd_from_args(**ns_create_kw)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def list(self, **kw):
+        """
+        lists all namespace in a given pool, if pool is not given then list in default pool i.e rbd.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool-name(str) : name of the pool into which namespace should be stored
+                format(str): json format output of listing namespace
+                See rbd help create for more supported keys
+        """
+        pool_name = kw.get("pool-name", None)
+        format = kw.get("format", None)
+        namespace_ls_kw = {}
+        if pool_name is not None:
+            namespace_ls_kw["pool"] = pool_name
+        if format is not None:
+            namespace_ls_kw["format"] = format
+        cmd = f"{self.base_cmd} ls {build_cmd_from_args(**namespace_ls_kw)}"
+
+        return self.execute_as_sudo(cmd=cmd)
+
+    def remove(self, **kw):
+        """
+        Removes a namespace in a given pool, if pool is not given then remove in default pool i.e rbd.
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool-name(str) : name of the pool into which namespace should be deleted
+                namespace(str): namespace to delete in the pool
+                See rbd help create for more supported keys
+        """
+        pool_name = kw.get("pool-name", None)
+        namespace_name = kw.get("namespace", None)
+        ns_remove_kw = {}
+        ns_remove_kw["namespace"] = namespace_name
+        if pool_name is not None:
+            ns_remove_kw["pool"] = pool_name
+        cmd = f"{self.base_cmd} rm {build_cmd_from_args(**ns_remove_kw)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/pool.py
+++ b/cli/rbd/pool.py
@@ -2,6 +2,9 @@ from copy import deepcopy
 
 from cli import Cli
 from cli.utilities.utils import build_cmd_from_args
+from utility.log import Log
+
+log = Log(__name__)
 
 
 class Pool(Cli):
@@ -26,5 +29,20 @@ class Pool(Cli):
         kw_copy = deepcopy(kw)
         pool_name = kw_copy.pop("pool-name", "")
         cmd = f"{self.base_cmd} init {pool_name} {build_cmd_from_args(**kw_copy)}"
+        return self.execute_as_sudo(cmd=cmd)
 
+    def stats(self, **kw):
+        """
+        Checks the statistics like total images, total snapshots, provisioned size of the pool given
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+        Example::
+            Supported keys:
+                pool-name(str) : name of the pool
+        """
+        kw_copy = deepcopy(kw)
+        pool_name = kw_copy.pop("pool-name", "")
+        stats_args = {}
+        stats_args["pool"] = pool_name
+        cmd = f"{self.base_cmd} stats {build_cmd_from_args(**stats_args)}"
         return self.execute_as_sudo(cmd=cmd)

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -8,6 +8,7 @@ from .device import Device
 from .feature import Feature
 from .image_meta import Image_meta
 from .mirror.mirror import Mirror
+from .namespace import Namespace
 from .pool import Pool
 from .snap import Snap
 
@@ -23,6 +24,7 @@ class Rbd(Cli):
         self.feature = Feature(nodes, self.base_cmd)
         self.image_meta = Image_meta(nodes, self.base_cmd)
         self.config = Config(nodes, self.base_cmd)
+        self.namespace = Namespace(nodes, self.base_cmd)
 
     def create(self, **kw):
         """

--- a/suites/quincy/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_namespace.yaml
@@ -1,0 +1,85 @@
+# Tier2: Test suite to cover RBD namespace related tests
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_namespace.yaml
+#
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/quincy/rbd/4-node-cluster-with-1-client.yaml
+#    Node 4 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-83582474 - Testing RBD namespace create in default pool
+tests:
+  # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+# Test to be executed
+  - test:
+      desc: Run namespace creation in default pool
+      module: test_rbd_namespace_default_pool.py
+      name: RBD namespace creation in default pool
+      polarion-id: CEPH-83582474
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}

--- a/suites/reef/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/reef/rbd/tier-2_rbd_namespace.yaml
@@ -1,0 +1,85 @@
+# Tier2: Test suite to cover RBD namespace related tests
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_namespace.yaml
+#
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - conf/reef/rbd/4-node-cluster-with-1-client.yaml
+#    Node 4 must to be a client node
+#
+# The following tests are covered
+#   - CEPH-83582474 - Testing RBD namespace create in default pool
+tests:
+  # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+# Test to be executed
+  - test:
+      desc: Run namespace creation in default pool
+      module: test_rbd_namespace_default_pool.py
+      name: RBD namespace creation in default pool
+      polarion-id: CEPH-83582474
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}

--- a/tests/rbd/test_rbd_namespace_default_pool.py
+++ b/tests/rbd/test_rbd_namespace_default_pool.py
@@ -1,0 +1,53 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import create_namespace_and_verify
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_creation_default_pool(client, **kw):
+    """
+    Tests the namespace creation in default pool
+    Args:
+        client: rbd client obj
+        **kw: test data
+    """
+    kw["client"] = client
+    kw["namespace"] = "ns_default_pool"
+    return create_namespace_and_verify(**kw)
+
+
+def run(**kw):
+    """RBD namespace creation in default pool testing.
+
+    Args:
+        **kw: test data
+    """
+    log.info(
+        "Running test CEPH-83582474 - Testing RBD namespace create in default pool."
+    )
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_creation_default_pool(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD namespace creation in default rbd pool failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val


### PR DESCRIPTION
This PR is to automate namespace test in default pool and required cli and workflow files to support the test. The tests covered as part of this PR are (1) creating a namespace in default pool.

Logs are attached here.

To extract and check logs:
(1) mkdir test 
(2) cd test
(3) cp <namespace_log.tar.gz> .
(4) tar -xvzf namespace_log.tar.gz

[namespace_log.tar.gz](https://github.com/red-hat-storage/cephci/files/14214234/namespace_log.tar.gz)

![image](https://github.com/red-hat-storage/cephci/assets/9339364/a65219c7-79ef-4e46-9081-0a4d9560fd8d)

