### PR TITLE
[tfa-fix] Add purge cluster in suite for cluster redeployment

### DIFF
--- a/suites/reef/cephadm/tier1-cephadm-ansible-wrapper-bootstrap-with-custom-ssh.yaml
+++ b/suites/reef/cephadm/tier1-cephadm-ansible-wrapper-bootstrap-with-custom-ssh.yaml
@@ -24,6 +24,12 @@ tests:
             ssh_user: cephuser
 
   - test:
+      name: Delete cluster using cephadm rm-cluster command
+      desc:  Verify cluster purge via cephamd commands
+      polarion-id: CEPH-83573765
+      module: test_remove_cluster.py
+
+  - test:
       name: Bootstrap cluster using cephadm-ansible wrapper modules
       desc: Execute 'bootstrap-with-exisitng-keys.yaml' playbook
       polarion-id: CEPH-83575205


### PR DESCRIPTION
# Description

### Problem:
Test suite `tier1-cephadm-ansible-wrapper-bootstrap-with-custom-ssh` failed to perform bootstrap.

### Reason for Failure:
The initial bootstrap was not cleaned up before redeployment of the cluster using different cephadm-ansible module.

### Solution:
Added a purge cluster between the deployments to ensure the bootstrap is done in a clean cluster.