### PR TITLE
[Lib] Add OSD ls library

### DIFF
--- a/cli/ceph/osd/osd.py
+++ b/cli/ceph/osd/osd.py
@@ -22,6 +22,14 @@ class Osd(Cli):
             return out[0].strip()
         return out
 
+    def ls(self):
+        """List OSD id"""
+        cmd = f"{self.base_cmd} ls"
+        out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].splitlines()
+        return out
+
     def set(self, flag):
         """Set osd flag
 


### PR DESCRIPTION
Add support for ceph osd ls to list osd ids.

Full logs: http://magna002.ceph.redhat.com/cephci-jenkins/aramteke/automation/cephci-run-2LOTLE/ 


