### PR TITLE
Adding NFS extensa config file

### DIFF
--- a/conf/baremetal/nfs_extensa_1admin_3node_4client.yaml
+++ b/conf/baremetal/nfs_extensa_1admin_3node_4client.yaml
@@ -1,0 +1,85 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      networks:
+        public: ['10.8.128.0/21']
+      nodes:
+        - hostname: extensa005
+          ip: 10.8.130.205
+          id: node1
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - osd
+            - node-exporter
+            - alertmanager
+            - grafana
+            - prometheus
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+        - hostname: extensa006
+          ip: 10.8.130.206
+          id: node2
+          root_password: passwd
+          role:
+            - osd
+            - mon
+            - mgr
+            - mds
+            - node-exporter
+            - alertmanager
+            - crash
+            - rgw
+            - nfs
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+        - hostname: extensa007
+          ip: 10.8.130.207
+          id: node3
+          root_password: passwd
+          role:
+            - mon
+            - osd
+            - node-exporter
+            - crash
+            - rgw
+            - mds
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+        - hostname: extensa003
+          ip: 10.8.130.203
+          id: node4
+          root_password: passwd
+          role:
+            - client
+        - hostname: extensa004
+          ip: 10.8.130.204
+          id: node5
+          root_password: passwd
+          role:
+            - client
+        - hostname: extensa008
+          ip: 10.8.130.208
+          id: node6
+          root_password: passwd
+          role:
+            - client
+        - hostname: extensa009
+          ip: 10.8.130.209
+          id: node7
+          root_password: passwd
+          role:
+            - client

--- a/suites/reef/baremetal/deploy/nfs_extensa_3node_4client.yaml
+++ b/suites/reef/baremetal/deploy/nfs_extensa_3node_4client.yaml
@@ -1,0 +1,144 @@
+---
+tests:
+  - test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          - config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          - config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          - config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          - config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  - test:
+      name: Configure OSD
+      module: homogenous_osd_cluster.py
+      desc: Deploy OSDs on specifc devices on the node.
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node4
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node5
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+        node: node6
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+        node: node7
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: false
+      desc: "Fill the cluster with specific percentage"
+      name: "Fill Cluster"
+      module: test_io.py
+      config:
+        wait_for_io: True
+        cephfs:
+          "fill_data": 10
+          "num_of_clients": 4
+          "io_tool": "smallfile"
+          "mount": "fuse"
+          "batch_size": 30
+          "filesystem": "cephfs_io_2"
+          "mount_dir": ""

--- a/suites/reef/baremetal/upgrade/rh_nfs_extensa_3node_4client.yaml
+++ b/suites/reef/baremetal/upgrade/rh_nfs_extensa_3node_4client.yaml
@@ -1,0 +1,27 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Validate the ceph version before upgrade"
+      module: validate_version.py
+      config:
+        env_type: "RH"
+      name: "Validate the ceph version before upgrade"
+  - test:
+      name: Upgrade ceph
+      desc: Upgrade cluster to latest version
+      module: cephadm.test_cephadm_upgrade.py
+      polarion-id: CEPH-83574638
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        benchmark:
+          type: rados                      # future-use
+          pool_per_client: true
+          pg_num: 128
+          duration: 10
+        verify_cluster_health: true
+      destroy-cluster: false


### PR DESCRIPTION
# Description

Adding NFS extensa config file.


cluster:
    id:     590506da-dba4-11ee-9ac5-ac1f6bb2708c
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum extensa005,extensa007,extensa006 (age 75m)
    mgr: extensa005.tgiyxp(active, since 78m), standbys: extensa006.uxtvuv
    mds: 3/3 daemons up, 1 standby
    osd: 12 osds: 12 up (since 68m), 12 in (since 68m); 25 remapped pgs
 
  data:
    volumes: 2/2 healthy
    pools:   5 pools, 801 pgs
    objects: 443.49k objects, 401 GiB
    usage:   1.2 TiB used, 42 TiB / 44 TiB avail
    pgs:     71453/1330467 objects misplaced (5.371%)
             765 active+clean
             23  active+remapped+backfill_wait
             8   active+clean+scrubbing
             3   active+clean+scrubbing+deep
             2   active+remapped+backfilling
 
  io:
    client:   0 B/s rd, 102 MiB/s wr, 4 op/s rd, 1.03k op/s wr
    recovery: 2.3 MiB/s, 55 keys/s, 9 objects/s
