### PR TITLE
Adding a comment for TFA, known issue

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -636,6 +636,7 @@ tests:
       polarion-id: CEPH-83575917
       module: sanity_rgw_multisite.py
       name: Upload 5000 objects via s3cmd to test full sync at archive
+      comments: Known issue in 7.1, Bug 2262400
   - test:
       clusters:
         ceph-pri:


### PR DESCRIPTION
# Description

Adding a comment 'Known issue in 7.1, Bug 2262400' for the 5000 upload and sync test to the archive that fails with duplicate objects.

