### PR TITLE
Persistant write back cache with encrypted images

### DIFF
--- a/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -491,3 +491,30 @@ tests:
       module: test_rbd_pwl_cache_cluster_operation.py
       name: Validate cluster operation with persistent cache enabled
       polarion-id: CEPH-83574891
+
+  - test:
+      abort-on-fail: true
+      config:
+        levels:
+          - client
+          - pool
+          - image
+        cache_file_size: 1073741824         # 1 GB
+        rbd_persistent_cache_mode: ssd      # "ssd" or "rwl" on pmem device
+        drive: /dev/nvme0n1
+        client: node10
+        cleanup: true
+        validate_cache_path: true
+        rep-pool-only: True
+        do_not_create_image: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          size: 100M
+      desc: Validate PWL cache status on encrypted images
+      destroy-cluster: false
+      module: test_rbd_pwl_with_encrypted_images.py
+      name: PWL cache creation on encrypted images
+      polarion-id: CEPH-83575409

--- a/suites/reef/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/reef/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -324,3 +324,29 @@ tests:
       name: Validate cluster operation with persistent cache enabled
       polarion-id: CEPH-83574891
 
+  - test:
+      abort-on-fail: true
+      config:
+        levels:
+          - client
+          - pool
+          - image
+        cache_file_size: 1073741824         # 1 GB
+        rbd_persistent_cache_mode: ssd      # "ssd" or "rwl" on pmem device
+        drive: /dev/nvme0n1
+        client: node10
+        cleanup: true
+        validate_cache_path: true
+        rep-pool-only: True
+        do_not_create_image: True
+        rep_pool_config:
+          pool: pool1
+          image: image1
+          size: 10G
+        fio:
+          size: 100M
+      desc: Validate PWL cache status on encrypted images
+      destroy-cluster: false
+      module: test_rbd_pwl_with_encrypted_images.py
+      name: PWL cache creation on encrypted images
+      polarion-id: CEPH-83575409

--- a/tests/rbd/test_rbd_pwl_with_encrypted_images.py
+++ b/tests/rbd/test_rbd_pwl_with_encrypted_images.py
@@ -1,0 +1,138 @@
+"""RBD Persistent write back cache with encrypted images.
+
+Test Case Covered:
+CEPH-83575409 - Pmem/SSD mode write back cache on encrypted images.
+
+Steps :
+1) create image with encryption(luks1,luks2) feature enabled
+2) Setup persistent write cache for that encrypted image
+3) Write data to the image using fio jobs check cache status
+4) Repeat the test on client, pool and image level
+
+Pre-requisites :
+- need client node with ceph-common package, conf and keyring files
+- FIO should be installed on the client.
+
+Environment and limitations:
+- The cluster should have 5 nodes + 1 SSD cache node
+- cluster/global-config-file: config/quincy/upi/octo-5-node-env.yaml
+- Should be Bare-metal.
+
+Support
+- Configure cluster with PWL Cache.
+- Only replicated pool supported, No EC pools."""
+
+from ceph.parallel import parallel
+from ceph.rbd.utils import random_string
+from tests.rbd.rbd_peristent_writeback_cache import (
+    PersistentWriteAheadLog,
+    get_entity_level,
+)
+from tests.rbd.rbd_utils import create_passphrase_file, initial_rbd_config
+from utility.log import Log
+from utility.utils import run_fio
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """RBD Persistent write back cache with encrypted images.
+
+    Args:
+        ceph_cluster: ceph cluster object
+        **kw: test parameters
+
+    Returns:
+        int: 0 on success, 1 on failure
+
+    """
+    log.info(
+        "Running test - CEPH-83575409 - Pmem/SSD mode write back cache on encrypted images"
+    )
+    config = kw.get("config")
+
+    try:
+        for level in config.get("levels"):
+            config["level"] = level
+            rbd = initial_rbd_config(**kw)["rbd_reppool"]
+
+            pool = config["rep_pool_config"]["pool"]
+            image = config["rep_pool_config"]["image"]
+            image_spec = f"{pool}/{image}"
+            size = config["rep_pool_config"]["size"]
+
+            cache_client = ceph_cluster.get_nodes(role="client")[0]
+            pwl = PersistentWriteAheadLog(rbd, cache_client, config.get("drive"))
+            config_level, entity = get_entity_level(config)
+
+            rbd.create_image(pool, image, size)
+
+            # Configute cache client
+            pwl.configure_cache_client()
+
+            # Configure PWL
+            pwl.configure_pwl_cache(
+                config["rbd_persistent_cache_mode"],
+                config_level,
+                entity,
+                config["cache_file_size"],
+            )
+
+            for luks in ["luks1", "luks2"]:
+                # Adding this check as removed image for luks1
+                if luks == "luks2":
+                    rbd.create_image(pool, image, size)
+
+                # For image level config reconfigure cache client and PWL for luks2
+                if luks == "luks2" and level == "image":
+                    pwl.configure_cache_client()
+                    pwl.configure_pwl_cache(
+                        config["rbd_persistent_cache_mode"],
+                        config_level,
+                        entity,
+                        config["cache_file_size"],
+                    )
+
+                # Create passaphrase file and encrypt the image
+                passphrase = random_string(len=4) + "_passphrase.bin"
+                create_passphrase_file(rbd, passphrase)
+
+                if rbd.encrypt(image_spec, luks, passphrase):
+                    log.error(f"Apply RBD {luks} encryption failed on {image_spec}")
+                    return 1
+                log.info(f"Applied RBD {luks} encryption success on {image_spec}")
+
+                fio_args = {
+                    "client_node": cache_client,
+                    "pool_name": pool,
+                    "image_name": image,
+                    "io_type": "write",
+                    "size": config["fio"]["size"],
+                }
+
+                # Run FIO, validate cache file existence in self.pwl_path under cache node
+                with parallel() as p:
+                    p.spawn(run_fio, **fio_args)
+                    pwl.check_cache_file_exists(
+                        image_spec,
+                        config["fio"].get("runtime", 120),
+                        **config,
+                    )
+                log.info(
+                    f"Persistent write back cache with {level} level on encryption {luks} passed"
+                )
+
+                # Removing image to apply encryption of each type
+                if rbd.remove_image(pool, image):
+                    log.error(f"Removal of image {image} failed")
+                    return 1
+        return 0
+
+    except Exception as err:
+        log.error(err)
+        return 1
+
+    finally:
+        if config.get("cleanup"):
+            rbd.clean_up(pools=[pool])
+            pwl.cleanup()


### PR DESCRIPTION
# Description
Automation of Pmem/SSD mode write back cache on encrypted images
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575409

Test steps:
1) create image with encryption(luks1,luks2) feature enabled
2) Setup persistent write cache for that encrypted image
3) Write data to the image using fio jobs check cache status
4) Repeat the test on client, pool and image level

Test results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ALH3UW/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
