### PR TITLE
Test to integrate LDAP users with RGW on containerised ceph

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ldap_integration.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ldap_integration.yaml
@@ -1,0 +1,161 @@
+# Tier 2: CEPH-9793
+#
+# This test suite integrates RGW with LDAP authentication of users
+# Prereq - We need a LDAP server with users configured
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm.
+      polarion-id: CEPH-83573713
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: prometheus
+                  placement:
+                    count: 1
+                    nodes:
+                      - node1
+                - service_type: grafana
+                  placement:
+                    nodes:
+                      - node1
+                - service_type: alertmanager
+                  placement:
+                    count: 1
+                - service_type: node-exporter
+                  placement:
+                    host_pattern: "*"
+                - service_type: crash
+                  placement:
+                    host_pattern: "*"
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: rgw
+        sudo: true
+        commands:
+          - "echo '1*redhat' >/etc/bindpass"
+      desc: Copy Ldap bind password
+      module: exec.py
+      name: Copy Ldap bind password
+
+# deploy RGW with bindpass patched through to container
+  - test:
+      name: Service deployment with spec
+      desc: Add services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574887
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              specs:
+                - service_type: rgw
+                  service_id: rgw.1
+                  placement:
+                    nodes:
+                      - node5
+                  spec:
+                    rgw_frontend_port: 80
+                  extra_container_args:
+                    - "-v /etc/bindpass:/etc/bindpass"
+
+  - test:
+      abort-on-fail: true
+      config:
+        cephadm: true
+        commands:
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_ldap_binddn cn=RGW"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_ldap_dnattr uid"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_ldap_searchdn ou=ceph,dc=ceph-amk-test-r5ozm1-node8"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_ldap_secret /etc/bindpass"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_ldap_uri ldap://10.0.209.121:389"
+          - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_s3_auth_use_ldap true"
+          - "ceph orch restart {service_name:rgw.1}"
+      desc: Configure the conf options needed for LDAP authentication
+      module: exec.py
+      name: LDAP Config options set
+
+  - test:
+      name: Test LDAP auth for RGW
+      desc: Test LDAP auth for RGW
+      polarion-id: CEPH-9793
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_ldap_auth.py
+        config-file-name: ../../aws/configs/test_ldap_auth.yaml
+        timeout: 300


### PR DESCRIPTION
Steps : 
- Create a RGW service from spec after passing the bind password as an extra argument
- Base encode the ldap token from json
- Query RGW using s3cmd with the base encoded token as the access key
- Create a bucket on the LDAP user obtained.

Pass log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/tejas/cephci-run-VVHULL/