### PR TITLE
Clone scale operations for a snapshot of an image

### DIFF
--- a/ceph/rbd/workflows/krbd_io_handler.py
+++ b/ceph/rbd/workflows/krbd_io_handler.py
@@ -194,7 +194,7 @@ def krbd_io_handler(**kw):
                     }
                     if operations.get("device_map"):
                         cleanup_config.update(
-                            {"device_type": config.get("device_type", "nbd")}
+                            {"device-type": config.get("device_type", "nbd")}
                         )
                     return_flag = device_cleanup(**cleanup_config)
     kw["config"]["device_names"] = device_names

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -75,6 +75,7 @@ def create_single_image(
                     "snap_schedule_intervals",
                     "io_size",
                     "num_of_snaps",
+                    "num_of_clones",
                 ]
             }
         )
@@ -684,6 +685,7 @@ def run_io_and_check_rbd_status(**kw):
         image_spec = f"{pool}/{image}"
         image_conf = kw.pop("image_conf", {})
         client = kw.get("client")
+        timeout = kw.get("timeout", 120)
         test_ops_parallely = kw.get("test_ops_parallely", False)
         if image_conf.get("io_size"):
             io_size = image_conf.get("io_size")
@@ -716,7 +718,7 @@ def run_io_and_check_rbd_status(**kw):
         }
         with parallel() as p:
             p.spawn(krbd_io_handler, **io_config)
-            p.spawn(check_rbd_status, rbd=rbd, pool=pool, image=image, timeout=120)
+            p.spawn(check_rbd_status, rbd=rbd, pool=pool, image=image, timeout=timeout)
 
         out, err = rbd.status(pool=pool, image=image, format="json")
         if err:

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -371,3 +371,19 @@ class Rbd(Cli):
         cmd = f"{self.base_cmd} rename {image_spec} {dest_spec} {build_cmd_from_args(**kw_copy)}"
 
         return self.execute_as_sudo(cmd=cmd, check_ec=False, long_running=False)
+
+    def du(self, **kw):
+        """
+        Display usage of images/snapshots/clones in a pool
+        kw(dict): Key/value pairs that needs to be provided
+        Example supported keys:
+            pool(str): <pool-name>
+            namespace(str): <namespace-name>
+            image(str): <image-name>
+            snap(str): <snap-name>
+            format(str): <format-type>
+            image-or-snap-spec: [<pool-name>/[<namespace>]/<image>/[<snap>]]
+        """
+        cmd = f"{self.base_cmd} du {build_cmd_from_args(**kw)}"
+
+        return self.execute_as_sudo(cmd=cmd)

--- a/suites/quincy/rbd/tier-3_rbd_snap_clone_operations.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_snap_clone_operations.yaml
@@ -1,0 +1,104 @@
+# Tier3: Test suite to cover RBD clone related tests in scale
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_snap_clone_operations.yaml
+#
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - Baremetal config
+#    Node 10 must to be a client node
+tests:
+
+  # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node10
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd -y"
+
+  - test:
+      desc: Run all image snap clone operations in scale
+      module: test_rbd_image_snap_clone_operations.py
+      name: RBD image snap clone operations in scale
+      polarion-id: CEPH-83584436
+      config:
+        rep_pool_config:
+          rbd_scale_snap_pool:
+            rbd_scale_snap_image:
+              size: 4G
+              num_of_clones: 500
+          test_ops_parallely: true
+        ec_pool_config:
+          rbd_ec_scale_snap_pool:
+            data_pool: rbd_ec_pool
+            rbd_ec_scale_snap_image:
+              size: 4G
+              num_of_clones: 500
+          test_ops_parallely: true
+        fio:
+          size: 100M

--- a/suites/reef/rbd/tier-3_rbd_snap_clone_operations.yaml
+++ b/suites/reef/rbd/tier-3_rbd_snap_clone_operations.yaml
@@ -1,0 +1,104 @@
+# Tier3: Test suite to cover RBD clone related tests in scale
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_snap_clone_operations.yaml
+#
+# Ceph RBD component.
+#
+# Cluster Configuration:
+#    Conf file - Baremetal config
+#    Node 10 must to be a client node
+tests:
+
+  # Setup the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node10
+        install_packages:
+          - ceph-common
+          - fio
+        copy_admin_keyring: true
+      desc: Configure client node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd -y"
+
+  - test:
+      desc: Run all image snap clone operations in scale
+      module: test_rbd_image_snap_clone_operations.py
+      name: RBD image snap clone operations in scale
+      polarion-id: CEPH-83584436
+      config:
+        rep_pool_config:
+          rbd_scale_snap_pool:
+            rbd_scale_snap_image:
+              size: 4G
+              num_of_clones: 500
+          test_ops_parallely: true
+        ec_pool_config:
+          rbd_ec_scale_snap_pool:
+            data_pool: rbd_ec_pool
+            rbd_ec_scale_snap_image:
+              size: 4G
+              num_of_clones: 500
+          test_ops_parallely: true
+        fio:
+          size: 100M

