### PR TITLE
Adding os check in reimage and removing mero003

### DIFF
--- a/conf/reef/baremetal/mero_conf.yaml
+++ b/conf/reef/baremetal/mero_conf.yaml
@@ -14,15 +14,15 @@ globals:
             - installer
             - mon
           root_password: passwd
-        - hostname: mero003
-          id: node2
-          ip: 10.8.129.223
-          role:
-            - mds
-            - mgr
-            - mon
-            - _admin
-          root_password: passwd
+#        - hostname: mero003
+#          id: node2
+#          ip: 10.8.129.223
+#          role:
+#            - mds
+#            - mgr
+#            - mon
+#            - _admin
+#          root_password: passwd
         - hostname: mero004
           id: node3
           ip: 10.8.129.224

--- a/pipeline/scripts/ci/reimage-octo-node.sh
+++ b/pipeline/scripts/ci/reimage-octo-node.sh
@@ -47,8 +47,33 @@ while true; do
 done
 
 echo "Initiating reimage of nodes"
-${REIMAGE_CMD} --os-type rhel --os-version ${OS_VER} ${NODES}
+# Run reimage command with error handling
+if ! ${REIMAGE_CMD} --os-type rhel --os-version ${OS_VER} ${NODES}; then
+    echo "Reimage command failed, continuing with checks..."
+fi
 
+# Check OS on each node
+nodes_with_mismatch=()
+for node in ${NODES} ; do
+    echo "Checking OS on ${node}"
+    actual_os=$(ssh ubuntu@${node}.ceph.redhat.com 'cat /etc/os-release | grep VERSION_ID' | awk -F '"' '{print $2}')
+    if [ "${actual_os}" != "${OS_VER}" ]; then
+        echo "Error: OS version mismatch on ${node}. Expected: ${OS_VER}, Actual: ${actual_os}"
+        nodes_with_mismatch+=("${node}")
+    else
+        echo "OS version matches on ${node}: ${actual_os}"
+    fi
+    echo "-----------------------------------"
+done
+
+# Check if any nodes have OS mismatches
+if [ ${#nodes_with_mismatch[@]} -gt 0 ]; then
+    echo "Nodes with OS version mismatches:"
+    printf '%s\n' "${nodes_with_mismatch[@]}"
+    exit 1
+fi
+
+# Additional setup steps
 for node in ${NODES} ; do
     initial_setup "${node}"
     wipe_drives "${node}"


### PR DESCRIPTION
# Description
Adding os check in reimage and removing mero003

As part of this pr we are validating the OS on the reimaged Nodes

Logs : http://magna002.ceph.redhat.com/ceph-qe-logs/amar/reimage_error.log 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
