### PR TITLE
RBD namespace related 4 more tests

### DIFF
--- a/suites/quincy/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_namespace.yaml
@@ -73,12 +73,53 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
-# Test to be executed
+# Tests to be executed
   - test:
       desc: Run namespace creation in default pool
       module: test_rbd_namespace_default_pool.py
       name: RBD namespace creation in default pool
       polarion-id: CEPH-83582474
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace creation in custom pool
+      module: test_rbd_namespace_custom_pool.py
+      name: RBD namespace creation in custom pool
+      polarion-id: CEPH-83582475
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd03: {}
+
+  - test:
+      desc: Run image creation in the namespace
+      module: test_rbd_namespace_image_pool.py
+      name: RBD image creation in the namespace
+      polarion-id: CEPH-83582476
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace creation with the same name in diff pool
+      module: test_rbd_namespace_same_ns_diff_pool.py
+      name: RBD namespace creation with the same name in diff pool
+      polarion-id: CEPH-83582478
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd05: {}
+          rbd06: {}
+
+  - test:
+      desc: Run img creation with the same name in diff ns
+      module: test_rbd_namespace_same_img_diff_ns.py
+      name: RBD img creation with the same name in diff ns
+      polarion-id: CEPH-83582479
       config:
         rep-pool-only: True
         rep_pool_config:

--- a/suites/reef/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/reef/rbd/tier-2_rbd_namespace.yaml
@@ -73,7 +73,7 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
-# Test to be executed
+# Tests to be executed
   - test:
       desc: Run namespace creation in default pool
       module: test_rbd_namespace_default_pool.py
@@ -83,3 +83,45 @@ tests:
         rep-pool-only: True
         rep_pool_config:
           rbd: {}
+
+  - test:
+      desc: Run namespace creation in custom pool
+      module: test_rbd_namespace_custom_pool.py
+      name: RBD namespace creation in custom pool
+      polarion-id: CEPH-83582475
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd03: {}
+
+  - test:
+      desc: Run image creation in the namespace
+      module: test_rbd_namespace_image_pool.py
+      name: RBD image creation in the namespace
+      polarion-id: CEPH-83582476
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace creation with the same name in diff pool
+      module: test_rbd_namespace_same_ns_diff_pool.py
+      name: RBD namespace creation with the same name in diff pool
+      polarion-id: CEPH-83582478
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd05: {}
+          rbd06: {}
+
+  - test:
+      desc: Run img creation with the same name in diff ns
+      module: test_rbd_namespace_same_img_diff_ns.py
+      name: RBD img creation with the same name in diff ns
+      polarion-id: CEPH-83582479
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+

