### PR TITLE
[Tier-3]: CEPH-83575073 [PUT Workload] Test sync bi-directional with Versioned bucket

### DIFF
--- a/suites/quincy/baremetal_pipeline/tier-1_rgw_ms.yaml
+++ b/suites/quincy/baremetal_pipeline/tier-1_rgw_ms.yaml
@@ -374,3 +374,77 @@ tests:
       desc: initiate cosbench hybrid workload
       module: push_cosbench_workload.py
       name: push cosbench hybrid workload
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../aws/test_aws.py
+            config-file-name: ../../aws/configs/test_aws_versioned_bucket_creation.yaml
+            verify-io-on-site: ["ceph-sec"]
+            timeout: 300
+      desc: create versioned bucket in primary
+      module: sanity_rgw_multisite.py
+      name: create versioned bucket in primary
+      polarion-id: CEPH-83575073
+
+  - test:
+      name: Parallel upload of objects to versioned bucket
+      desc: Parallel upload of objects to versioned bucket
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: true
+            clusters:
+              ceph-pri:
+                config:
+                  controllers:
+                    - folio01
+                  drivers: # if drivers are not specified will use one of the rgw node
+                    - folio01
+                    - folio02
+                    - folio03
+                  fill_percent: 35
+                  workload_type: symmetrical
+                  record_sync_on_site: ceph-sec
+                  bucket_prefix: cosbench01-bkt-
+                  number_of_buckets: 1
+            desc: initiate cosbench push workload from primary
+            module: push_cosbench_workload.py
+            name: push cosbench push workload from primary
+            polarion-id: CEPH-83575073
+        - test:
+            abort-on-fail: true
+            clusters:
+              ceph-sec:
+                config:
+                  controllers:
+                    - folio04
+                  drivers: # if drivers are not specified will use one of the rgw node
+                    - folio04
+                    - folio05
+                    - folio06
+                  fill_percent: 35
+                  workload_type: symmetrical
+                  record_sync_on_site: ceph-pri
+                  bucket_prefix: cosbench01-bkt-
+                  number_of_buckets: 1
+            desc: initiate cosbench push workload from secondary
+            module: push_cosbench_workload.py
+            name: push cosbench push workload from secondary
+            polarion-id: CEPH-83575073

--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -68,7 +68,14 @@ def execute(test, args, results: dict):
     """
 
     test = test.get("test")
-    config = test.get("config", dict())
+    if "clusters" in test:
+        log.info("Its a multisite setup")
+        cluster = test["clusters"].get(
+            "ceph-rgw1", test["clusters"][list(test["clusters"].keys())[0]]
+        )
+        config = cluster["config"]
+    else:
+        config = test.get("config", dict())
     config.update(args["config"])
     file_name = test.get("module")
     mod_file_name = os.path.splitext(file_name)[0]


### PR DESCRIPTION
# Description
[Tier-3]: CEPH-83575073 [PUT Workload] Test sync bi-directional with Versioned bucket
1. create versioned bucket using aws
2. perform object upload from both site parallel

create bucket : http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-XSAVYE/create_versioned_bucket_in_primary_0.log

object upload parallely for created versioned bucket: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-XSAVYE/Parallel_upload_of_objects_to_versioned_bucket_0.log


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
