### PR TITLE
Automation of the avoid ballooning client_mount_timeout(BZ#2233800)

### DIFF
--- a/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
@@ -1,0 +1,120 @@
+# Suite contains  tier-2 rados bug verification automation
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 - Bug verification  automation   ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/quincy/rados/7-node-cluster.yaml
+# Bugs:
+#     1. https://bugzilla.redhat.com/show_bug.cgi?id=2233800
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verification of the Mon ballooning
+      module: test_rados_ballooning_client.py
+      polarion-id: CEPH-83584004
+      desc: Verify MON ballooning client

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -1,0 +1,120 @@
+# Suite contains  tier-2 rados bug verification automation
+#===============================================================================================
+#------------------------------------------------------------------------------------------
+#----- Tier-2 - Bug verification  automation   ------
+#------------------------------------------------------------------------------------------
+# Conf: conf/reef/rados/7-node-cluster.yaml
+# Bugs:
+#     1. https://bugzilla.redhat.com/show_bug.cgi?id=2233800
+#===============================================================================================
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                allow-fqdn-hostname: true
+                orphan-initial-daemons: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node6
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node7                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verification of the Mon ballooning
+      module: test_rados_ballooning_client.py
+      polarion-id: CEPH-83584004
+      desc: Verify MON ballooning client

--- a/tests/rados/test_rados_ballooning_client.py
+++ b/tests/rados/test_rados_ballooning_client.py
@@ -1,0 +1,72 @@
+"""
+1. From the client node blocked the outgoing connection to the MONs. In my case, I blocked for 3 Mon's
+   Command used: iptables -A OUTPUT -d <Mon-IP>  -j DROP
+   Example on Client node:
+     [root@ceph-7-0-zmjrew-node7 ceph]# iptables -A OUTPUT -d 10.0.210.81  -j DROP
+
+3. Executed any rados cli command.
+    Example: rados df
+4. Calculated the timeout of the command.The timeout should be 5 minutes.
+
+Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2233800
+"""
+
+import datetime
+import time
+import traceback
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_object = RadosOrchestrator(node=cephadm)
+    ceph_nodes = kw.get("ceph_nodes")
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    mon_hosts = []
+    try:
+        for node in ceph_nodes:
+            if node.role == "mon":
+                mon_hosts.append(node)
+
+        log.info(f"The mon ip address are -{mon_hosts}")
+
+        for mon_node in mon_hosts:
+            log.info(f"Dropping the packets on the {mon_node.hostname} MON node")
+            if not rados_object.block_in_out_packets_on_host(
+                source_host=client, target_host=mon_node
+            ):
+                log.error(
+                    f"Failed to add IPtable rules to block {client.hostname} on {mon_node.hostname}"
+                )
+        start_time = datetime.datetime.now()
+        try:
+            rados_object.client.exec_command(cmd="ceph -s", sudo=True)
+        except Exception as err:
+            log.info(f"The exception while execution the ceph command-{err}")
+            end_time = datetime.datetime.now()
+            time_difference = end_time - start_time
+            # Actual checking time is exactly 300 seconds. As a execution time included 3 seconds more.
+            if time_difference.seconds > 303:
+                log.error(
+                    f"The time out is more than 303 seconds.The actual time out is- {time_difference.seconds}"
+                )
+                return 1
+            log.info(f"Time out for the command is -{time_difference.seconds}")
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        log.info("Execution of finally block")
+        client.exec_command(sudo=True, cmd="iptables -F", long_running=True)
+        log.debug("Sleeping for 30 seconds...")
+        time.sleep(30)
+    return 0


### PR DESCRIPTION
# Description
Automation of the following scenario:- 
1. From the client node blocked the outgoing connection to the MONs. 
   Command used: iptables -A OUTPUT -d <Mon-IP>  -j DROP
   Example on Client node:
     [root@ceph-7-0-zmjrew-node7 ceph]# iptables -A OUTPUT -d 10.0.210.81  -j DROP

3. Executed any rados cli command.
    Example: rados df
4. Calculate the timeout of the command. The timeout should be 5 minutes.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2233800
Polarion test case link:   https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83584004

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
