### PR TITLE
TFA fixes

### DIFF
--- a/tests/cephfs/cephfs_scale/max_smallfile_snap.py
+++ b/tests/cephfs/cephfs_scale/max_smallfile_snap.py
@@ -95,6 +95,12 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd=f"ceph fs subvolume getpath {default_fs} subvol_max_snap",
         )
+        log.info("Note default value for mds_max_snaps_per_dir")
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph config get mds mds_max_snaps_per_dir"
+        )
+        default_retention = int(out.strip())
+        log.info(f"Default value for mds_max_snaps_per_dir:{default_retention}")
         client1.exec_command(
             sudo=True,
             cmd=f"ceph config set mds mds_max_snaps_per_dir {max_snap}",
@@ -150,6 +156,10 @@ def run(ceph_cluster, **kw):
         for cmd in cmd_list:
             collect_ceph_details(client1, cmd)
         log.info("Clean Up in progess")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph config set mds mds_max_snaps_per_dir {default_retention}",
+        )
         for snapshot in snapshot_list:
             fs_util.remove_snapshot(client1, **snapshot)
         fs_util.remove_subvolume(client1, **subvolume, check_ec=False)

--- a/tests/cephfs/cephfs_scale/max_snapshots.py
+++ b/tests/cephfs/cephfs_scale/max_snapshots.py
@@ -85,6 +85,12 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd=f"ceph fs subvolume getpath {default_fs} subvol_max_snap",
         )
+        log.info("Note default value for mds_max_snaps_per_dir")
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph config get mds mds_max_snaps_per_dir"
+        )
+        default_retention = int(out.strip())
+        log.info(f"Default value for mds_max_snaps_per_dir:{default_retention}")
         client1.exec_command(
             sudo=True,
             cmd=f"ceph config set mds mds_max_snaps_per_dir {max_snap}",
@@ -150,6 +156,12 @@ def run(ceph_cluster, **kw):
         for cmd in cmd_list:
             collect_ceph_details(client1, cmd)
         log.info("Clean Up in progess")
+        log.info("Reset mds_max_snaps_per_dir to default")
+        out, rc = client1.exec_command(
+            sudo=True,
+            cmd=f"ceph config set mds mds_max_snaps_per_dir {default_retention}",
+        )
+
         fs_util.enable_mds_logs(client1, default_fs)
         try:
             retry_remove_snapshot = retry(CommandFailed, tries=3, delay=30)(

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -2730,7 +2730,7 @@ os.system('sudo systemctl start  network')
             dir_suffix = "".join(
                 [
                     random.choice(string.ascii_lowercase + string.digits)
-                    for _ in range(3)
+                    for _ in range(4)
                 ]
             )
             io_path = f"{mounting_dir}/{io_params['testdir_prefix']}_{dir_suffix}"

--- a/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
+++ b/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
@@ -466,9 +466,11 @@ class SnapUtils(object):
         cmd = f"ceph fs snap-schedule status {sched_path} --fs {fs_name} -f json"
         out, rc = client.exec_command(sudo=True, cmd=cmd)
         sched_status = json.loads(out)
+        log.info(f"sched_status:{sched_status}")
         for sched_item in sched_status:
             if sched_item["path"] == sched_path:
                 if sched_item.get("retention"):
+                    log.info(f"sched_item:{sched_item}")
                     for key, value in sched_item["retention"].items():
                         if key == ret_type:
                             ret_num = value
@@ -477,16 +479,19 @@ class SnapUtils(object):
                             int(sched_item["created_count"])
                             - int(sched_item["pruned_count"])
                         )
+                        log.info(f"ret_verified : {ret_verified},ret_type:{ret_type}")
                     elif "h" in sched_item["schedule"] and ret_type == "h":
                         ret_verified = abs(
                             int(sched_item["created_count"])
                             - int(sched_item["pruned_count"])
                         )
+                        log.info(f"ret_verified : {ret_verified},ret_type:{ret_type}")
                     elif "M" in sched_item["schedule"] and ret_type == "n":
                         ret_verified = abs(
                             int(sched_item["created_count"])
                             - int(sched_item["pruned_count"])
                         )
+                        log.info(f"ret_verified : {ret_verified},ret_type:{ret_type}")
                 else:
                     out, rc = client.exec_command(
                         sudo=True, cmd="ceph config get mds mds_max_snaps_per_dir"

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -1,4 +1,5 @@
 import json
+import random
 import re
 import secrets
 import string
@@ -238,9 +239,12 @@ def run_snap_test(snap_test_params):
             "vol_name": snap_test_params["fs_name"],
             "group_name": "subvolgroup_snap_schedule",
         }
+        dir_suffix = "".join(
+            [random.choice(string.ascii_lowercase + string.digits) for _ in range(3)]
+        )
         subvolume = {
             "vol_name": snap_test_params["fs_name"],
-            "subvol_name": "snap_subvolume",
+            "subvol_name": f"snap_subvolume_{dir_suffix}",
             "group_name": "subvolgroup_snap_schedule",
             "size": "6442450944",
         }


### PR DESCRIPTION
# Description

JIRA : https://issues.redhat.com/browse/RHCEPHQE-13095

Fixes for,
- mds_max_snaps_per_dir set to 4096 in prev tests causes snap_retention_count_validate test to run for 16hrs and fail with smallfile io dir name already exists error
log - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-196/Weekly/cephfs/21/tier-3_cephfs_scale/snap_retention_count_validate_0.log
  Add code in scale tests max_snapshots.py and max_smallfile_snap.py to note default value of mds_max_snaps_per_dir and reset to default in cleanup.
- snap_retention_subvol test fails while validating retention, with error actual and expected snapshots mismatch.
Logs - http://magna006.ceph.redhat.com/cephci-jenkins/test-runs/18.2.1-10/Regression/cephfs/56/tier-2_cephfs_test-snapshot-clone/snap_schedule_retention_vol_subvol_0.log
actual snaps obtained with diff of pruned_count and created_count fields in snap schedule status output for given minuetly schedule. This has not failed even after 7 local runs of the test. So, added debug cmds to fetch more details in next failure.

Passed log with fix: 
snap_retention_count_validate : As the run is for scale tests, it will take longer time to complete, but since the code added is not expected to cause any regression proceeding with PR. Will add logs as soon as runs complete.

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M774OA/cephfs_Scale_test_for_max_Snapshots_per_volume_0.log
(It has failed during cleanup due to socket timeout, and next two tests failed because cluster was unhealthy)
Log snippet:
2024-02-14 06:23:53,541 (cephci.cephfs_scale.max_smallfile_snap) [INFO] - cephci.tests.cephfs.cephfs_scale.max_smallfile_snap.py:158 - Clean Up in progess
2024-02-14 06:23:53,541 (cephci.cephfs_scale.max_smallfile_snap) [INFO] - cephci.ceph.ceph.py:1563 - Running command ceph config set mds mds_max_snaps_per_dir 100 on 10.0.204.71 timeout 600
2024-02-14 06:23:53,899 (cephci.cephfs_scale.max_smallfile_snap) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully

snap_retention_subvol : 7 local runs that passed, and has debug cmds added.
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-LWM2NN/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
