### PR TITLE
[tfa-fix] Remove dashboard parameter from the bootstrap modules

### DIFF
--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-custom-ssh.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-custom-ssh.yaml
@@ -8,7 +8,6 @@
       cephadm_bootstrap:
         mon_ip: "{{ mon_ip }}"
         image: "{{ image | default(False) }}"
-        dashboard: "{{ dashboard | default(True) }}"
         monitoring: "{{ monitoring | default(False) }}"
         firewalld: "{{ firewalld | default(False) }}"
         ssh_user: "{{ ssh_user }}"

--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-exisitng-keys.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-exisitng-keys.yaml
@@ -7,5 +7,4 @@
     - name: Bootstrap cluster overriding existing keys
       cephadm_bootstrap:
         mon_ip: "{{ mon_ip }}"
-        dashboard: "{{ dashboard | default(True) }}"
         allow_overwrite: "{{ allow_overwrite | default(False) }}"

--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/cephadm-bootstrap.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/cephadm-bootstrap.yaml
@@ -9,6 +9,5 @@
         docker: "{{ docker | default(False) }}"
         image: "{{ image | default(False) }}"
         mon_ip: "{{ mon_ip }}"
-        dashboard: "{{ dashboard | default(True) }}"
         monitoring: "{{ monitoring | default(False) }}"
         firewalld: "{{ firewalld | default(False) }}"


### PR DESCRIPTION
# Description

### Problem:
Test suite `tier2-permissive-mode-scenarios` failed to perform bootstrap with error `cephadm: error: unrecognized arguments: --dashboard-user`

### Reason for Failure:
When providing the "dashboard" parameter to the cephadm-ansible modules for bootstrap, we encounter the above error and a bug has been raised for the same : https://bugzilla.redhat.com/show_bug.cgi?id=2267865

### Solution:
The dashboard is enabled by default in deployments so the parameter can be removed from the bootstrap modules.
The test suites which use the modules do not involve any dashboard specific testing so removing the parameter will not affect the tests.