### PR TITLE
Perform snap create operation parallely/scale

### DIFF
--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -74,6 +74,7 @@ def create_single_image(
                     "snap_schedule_levels",
                     "snap_schedule_intervals",
                     "io_size",
+                    "num_of_snaps",
                 ]
             }
         )

--- a/suites/quincy/rbd/tier-3_rbd_snap_operations.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_snap_operations.yaml
@@ -1,0 +1,101 @@
+# Tier3: Test suite to cover RBD snap related tests in scale
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_snap_operations.yaml
+#
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - Baremetal config
+#    Node 10 must to be a client node
+tests:
+
+  # # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node10
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd -y"
+
+  - test:
+      desc: Run all image snap operations in scale
+      module: test_rbd_image_snap_operations.py
+      name: RBD image snap operations in scale
+      config:
+        rep_pool_config:
+          rbd_scale_snap_pool:
+            rbd_scale_snap_image:
+              size: 1G
+              num_of_snaps: 5
+          test_ops_parallely: true
+        ec_pool_config:
+          rbd_ec_scale_snap_pool:
+            data_pool: rbd_ec_pool
+            rbd_ec_scale_snap_image:
+              size: 1G
+              num_of_snaps: 5
+          test_ops_parallely: true

--- a/suites/reef/rbd/tier-3_rbd_snap_operations.yaml
+++ b/suites/reef/rbd/tier-3_rbd_snap_operations.yaml
@@ -1,0 +1,101 @@
+# Tier3: Test suite to cover RBD snap related tests in scale
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_snap_operations.yaml
+#
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - Baremetal config
+#    Node 10 must to be a client node
+tests:
+
+  # # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node10
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd -y"
+
+  - test:
+      desc: Run all image snap operations in scale
+      module: test_rbd_image_snap_operations.py
+      name: RBD image snap operations in scale
+      config:
+        rep_pool_config:
+          rbd_scale_snap_pool:
+            rbd_scale_snap_image:
+              size: 1G
+              num_of_snaps: 5
+          test_ops_parallely: true
+        ec_pool_config:
+          rbd_ec_scale_snap_pool:
+            data_pool: rbd_ec_pool
+            rbd_ec_scale_snap_image:
+              size: 1G
+              num_of_snaps: 5
+          test_ops_parallely: true

--- a/tests/rbd/test_rbd_image_snap_operations.py
+++ b/tests/rbd/test_rbd_image_snap_operations.py
@@ -1,0 +1,85 @@
+# This test case is to automate image snap operations
+# in scale for baremetal configuration. Image snap operations
+# covered as part of this test are - snap create
+# and verify the same
+# for multiple pools and images at scale.
+
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.snap_clone_operations import wrapper_for_image_snap_ops
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_rbd_image_snap_operations(rbd_obj, **kw):
+    """
+    This method tests the image snap operations in scale controlled by test_ops_parallely param.
+    Steps:
+    1. Get the config data for different pool_types
+    2. For each pool_type get pool, pool_config
+    3. For each pool_config get image_config
+    4. For each image_config get the num_of_snaps to create snaps parallely or sequentially
+
+    Args:
+        rbd_obj: RBD obj from initial RBD config
+        kw: any other kw args
+    """
+    log.info(f"Performing image snap operations for pool type {rbd_obj['pool_types']}")
+    rbd = rbd_obj.get("rbd")
+    for pool_type in rbd_obj.get("pool_types"):
+        rbd_config = kw.get("config", {}).get(pool_type, {})
+        multi_pool_config = getdict(rbd_config)
+        test_ops_parallely = rbd_config.get("test_ops_parallely", False)
+        for pool, pool_config in multi_pool_config.items():
+            if "data_pool" in pool_config.keys():
+                _ = pool_config.pop("data_pool")
+            for image, image_config in pool_config.items():
+                num_of_snaps = image_config.get("num_of_snaps", 2)
+                snap_names = [
+                    f"snap_{snap_suffix}" for snap_suffix in range(num_of_snaps)
+                ]
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="snap_create_list_and_verify",
+                    test_ops_parallely=test_ops_parallely,
+                )
+                if rc:
+                    log.error(f"Snap operations on the {pool}/{image} failed")
+                    return 1
+    return 0
+
+
+def run(**kw):
+    """RBD image operations testing.
+
+    Args:
+        **kw: test data
+    """
+    log.info("Running test - Testing RBD image operations.")
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_rbd_image_snap_operations(rbd_obj=rbd_obj, client=client, **kw)
+    except Exception as e:
+        log.error(f"Testing RBD image snap operations failed with the error {str(e)}")
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val


### PR DESCRIPTION
 This PR is to test the image snap operations in scale controlled by test_ops_parallely parameter.

   **Steps:**
    1. Get the config data for different pool_types
    2. For each pool_type get pool, pool_config
    3. For each pool_config get image_config
    4. For each image_config get the num_of_snaps to create snaps parallely or sequentially

**Magna logs:**

http://magna002.ceph.redhat.com:8083/snap_create_scale/

**Run Summary:**
<img width="1690" alt="image" src="https://github.com/red-hat-storage/cephci/assets/9339364/558918b8-f696-46e7-b110-8c9de4cb44c0">

**Sample log snippet showing parallel snap create:**

```
2024-02-27 09:14:43,532 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd create  --size 1G  --pool rbd_ec_scale_snap_pool --image rbd_ec_scale_snap_image --data-pool rbd_ec_pool --cluster ceph on 10.0.211.10 timeout 600
2024-02-27 09:14:44,572 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.tests.rbd.test_rbd_image_snap_operations.py:30 - Performing image snap operations for pool type ['rep_pool_config', 'ec_pool_config']
2024-02-27 09:14:44,575 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.rbd.workflows.snap_clone_operations.py:501 - Test image snap operations snap_create_list_and_verify for pool rbd_scale_snap_pool/rbd_scale_snap_image
2024-02-27 09:14:44,577 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0 on 10.0.211.10 timeout 600
2024-02-27 09:14:44,577 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_1 on 10.0.211.10 timeout 600
2024-02-27 09:14:44,577 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_2 on 10.0.211.10 timeout 600
2024-02-27 09:14:44,578 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_3 on 10.0.211.10 timeout 600
2024-02-27 09:14:44,578 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_4 on 10.0.211.10 timeout 600
2024-02-27 09:14:47,290 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.rbd.workflows.snap_clone_operations.py:116 - Snapshot creation successful in primary cluster for rbd_scale_snap_pool/rbd_scale_snap_image
2024-02-27 09:14:47,291 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap ls   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --all --format json on 10.0.211.10 timeout 600
2024-02-27 09:14:47,299 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.rbd.workflows.snap_clone_operations.py:116 - Snapshot creation successful in primary cluster for rbd_scale_snap_pool/rbd_scale_snap_image
2024-02-27 09:14:47,299 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.ceph.py:1563 - Running command rbd snap ls   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --all --format json on 10.0.211.10 timeout 600
2024-02-27 09:14:49,381 (cephci.test_rbd_image_snap_operations) [INFO] - cephci.cephci.ceph.rbd.workflows.snap_clone_operations.py:116 - Snapshot creation successful in primary cluster for rbd_scale_snap_pool/rbd_scale_snap_image
```