--- a/tests/rbd/test_rbd_namespace_custom_pool.py
+++ b/tests/rbd/test_rbd_namespace_custom_pool.py
@@ -1,0 +1,60 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import create_namespace_and_verify
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_creation_custom_pool(client, **kw):
+    """
+    Tests the namespace creation in custom pool
+    Args:
+        client: rbd client obj
+        **kw: test data
+    """
+    kw["client"] = client
+    kw["namespace"] = "ns_custom_pool"
+
+    # check for all the custom pools, if given in test suite
+    for pool, _ in kw["config"]["rep_pool_config"].items():
+        kw["pool-name"] = pool
+        rc = create_namespace_and_verify(**kw)
+        if rc != 0:
+            return rc
+    return rc
+
+
+def run(**kw):
+    """RBD namespace creation in custom pool testing.
+
+    Args:
+        **kw: test data
+    """
+    log.info(
+        "Running test CEPH-83582475 - Testing RBD namespace create in custom pool."
+    )
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_creation_custom_pool(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD namespace creation in custom rbd pool failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val

--- a/tests/rbd/test_rbd_namespace_image_pool.py
+++ b/tests/rbd/test_rbd_namespace_image_pool.py
@@ -1,0 +1,61 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import create_namespace_and_verify
+from ceph.rbd.workflows.rbd import create_single_image
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_creation_default_pool(client, **kw):
+    """
+    Tests the image creation in namespace
+    Args:
+        client: rbd client obj
+        **kw: test data
+    """
+    kw["client"] = client
+    kw["namespace"] = "ns_default_pool"
+    image_config_val = {"namespace": kw["namespace"], "size": "1G"}
+    pool = "rbd"
+
+    # for all the pools mentioned in testsuite, create a namespace followed by image creation
+    for pool, _ in kw["config"]["rep_pool_config"].items():
+        ns_rc = create_namespace_and_verify(**kw)
+        if ns_rc == 0:
+            return create_single_image(
+                {}, "ceph", Rbd(client), pool, None, "ns_image", image_config_val, None
+            )
+
+
+def run(**kw):
+    """RBD image creation in namespace.
+
+    Args:
+        **kw: test data
+    """
+    log.info("Running test CEPH-83582476 - Testing image creation in namespace.")
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_creation_default_pool(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD image creation in the namespace failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val

--- a/tests/rbd/test_rbd_namespace_same_img_diff_ns.py
+++ b/tests/rbd/test_rbd_namespace_same_img_diff_ns.py
@@ -1,0 +1,85 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import create_namespace_and_verify
+from ceph.rbd.workflows.rbd import create_single_image
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_creation_default_pool(client, **kw):
+    """
+    Tests image creation with the same name in different ns
+    Args:
+        client: rbd client obj
+        **kw: test data
+    """
+    kw["client"] = client
+
+    # for all the pools mentioned in the config perform the test
+    for pool, _ in kw["config"]["rep_pool_config"].items():
+        # namespace1 creation in pool
+        kw["namespace"] = "ns1"
+        rc_ns1 = create_namespace_and_verify(**kw)
+        if rc_ns1 != 0:
+            log.error(f"Namespace creation {kw['namespace']} failed")
+            return 1
+        # image creation in namespace ns_default_pool_1 in the default rbd pool
+        image_config_val = {"namespace": kw["namespace"], "size": "1G"}
+        rc_ns1_img1 = create_single_image(
+            {}, "ceph", Rbd(client), pool, None, "ns_image", image_config_val, None
+        )
+        if rc_ns1_img1 != 0:
+            log.error(f"Image creation failed in namespace {kw['namespace']}")
+            return 1
+
+        # namespace2 creation in pool
+        kw["namespace"] = "ns2"
+        rc_ns2 = create_namespace_and_verify(**kw)
+        if rc_ns2 != 0:
+            log.error(f"Namespace creation {kw['namespace']} failed")
+            return 1
+        # image with same name creation in namespace ns_default_pool_1 in the default rbd pool
+        image_config_val = {"namespace": kw["namespace"], "size": "1G"}
+        rc_ns1_img2 = create_single_image(
+            {}, "ceph", Rbd(client), pool, None, "ns_image", image_config_val, None
+        )
+        if rc_ns1_img2 != 0:
+            log.error(f"Image creation failed in namespace {kw['namespace']}")
+            return 1
+    return rc_ns1_img2
+
+
+def run(**kw):
+    """RBD image creation with the same name in diff ns.
+
+    Args:
+        **kw: test data
+    """
+    log.info(
+        "Running test CEPH-83582479 - Testing RBD image creation with the same name in different ns"
+    )
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_creation_default_pool(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD image creation with the same name in different ns failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val

--- a/tests/rbd/test_rbd_namespace_same_ns_diff_pool.py
+++ b/tests/rbd/test_rbd_namespace_same_ns_diff_pool.py
@@ -1,0 +1,60 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import create_namespace_and_verify
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_creation_custom_pool(client, **kw):
+    """
+    Tests the namespace creation with the same name in diff pool
+    Args:
+        client: rbd client obj
+        **kw: test data
+    """
+    kw["client"] = client
+    kw["namespace"] = "ns_custom_pool"
+
+    # check for all the custom pools, if given in test suite
+    for pool, _ in kw["config"]["rep_pool_config"].items():
+        kw["pool-name"] = pool
+        rc = create_namespace_and_verify(**kw)
+        if rc != 0:
+            return rc
+    return rc
+
+
+def run(**kw):
+    """RBD namespace creation with the same name in diff pool
+
+    Args:
+        **kw: test data
+    """
+    log.info(
+        "Running test CEPH-83582478 - Testing RBD namespace creation with the same name in diff pool."
+    )
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_creation_custom_pool(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD namespace creation with the same name in diff pool failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val


### PR DESCRIPTION
This PR consists of 4 more test coverage for namespace related tests. The details as below

(2) Create a namespace in the custom RBD pool 
 	 https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582475
(3) Create an image in the namespace 
     https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582476
(4) Create same namespace name in two different pools
     https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582478
(5) Create same image name in two different namespaces
     https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582479

Logs attached here: 
=================
[namespace_5tests_log.tar.gz](https://github.com/red-hat-storage/cephci/files/14258345/namespace_5tests_log.tar.gz)
to check logs
1. Download namespace_5tests.tar.gz file
2. mkdir test and cd test
3. tar -xvzf namespace_5tests.tar.gz

Run summary
===========
<img width="1709" alt="image" src="https://github.com/red-hat-storage/cephci/assets/9339364/ef31f075-c142-4439-b603-a9e7b303d054">

Lint details for coding standards
==========
(cephci) pavangovindraj@Pavans-MacBook-Pro cephci %
cat modified_added_files | xargs -tI{} python3 -m flake8 {}
python3 -m flake8 suites/quincy/rbd/tier-2_rbd_namespace.yaml
python3 -m flake8 suites/reef/rbd/tier-2_rbd_namespace.yaml
python3 -m flake8 tests/rbd/test_rbd_namespace_custom_pool.py
python3 -m flake8 tests/rbd/test_rbd_namespace_image_pool.py
python3 -m flake8 tests/rbd/test_rbd_namespace_same_img_diff_ns.py
python3 -m flake8 tests/rbd/test_rbd_namespace_same_ns_diff_pool.py

(cephci) pavangovindraj@Pavans-MacBook-Pro cephci %
cat modified_added_files | xargs -tI{} python3 -m isort {}
python3 -m isort suites/quincy/rbd/tier-2_rbd_namespace.yaml
python3 -m isort suites/reef/rbd/tier-2_rbd_namespace.yaml
python3 -m isort tests/rbd/test_rbd_namespace_custom_pool.py
python3 -m isort tests/rbd/test_rbd_namespace_image_pool.py
python3 -m isort tests/rbd/test_rbd_namespace_same_img_diff_ns.py
python3 -m isort tests/rbd/test_rbd_namespace_same_ns_diff_pool.py

(cephci) pavangovindraj@Pavans-MacBook-Pro cephci %
cat modified_added_files | grep ".yaml" | xargs -tI{} yamllint -d relaxed --no-warnings {}
yamllint -d relaxed --no-warnings suites/quincy/rbd/tier-2_rbd_namespace.yaml
yamllint -d relaxed --no-warnings suites/reef/rbd/tier-2_rbd_namespace.yaml

(cephci) pavangovindraj@Pavans-MacBook-Pro cephci %
cat modified_added_files | grep -v ".yaml" | xargs -tI{} python3 -m black {}
python3 -m black tests/rbd/test_rbd_namespace_custom_pool.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black tests/rbd/test_rbd_namespace_image_pool.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black tests/rbd/test_rbd_namespace_same_img_diff_ns.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black tests/rbd/test_rbd_namespace_same_ns_diff_pool.py
All done! ✨ 🍰 ✨
1 file left unchanged.