--- a/tests/rbd/test_rbd_image_snap_clone_operations.py
+++ b/tests/rbd/test_rbd_image_snap_clone_operations.py
@@ -1,0 +1,186 @@
+# This test case is to automate image clone operations per snap
+# in scale for baremetal configuration. Image snap clone operations
+# covered as part of this test are - snap create
+# and verify the same
+# for multiple pools and images at scale.
+
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.rbd import wrapper_for_image_ops
+from ceph.rbd.workflows.snap_clone_operations import wrapper_for_image_snap_ops
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def test_rbd_image_snap_clone_operations(rbd_obj, client, **kw):
+    """
+    This method tests the image snap operations in scale controlled by test_ops_parallely param.
+    Steps:
+    1. Get the config data for different pool_types
+    2. For each pool_type get pool, pool_config and run IO
+    3. For each pool_config get image_config
+    4. For a give snap or list of snaps
+    5. For each image_config/snap_name get the num_of_clones to create clones parallely or sequentially
+
+    Args:
+        rbd_obj: RBD obj from initial RBD config
+        client: client node
+        kw: any other kw args
+    """
+    log.info(
+        f"Performing image snap clone operations for pool type {rbd_obj['pool_types']}"
+    )
+    rbd = rbd_obj.get("rbd")
+    for pool_type in rbd_obj.get("pool_types"):
+        rbd_config = kw.get("config", {}).get(pool_type, {})
+        multi_pool_config = getdict(rbd_config)
+        test_ops_parallely = rbd_config.get("test_ops_parallely", False)
+        for pool, pool_config in multi_pool_config.items():
+            if "data_pool" in pool_config.keys():
+                _ = pool_config.pop("data_pool")
+            log.info(f"Run IOs and verify rbd status for images in pool {pool}")
+            rc = wrapper_for_image_ops(
+                rbd=rbd,
+                pool=pool,
+                image_config=pool_config,
+                client=client,
+                ops_module="ceph.rbd.workflows.rbd",
+                ops_method="run_io_and_check_rbd_status",
+                test_ops_parallely=test_ops_parallely,
+            )
+            if rc:
+                log.error(f"Run IOs and verify rbd status failed for pool {pool}")
+                return 1
+            for image, image_config in pool_config.items():
+                num_of_snaps = image_config.get("num_of_snaps", 1)
+                snap_names = [
+                    f"snap_{snap_suffix}" for snap_suffix in range(num_of_snaps)
+                ]
+                # 1. Perform snap create operation, parallel is also supported
+                log.info("Test image snap create operation")
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="snap_create_list_and_verify",
+                    test_ops_parallely=False,
+                )
+                if rc:
+                    log.error(f"Snap create operations on the {pool}/{image} failed")
+                    return 1
+                else:
+                    log.info(f"Snap create operations on the {pool}/{image} succeeded")
+
+                # 2. Protect the snaps before clone operation
+
+                log.info("Protecting the snap")
+                clone_operations_kw = {
+                    "protect_snap": True,
+                    "create_clone": False,
+                    "unprotect_snap": False,
+                    "flatten_clone": False,
+                }
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="clone_ops",
+                    test_ops_parallely=test_ops_parallely,
+                    operations=clone_operations_kw,
+                )
+                if rc:
+                    log.error(f"Snap protect operations on the {pool}/{image} failed")
+                    return 1
+                else:
+                    log.info(f"Snap protect operations on the {pool}/{image} succeeded")
+
+                # 3. Perform snap clone operation per snap
+                # parallel is also supported
+                log.info("Test image snap clone operation")
+                num_of_clones = image_config.get("num_of_clones", 2)
+                _snap_names = list()
+                _snap_names = [
+                    _snap_names.extend(snap_names) for _ in range(num_of_clones)
+                ]
+                clone_operations_kw = {
+                    "protect_snap": False,
+                    "create_clone": True,
+                    "unprotect_snap": False,
+                    "flatten_clone": True,
+                }
+
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=_snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="clone_ops",
+                    test_ops_parallely=test_ops_parallely,
+                    operations=clone_operations_kw,
+                )
+                if rc:
+                    log.error(f"Snap clone operations on the {pool}/{image} failed")
+                    return 1
+                else:
+                    log.info(f"Snap clone operations on the {pool}/{image} succeeded")
+
+                # 4. Remove the snaps, parallel is also supported
+                log.info("Test image snap rm operation")
+                rc = wrapper_for_image_snap_ops(
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_names=snap_names,
+                    ops_module="ceph.rbd.workflows.snap_clone_operations",
+                    ops_method="remove_snap_and_verify",
+                    test_ops_parallely=False,
+                    protected="true",
+                )
+                if rc:
+                    log.error(f"Snap remove operations on the {pool}/{image} failed")
+                    return 1
+                else:
+                    log.info(f"Snap remove operations on the {pool}/{image} succeeded")
+
+    return 0
+
+
+def run(**kw):
+    """RBD image snap clone operations testing.
+
+    Args:
+        **kw: test data
+    """
+    log.info("Running test - Testing RBD image snap clone operations.")
+
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_rbd_image_snap_clone_operations(
+            rbd_obj=rbd_obj, client=client, **kw
+        )
+    except Exception as e:
+        log.error(
+            f"Testing RBD image snap clone operations failed with the error {str(e)}"
+        )
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val


### PR DESCRIPTION
This test the clone operations at scale for a given snapshot. All details of testcase is covered in https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83584436.

**Steps**:

1. Create snap Eg rbd snap create   --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0
2. Perform snap clone parallely Eg rbd clone rbd_scale_snap_pool/rbd_scale_snap_image@snap_0 rbd_scale_snap_pool/clone_SfiDL
3. 3. Remove snap Eg rbd snap rm --pool rbd_scale_snap_pool --image rbd_scale_snap_image --snap snap_0

**Run Summary:**
<img width="1711" alt="image" src="https://github.com/red-hat-storage/cephci/assets/9339364/44c60448-cb91-4981-aa79-fe4d62df5729">

**Magna logs location:**

http://magna002.ceph.redhat.com:8083/clone_scale/
