### PR TITLE
snap clone, remove operations parallely and scale 

### DIFF
--- a/suites/quincy/rbd/tier-3_rbd_snap_operations.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_snap_operations.yaml
@@ -85,6 +85,7 @@ tests:
       desc: Run all image snap operations in scale
       module: test_rbd_image_snap_operations.py
       name: RBD image snap operations in scale
+      polarion-id: CEPH-83584063
       config:
         rep_pool_config:
           rbd_scale_snap_pool:
@@ -97,5 +98,5 @@ tests:
             data_pool: rbd_ec_pool
             rbd_ec_scale_snap_image:
               size: 1G
-              num_of_snaps: 5
+              num_of_snaps: 500
           test_ops_parallely: true

--- a/suites/reef/rbd/tier-3_rbd_snap_operations.yaml
+++ b/suites/reef/rbd/tier-3_rbd_snap_operations.yaml
@@ -9,7 +9,7 @@
 #    Node 10 must to be a client node
 tests:
 
-  # # Setup the cluster
+  # Setup the cluster
   - test:
       abort-on-fail: true
       module: install_prereq.py
@@ -85,6 +85,7 @@ tests:
       desc: Run all image snap operations in scale
       module: test_rbd_image_snap_operations.py
       name: RBD image snap operations in scale
+      polarion-id: CEPH-83584063
       config:
         rep_pool_config:
           rbd_scale_snap_pool:
@@ -97,5 +98,5 @@ tests:
             data_pool: rbd_ec_pool
             rbd_ec_scale_snap_image:
               size: 1G
-              num_of_snaps: 5
+              num_of_snaps: 500
           test_ops_parallely: true

--- a/tests/rbd/test_rbd_image_snap_operations.py
+++ b/tests/rbd/test_rbd_image_snap_operations.py
@@ -42,6 +42,8 @@ def test_rbd_image_snap_operations(rbd_obj, **kw):
                 snap_names = [
                     f"snap_{snap_suffix}" for snap_suffix in range(num_of_snaps)
                 ]
+                # 1. Perform snap create operation, parallel is also supported
+                log.info("Test image snap create operation")
                 rc = wrapper_for_image_snap_ops(
                     rbd=rbd,
                     pool=pool,
@@ -52,8 +54,47 @@ def test_rbd_image_snap_operations(rbd_obj, **kw):
                     test_ops_parallely=test_ops_parallely,
                 )
                 if rc:
-                    log.error(f"Snap operations on the {pool}/{image} failed")
+                    log.error(f"Snap create operations on the {pool}/{image} failed")
                     return 1
+                else:
+                    log.info(f"Snap create operations on the {pool}/{image} succeeded")
+
+                # 2. Perform snap clone operation i.e which in turn calls
+                # a. protect snap b. clone snap c. flatten snap d.unprotect snap
+                # parallel is also supported
+                log.info("Test image snap clone operation")
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="clone_ops",
+                    test_ops_parallely=test_ops_parallely,
+                )
+                if rc:
+                    log.error(f"Snap clone operations on the {pool}/{image} failed")
+                    return 1
+                else:
+                    log.info(f"Snap clone operations on the {pool}/{image} succeeded")
+
+                # 3. Remove the snaps, paralle is also supported
+                log.info("Test image snap rm operation")
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="remove_snap_and_verify",
+                    test_ops_parallely=test_ops_parallely,
+                )
+                if rc:
+                    log.error(f"Snap remove operations on the {pool}/{image} failed")
+                    return 1
+                else:
+                    log.info(f"Snap remove operations on the {pool}/{image} succeeded")
+
     return 0
 
 


### PR DESCRIPTION
This PR address further extension of snap operations at scale like protect->clone->flatten->unprotect->remove.

**Steps :**

1. Create snap parallely 
Eg rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0 

2. Protect the snap parallely before cloning 
Eg rbd snap protect   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0 

3. Perform snap clone parallely 
Eg rbd clone rbd_scale_snap_pool/rbd_scale_snap_image@snap_0 rbd_scale_snap_pool/clone_SfiDL 

4. Perform snap flatten parallely 
Eg rbd flatten   --pool rbd_scale_snap_pool --image clone_SfiDL 

5.Unprotect snap parallely 
EG rbd snap unprotect   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0 

6. Remove snap parallely 
Eg rbd snap rm --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0 

**Magna log location:**

http://magna002.ceph.redhat.com:8083/snap_clone_remove_scale/

**Test Summary:**

<img width="1706" alt="image" src="https://github.com/red-hat-storage/cephci/assets/9339364/a9f16d79-15f9-44c7-9ae7-276174d2209a">




