### PR TITLE
RBD namespace removal 2 tests

### DIFF
--- a/ceph/rbd/workflows/namespace.py
+++ b/ceph/rbd/workflows/namespace.py
@@ -63,3 +63,69 @@ def create_namespace_and_verify(**kw):
     if namespace_name in ns_ls_out[0]:
         log.info(f"namespace {namespace_name} creation successfully verified")
         return 0
+    else:
+        log.error(f"namespace {namespace_name} creation verified failed")
+        return 1
+
+
+def remove_namespace_and_verify(**kw):
+    """
+    Removes a namespace in a given pool
+        Args:
+        kw(dict): Key/value pairs that needs to be provided to the installer
+            Example::
+            Supported keys:
+                pool-name(str) : name of the pool in which namespace should be removed, default pool is rbd
+                namespace(str): namespace to removed in the pool
+                See rbd help create for more supported keys
+    """
+    rbd = Rbd(kw["client"])
+
+    # verify if the pool exists, if pool is not passed then consider default pool name i.e rbd
+    pool_name = kw.get("pool-name", "rbd")
+    log.info(f"verifying if pool {pool_name} exists")
+    pool_init_kw = {}
+    pool_init_kw["pool-name"] = pool_name
+    (_, pool_stats_err) = rbd.pool.stats(**pool_init_kw)
+
+    # if pool does not exists,  exit
+    if pool_stats_err:
+        log.error(
+            f"The pool {pool_name} where namespace is suppose to be delete does not exist"
+        )
+        return 1
+
+    # remove a namespace
+    namespace_name = kw.get("namespace", None)
+    log.info(f"namespace {namespace_name} in {pool_name} is getting deleted")
+    ns_delete_kw = {}
+    if namespace_name is None:
+        log.error("namespace name is a must for delete namespace method")
+        return 1
+    _pool_name = kw.get("pool-name", None)
+    ns_delete_kw["namespace"] = namespace_name
+    ns_delete_kw["pool-name"] = _pool_name
+    (_, ns_delete_err) = rbd.namespace.remove(**ns_delete_kw)
+    if not ns_delete_err:
+        log.info(
+            f"SUCCESS: Namespace {namespace_name} got deleted in pool {pool_name} "
+        )
+    else:
+        log.error(
+            f"FAIL: Namespace {namespace_name} deletion failed in pool {pool_name} with error {ns_delete_err}"
+        )
+        return 1
+
+    # verify deleted namespace using namespace ls command
+    log.info(
+        f"Verifying the deleted namespace {namespace_name} in pool {pool_name} using namespace ls command"
+    )
+    ns_verify_kw = {}
+    ns_verify_kw["pool-name"] = _pool_name
+    ns_ls_out = rbd.namespace.list(**ns_verify_kw)
+    if namespace_name not in ns_ls_out[0]:
+        log.info(f"namespace {namespace_name} deletion successfully verified")
+        return 0
+    else:
+        log.error(f"namespace {namespace_name} deletion verified failed")
+        return 1

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -54,6 +54,7 @@ class Rbd(Cli):
             Example::
             Supported keys:
                 pool(str)  : name of the pool(optional)
+                namespace(str): name of the namespace(optional)
                 pool-spec(str) : <pool_name>[/<namespace>]
                 See rbd help ls for more supported keys
         """
@@ -199,6 +200,7 @@ class Rbd(Cli):
                 image-spec(str) : [<pool-name>/[<namespace>/]]<image-name
                 image(str) : name of the image that should be removed
                 pool(str)  : name of the pool from which image should be retreived(optional)
+                namespace(str): name of the namespace from which image should be remoevd(optional)
                 See rbd help rm for more supported keys
         """
         kw_copy = deepcopy(kw)

--- a/suites/quincy/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/quincy/rbd/tier-2_rbd_namespace.yaml
@@ -124,3 +124,23 @@ tests:
         rep-pool-only: True
         rep_pool_config:
           rbd: {}
