### PR TITLE
[TFA] removing network delay from suite which are part of regression

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -10,8 +10,7 @@
 # This particular yaml runs the tests on the primary and verifies IOs on the
 # secondary site.
 
-# In addition to the above, the data bucket is configured to use EC along with
-# network delays between the two clusters.
+# In addition to the above, the data bucket is configured to use EC
 ---
 
 tests:
@@ -23,24 +22,6 @@ tests:
       desc: Install software pre-requisites for cluster deployment.
       module: install_prereq.py
       name: setup pre-requisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 30ms 1ms distribution normal
-        ceph-sec:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 20ms 5ms distribution normal
-      desc: Configuring network traffic delay
-      module: configure-tc.py
-      name: apply-net-qos
-      polarion-id: CEPH-83575222
 
   - test:
       abort-on-fail: true

--- a/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -11,8 +11,7 @@
 # This particular yaml runs the tests on the primary and verifies IOs on the
 # secondary site and tertiary site.
 
-# In addition to the above, the data bucket is configured to use EC along with
-# network delays between the two clusters.
+# In addition to the above, the data bucket is configured to use EC along
 ---
 
 tests:
@@ -24,29 +23,6 @@ tests:
       desc: Install software pre-requisites for cluster deployment.
       module: install_prereq.py
       name: setup pre-requisites
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 30ms 6ms distribution normal
-        ceph-sec:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 20ms 5ms distribution normal
-        ceph-ter:
-          config:
-            roles:
-              - rgw
-            rule: root netem delay 20ms 5ms distribution normal
-      desc: Configuring network traffic delay
-      module: configure-tc.py
-      name: apply-net-qos
-      polarion-id: CEPH-83575222
 
   - test:
       abort-on-fail: true


### PR DESCRIPTION
# Description
Suite which are part of regression should not contain network delay, delay can be used in weekly or in baremetal suites
log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-PTWPL3/ --> http://magna006.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-PTWPL3/
http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-Q02M2W/ --> http://magna006.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-Q02M2W/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
