### PR TITLE
CEPH-83571692: Extending coverage for non-collocated operations with CBT

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3151,3 +3151,22 @@ class RadosOrchestrator:
         """
         base_cmd = f"ceph tell osd.{osd_id} perf dump"
         return self.run_ceph_command(cmd=base_cmd)
+
+    def get_available_devices(self, node, device_type):
+        """
+        Method to fetch list of available device paths in the provided node.
+            Args:
+                node: node hostname
+                device_type: hdd or ssd or nvme
+            Returns:
+                available device path list of the node.
+        """
+        device_paths = []
+        available_device_list = self.get_orch_device_list(node)
+        for path_list in available_device_list[0]["devices"]:
+            if (
+                path_list["human_readable_type"] == device_type
+                and path_list["available"] is True
+            ):
+                device_paths.append(path_list["path"])
+        return device_paths

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -2618,9 +2618,9 @@ class RadosOrchestrator:
         """
 
         if node is None:
-            cmd_orch_device = "ceph orch device ls"
+            cmd_orch_device = "ceph orch device ls --refresh"
         else:
-            cmd_orch_device = f"ceph orch device ls  {node}"
+            cmd_orch_device = f"ceph orch device ls {node} --refresh"
 
         orch_device_output = self.run_ceph_command(cmd=cmd_orch_device)
         return orch_device_output

--- a/cli/utilities/windows_utils.py
+++ b/cli/utilities/windows_utils.py
@@ -1,0 +1,58 @@
+from socket import socket
+
+from paramiko.ssh_exception import SSHException
+
+from ceph.ceph import SocketTimeoutException, SSHConnectionManager
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def establish_windows_client_conn(windows_clients):
+    """
+    Establishes connection to the given windows clients
+    Args:
+        windows_clients(dict(dict)): Dict containing ip address and user creds of windows nodes
+                               e.g: {"10.70.1.1":{"user":"root",
+                                                  "password": "passwd"},
+                                     "10.70.1.2":{"user":"user1",
+                                                  "password": "passwd"}}
+    """
+    win_clients = []
+    for ip, user_creds in windows_clients.items():
+        # If user is not specified, use root
+        user = user_creds["user"] if "user" in user_creds.keys() else "root"
+        root_connection = SSHConnectionManager(ip, user, user_creds["password"])
+        win_clients.append(root_connection.get_client)
+
+    return win_clients
+
+
+def execute_command_on_windows_node(node, cmd):
+    """
+    Executes command on given windows node
+    Args:
+        node(SSHConnectionManager): Node details
+        cmd(str): Command to execute
+    """
+    stdout = str()
+    stderr = str()
+    _stdout = None
+    _stderr = None
+    try:
+        log.info(f"Running command {cmd} on windows node")
+        _, _stdout, _stderr = node().exec_command(cmd, timeout=60)
+        for line in _stdout:
+            if line:
+                stdout += line
+        for line in _stderr:
+            if line:
+                stderr += line
+        log.info(f"stdout: {stdout}")
+        log.info(f"stderr: {stderr}")
+    except socket.timeout as sock_err:
+        log.error("socket.timeout happened while connecting to the node")
+        node().close()
+        raise SocketTimeoutException(sock_err)
+    except SSHException as e:
+        log.error("SSHException during cmd: %s", str(e))

--- a/conf/pacific/rados/11-node-cluster.yaml
+++ b/conf/pacific/rados/11-node-cluster.yaml
@@ -22,6 +22,7 @@ globals:
           - node-exporter
           - alertmanager
           - crash
+          - nfs
       node3:
         role:
           - osd
@@ -50,6 +51,7 @@ globals:
           - mds
           - node-exporter
           - crash
+          - nfs
       node7:
         role:
           - client

--- a/conf/quincy/rados/11-node-cluster.yaml
+++ b/conf/quincy/rados/11-node-cluster.yaml
@@ -22,6 +22,7 @@ globals:
           - node-exporter
           - alertmanager
           - crash
