### PR TITLE
CEPH-83573627: Verify Mon election strategies in stretch mode and normal cluster

### DIFF
--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -64,7 +64,7 @@ globals:
         disk-size: 25
       node8:
         image-name:
-          openstack: RHEL-8.8.0-x86_64-ga-latest
-          ibmc: rhel-87-server-released
+          openstack: RHEL-9.3.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         role:
           - client

--- a/conf/reef/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/reef/rados/stretch-mode-host-location-attrs.yaml
@@ -65,7 +65,7 @@ globals:
         disk-size: 25
       node8:
         image-name:
-          openstack: RHEL-9.2.0-x86_64-ga-latest
+          openstack: RHEL-9.3.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         role:
           - client

--- a/suites/pacific/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/pacific/rados/tier-2-rados-basic-regression.yaml
@@ -351,3 +351,8 @@ tests:
 #      polarion-id: CEPH-83574794
 #      desc: verify autoscaler flags functionality
 
+  - test:
+      name: Mon election strategies
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      desc: Change Mon election strategies and verify status

--- a/suites/pacific/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-brownfield.yaml
@@ -1,5 +1,5 @@
 # Suite contains tests to be run after upgrade [brownfield deployment]
-# Use cluster-conf file: conf/reef/rados/7-node-cluster.yaml
+# Use cluster-conf file: conf/pacific/rados/7-node-cluster.yaml
 
 tests:
   - test:

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
@@ -162,6 +162,13 @@ tests:
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
 
+  - test:
+      name: Mon election strategies in stretch mode
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      config:
+        stretch_mode: True
+      desc: Run Mon election strategies workflow for a stretch cluster
 
   - test:
       name: rbd-io

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -375,3 +375,9 @@ tests:
 #      module: test_pg_autoscale_flag.py
 #      polarion-id: CEPH-83574794
 #      desc: verify autoscaler flags functionality
+
+  - test:
+      name: Mon election strategies
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      desc: Change Mon election strategies and verify status

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
@@ -162,6 +162,13 @@ tests:
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
 
+  - test:
+      name: Mon election strategies in stretch mode
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      config:
+        stretch_mode: True
+      desc: Run Mon election strategies workflow for a stretch cluster
 
   - test:
       name: rbd-io

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -371,9 +371,16 @@ tests:
       polarion-id: CEPH-83573478
       desc: Config sources - Verify config source changes and reset config
 
-# Commenting untill bug fix : https://bugzilla.redhat.com/show_bug.cgi?id=2252788
+# Commenting until bug fix : https://bugzilla.redhat.com/show_bug.cgi?id=2252788
 #  - test:
 #      name: autoscaler flags
 #      module: test_pg_autoscale_flag.py
 #      polarion-id: CEPH-83574794
 #      desc: verify autoscaler flags functionality
+#      comments: BZ-2252788
+
+  - test:
+      name: Mon election strategies
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      desc: Change Mon election strategies and verify status

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode.yaml
@@ -1,3 +1,4 @@
+# Use cluster-conf file: conf/reef/rados/stretch-mode-host-location-attrs.yaml
 # Suite contains tests related to election strategy and Stretched mode
 ---
 tests:
@@ -162,6 +163,13 @@ tests:
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
 
+  - test:
+      name: Mon election strategies in stretch mode
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      config:
+        stretch_mode: True
+      desc: Run Mon election strategies workflow for a stretch cluster
 
   - test:
       name: rbd-io

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -42,7 +42,7 @@ class MonElectionStrategies:
         """
         allows to add mon to  disallowed leaders list in ceph
         Args:
-            mon: name of the monitor to be added/removed
+            mon: name of the monitor to be added
         Returns: True -> Pass, False -> fail
         """
         cmd = f" ceph mon add disallowed_leader {mon}"
@@ -58,9 +58,9 @@ class MonElectionStrategies:
 
     def remove_disallow_mon(self, mon):
         """
-        allows to add mon to  disallowed leaders list in ceph
+        allows to remove a mon from the disallowed leaders' list
         Args:
-            mon: name of the monitor to be added/removed
+            mon: name of the monitor to be removed
         Returns: True -> Pass, False -> fail
         """
         cmd = f" ceph mon rm disallowed_leader {mon}"

--- a/tests/rados/test_election_strategies.py
+++ b/tests/rados/test_election_strategies.py
@@ -20,73 +20,165 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     mon_obj = MonElectionStrategies(rados_obj=rados_obj)
-    cephadm_node_mon = ceph_cluster.get_nodes(role="installer")[0]
+    installer_node = ceph_cluster.get_nodes(role="installer")[0]
 
     # Collecting the number of mons in the quorum before the test
     mon_init_count = len(mon_obj.get_mon_quorum().keys())
 
