### PR TITLE
Modified code to remove the configuration parameter settings

### DIFF
--- a/ceph/rados/rados_scrub.py
+++ b/ceph/rados/rados_scrub.py
@@ -176,9 +176,15 @@ class RadosScrubber(RadosOrchestrator):
                 norebalance|norecover|noscrub|nodeep-scrub|notieragent
         Returns: True/False
         """
+        if value == "pause":
+            chk_string = f"pauserd,pausewr is {flag}"
+        else:
+            chk_string = f"{value} is {flag}"
+
         cmd = f"ceph osd {flag} {value}"
         out, err = self.node.shell([cmd])
-        if err:
-            log.info(f"The OSD falg {value} not {flag} on the cluster. Error: {err}")
-            return False
-        return True
+        if chk_string in out or chk_string in err:
+            log.info(f"The OSD falg {value} is {flag} on the cluster.")
+            return True
+        log.error(f"Failed to {flag} OSD flag {value}")
+        return False


### PR DESCRIPTION
# Description
TFA- Fix: Removed the configuration setting after the test execution.
Parameters:
  1. osd_scrub_min_interval
  2. osd_scrub_max_interval
  3. osd_deep_scrub_interval
  4. osd_scrub_begin_week_day
  5. osd_scrub_end_week_day
  6. osd_scrub_begin_hour
  7. osd_scrub_end_hour


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