+
+  - test:
+    desc: Run namespace deletion positive flow
+    module: test_rbd_namespace_remove_pos.py
+    name: RBD namespace deletion positive flow
+    polarion-id: CEPH-83583642
+    config:
+      rep-pool-only: True
+      rep_pool_config:
+        rbd: {}
+
+  - test:
+      desc: Run namespace deletion negative flow
+      module: test_rbd_namespace_remove_neg.py
+      name: RBD namespace deletion negative flow
+      polarion-id: CEPH-83582477
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}

--- a/suites/reef/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/reef/rbd/tier-2_rbd_namespace.yaml
@@ -73,7 +73,7 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
-# Tests to be executed
+#Tests to be executed
   - test:
       desc: Run namespace creation in default pool
       module: test_rbd_namespace_default_pool.py
@@ -120,6 +120,26 @@ tests:
       module: test_rbd_namespace_same_img_diff_ns.py
       name: RBD img creation with the same name in diff ns
       polarion-id: CEPH-83582479
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace deletion positive flow
+      module: test_rbd_namespace_remove_pos.py
+      name: RBD namespace deletion positive flow
+      polarion-id: CEPH-83583642
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace deletion negative flow
+      module: test_rbd_namespace_remove_neg.py
+      name: RBD namespace deletion negative flow
+      polarion-id: CEPH-83582477
       config:
         rep-pool-only: True
         rep_pool_config:

--- a/tests/rbd/test_rbd_namespace_remove_neg.py
+++ b/tests/rbd/test_rbd_namespace_remove_neg.py
@@ -1,0 +1,78 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import (
+    create_namespace_and_verify,
+    remove_namespace_and_verify,
+)
+from ceph.rbd.workflows.rbd import create_single_image
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_removal_neg(client, **kw):
+    """
+    Tests the namespace removal negative flow
+    Args:
+        client: rbd client obj
+        **kw: test data
+    Steps:
+        (1) Create a rbd pool if it does not exist	- pool creation should succeed
+        (2) Create a namespace - 	namespace creation should succeed
+        (3) Create an image in the namespace - image creation in the namespace should succeed
+        (4) DONOT delete an image	image - deletion in the namespace should succeed
+        (5) Delete the namespace - namespace deletion should fail
+    """
+    kw["client"] = client
+    kw["namespace"] = "ns_deletable"
+    image_config_val = {"namespace": kw["namespace"], "size": "1G"}
+
+    # check for all the pools, if given in test suite
+    for pool, _ in kw["config"]["rep_pool_config"].items():
+        kw["pool-name"] = pool
+        if create_namespace_and_verify(**kw) != 0:
+            return 1
+        image_creation_rc = create_single_image(
+            {}, "ceph", Rbd(client), pool, None, "ns_image", image_config_val, None
+        )
+        if image_creation_rc != 0:
+            return 1
+        if remove_namespace_and_verify(**kw) != 0:
+            return 0
+        else:
+            return 1
+
+
+def run(**kw):
+    """RBD namespace removal negative testing.
+
+    Args:
+        **kw: test data
+    """
+    log.info(
+        "Running test CEPH-83582477 - Testing RBD namespace removal negative flow."
+    )
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_removal_neg(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD namespace removal negative flow in rbd pool failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val

--- a/tests/rbd/test_rbd_namespace_remove_pos.py
+++ b/tests/rbd/test_rbd_namespace_remove_pos.py
@@ -1,0 +1,89 @@
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.namespace import (
+    create_namespace_and_verify,
+    remove_namespace_and_verify,
+)
+from ceph.rbd.workflows.rbd import create_single_image, remove_single_image_and_verify
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_namespace_removal_pos(client, **kw):
+    """
+    Tests the namespace removal positive flow
+    Args:
+        client: rbd client obj
+        **kw: test data
+    Steps:
+        (1) Create a rbd pool if it does not exist	- pool creation should succeed
+        (2) Create a namespace - 	namespace creation should succeed
+        (3) Create an image in the namespace - image creation in the namespace should succeed
+        (4) Delete an image	image - deletion in the namespace should succeed
+        (5) Delete the namespace - namespace deletion should succeed
+    """
+    kw["client"] = client
+    kw["namespace"] = "ns_deletable"
+    image_config_val = {"namespace": kw["namespace"], "size": "1G"}
+
+    # check for all the pools, if given in test suite
+    for pool, _ in kw["config"]["rep_pool_config"].items():
+        kw["pool-name"] = pool
+        if create_namespace_and_verify(**kw) != 0:
+            return 1
+        image_creation_rc = create_single_image(
+            {}, "ceph", Rbd(client), pool, None, "ns_image", image_config_val, None
+        )
+        if image_creation_rc != 0:
+            return 1
+        rm_image_kw = {}
+        rm_image_kw.update(
+            {
+                "rbd": Rbd(client),
+                "pool": pool,
+                "namespace": kw["namespace"],
+                "image": "ns_image",
+            }
+        )
+        if remove_single_image_and_verify(**rm_image_kw) != 0:
+            return 1
+        if remove_namespace_and_verify(**kw) != 0:
+            return 1
+        else:
+            return 0
+
+
+def run(**kw):
+    """RBD namespace removal positive testing.
+
+    Args:
+        **kw: test data
+    """
+    log.info(
+        "Running test CEPH-83583642 - Testing RBD namespace removal positive flow."
+    )
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        kw["do_not_create_image"] = True
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_namespace_removal_pos(client=client, **kw)
+    except Exception as e:
+        log.error(
+            f"Testing RBD namespace removal in rbd pool failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val


### PR DESCRIPTION
This PR addresses automation of RBD namespace removal 2 tests, namely:

**Summary** 

(1) CEPH-83583642: RBD namespace removal positive case
(2) CEPH-83582477: RBD namespace removal negative case

Detailed steps are mentioned in polarion tests as well.

[namespace_remove_2tests_log.tar.gz](https://github.com/red-hat-storage/cephci/files/14336448/namespace_remove_2tests_log.tar.gz)

**Logs attached**

steps to view -> tar -xvxf <tar.gz file> 

**Test summary**

<img width="1715" alt="image" src="https://github.com/red-hat-storage/cephci/assets/9339364/dd1a210d-3efa-47d8-88cd-6ee87ed58c85">


**Lint checker**

(cephci) pavangovindraj@Pavans-MacBook-Pro cephci %
cat modified_added_files | xargs -tI{} python3 -m flake8 {}
cat modified_added_files | xargs -tI{} python3 -m isort {}
cat modified_added_files | grep -v ".yaml" |  xargs -tI{} python3 -m black {}
cat modified_added_files | grep ".yaml" | xargs -tI{} yamllint -d relaxed --no-warnings {}
python3 -m flake8 suites/quincy/rbd/tier-2_rbd_namespace.yaml
python3 -m flake8 suites/reef/rbd/tier-2_rbd_namespace.yaml
python3 -m flake8 tests/rbd/test_rbd_namespace_remove_neg.py
python3 -m flake8 tests/rbd/test_rbd_namespace_remove_pos.py
python3 -m flake8 ceph/rbd/workflows/namespace.py
python3 -m flake8 ceph/rbd/workflows/rbd.py
python3 -m flake8 cli/rbd/rbd.py
python3 -m isort suites/quincy/rbd/tier-2_rbd_namespace.yaml
python3 -m isort suites/reef/rbd/tier-2_rbd_namespace.yaml
python3 -m isort tests/rbd/test_rbd_namespace_remove_neg.py
python3 -m isort tests/rbd/test_rbd_namespace_remove_pos.py
python3 -m isort ceph/rbd/workflows/namespace.py
python3 -m isort ceph/rbd/workflows/rbd.py
python3 -m isort cli/rbd/rbd.py
python3 -m black tests/rbd/test_rbd_namespace_remove_neg.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black tests/rbd/test_rbd_namespace_remove_pos.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black ceph/rbd/workflows/namespace.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black ceph/rbd/workflows/rbd.py
All done! ✨ 🍰 ✨
1 file left unchanged.
python3 -m black cli/rbd/rbd.py
All done! ✨ 🍰 ✨
1 file left unchanged.
yamllint -d relaxed --no-warnings suites/quincy/rbd/tier-2_rbd_namespace.yaml
yamllint -d relaxed --no-warnings suites/reef/rbd/tier-2_rbd_namespace.yaml