-    # By default, the election strategy is classic. Verifying that
-    strategy = mon_obj.get_election_strategy()
-    if strategy != 1:
-        log.error(
-            f"cluster created election strategy other than classic, i.e {strategy}"
+    if config.get("stretch_mode"):
+        log.info(
+            "Verifying ceph mon election strategies in Stretch mode enabled stretch cluster"
         )
-        return 1
 
-    # Changing strategy to 2. i.e disallowed mode.
-    if not mon_obj.set_election_strategy(mode="disallow"):
-        log.error("could not set election strategy to disallow mode")
-        return 1
+        # Verifying the default mode of election strategy is connectivity.
+        default_strategy = mon_obj.get_election_strategy()
+        if default_strategy != 3:
+            log.error(
+                f"Stretch cluster election strategy was not 'connectivity', i.e {default_strategy}"
+            )
+            return 1
+        log.info(
+            f"Default election strategy for Mon verified successfully: {default_strategy}"
+        )
 
-    # sleeping for 2 seconds for new elections to be triggered and new leader to be elected
-    time.sleep(2)
+        # Try changing the election strategy mode to classic or disallow, should fail
+        # RFE raised to restrict user from changing Mon election strategy in Stretch mode
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2264124
+        # Changing strategy to 1. i.e. classic mode
+        """
+        log.info("Trying to change mon election strategy to 1. i.e. classic mode")
+        if mon_obj.set_election_strategy(mode="classic"):
+            log.error(
+                "Able to set election strategy to classic mode in stretch mode, should not have worked"
+            )
+            return 1
 
-    log.info("Set election strategy to disallow mode. adding disallowed mons")
-    # Checking if new leader will be chosen if leader is added to disallowed list
-    old_leader = mon_obj.get_mon_quorum_leader()
-    if not mon_obj.set_disallow_mon(mon=old_leader):
-        log.error(f"could not add mon: {old_leader} to the disallowed list")
-        return 1
+        # Changing strategy to 2. i.e. disallowed mode
+        log.info("Trying to change mon election strategy to 2. i.e. disallow mode")
+        if mon_obj.set_election_strategy(mode="disallow"):
+            log.error(
+                "Able to set election strategy to disallow mode in stretch mode, should not have worked"
+            )
+            return 1
+        """
 
-    # sleeping for 2 seconds for new elections to be triggered and new leader to be elected
-    time.sleep(2)
+        # Checking connectivity scores of all the mons
+        cmd = f"ceph daemon mon.{installer_node.hostname} connection scores dump"
+        mon_conn_score = rados_obj.run_ceph_command(cmd=cmd)
+        log.info(
+            f"Connectivity score of all daemons in the cluster: \n {mon_conn_score}"
+        )
 
-    current_leader = mon_obj.get_mon_quorum_leader()
-    if re.search(current_leader, old_leader):
-        log.error(f"The mon: {old_leader} added to disallow list is still leader")
-        return 1
+        # reset the connectivity scores of all the mons
+        log.info("Reset the connectivity scores of all the mons")
+        cmd = f"ceph daemon mon.{installer_node.hostname} connection scores reset"
+        cephadm.shell(args=[cmd])
 
-    # removing the mon from the disallowed list
-    if not mon_obj.remove_disallow_mon(mon=old_leader):
-        log.error(f"could not remove mon: {old_leader} from disallowed list")
-        return 1
+        # Print the connectivity scores of all the mons post reset
+        cmd = f"ceph daemon mon.{installer_node.hostname} connection scores dump"
+        mon_conn_score = rados_obj.run_ceph_command(cmd=cmd)
+        log.info(f"Connectivity score of all daemons post reset: \n {mon_conn_score}")
 
-    # sleeping for 2 seconds for new elections to be triggered and new leader to be elected
-    time.sleep(2)
+        if not check_mon_status(rados_obj, mon_obj):
+            log.error("All Mon daemons are not in running state")
+            return 1
 
-    # Changing strategy to 3. i.e Connectivity mode.
-    if not mon_obj.set_election_strategy(mode="connectivity"):
-        log.error("could not set election strategy to connectivity mode")
-        return 1
+        log.info("Completed all mon election test scenarios valid for stretch mode")
+        return 0
 
-    # Checking connectivity scores of all the mons
-    cmd = f"ceph daemon mon.{cephadm_node_mon.hostname} connection scores dump"
-    rados_obj.run_ceph_command(cmd=cmd)
+    else:
+        # By default, the election strategy is classic. Verifying that
+        default_strategy = mon_obj.get_election_strategy()
+        if default_strategy != 1:
+            log.error(
+                f"cluster created election strategy other than classic, i.e {default_strategy}"
+            )
+            return 1
 
-    # Changing strategy to default
-    if not mon_obj.set_election_strategy(mode="classic"):
-        log.error("could not set election strategy to classic mode")
-        return 1
+        # Changing strategy to 2. i.e. disallowed mode
+        if not mon_obj.set_election_strategy(mode="disallow"):
+            log.error("could not set election strategy to disallow mode")
+            return 1
 
-    # sleeping for 5 seconds for new elections to be triggered and new leader to be elected
-    time.sleep(5)
+        # sleeping for 2 seconds for new elections to be triggered and new leader to be elected
+        time.sleep(2)
 
-    # Collecting the number of mons in the quorum after the test
-    # todo: add other tests to ascertain the health of mon daemons in quorum
-    mon_final_count = len(mon_obj.get_mon_quorum().keys())
-    if mon_init_count < mon_final_count:
-        log.error("There are less mons in the quorum at the end than there before")
-        return 1
+        log.info(
+            "Election strategy set to disallow mode. adding leader mon to disallowed list"
+        )
+        # Checking if new leader will be chosen if leader is added to disallowed list
+        old_leader = mon_obj.get_mon_quorum_leader()
+        if not mon_obj.set_disallow_mon(mon=old_leader):
+            log.error(f"could not add Mon {old_leader} to the disallowed list")
+            return 1
 
-    log.info("Completed all mon election test cases")
-    return 0
+        # sleeping for 2 seconds for new elections to be triggered and new leader to be elected
+        time.sleep(2)
+
+        current_leader = mon_obj.get_mon_quorum_leader()
+        if re.search(current_leader, old_leader):
+            log.error(f"The mon: {old_leader} added to disallow list is still leader")
+            return 1
+
+        # removing the mon from the disallowed list
+        if not mon_obj.remove_disallow_mon(mon=old_leader):
+            log.error(f"could not remove mon: {old_leader} from disallowed list")
+            return 1
+
+        # sleeping for 2 seconds for new elections to be triggered and new leader to be elected
+        time.sleep(2)
+
+        # Changing strategy to 3. i.e Connectivity mode.
+        if not mon_obj.set_election_strategy(mode="connectivity"):
+            log.error("could not set election strategy to connectivity mode")
+            return 1
+
+        # Checking connectivity scores of all the mons
+        cmd = f"ceph daemon mon.{installer_node.hostname} connection scores dump"
+        mon_conn_score = rados_obj.run_ceph_command(cmd=cmd)
+        log.info(
+            f"Connectivity score of all daemons in the cluster: \n {mon_conn_score}"
+        )
+
+        # Changing strategy to default
+        if not mon_obj.set_election_strategy(mode="classic"):
+            log.error("could not set election strategy to classic mode")
+            return 1
+
+        # sleeping for 5 seconds for new elections to be triggered and new leader to be elected
+        time.sleep(5)
+
+        # todo: add other tests to ascertain the health of mon daemons in quorum
+        # [12-Feb-2024] added ^
+        if not check_mon_status(rados_obj, mon_obj):
+            log.error("All Mon daemons are not in running state")
+            return 1
+
+        # Collecting the number of mons in the quorum after the test
+        mon_final_count = len(mon_obj.get_mon_quorum().keys())
+        if mon_init_count < mon_final_count:
+            log.error("There are less mons in the quorum at the end than there before")
+            return 1
+
+        log.info("Completed all mon election test cases")
+        return 0
+
+
+def check_mon_status(rados_obj, mon_obj):
+    """Method to verify all Mon daemons are in running state
+    Args:
+        rados_obj: CephAdmin object
+        mon_obj: MonElectionStrategies class object
+    Returns:
+        True -> pass | False -> fail
+    """
+    # check running status of each mon daemon
+    mon_list = mon_obj.get_mon_quorum().keys()
+    log.debug(f"List of Monitors in the cluster: {mon_list}")
+    for mon in mon_list:
+        status, desc = rados_obj.get_daemon_status(daemon_type="mon", daemon_id=mon)
+        if status != 1 or desc != "running":
+            log.error(f"{mon} is not in running state: {status} | {desc}")
+            return False
+        log.info(f"Mon {mon} is in healthy state: {status} | {desc}")
+    return True


### PR DESCRIPTION
[CEPH-83573627](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573627): Tier-3 test to verify all possible Mon election strategies in a normal cluster and a stretch mode enabled stretch cluster

Jira: [RHCEPHQE-13018](https://issues.redhat.com/browse/RHCEPHQE-13018)

> By default, the monitors are in `classic` mode (normal deployment). In a stretch mode deployment, Mon election strategy is `connectivity`
> 
> If you want to switch modes BEFORE constructing the cluster, change the mon election default strategy option. This option takes an integer value:
>    - 1 for classic
>    - 2 for disallow
>    - 3 for connectivity

Test modules modified:
- `tests/rados/monitor_configurations.py`
- `tests/rados/test_election_strategies.py`

Test suites modified:
- `suites/pacific/rados/tier-2_rados_test-brownfield.yaml`
- `suites/reef/rados/tier-2_rados_test-stretch-mode.yaml`
- `suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml`
- `suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml`

Logs -
Stretch mode - 
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UL549Y
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2I0JBK
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K4O412

Regression -
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K7Y6JN/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GFAS40
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZJWOFI

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