+          - nfs
       node3:
         role:
           - osd
@@ -50,6 +51,7 @@ globals:
           - mds
           - node-exporter
           - crash
+          - nfs
       node7:
         role:
           - client

--- a/conf/reef/rados/11-node-cluster.yaml
+++ b/conf/reef/rados/11-node-cluster.yaml
@@ -22,6 +22,7 @@ globals:
           - node-exporter
           - alertmanager
           - crash
+          - nfs
       node3:
         role:
           - osd
@@ -50,6 +51,7 @@ globals:
           - mds
           - node-exporter
           - crash
+          - nfs
       node7:
         role:
           - client

--- a/suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,10 +1,9 @@
-# Suite contains basic tier-2 rados tests
 #===============================================================================================
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
 # Conf: conf/pacific/rados/7-node-cluster.yaml
-#
+# Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
   - test:
@@ -17,7 +16,7 @@ tests:
       name: cluster deployment
       desc: Execute the cluster deployment workflow.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574887
       config:
         verify_cluster_health: true
         steps:
@@ -48,19 +47,63 @@ tests:
               args:
                 placement:
                   label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -69,22 +112,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -112,10 +139,56 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,10 +1,9 @@
-# Suite contains basic tier-2 rados tests
 #===============================================================================================
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
 # Conf: conf/quincy/rados/7-node-cluster.yaml
-#
+# Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
   - test:
@@ -17,7 +16,7 @@ tests:
       name: cluster deployment
       desc: Execute the cluster deployment workflow.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574887
       config:
         verify_cluster_health: true
         steps:
@@ -48,19 +47,63 @@ tests:
               args:
                 placement:
                   label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -69,22 +112,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -112,10 +139,56 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/reef/nfs/tier1-nfs-ganesha-windows-clients.yaml
+++ b/suites/reef/nfs/tier1-nfs-ganesha-windows-clients.yaml
@@ -1,0 +1,97 @@
+#===============================================================================================
+#------------------------------------------------------------
+#---    Test Suite for Nfs Ganesha with Windows clients   ---
+#------------------------------------------------------------
+# Conf: conf/reef/nfs/1admin-3client-7node.yaml
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      desc: bootstrap and deploy services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: Deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        copy_admin_keyring: true
+      desc: Configure the RGW,RBD client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      name: Nfs Verify nfs mount on windows client
+      module: nfs_verify_windows_client.py
+      desc: Verify accessing and performing mount on windows client
+      polarion-id:
+      abort-on-fail: false
+      config:
+        nfs_version: 3
+        clients: 1
+        win-clients:
+          - ip: 10.70.45.148
+            user: manisha
+            password: Redhat

--- a/suites/reef/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/reef/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,10 +1,9 @@
-# Suite contains basic tier-2 rados tests
 #===============================================================================================
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
 # Conf: conf/reef/rados/7-node-cluster.yaml
-#
+# Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
   - test:
@@ -17,7 +16,7 @@ tests:
       name: cluster deployment
       desc: Execute the cluster deployment workflow.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574887
       config:
         verify_cluster_health: true
         steps:
@@ -48,19 +47,63 @@ tests:
               args:
                 placement:
                   label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -69,22 +112,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -112,10 +139,56 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
 
   - test:
       name: ceph-objectstore-tool utility

--- a/tests/misc_env/lvm_deployer.py
+++ b/tests/misc_env/lvm_deployer.py
@@ -1,3 +1,4 @@
+import random
 from copy import deepcopy
 from time import sleep
 
@@ -40,19 +41,21 @@ def find_storage_unit(value):
         return f"{metric}T"
 
 
-def create_lvms(node, count, size):
+def create_lvms(node, count, size, devices=None):
     """Create LVs on node.
 
     Args:
         node: CephNode obj
         count: number of LVMs
         size: LVM size
+        devices: custom volume list
     """
-    vg_name = "data_vg"
+    vg_name = "data_vg" + str(random.randrange(10))
     if not hasattr(node, "volume_list"):
         raise Exception(f"{node.hostname} has no volume_list!!!")
 
