### PR TITLE
Integration of LC cloud automation(IBM-COS)

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -556,7 +556,7 @@ tests:
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
       name: m buckets with n objects
-      comments: bug-2213138, workaround test, should pass
+      comments: bug-2213138, workaround test, should pass, workaround fail [bz-2262400]
   - test:
       clusters:
         ceph-sec:
@@ -568,6 +568,7 @@ tests:
             timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
+      comments: workaround sync fail [bz-2262400]
       name: test M buckets multipart uploads on haproxy node
       polarion-id: CEPH-83575433
 

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -516,3 +516,26 @@ tests:
       name: Perform zone rename in non master that is secondary
       polarion-id: CEPH-10740
       comments: known issue (BZ2210757)
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
+            timeout: 30
+      desc: test LC cloud transition to IBM cos with retain true
+      polarion-id: CEPH-83581972 #CEPH-83575498
+      module: sanity_rgw_multisite.py
+      name: test LC cloud transition to IBM cos with retain true
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
+            timeout: 30
+      desc: test LC cloud transition to IBM cos with retain false
+      polarion-id: CEPH-83581973 #CEPH-83581975
+      module: sanity_rgw_multisite.py
+      name: test LC cloud transition to IBM cos with retain false


### PR DESCRIPTION
ceph-qe-scripts pr : https://github.com/red-hat-storage/ceph-qe-scripts/pull/557

This would automate the below test cases

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581972
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581975
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581973
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575498
Logs :

http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/cloud_trans_retain_false_log_ibm
http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/cloud_trans_retain_true_log_ibm (with multisite)


Also adding a comment to the archive-haproxy suite for workaround bug failure on 7.1
