### PR TITLE
fixing ingress daemon failures on reef using rhos-01 floating ip as vip

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -163,26 +163,7 @@ tests:
                       - node4
                   spec:
                     backend_service: rgw.rgw.realm1
-                    virtual_ip: 127.1.1.100/8
-                    virtual_interface_networks:
-                      # rhos-d network id's
-                      - '10.0.208.0/22'  # provider_net_cci_12
-                      - '10.0.204.0/22'  # provider_net_cci_11
-                      - '10.0.108.0/22'  # provider_net_cci_9
-                      - '10.0.104.0/22'  # provider_net_cci_8
-                      - '10.0.100.0/22'  # provider_net_cci_7
-                      - '10.0.96.0/22'  # provider_net_cci_6
-                      - '10.0.152.0/22'  # provider_net_cci_5
-                      - '10.0.148.0/22'  # provider_net_cci_4
-                      # rhos-01 network id's
-                      - '10.0.195.0/24'  # shared_net_12
-                      - '10.0.194.0/24'  # shared_net_11
-                      - '10.0.192.0/24'  # shared_net_9
-                      - '10.0.191.0/24'  # shared_net_8
-                      - '10.0.190.0/24'  # shared_net_7
-                      - '10.0.189.0/24'  # shared_net_6
-                      - '10.0.188.0/24'  # shared_net_5
-                      - '10.0.201.0/24'  # shared_net_4
+                    virtual_ip: 10.0.195.174/24 # floating ip1 in rhos-01
                     frontend_port: 443
                     monitor_port: 1967
                     ssl_cert: create-cert
@@ -208,25 +189,6 @@ tests:
                       - node6
                   spec:
                     backend_service: rgw.rgw.realm2
-                    virtual_ip: 127.1.1.200/8
-                    virtual_interface_networks:
-                      # rhos-d network id's
-                      - '10.0.208.0/22'  # provider_net_cci_12
-                      - '10.0.204.0/22'  # provider_net_cci_11
-                      - '10.0.108.0/22'  # provider_net_cci_9
-                      - '10.0.104.0/22'  # provider_net_cci_8
-                      - '10.0.100.0/22'  # provider_net_cci_7
-                      - '10.0.96.0/22'  # provider_net_cci_6
-                      - '10.0.152.0/22'  # provider_net_cci_5
-                      - '10.0.148.0/22'  # provider_net_cci_4
-                      # rhos-01 network id's
-                      - '10.0.195.0/24'  # shared_net_12
-                      - '10.0.194.0/24'  # shared_net_11
-                      - '10.0.192.0/24'  # shared_net_9
-                      - '10.0.191.0/24'  # shared_net_8
-                      - '10.0.190.0/24'  # shared_net_7
-                      - '10.0.189.0/24'  # shared_net_6
-                      - '10.0.188.0/24'  # shared_net_5
-                      - '10.0.201.0/24'  # shared_net_4
+                    virtual_ip: 10.0.195.111/24 # floating ip2 in rhos-01
                     frontend_port: 8083
                     monitor_port: 1967


### PR DESCRIPTION
the below ip addresses under shared_net_12 are reserved as floating ip's in rhos-01
10.0.195.174/24
10.0.195.111/24

loop back address is not working as vip on reef
fail log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.0-152/Weekly/rgw/25/tier-2_rgw_ingress_multi_realm/Deploy_RGW_Ingress_daemon_with_SSL_0.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