-    devices = [vol.path for vol in node.volume_list]
+    if not devices:
+        devices = [vol.path for vol in node.volume_list]
     pvcreate(node, " ".join(devices))
     vgcreate(node, vg_name, " ".join(devices))
     lvms = []
@@ -63,6 +66,7 @@ def create_lvms(node, count, size):
         )
         lvms.append(f"/dev/{vg_name}/lv{i}")
     node.volume_list = deepcopy(lvms)
+    return lvms
 
 
 def run(ceph_cluster, **kw):

--- a/tests/nfs/nfs_verify_windows_client.py
+++ b/tests/nfs/nfs_verify_windows_client.py
@@ -1,0 +1,89 @@
+from nfs_operations import cleanup_cluster, setup_nfs_cluster
+
+from cli.exceptions import ConfigError
+from cli.utilities.windows_utils import (
+    establish_windows_client_conn,
+    execute_command_on_windows_node,
+)
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Verify NFS HA cluster creation
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test.
+    """
+    config = kw.get("config")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    clients = ceph_cluster.get_nodes("client")
+
+    port = config.get("port", "2049")
+    version = config.get("nfs_version", "4.2")
+    no_clients = int(config.get("clients", "2"))
+    no_servers = int(config.get("servers", "1"))
+    ha = bool(config.get("ha", False))
+    vip = config.get("vip", None)
+    windows_clients = config.get("win-clients", None)
+    win_clients = []
+
+    # If the setup doesn't have required number of clients, exit.
+    if no_clients > len(clients):
+        raise ConfigError("The test requires more clients than available")
+
+    if no_servers > len(nfs_nodes):
+        raise ConfigError("The test requires more servers than available")
+
+    clients = clients[:no_clients]  # Select only the required number of clients
+    servers = nfs_nodes[:no_servers]
+    fs_name = "cephfs"
+    nfs_name = "cephfs-nfs"
+    nfs_export = "/export"
+    nfs_mount = "/mnt/nfs"
+    fs = "cephfs"
+    nfs_server_name = [nfs_node.hostname for nfs_node in servers]
+    if windows_clients:
+        for wn in windows_clients:
+            win_nodes = {
+                wn.get("ip"): {
+                    "user": wn.get("user"),
+                    "password": wn.get("password"),
+                }
+            }
+            win_clients = establish_windows_client_conn(windows_clients=win_nodes)
+
+    try:
+        # Setup nfs cluster
+        setup_nfs_cluster(
+            clients,
+            nfs_server_name,
+            port,
+            version,
+            nfs_name,
+            nfs_mount,
+            fs_name,
+            nfs_export,
+            fs,
+            ha,
+            vip,
+            ceph_cluster=ceph_cluster,
+        )
+        # If windows clients are present, perform mount
+        if win_clients:
+            cmd = f"mount {nfs_nodes[0].ip_address}:/export_0 Z:"
+            execute_command_on_windows_node(win_clients[0], cmd)
+
+        log.info("Successfully setup NFS HA cluster")
+
+        # Mount windows client
+    except Exception as e:
+        log.error(f"Failed to setup nfs ha cluster {e}")
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+        return 1
+    finally:
+        # Unmount windows mount
+        cmd = r"umount Z:"
+        execute_command_on_windows_node(win_clients[0], cmd)
+        cleanup_cluster(clients, nfs_mount, nfs_name, nfs_export)
+    return 0

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -33,7 +33,6 @@ def run(ceph_cluster, **kw):
     *** Currently, covers commands/workflows valid only for collocated OSDs
     Commands reserved for future coverage with non-collocated OSDs:
     - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
-    - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
     - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
     - ceph-bluestore-tool bluefs-bdev-migrate --path osd path --dev-target new-device --devs-source device1
     - ceph-bluestore-tool restore_cfb --path osd path
@@ -44,143 +43,208 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+    client = ceph_cluster.get_nodes(role="client")[0]
 
     out, _ = cephadm.shell(args=["ceph osd ls"])
     osd_list = out.strip().split("\n")
 
     try:
-        # Execute ceph-bluestore-tool --help
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Running cbt help for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.help(osd_id=osd_id)
-        log.info(out)
-
-        # Execute ceph-bluestore-tool fsck --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Running consistency check for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.run_consistency_check(osd_id=osd_id)
-        log.info(out)
-        assert "success" in out
-
-        # Execute ceph-bluestore-tool fsck --deep --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Running deep consistency check for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.run_consistency_check(osd_id=osd_id, deep=True)
-        log.info(out)
-        assert "success" in out
-
-        if rhbuild.split(".")[0] >= "6":
-            # Execute ceph-bluestore-tool qfsck --path <osd_path>
+        if config.get("non-collocated"):
+            # Execute ceph-bluestore-tool --help
             osd_id = random.choice(osd_list)
             log.info(
                 f"\n --------------------"
-                f"\n Running quick consistency check for OSD {osd_id}"
+                f"\n Running cbt help for OSD {osd_id}"
                 f"\n --------------------"
             )
-            out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+            out = bluestore_obj.help(osd_id=osd_id)
             log.info(out)
-            assert "success" in out
 
-            # Execute ceph-bluestore-tool allocmap --path <osd_path>
+            # Add a new dedicated WAL device to existing collocated OSD
+            # ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
             osd_id = random.choice(osd_list)
             log.info(
                 f"\n --------------------"
-                f"\n Fetching allocmap for OSD {osd_id}"
-                f"\n ---------------------"
+                f"\n Adding a dedicated WAL device for OSD.{osd_id}"
+                f"\n --------------------"
             )
-            out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+            osd_host = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=osd_id)
+            empty_devices = rados_obj.get_available_devices(
+                node=osd_host, device_type="hdd"
+            )
+            log.info(
+                f"List of available devices on osd host {osd_host}: {empty_devices}"
+            )
+            log.info(f"WAL will be added on device: {empty_devices[0]}")
+
+            out = bluestore_obj.add_wal_device(
+                osd_id=osd_id, new_device=empty_devices[0]
+            )
+            assert f"WAL device added {empty_devices[0]}" in out
+            osd_metadata = ceph_cluster.get_osd_metadata(
+                osd_id=int(osd_id), client=client
+            )
+            assert int(osd_metadata["bluefs_dedicated_wal"]) == 1
+            assert (
+                osd_metadata["bluefs_wal_dev_node"]
+                == osd_metadata["bluefs_wal_partition_path"]
+                == empty_devices[0]
+            )
+        else:
+            # Execute ceph-bluestore-tool --help
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Running cbt help for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.help(osd_id=osd_id)
+            log.info(out)
+
+            # Execute ceph-bluestore-tool fsck --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Running consistency check for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.run_consistency_check(osd_id=osd_id)
             log.info(out)
             assert "success" in out
 
-        # Execute ceph-bluestore-tool repair --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Run BlueFS repair for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.repair(osd_id=osd_id)
-        log.info(out)
-        assert "success" in out
+            # Execute ceph-bluestore-tool fsck --deep --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Running deep consistency check for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.run_consistency_check(osd_id=osd_id, deep=True)
+            log.info(out)
+            assert "success" in out
 
-        """
-        # Execute ceph-bluestore-tool restore_cfb --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(f"\n --------------------"
-                 f"\n Restoring Column-Family B for OSD {osd_id}"
-                 f"\n --------------------")
-        out = bluestore_obj.restore_cfb(osd_id=osd_id)
-        log.info(out)
+            if rhbuild.split(".")[0] >= "6":
+                # Execute ceph-bluestore-tool qfsck --path <osd_path>
+                osd_id = random.choice(osd_list)
+                log.info(
+                    f"\n --------------------"
+                    f"\n Running quick consistency check for OSD {osd_id}"
+                    f"\n --------------------"
+                )
+                out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+                log.info(out)
+                assert "success" in out
 
