### PR TITLE
Adding spec storage tests to FS

### DIFF
--- a/suites/reef/cephfs/tier-2_cephfs_io.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_io.yaml
@@ -1,0 +1,248 @@
+---
+#=======================================================================================================================
+# Tier-level: 0
+# Test-Suite: tier-0_fs.yaml
+# Conf file : conf/quincy/cephfs/tier-0_fs.yaml
+# options : --cloud baremetal if required to run on baremetal
+# Test-Case Covered:
+#	CEPH-83573777: Execute the cluster deployment workflow with label placement.
+#	CEPH-XXXXX: FS_FIO_REPL_MAX_MDS_2
+#	CEPH-XXXXX: FS_FIO_REPL_MAX_MDS_1
+#	CEPH-XXXXX: FS_FIO_EC_MAX_MDS_1
+#	CEPH-XXXXX: FS_FIO_EC_MAX_MDS_2
+#   CEPH-XXXXX: Run SWBUILD Workload
+#=======================================================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: FS_FIO_REPL_MAX_MDS_2
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs
+        max_mds: 2
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_REPL_MAX_MDS_2
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+
+  - test:
+      name: FS_FIO_REPL_MAX_MDS_1
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs
+        max_mds: 1
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_REPL_MAX_MDS_1
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+
+  - test:
+      name: FS_FIO_EC_MAX_MDS_1
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs-ec
+        erasure: yes
+        max_mds: 1
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_EC_MAX_MDS_1.
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+  - test:
+      name: FS_FIO_EC_MAX_MDS_2
+      module: cephfs_fio_storage.py
+      config:
+        io_tool: fio
+        fs_name: cephfs-ec
+        erasure: yes
+        max_mds: 2
+        fio_config:
+          global_params:
+            ioengine: libaio
+            direct: "1"
+            size: [ "500m" ]
+            time_based: ""
+            runtime: "60"
+          workload_params:
+            random_rw:
+              rw: [ "read","write" ]
+              bs: 4k
+              numjobs: "2"
+              iodepth: [ "1" ]
+      desc: FS_FIO_EC_MAX_MDS_2
+      polarion-id: CEPH-83575092
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_REPL_MAX_MDS_2
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        benchmark: SWBUILD
+        fs_name: cephfs
+        max_mds: 2
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+  - test:
+      abort-on-fail: false
+      desc: "Run SWBUILD Workload on EC FS max mds 1"
+      module: cephfs_spec_storage.py
+      name: FS_SPEC_EC_MAX_MDS_1
+      polarion-id: "CEPH-XXXXX"
+      config:
+        clients:
+          - client1
+        fs_name: cephfs-ec
+        erasure: yes
+        max_mds: 1
+        benchmark: SWBUILD
+        benchmark_defination:
+          Warmup_time: 30
+          Dir_count: 1
+          Files_per_dir: 1
+          File_size: 1k
+          Instances: 1
+

