### PR TITLE
Adding db and wal to an OSD

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -2640,9 +2640,9 @@ class RadosOrchestrator:
         """
 
         if node is None:
-            cmd_orch_device = "ceph orch device ls"
+            cmd_orch_device = "ceph orch device ls --refresh"
         else:
-            cmd_orch_device = f"ceph orch device ls  {node}"
+            cmd_orch_device = f"ceph orch device ls  {node} --refresh"
 
         orch_device_output = self.run_ceph_command(cmd=cmd_orch_device)
         return orch_device_output
@@ -3173,3 +3173,25 @@ class RadosOrchestrator:
         """
         base_cmd = f"ceph tell osd.{osd_id} perf dump"
         return self.run_ceph_command(cmd=base_cmd)
+
+    def get_available_path_list(self, node: str, device_type: str):
+        """
+        Method returns the available device list in the provided node.
+            Args:
+                 rados_object: RadosOrchestrator class object
+                 node: node name
+
+             Returns: Returns the available device path list of the node.
+
+        """
+        device_paths = []
+        available_device_list = self.get_orch_device_list(node)
+        for path_list in available_device_list[0]["devices"]:
+            if path_list["human_readable_type"] != device_type:
+                continue
+            if (
+                path_list["human_readable_type"] == device_type
+                and path_list["available"] is True
+            ):
+                device_paths.append(path_list["path"])
+        return device_paths

--- a/suites/quincy/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
+++ b/suites/quincy/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
@@ -1,0 +1,159 @@
+# Suite contains  tier-2 rados tests which adds DB and wal to the OSD
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#-----      Tier-2- Using bluestore-tool add DB & Wal  to the existing OSD          ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/quincy/baremetal_pipeline/mero_4_node_4_client_conf.yaml
+# Requirements:  Minimum one SSD and NVME is required to verify this testcase.In Mero nodes
+#                initially configuring the OSD's on HDD devices.On test OSD adding DB using SSD
+#                and adding WAL using NVME device.
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_hdd
+                  placement:
+                    host_pattern: '*'
+                  spec:
+                    data_devices:
+                      rotational: 1
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - cephadm
+        node: node4
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      name: Using Blustore-tool add DB and WAL to existing OSD
+      desc: Using Blustore-tool add DB and WAL to existing OSD
+      module: test_add_db_wal_cbt.py
+      polarion-id: CEPH-83584018
+      abort-on-fail: true

--- a/suites/reef/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
+++ b/suites/reef/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
@@ -1,0 +1,159 @@
+# Suite contains  tier-2 rados tests which adds DB and wal to the OSD
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#-----      Tier-2- Using bluestore-tool add DB & Wal  to the existing OSD          ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/reef/baremetal/mero_4_node_4_client_conf.yaml
+# Requirements:  Minimum one SSD and NVME is required to verify this testcase.In Mero nodes
+#                initially configuring the OSD's on HDD devices.On test OSD adding DB using SSD
+#                and adding WAL using NVME device.
+#===============================================================================================
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_hdd
+                  placement:
+                    host_pattern: '*'
+                  spec:
+                    data_devices:
+                      rotational: 1
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - cephadm
+        node: node4
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the client system "
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      name: Using Blustore-tool add DB and WAL to existing OSD
+      desc: Using Blustore-tool add DB and WAL to existing OSD
+      module: test_add_db_wal_cbt.py
+      polarion-id: CEPH-83584018
+      abort-on-fail: true