-        Execution failed with below msg -
-        restore_cfb failed: (1) Operation not permitted
-        7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::cct->_conf->bluestore_allocation_from_file
-        must be cleared first
-        7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::please change default to false in ceph.conf file>
-        *** Needs further investigation as upstream documentation says this command is supposed to reserve changes
-        done by the new NCB code | restore_cfb: Reverses changes done by the new NCB code (either through
-         ceph restart or when running allocmap command) and restores RocksDB B Column-Family (allocator-map).
-        The failure may only be applicable in certain scenarios, BZ will be raised if found otherwise.
-        https://docs.ceph.com/en/quincy/man/8/ceph-bluestore-tool/#commands
-        """
+                # Execute ceph-bluestore-tool allocmap --path <osd_path>
+                osd_id = random.choice(osd_list)
+                log.info(
+                    f"\n --------------------"
+                    f"\n Fetching allocmap for OSD {osd_id}"
+                    f"\n ---------------------"
+                )
+                out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+                log.info(out)
+                assert "success" in out
 
-        # Execute ceph-bluestore-tool bluefs-export --out-dir <dir> --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Exporting BlueFS contents to an output directory for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.do_bluefs_export(osd_id=osd_id, output_dir="/tmp/")
-        log.info(out)
-        assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+            # Execute ceph-bluestore-tool repair --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Run BlueFS repair for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.repair(osd_id=osd_id)
+            log.info(out)
+            assert "success" in out
 
-        # Execute ceph-bluestore-tool bluefs-bdev-sizes --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Print the device sizes, as understood by BlueFS, to stdout for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.block_device_sizes(osd_id=osd_id)
-        log.info(out)
-        assert "device size" in out
+            """
+            # Execute ceph-bluestore-tool restore_cfb --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(f"\n --------------------"
+                     f"\n Restoring Column-Family B for OSD {osd_id}"
+                     f"\n --------------------")
+            out = bluestore_obj.restore_cfb(osd_id=osd_id)
+            log.info(out)
+    
+            Execution failed with below msg -
+            restore_cfb failed: (1) Operation not permitted
+            7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::cct->_conf->bluestore_allocation_from_file
+            must be cleared first
+            7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::please change default to false in ceph.conf file>
+            *** Needs further investigation as upstream documentation says this command is supposed to reserve changes
+            done by the new NCB code | restore_cfb: Reverses changes done by the new NCB code (either through
+             ceph restart or when running allocmap command) and restores RocksDB B Column-Family (allocator-map).
+            The failure may only be applicable in certain scenarios, BZ will be raised if found otherwise.
+            https://docs.ceph.com/en/quincy/man/8/ceph-bluestore-tool/#commands
+            """
 
-        # Execute ceph-bluestore-tool bluefs-bdev-expand --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Checking if size of block device is expanded for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.block_device_expand(osd_id=osd_id)
-        log.info(out)
-        assert "device size" in out and "Expanding" in out
+            # Execute ceph-bluestore-tool bluefs-export --out-dir <dir> --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Exporting BlueFS contents to an output directory for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.do_bluefs_export(osd_id=osd_id, output_dir="/tmp/")
+            log.info(out)
+            assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
 
-        # Execute ceph-bluestore-tool show-label
-        log.info(
-            f"\n --------------------"
-            f"\n Dump label content for block device for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.show_label(osd_id=osd_id)
-        log.info(out)
-        assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+            # Execute ceph-bluestore-tool bluefs-bdev-sizes --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Print the device sizes, as understood by BlueFS, to stdout for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.block_device_sizes(osd_id=osd_id)
+            log.info(out)
+            assert "device size" in out
 
-        # Execute ceph-bluestore-tool show-label --dev <device>
-        for device in ["block", "db", "wal"]:
+            # Execute ceph-bluestore-tool bluefs-bdev-expand --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Checking if size of block device is expanded for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.block_device_expand(osd_id=osd_id)
+            log.info(out)
+            assert "device size" in out and "Expanding" in out
+
+            # Execute ceph-bluestore-tool show-label
+            log.info(
+                f"\n --------------------"
+                f"\n Dump label content for block device for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.show_label(osd_id=osd_id)
+            log.info(out)
+            assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+
+            # Execute ceph-bluestore-tool show-label --dev <device>
+            for device in ["block", "db", "wal"]:
+                osd_id = random.choice(osd_list)
+                osd_node = rados_obj.fetch_host_node(
+                    daemon_type="osd", daemon_id=str(osd_id)
+                )
+                lvm_list, _ = osd_node.exec_command(
+                    sudo=True,
+                    cmd=f"cephadm shell -- ceph-volume lvm list {osd_id} --format json",
+                )
+                lvm_json = json.loads(lvm_list)
+                dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
+                device_type = lvm_json[f"{osd_id}"][0]["type"]
+                if device in device_type:
+                    log.info(
+                        f"\n --------------------"
+                        f"\n Dump label content for {device_type} device {dev} for OSD {osd_id}"
+                        f"\n --------------------"
+                    )
+                    out = bluestore_obj.show_label(osd_id=osd_id, device=dev)
+                    log.info(out)
+                    assert dev in out
+
+            # Execute ceph-bluestore-tool prime-osd-dir --dev <main_device> --path <osd_path>
             osd_id = random.choice(osd_list)
             osd_node = rados_obj.fetch_host_node(
                 daemon_type="osd", daemon_id=str(osd_id)
@@ -191,107 +255,87 @@ def run(ceph_cluster, **kw):
             )
             lvm_json = json.loads(lvm_list)
             dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
-            device_type = lvm_json[f"{osd_id}"][0]["type"]
-            if device in device_type:
-                log.info(
-                    f"\n --------------------"
-                    f"\n Dump label content for {device_type} device {dev} for OSD {osd_id}"
-                    f"\n --------------------"
-                )
-                out = bluestore_obj.show_label(osd_id=osd_id, device=dev)
-                log.info(out)
-                assert dev in out
+            log.info(
+                f"\n --------------------"
+                f"\n Generate the content for an OSD data directory "
+                f"that can start up a BlueStore OSD for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.generate_prime_osd_dir(osd_id=osd_id, device=dev)
+            log.info(out)
 
-        # Execute ceph-bluestore-tool prime-osd-dir --dev <main_device> --path <osd_path>
-        osd_id = random.choice(osd_list)
-        osd_node = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=str(osd_id))
-        lvm_list, _ = osd_node.exec_command(
-            sudo=True,
-            cmd=f"cephadm shell -- ceph-volume lvm list {osd_id} --format json",
-        )
-        lvm_json = json.loads(lvm_list)
-        dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
-        log.info(
-            f"\n --------------------"
-            f"\n Generate the content for an OSD data directory "
-            f"that can start up a BlueStore OSD for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.generate_prime_osd_dir(osd_id=osd_id, device=dev)
-        log.info(out)
+            # Execute ceph-bluestore-tool free-dump --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Dump all free regions in allocator for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = (
+                bluestore_obj.get_free_dump(osd_id=osd_id)
+                if rhbuild.split(".")[0] >= "6"
+                else bluestore_obj.get_free_dump(osd_id=osd_id, allocator_type="block")
+            )
+            log.debug(out)
+            assert "alloc_name" in out and "extents" in out
 
-        # Execute ceph-bluestore-tool free-dump --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Dump all free regions in allocator for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = (
-            bluestore_obj.get_free_dump(osd_id=osd_id)
-            if rhbuild.split(".")[0] >= "6"
-            else bluestore_obj.get_free_dump(osd_id=osd_id, allocator_type="block")
-        )
-        log.debug(out)
-        assert "alloc_name" in out and "extents" in out
+            # Execute ceph-bluestore-tool free-score --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Get fragmentation score for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = (
+                bluestore_obj.get_free_score(osd_id=osd_id)
+                if rhbuild.split(".")[0] >= "6"
+                else bluestore_obj.get_free_score(osd_id=osd_id, allocator_type="block")
+            )
+            log.info(out)
+            assert "fragmentation_rating" in out
 
-        # Execute ceph-bluestore-tool free-score --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Get fragmentation score for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = (
-            bluestore_obj.get_free_score(osd_id=osd_id)
-            if rhbuild.split(".")[0] >= "6"
-            else bluestore_obj.get_free_score(osd_id=osd_id, allocator_type="block")
-        )
-        log.info(out)
-        assert "fragmentation_rating" in out
+            # Execute ceph-bluestore-tool show-sharding --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Show sharding that is currently applied to "
+                f"BlueStore's RocksDB for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.show_sharding(osd_id=osd_id)
+            log.info(out)
+            assert "block_cache" in out
 
-        # Execute ceph-bluestore-tool show-sharding --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Show sharding that is currently applied to "
-            f"BlueStore's RocksDB for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.show_sharding(osd_id=osd_id)
-        log.info(out)
-        assert "block_cache" in out
+            # Execute ceph-bluestore-tool bluefs-stats --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Display BlueFS statistics for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
+            log.info(out)
+            if rhbuild.split(".")[0] >= "7":
+                for pattern in [
+                    "device size",
+                    "DEV/LEV",
+                    "LOG",
+                    "WAL",
+                    "DB",
+                    "SLOW",
+                    "MAXIMUMS",
+                    "TOTAL",
+                ]:
+                    assert pattern in out
+            else:
+                for pattern in ["device size", "wal_total", "db_total", "slow_total"]:
+                    assert pattern in out
 
-        # Execute ceph-bluestore-tool bluefs-stats --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Display BlueFS statistics for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
-        log.info(out)
-        if rhbuild.split(".")[0] >= "7":
-            for pattern in [
-                "device size",
-                "DEV/LEV",
-                "LOG",
-                "WAL",
-                "DB",
-                "SLOW",
-                "MAXIMUMS",
-                "TOTAL",
-            ]:
-                assert pattern in out
-        else:
-            for pattern in ["device size", "wal_total", "db_total", "slow_total"]:
-                assert pattern in out
-
-        # restart OSD services
-        osd_services = rados_obj.list_orch_services(service_type="osd")
-        for osd_service in osd_services:
-            cephadm.shell(args=[f"ceph orch restart {osd_service}"])
-        time.sleep(30)
+            # restart OSD services
+            osd_services = rados_obj.list_orch_services(service_type="osd")
+            for osd_service in osd_services:
+                cephadm.shell(args=[f"ceph orch restart {osd_service}"])
+            time.sleep(30)
 
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")

--- a/utility/lvm_utils.py
+++ b/utility/lvm_utils.py
@@ -1,5 +1,5 @@
 def pvcreate(osd, devices):
-    osd.exec_command(cmd="sudo pvcreate %s" % devices)
+    osd.exec_command(cmd="sudo pvcreate -ff %s" % devices)
 
 
 def vgcreate(osd, vg_name, devices):


### PR DESCRIPTION
[CEPH-83571692](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571692l): Automation of ceph-bluestore-tool functionalities and workflows for non-collocated operations

This PR extends the existing automation to cover addition of WAL, addition of dedicated DB and resharding, all three of which were not covered in the parent PR #2634 

Jira - [RHCEPHQE-9439](https://issues.redhat.com/browse/RHCEPHQE-9439)

Test modules modified:
- `ceph/rados/bluestoretool_workflows.py`
- `tests/rados/test_bluestoretool_workflows.py`
- `ceph/rados/core_workflows.py`

Test suites modified:
- `suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/reef/rados/tier-2_rados_test_cot_cbt.yaml`

ceph-bluestore-tool commands covered:
 - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
 - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
 - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
 
Logs:
RHCS 6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XLO5NR
RHCS 7.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-I0Y96Q

Signed-off-by: Harsh Kumar <hakumar@redhat.com>