--- a/tests/cephfs/cephfs_fio_storage.py
+++ b/tests/cephfs/cephfs_fio_storage.py
@@ -1,0 +1,160 @@
+import os
+import random
+import string
+import traceback
+from datetime import datetime
+
+from ceph.ceph import CommandFailed
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    try:
+        log.info(f"MetaData Information {log.metadata} in {__name__}")
+        fs_util = FsUtils(ceph_cluster)
+        log_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
+        config = kw.get("config")
+        build = config.get("build", config.get("rhbuild"))
+        clients = ceph_cluster.get_ceph_objects("client")
+        fs_name = config.get("fs_name", "cephfs")
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        fs_details = FsUtils.get_fs_info(clients[0], fs_name)
+        mdss = ceph_cluster.get_ceph_objects("mds")
+        if len(mdss) < 3:
+            log.error("This test requires atleast 3 mds nodes with role in config file")
+            return 1
+        mds1 = mdss[0].node.hostname
+        mds2 = mdss[1].node.hostname
+        mds3 = mdss[2].node.hostname
+        if not fs_details:
+            if not config.get("erasure"):
+                fs_util.create_fs(
+                    client=clients[0],
+                    vol_name=fs_name,
+                    placement=f"3 {mds1} {mds2} {mds3}",
+                )
+            else:
+                clients[0].exec_command(
+                    sudo=True, cmd=f"ceph osd pool create {fs_name}-data-ec 64 erasure"
+                )
+                clients[0].exec_command(
+                    sudo=True, cmd=f"ceph osd pool create {fs_name}-metadata-ec 64"
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph osd pool set {fs_name}-data-ec allow_ec_overwrites true",
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph fs new {fs_name} {fs_name}-metadata-ec {fs_name}-data-ec --force",
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch apply mds {fs_name} --placement='3 {mds1} {mds2} {mds3}'",
+                )
+        if config.get("max_mds"):
+            clients[0].exec_command(
+                sudo=True,
+                cmd=f"ceph orch apply mds {fs_name} --placement='3 {mds1} {mds2} {mds3}'",
+            )
+            clients[0].exec_command(
+                sudo=True, cmd=f"ceph fs set {fs_name} max_mds {config.get('max_mds')}"
+            )
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        fuse_mounting_dir = f"/mnt/cephfs_fuse{mounting_dir}/"
+        fs_util.fuse_mount(
+            clients, fuse_mounting_dir, extra_params=f" --client_fs {fs_name}"
+        )
+
+        kernel_mounting_dir = f"/mnt/cephfs_kernel{mounting_dir}/"
+        mon_node_ips = fs_util.get_mon_node_ips()
+        fs_util.kernel_mount(
+            clients,
+            kernel_mounting_dir,
+            ",".join(mon_node_ips),
+            extra_params=f",fs={fs_name}",
+        )
+        run_fio(
+            [kernel_mounting_dir, fuse_mounting_dir],
+            config,
+            clients[0],
+            log_dir,
+            fs_util,
+            fs_name,
+        )
+        return 0
+
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Cleaning up!-----")
+        rc = fs_util.client_clean_up(
+            [],
+            clients,
+            kernel_mounting_dir,
+            "umount",
+        )
+        if rc != 0:
+            raise CommandFailed("fuse clients cleanup failed")
+        log.info("Fuse clients cleaned up successfully")
+
+        rc = fs_util.client_clean_up(
+            clients,
+            [],
+            fuse_mounting_dir,
+            "umount",
+        )
+        if rc != 0:
+            raise CommandFailed("kernel clients cleanup failed")
+        log.info("kernel clients cleaned up successfully")
+
+
+def run_fio(mount_points, config, client, log_dir, fs_util, fs_name):
+    for mount in mount_points:
+        start_time = datetime.now()
+        fio_filenames = fs_util.generate_all_combinations(
+            client,
+            config.get("fio_config").get("global_params").get("ioengine"),
+            mount,
+            config.get("fio_config").get("workload_params").get("random_rw").get("rw"),
+            config.get("fio_config").get("global_params").get("size", ["1G"]),
+            config.get("fio_config")
+            .get("workload_params")
+            .get("random_rw")
+            .get("iodepth", ["1"]),
+            config.get("fio_config")
+            .get("workload_params")
+            .get("random_rw")
+            .get("numjobs", ["4"]),
+        )
+        for file in fio_filenames:
+            client.exec_command(
+                sudo=True,
+                cmd=f"fio {file} --output-format=json "
+                f"--output={file}_{client.node.hostname}_{mount.replace('/', '')}_{fs_name}.json",
+                long_running=True,
+                timeout="notimeout",
+            )
+            end_time = datetime.now()
+            exec_time = (end_time - start_time).total_seconds()
+            log.info(
+                f"Iteration Details \n"
+                f"Export name created : {mount}\n"
+                f"Time Taken for the Iteration : {exec_time}\n"
+            )
+            os.makedirs(f"{log_dir}/{client.node.hostname}", exist_ok=True)
+            client.download_file(
+                src=f"/root/{file}_{client.node.hostname}_{mount.replace('/', '')}_{fs_name}.json",
+                dst=f"{log_dir}/{client.node.hostname}/{file}_{client.node.hostname}"
+                f"_{mount.replace('/', '')}.json",
+                sudo=True,
+            )

