### PR TITLE
[tfa-fix] Change bootstrap playbook to use registry details

### DIFF
--- a/suites/reef/cephadm/tier1-cephadm-ansible-wrapper-modules.yaml
+++ b/suites/reef/cephadm/tier1-cephadm-ansible-wrapper-modules.yaml
@@ -18,7 +18,7 @@ tests:
       module: test_cephadm_ansible_bootstrap.py
       config:
         bootstrap:
-          playbook: cephadm-bootstrap.yaml
+          playbook: bootstrap-with-registry-details.yaml
           module_args:
             mon_ip: node1
       abort-on-fail: true


### PR DESCRIPTION
# Description

### Problem:
Test suite `tier1-cephadm-ansible-wrapper-modules` is failing to pull ceph image

### Reason for Failure:
The registry details are not being populated for the image pull and hence the podman pull is failing for the ceph image during bootstrap.
```
2024-02-12 15:40:33,645 (cephci.install_prereq) [DEBUG] - cephci.Regression.dmfg.59.cephci.ceph.ceph.py:1528 - b'      registry_json: null'
2024-02-12 15:40:33,646 (cephci.install_prereq) [DEBUG] - cephci.Regression.dmfg.59.cephci.ceph.ceph.py:1528 - b'      registry_password: null'
2024-02-12 15:40:33,646 (cephci.install_prereq) [DEBUG] - cephci.Regression.dmfg.59.cephci.ceph.ceph.py:1528 - b'      registry_url: null'
2024-02-12 15:40:33,647 (cephci.install_prereq) [DEBUG] - cephci.Regression.dmfg.59.cephci.ceph.ceph.py:1528 - b'      registry_username: null'
```

### Solution:
Change the ansible wrapper playbook to use `tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-registry-details.yaml` instead of `tests/cephadm/ansible_wrapper/cephadm_bootstrap/cephadm-bootstrap.yaml`
to ensure that the registry details are populated properly.
