### PR TITLE
[Cephadm] Add test to verify OSD memory usage data

### DIFF
--- a/cli/exceptions.py
+++ b/cli/exceptions.py
@@ -69,3 +69,9 @@ class RemoteConnectionError(Exception):
     """
     Custom exception thrown when Remote Connection fails
     """
+
+
+class OsdOperationError(Exception):
+    """
+    Custom exception thrown when OSD operation fails
+    """

--- a/suites/reef/cephadm/tier2-osd-scenarios.yaml
+++ b/suites/reef/cephadm/tier2-osd-scenarios.yaml
@@ -145,3 +145,10 @@ tests:
         value: 8888888888
       polarion-id: CEPH-83575349
       abort-on-fail: true
+
+  - test:  # The test is expected fail till BZ:2259884 is fixed
+      name: Test OSD memory usage
+      desc: Verify ceph orch ps output does show an incorrect amount of used memory for OSDs
+      module: test_verify_incorrect_mem_usage.py
+      polarion-id: CEPH-83584007
+      abort-on-fail: true

--- a/tests/cephadm/test_verify_incorrect_mem_usage.py
+++ b/tests/cephadm/test_verify_incorrect_mem_usage.py
@@ -1,0 +1,53 @@
+from json import loads
+
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OsdOperationError
+from cli.utilities.utils import get_process_id
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Verify ceph orch ps output does show an incorrect amount of used memory for OSDs
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        **kw :     Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+    """
+    node = ceph_cluster.get_nodes("osd")[0]
+
+    osd_details = loads(CephAdm(node).ceph.orch.ps(daemon_type="osd", format="json"))
+    mem_usage_from_ceph = []
+    mem_usage_from_ps = []
+
+    # Get Memory usage value from ceph orch ps command
+    for item in osd_details:
+        if item.get("hostname") == node.hostname:
+            mem = int(item.get("memory_usage")) / (1024 * 1024)
+            mem_usage_from_ceph.append(int(mem))
+    mem_usage_from_ceph.sort()
+
+    # Get Memory usage value from system ps command
+    pids = get_process_id(node, "ceph-osd")
+    for pid in pids.split(" "):
+        cmd = f"ps -p {pid.strip()} -o rss="  # Get RSS value
+        rss, _ = node.exec_command(cmd=cmd, sudo=True)
+        rss = int(rss) / 1024
+        mem_usage_from_ps.append(int(rss))
+
+    # Compare the mem usage data
+    if not (mem_usage_from_ceph == mem_usage_from_ps):
+        log.error(
+            f"Memory usages returned by ceph orch ps {mem_usage_from_ceph} and ps {mem_usage_from_ps}"
+        )
+        raise OsdOperationError(
+            "Error!!! There is a mismatch in the Memory usage returned by ps and ceph orch ps"
+        )
+
+    log.info("There is no mismatch in the Memory usage returned by ps and ceph orch ps")
+    return 0


### PR DESCRIPTION
The ceph orch ps output does show an incorrect amount of used memory for OSDs when comparing with ps output

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