--- a/tests/rados/test_add_db_wal_cbt.py
+++ b/tests/rados/test_add_db_wal_cbt.py
@@ -1,0 +1,150 @@
+"""
+This file contains verification of adding db and wal to an OSD.This contains-
+1. Get the available osds
+2. Get available SSD and NVME paths
+3. Add the DB and wal to the OSD
+4. Check the devices are not added or not at "ceph orch device" and "osd metadata"
+"""
+
+import datetime
+import math
+import random
+import time
+import traceback
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    ceph_nodes = kw.get("ceph_nodes")
+    rados_object = RadosOrchestrator(node=cephadm)
+    bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+    client = ceph_cluster.get_nodes(role="client")[0]
+    osd_flag_status = 0
+
+    try:
+        # Get the OSD list
+        for node in ceph_nodes:
+            if node.role == "osd":
+                host_name = node.hostname
+                ssd_path_list = rados_object.get_available_path_list(host_name, "ssd")
+                if not ssd_path_list:
+                    log.info(f"The device paths are empty to add on the {host_name}")
+                    continue
+                osds_id_in_node = rados_object.collect_osd_daemon_ids(node)
+                log.info(f"The osd's  configured on the HDD are-{osds_id_in_node}")
+                test_osd = random.choice(osds_id_in_node)
+                log.info(f"Performing the configurations on {test_osd}")
+                osd_size = rados_object.get_osd_df_stats(
+                    tree=False, filter_by="name", filter=f"osd.{test_osd}"
+                )["summary"]["total_kb"]
+                log.info(f"The OSD size in KB is - {osd_size}")
+                db_size = math.floor(osd_size * 1000 * 0.04)
+                log.info(f"The DB size in bytes are -{db_size}")
+                nvme_flag = False
+                ssd_flag = False
+
+                for dev_path in ssd_path_list:
+                    if "nvme" in dev_path and not nvme_flag:
+                        bluestore_obj.add_wal_device(test_osd, dev_path)
+                        # Check 1: Checking the path at orch device ls output
+                        osd_config_result = check_osd_config(
+                            rados_object, host_name, dev_path
+                        )
+
+                        # Cehck2: Checking device in the OSD metadata
+                        osd_metadata_result = check_osd_metadata(
+                            ceph_cluster, client, test_osd, dev_path
+                        )
+                        if not osd_config_result and not osd_metadata_result:
+                            log.error(
+                                f"The NVME-{dev_path} is not added on osd -{test_osd} in the {host_name} node"
+                            )
+                            continue
+                        log.info(
+                            f"The NVME-{dev_path} is added on osd -{test_osd} in the {host_name} node"
+                        )
+                        nvme_flag = True
+                    elif "nvme" not in dev_path and not ssd_flag:
+                        bluestore_obj.add_db_device(test_osd, dev_path, db_size)
+                        osd_config_result = check_osd_config(
+                            rados_object, host_name, dev_path
+                        )
+                        osd_metadata_result = check_osd_metadata(
+                            ceph_cluster, client, test_osd, dev_path
+                        )
+                        if not osd_config_result and not osd_metadata_result:
+                            log.error(
+                                f"The SSD -{dev_path} is not added on osd -{test_osd} in the {host_name} node"
+                            )
+                            continue
+                        log.info(
+                            f"The SSD -{dev_path} is added on osd -{test_osd} in the {host_name} node"
+                        )
+                        ssd_flag = True
+                osd_flag_status = osd_flag_status + 1
+
+        if osd_flag_status == 0:
+            log.error("Any of the devices are not configured as OSDs")
+            return 1
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    return 0
+
+
+def check_osd_config(node_object, host_name, dev_path):
+    """
+    Method  used to check the device path is available or not  in orch device list
+    Args:
+          node_object: node object for calling the method
+          host_name: host name in the cluster where the device need to check
+          dev_path: device path
+          Example: /dev/sdb
+    Returns : True/False
+    """
+    end_time = datetime.datetime.now() + datetime.timedelta(seconds=600)
+    while end_time > datetime.datetime.now():
+        ssd_path_list = node_object.get_available_path_list(host_name, "ssd")
+        if dev_path not in ssd_path_list:
+            log.info(f"OSD is configured on the {dev_path} at {host_name}")
+            return True
+        time.sleep(30)
+        log.info("Waiting for 30 seconds to check the OSD configuration")
+    log.error(f" The device {dev_path} is not added to the OSD")
+    return False
+
+
+def check_osd_metadata(ceph_cluster, client_object, osd_id, dev_path):
+    """
+    Method  used to check the device path is available or not in the OSD metadata
+    Args:
+          ceph_cluster: ceph cluster object
+          client_object: client node object for calling the method
+          osd_id: osd id
+          dev_path: device path
+          Example: /dev/sdb
+
+    Returns : True/False
+
+    """
+    osd_metadata = ceph_cluster.get_osd_metadata(
+        osd_id=int(osd_id), client=client_object
+    )
+    log.debug(osd_metadata)
+    if "nvme" in dev_path:
+        actual_device = osd_metadata["bluefs_wal_devices"]
+    else:
+        actual_device = osd_metadata["bluefs_db_devices"]
+    if actual_device not in dev_path:
+        return False
+    return True


### PR DESCRIPTION
# Description
This code contains verification of adding db and wal to an OSD.The steps are-
1. Get the available OSD nodes and OSD ids of the node.
2. Get available SSD and NVME paths on the existing node
3. Add the DB and wal to the OSD

Testcase: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83584018

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