--- a/tests/cephfs/cephfs_spec_storage.py
+++ b/tests/cephfs/cephfs_spec_storage.py
@@ -1,0 +1,225 @@
+import os
+import random
+import string
+import traceback
+import xml.etree.ElementTree as ET
+
+from ceph.ceph import CommandFailed
+from cli.exceptions import OperationFailedError
+from cli.io.spec_storage import SpecStorage
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run_spec_storage_io(
+    primary_client,
+    benchmark,
+    load,
+    incr_load,
+    num_runs,
+    clients,
+    nfs_mount,
+    benchmark_defination,
+):
+    if SpecStorage(primary_client).run_spec_storage(
+        benchmark, load, incr_load, num_runs, clients, nfs_mount, benchmark_defination
+    ):
+        raise OperationFailedError("SPECstorage run failed")
+    log.info("SPECstorage run completed")
+
+
+def run(ceph_cluster, **kw):
+    try:
+        log.info(f"MetaData Information {log.metadata} in {__name__}")
+        fs_util = FsUtils(ceph_cluster)
+        log_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
+        config = kw.get("config")
+        build = config.get("build", config.get("rhbuild"))
+        clients = ceph_cluster.get_ceph_objects("client")
+        spec_clients = ceph_cluster.get_nodes("client")
+        fs_name = config.get("fs_name", "cephfs")
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        fs_details = FsUtils.get_fs_info(clients[0], fs_name)
+        mdss = ceph_cluster.get_ceph_objects("mds")
+        if len(mdss) < 3:
+            log.error("This test requires atleast 3 mds nodes with role in config file")
+            return 1
+        mds1 = mdss[0].node.hostname
+        mds2 = mdss[1].node.hostname
+        mds3 = mdss[2].node.hostname
+        if not fs_details:
+            if not config.get("erasure"):
+                fs_util.create_fs(
+                    client=clients[0],
+                    vol_name=fs_name,
+                    placement=f"3 {mds1} {mds2} {mds3}",
+                )
+            else:
+                clients[0].exec_command(
+                    sudo=True, cmd=f"ceph osd pool create {fs_name}-data-ec 64 erasure"
+                )
+                clients[0].exec_command(
+                    sudo=True, cmd=f"ceph osd pool create {fs_name}-metadata-ec 64"
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph osd pool set {fs_name}-data-ec allow_ec_overwrites true",
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph fs new {fs_name} {fs_name}-metadata-ec {fs_name}-data-ec --force",
+                )
+                clients[0].exec_command(
+                    sudo=True,
+                    cmd=f"ceph orch apply mds {fs_name} --placement='3 {mds1} {mds2} {mds3}'",
+                )
+        if config.get("max_mds"):
+            clients[0].exec_command(
+                sudo=True,
+                cmd=f"ceph orch apply mds {fs_name} --placement='3 {mds1} {mds2} {mds3}'",
+            )
+            clients[0].exec_command(
+                sudo=True, cmd=f"ceph fs set {fs_name} max_mds {config.get('max_mds')}"
+            )
+        mounting_dir = "".join(
+            random.choice(string.ascii_lowercase + string.digits)
+            for _ in list(range(10))
+        )
+        fuse_mounting_dir = f"/mnt/cephfs_fuse{mounting_dir}/"
+        fs_util.fuse_mount(
+            clients, fuse_mounting_dir, extra_params=f" --client_fs {fs_name}"
+        )
+
+        kernel_mounting_dir = f"/mnt/cephfs_kernel{mounting_dir}/"
+        mon_node_ips = fs_util.get_mon_node_ips()
+        fs_util.kernel_mount(
+            clients,
+            kernel_mounting_dir,
+            ",".join(mon_node_ips),
+            extra_params=f",fs={fs_name}",
+        )
+        benchmark = config.get("benchmark", "SWBUILD")
+
+        run_spec_storage(config, spec_clients, [kernel_mounting_dir, fuse_mounting_dir])
+
+        log.info("Cleaning up!-----")
+        rc = fs_util.client_clean_up(
+            [],
+            clients,
+            kernel_mounting_dir,
+            "umount",
+        )
+        if rc != 0:
+            raise CommandFailed("fuse clients cleanup failed")
+        log.info("Fuse clients cleaned up successfully")
+
+        rc = fs_util.client_clean_up(
+            clients,
+            [],
+            fuse_mounting_dir,
+            "umount",
+        )
+        if rc != 0:
+            raise CommandFailed("kernel clients cleanup failed")
+        log.info("kernel clients cleaned up successfully")
+        return 0
+
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        log_dir = os.path.dirname(log.logger.handlers[0].baseFilename)
+        os.makedirs(f"{log_dir}/spec_storage_{benchmark}_results/", exist_ok=True)
+        download_dir(
+            spec_clients[0],
+            remote_dir="/root/results",
+            local_dir=f"{log_dir}/spec_storage_{benchmark}_results/",
+        )
+
+
+def download_dir(client, remote_dir, local_dir):
+    os.makedirs(local_dir, exist_ok=True)
+    dir_items = client.get_dir_list(remote_dir, sudo=True)
+    for item in dir_items:
+        remote_path = remote_dir + "/" + item
+        local_path = os.path.join(local_dir, item)
+        out, rc = client.exec_command(
+            sudo=True, cmd=f"test -d {remote_path}", check_ec=False
+        )
+        log.info(f"Directory results {out}, {rc}")
+        if client.exit_status:
+            client.download_file(remote_path, local_path, sudo=True)
+        else:
+            download_dir(client, remote_path, local_path)
+
+
+def parse_xml(xml_file):
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+
+    data = {}
+    for metric in root.findall(".//metric"):
+        name = metric.get("name")
+        value = metric.text
+        unit = metric.get("units")
+        data[name] = f"{value} {unit}"
+
+    return data
+
+
+def print_table(data_list):
+    max_name_length = max(
+        max(len(name) for data in data_list for name in data.keys()), default=0
+    )
+    max_value_length = max(
+        max(len(value) for data in data_list for value in data.values()), default=0
+    )
+    table_width = (max_name_length + max_value_length + 10) * len(data_list) + 4
+
+    print("-" * table_width)
+    print("| Metric" + " " * (max_name_length - 6), end="")
+    for i in range(len(data_list)):
+        print(f"| Value (File {i+1})" + " " * (max_value_length - 10), end="")
+    print("|")
+    print("-" * table_width)
+    metrics = set().union(*[data.keys() for data in data_list])
+    for metric in metrics:
+        print(f"| {metric:>{max_name_length}} ", end="")
+        for data in data_list:
+            value = data.get(metric, "")
+            print(f"| {value:>{max_value_length}} ", end="")
+        print("|")
+    print("-" * table_width)
+
+
+def print_results(log_dir, benchmark, output_xml):
+    xml_files = [f"{log_dir}/spec_storage_{benchmark}_results/{i}" for i in output_xml]
+    data_list = [parse_xml(xml_file) for xml_file in xml_files]
+    print_table(data_list)
+
+
+def run_spec_storage(config, spec_clients, mount_points):
+    benchmark = config.get("benchmark", "SWBUILD")
+    benchmark_defination = config.get("benchmark_defination")
+    load = config.get("load", "1")
+    incr_load = config.get("incr_load", "1")
+    num_runs = config.get("num_runs", "1")
+    output_xml = []
+    for mount in mount_points:
+        run_spec_storage_io(
+            spec_clients[0],
+            benchmark,
+            load,
+            incr_load,
+            num_runs,
+            spec_clients,
+            mount,
+            benchmark_defination,
+        )
+        nfs_mount = mount.rstrip("/")
+        last_path_component = os.path.basename(nfs_mount)
+        output_xml.append(f"sfssum_{benchmark}-result-{last_path_component}.xml")

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1218,6 +1218,8 @@ class FsUtils(object):
 
         """
         fs_cmd = f"ceph fs volume create {vol_name}"
+        if kwargs.get("placement"):
+            fs_cmd += f" --placement {kwargs.get('placement')}"
         cmd_out, cmd_rc = client.exec_command(
             sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
         )


### PR DESCRIPTION
# Description
Adding spec storage tests to FS
We have made changes to the installation part of specstorage. Earlier we use to mount and run it. 
Now we are downloading it to the client and running the IOs

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-J7SAWU  -> VDA workload
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UNZLN9 --> SWBUILD

Complete Log :  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7NY5GT

FIO Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DP9HKX

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
