### PR TITLE
CEPH-83571692: Extending coverage for non-collocated operations with CBT

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -2642,7 +2642,7 @@ class RadosOrchestrator:
         if node is None:
             cmd_orch_device = "ceph orch device ls --refresh"
         else:
-            cmd_orch_device = f"ceph orch device ls  {node} --refresh"
+            cmd_orch_device = f"ceph orch device ls {node} --refresh"
 
         orch_device_output = self.run_ceph_command(cmd=cmd_orch_device)
         return orch_device_output
@@ -3174,18 +3174,17 @@ class RadosOrchestrator:
         base_cmd = f"ceph tell osd.{osd_id} perf dump"
         return self.run_ceph_command(cmd=base_cmd)
 
-    def get_available_path_list(self, node: str, device_type: str):
+    def get_available_devices(self, node_name: str, device_type: str):
         """
-        Method returns the available device list in the provided node.
+        Method to fetch list of available device paths on the provided node.
             Args:
-                 rados_object: RadosOrchestrator class object
-                 node: node name
-
-             Returns: Returns the available device path list of the node.
-
+                node_name: node hostname
+                device_type: hdd or ssd or nvme
+            Returns:
+                List of available device paths on the node.
         """
         device_paths = []
-        available_device_list = self.get_orch_device_list(node)
+        available_device_list = self.get_orch_device_list(node_name)
         for path_list in available_device_list[0]["devices"]:
             if path_list["human_readable_type"] != device_type:
                 continue

--- a/conf/pacific/rados/11-node-cluster.yaml
+++ b/conf/pacific/rados/11-node-cluster.yaml
@@ -22,6 +22,7 @@ globals:
           - node-exporter
           - alertmanager
           - crash
+          - nfs
       node3:
         role:
           - osd
@@ -50,6 +51,7 @@ globals:
           - mds
           - node-exporter
           - crash
+          - nfs
       node7:
         role:
           - client

--- a/conf/quincy/rados/11-node-cluster.yaml
+++ b/conf/quincy/rados/11-node-cluster.yaml
@@ -22,6 +22,7 @@ globals:
           - node-exporter
           - alertmanager
           - crash
+          - nfs
       node3:
         role:
           - osd
@@ -50,6 +51,7 @@ globals:
           - mds
           - node-exporter
           - crash
+          - nfs
       node7:
         role:
           - client

--- a/conf/reef/rados/11-node-cluster.yaml
+++ b/conf/reef/rados/11-node-cluster.yaml
@@ -22,6 +22,7 @@ globals:
           - node-exporter
           - alertmanager
           - crash
+          - nfs
       node3:
         role:
           - osd
@@ -50,6 +51,7 @@ globals:
           - mds
           - node-exporter
           - crash
+          - nfs
       node7:
         role:
           - client

--- a/suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,10 +1,9 @@
-# Suite contains basic tier-2 rados tests
 #===============================================================================================
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
 # Conf: conf/pacific/rados/7-node-cluster.yaml
-#
+# Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
   - test:
@@ -17,7 +16,7 @@ tests:
       name: cluster deployment
       desc: Execute the cluster deployment workflow.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574887
       config:
         verify_cluster_health: true
         steps:
@@ -48,19 +47,63 @@ tests:
               args:
                 placement:
                   label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -69,22 +112,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -112,10 +139,56 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,10 +1,9 @@
-# Suite contains basic tier-2 rados tests
 #===============================================================================================
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
 # Conf: conf/quincy/rados/7-node-cluster.yaml
-#
+# Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
   - test:
@@ -17,7 +16,7 @@ tests:
       name: cluster deployment
       desc: Execute the cluster deployment workflow.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574887
       config:
         verify_cluster_health: true
         steps:
@@ -48,19 +47,63 @@ tests:
               args:
                 placement:
                   label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -69,22 +112,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -112,10 +139,56 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/reef/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/reef/rados/tier-2_rados_test_cot_cbt.yaml
@@ -1,10 +1,9 @@
-# Suite contains basic tier-2 rados tests
 #===============================================================================================
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
 # Conf: conf/reef/rados/7-node-cluster.yaml
-#
+# Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
   - test:
@@ -17,7 +16,7 @@ tests:
       name: cluster deployment
       desc: Execute the cluster deployment workflow.
       module: test_cephadm.py
-      polarion-id:
+      polarion-id: CEPH-83574887
       config:
         verify_cluster_health: true
         steps:
@@ -48,19 +47,63 @@ tests:
               args:
                 placement:
                   label: mon
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
-              command: apply
-              service: osd
-              args:
-                all-available-devices: true
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osd_spec_collocated
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      rotational: 1
+                      limit: 3
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: shell
-              args:          # arguments to ceph orch
+              args:               # arguments to ceph orch
                 - ceph
                 - fs
                 - volume
                 - create
                 - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
           - config:
               command: apply
               service: rgw
@@ -69,22 +112,6 @@ tests:
               args:
                 placement:
                   label: rgw
-          - config:
-              command: apply
-              service: mds
-              base_cmd_args:          # arguments to ceph orch
-                verbose: true
-              pos_args:
-                - cephfs              # name of the filesystem
-              args:
-                placement:
-                  nodes:
-                    - node2
-                    - node6
-                  limit: 2            # no of daemons
-                  sep: " "            # separator to be used for placements
-      destroy-cluster: false
-      abort-on-fail: true
 
   - test:
       name: Configure client admin
@@ -112,10 +139,56 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
       name: ceph-bluestore-tool utility
       module: test_bluestoretool_workflows.py
       polarion-id: CEPH-83571692
       desc: Verify ceph-bluestore-tool functionalities
+
+# after the following test is executed, one or more OSD becomes non-collocated
+# while rest are still collocated, this renders the cluster in non-homogenous state.
+# subsequent tests should be added keeping this in account
+  - test:
+      name: ceph-bluestore-tool utility non-collocated
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      config:
+        non-collocated: true
+      desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
 
   - test:
       name: ceph-objectstore-tool utility

--- a/tests/misc_env/lvm_deployer.py
+++ b/tests/misc_env/lvm_deployer.py
@@ -1,3 +1,4 @@
+import random
 from copy import deepcopy
 from time import sleep
 
@@ -40,19 +41,21 @@ def find_storage_unit(value):
         return f"{metric}T"
 
 
-def create_lvms(node, count, size):
+def create_lvms(node, count, size, devices=None):
     """Create LVs on node.
 
     Args:
         node: CephNode obj
         count: number of LVMs
         size: LVM size
+        devices: custom volume list
     """
-    vg_name = "data_vg"
+    vg_name = "data_vg" + str(random.randrange(10))
     if not hasattr(node, "volume_list"):
         raise Exception(f"{node.hostname} has no volume_list!!!")
 
-    devices = [vol.path for vol in node.volume_list]
+    if not devices:
+        devices = [vol.path for vol in node.volume_list]
     pvcreate(node, " ".join(devices))
     vgcreate(node, vg_name, " ".join(devices))
     lvms = []
@@ -63,6 +66,7 @@ def create_lvms(node, count, size):
         )
         lvms.append(f"/dev/{vg_name}/lv{i}")
     node.volume_list = deepcopy(lvms)
+    return lvms
 
 
 def run(ceph_cluster, **kw):

--- a/tests/rados/test_add_db_wal_cbt.py
+++ b/tests/rados/test_add_db_wal_cbt.py
@@ -35,7 +35,9 @@ def run(ceph_cluster, **kw):
         for node in ceph_nodes:
             if node.role == "osd":
                 host_name = node.hostname
-                ssd_path_list = rados_object.get_available_path_list(host_name, "ssd")
+                ssd_path_list = rados_object.get_available_devices(
+                    node_name=host_name, device_type="ssd"
+                )
                 if not ssd_path_list:
                     log.info(f"The device paths are empty to add on the {host_name}")
                     continue
@@ -114,7 +116,9 @@ def check_osd_config(node_object, host_name, dev_path):
     """
     end_time = datetime.datetime.now() + datetime.timedelta(seconds=600)
     while end_time > datetime.datetime.now():
-        ssd_path_list = node_object.get_available_path_list(host_name, "ssd")
+        ssd_path_list = node_object.get_available_devices(
+            node_name=host_name, device_type="ssd"
+        )
         if dev_path not in ssd_path_list:
             log.info(f"OSD is configured on the {dev_path} at {host_name}")
             return True

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -11,14 +11,19 @@ Test Module to perform specific functionalities of ceph-bluestore-tool.
  - ceph-bluestore-tool free-dump|free-score --path osd path [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
  - ceph-bluestore-tool show-sharding --path osd path
  - ceph-bluestore-tool bluefs-stats --path osd path
+ - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
+ - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
+ - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
 """
 import json
+import math
 import random
 import time
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
 from ceph.rados.core_workflows import RadosOrchestrator
+from tests.misc_env.lvm_deployer import create_lvms
 from utility.log import Log
 
 log = Log(__name__)
@@ -32,11 +37,8 @@ def run(ceph_cluster, **kw):
         1 -> Fail, 0 -> Pass
     *** Currently, covers commands/workflows valid only for collocated OSDs
     Commands reserved for future coverage with non-collocated OSDs:
-    - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
-    - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
-    - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
-    - ceph-bluestore-tool bluefs-bdev-migrate --path osd path --dev-target new-device --devs-source device1
     - ceph-bluestore-tool restore_cfb --path osd path
+    - ceph-bluestore-tool bluefs-bdev-migrate --path osd path --dev-target new-device --devs-source device1
     """
     log.info(run.__doc__)
     config = kw["config"]
@@ -44,143 +46,333 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+    client = ceph_cluster.get_nodes(role="client")[0]
 
     out, _ = cephadm.shell(args=["ceph osd ls"])
     osd_list = out.strip().split("\n")
 
     try:
-        # Execute ceph-bluestore-tool --help
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Running cbt help for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.help(osd_id=osd_id)
-        log.info(out)
+        if config.get("non-collocated"):
+            log.info(
+                "\n\n*************** Execution begins for CBT non-collocated scenarios ************ \n\n"
+            )
+            # Execute ceph-bluestore-tool --help
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n ---------------------------------"
+                f"\n Running cbt help for OSD {osd_id}"
+                f"\n ---------------------------------"
+            )
+            out = bluestore_obj.help(osd_id=osd_id)
+            log.info(out)
 
-        # Execute ceph-bluestore-tool fsck --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Running consistency check for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.run_consistency_check(osd_id=osd_id)
-        log.info(out)
-        assert "success" in out
+            # Add a new dedicated WAL device to existing collocated OSD
+            # ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n -------------------------------------------"
+                f"\n Adding a dedicated WAL device for OSD.{osd_id}"
+                f"\n -------------------------------------------"
+            )
+            osd_host = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=osd_id)
+            empty_devices = rados_obj.get_available_devices(
+                node_name=osd_host.hostname, device_type="hdd"
+            )
+            if not empty_devices:
+                log.error(f"No spare disks available on OSD host {osd_host.hostname}")
+                raise Exception(
+                    f"No spare disks available on OSD host {osd_host.hostname}"
+                )
 
-        # Execute ceph-bluestore-tool fsck --deep --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Running deep consistency check for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.run_consistency_check(osd_id=osd_id, deep=True)
-        log.info(out)
-        assert "success" in out
+            # determine size of db and wal lvms
+            osd_df_stats = rados_obj.get_osd_df_stats(
+                tree=False, filter_by="name", filter=f"osd.{osd_id}"
+            )
+            osd_size = osd_df_stats["nodes"][0]["kb"]
+            log.info(osd_size)
+            db_size = int(int(osd_size) * 1024 * 0.05)
+            log.info(db_size)
+            # covert bytes to GB
+            wal_db_size = f"{math.ceil(db_size/1073741824)}G"
+            log.info(wal_db_size)
 
-        if rhbuild.split(".")[0] >= "6":
-            # Execute ceph-bluestore-tool qfsck --path <osd_path>
+            log.info(
+                f"List of available devices on osd host {osd_host.hostname}: {empty_devices}"
+            )
+
+            lvm_list = create_lvms(
+                node=osd_host, count=6, size=wal_db_size, devices=[empty_devices[0]]
+            )
+            log.info(f"List of LVMs created on {osd_host.hostname}: {lvm_list}")
+
+            wal_target = lvm_list.pop()
+            log.info(f"WAL will be added on device: {wal_target}")
+
+            out = bluestore_obj.add_wal_device(osd_id=osd_id, new_device=wal_target)
+            log.info(out)
+            assert "WAL device added" in out
+            osd_metadata = ceph_cluster.get_osd_metadata(
+                osd_id=int(osd_id), client=client
+            )
+            log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
+
+            if not int(osd_metadata["bluefs_dedicated_wal"]) == 1:
+                log.error("'bluefs_dedicated_wal' entry in OSD metadata is not 1")
+                raise AssertionError(
+                    "'bluefs_dedicated_wal' entry in OSD metadata is not 1"
+                )
+
+            if not (
+                osd_metadata["bluefs_wal_dev_node"]
+                == osd_metadata["bluefs_wal_partition_path"]
+            ):
+                log.error(
+                    "bluefs wal device node and bluefs wal partition path do not match"
+                )
+                raise AssertionError(
+                    "bluefs wal device node and bluefs wal partition path do not match"
+                )
+
+            if not osd_metadata["bluefs_wal_devices"] in empty_devices[0]:
+                log.error(f"bluefs WAL device is not pointing to {empty_devices[0]}")
+                raise AssertionError(
+                    f"bluefs WAL device is not pointing to {empty_devices[0]}"
+                )
+
+            log.info(
+                f"Dedicated WAL device successfully added for OSD {osd_id} on {empty_devices[0]}"
+            )
+
+            # Add a new DB device to existing collocated OSD
+            # ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
+            log.info(
+                f"\n -----------------------------------------------"
+                f"\n Adding a dedicated DB device for OSD.{osd_id}"
+                f"\n -----------------------------------------------"
+            )
+            db_target = lvm_list.pop()
+            log.info(f"DB will be added on device: {db_target}")
+
+            out = bluestore_obj.add_db_device(
+                osd_id=osd_id, new_device=db_target, db_size=db_size
+            )
+            log.info(out)
+            assert "DB device added" in out
+            osd_metadata = ceph_cluster.get_osd_metadata(
+                osd_id=int(osd_id), client=client
+            )
+            log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
+
+            if not int(osd_metadata["bluefs_dedicated_db"]) == 1:
+                log.error("'bluefs_dedicated_db' entry in OSD metadata is not 1")
+                raise AssertionError(
+                    "'bluefs_dedicated_db' entry in OSD metadata is not 1"
+                )
+
+            if not (
+                osd_metadata["bluefs_db_dev_node"]
+                == osd_metadata["bluefs_db_partition_path"]
+            ):
+                log.error(
+                    "bluefs DB device node and bluefs DB partition path do not match"
+                )
+                raise AssertionError(
+                    "bluefs DB device node and bluefs DB partition path do not match"
+                )
+
+            if not osd_metadata["bluefs_db_devices"] in empty_devices[0]:
+                log.error(f"bluefs DB device is not pointing to {empty_devices[0]}")
+                raise AssertionError(
+                    f"bluefs DB device is not pointing to {empty_devices[0]}"
+                )
+
+            log.info(
+                f"Dedicated DB device successfully added for OSD {osd_id} on {empty_devices[0]}"
+            )
+
+            # Migrating new DB device to existing collocated OSD
+            # ceph-bluestore-tool bluefs-bdev-migrate --dev-target {new_device} --devs-source {device_source}
+            # Not part of execution due to blocker BZ-2269101
+            if not True:
+                log.info(
+                    f"\n -----------------------------------------------"
+                    f"\n Migrating a dedicated DB device for OSD.{osd_id}"
+                    f"\n -----------------------------------------------"
+                )
+                existing_db_device = f"dev/{osd_metadata['bluefs_db_devices']}"
+                empty_devices = rados_obj.get_available_devices(
+                    node_name=osd_host.hostname, device_type="hdd"
+                )
+                log.info(
+                    f"List of available devices on osd host {osd_host.hostname}: {empty_devices}"
+                )
+                log.info(f"Existing DB will be migrated to device: {empty_devices[0]}")
+                out = bluestore_obj.block_device_migrate(
+                    osd_id=osd_id,
+                    new_device=empty_devices[0],
+                    device_source=existing_db_device,
+                )
+                log.info(out)
+                log.debug(f"OSD metadata for osd.{osd_id}: \n {osd_metadata}")
+        else:
+            log.info(
+                "\n\n*************** Execution begins for CBT collocated scenarios ************ \n\n"
+            )
+            # Execute ceph-bluestore-tool --help
             osd_id = random.choice(osd_list)
             log.info(
                 f"\n --------------------"
-                f"\n Running quick consistency check for OSD {osd_id}"
+                f"\n Running cbt help for OSD {osd_id}"
                 f"\n --------------------"
             )
-            out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+            out = bluestore_obj.help(osd_id=osd_id)
             log.info(out)
-            assert "success" in out
 
-            # Execute ceph-bluestore-tool allocmap --path <osd_path>
+            # Execute ceph-bluestore-tool fsck --path <osd_path>
             osd_id = random.choice(osd_list)
             log.info(
                 f"\n --------------------"
-                f"\n Fetching allocmap for OSD {osd_id}"
-                f"\n ---------------------"
+                f"\n Running consistency check for OSD {osd_id}"
+                f"\n --------------------"
             )
-            out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+            out = bluestore_obj.run_consistency_check(osd_id=osd_id)
             log.info(out)
             assert "success" in out
 
-        # Execute ceph-bluestore-tool repair --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Run BlueFS repair for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.repair(osd_id=osd_id)
-        log.info(out)
-        assert "success" in out
+            # Execute ceph-bluestore-tool fsck --deep --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Running deep consistency check for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.run_consistency_check(osd_id=osd_id, deep=True)
+            log.info(out)
+            assert "success" in out
 
-        """
-        # Execute ceph-bluestore-tool restore_cfb --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(f"\n --------------------"
-                 f"\n Restoring Column-Family B for OSD {osd_id}"
-                 f"\n --------------------")
-        out = bluestore_obj.restore_cfb(osd_id=osd_id)
-        log.info(out)
+            if rhbuild.split(".")[0] >= "6":
+                # Execute ceph-bluestore-tool qfsck --path <osd_path>
+                osd_id = random.choice(osd_list)
+                log.info(
+                    f"\n --------------------"
+                    f"\n Running quick consistency check for OSD {osd_id}"
+                    f"\n --------------------"
+                )
+                out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+                log.info(out)
+                assert "success" in out
 
-        Execution failed with below msg -
-        restore_cfb failed: (1) Operation not permitted
-        7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::cct->_conf->bluestore_allocation_from_file
-        must be cleared first
-        7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::please change default to false in ceph.conf file>
-        *** Needs further investigation as upstream documentation says this command is supposed to reserve changes
-        done by the new NCB code | restore_cfb: Reverses changes done by the new NCB code (either through
-         ceph restart or when running allocmap command) and restores RocksDB B Column-Family (allocator-map).
-        The failure may only be applicable in certain scenarios, BZ will be raised if found otherwise.
-        https://docs.ceph.com/en/quincy/man/8/ceph-bluestore-tool/#commands
-        """
+                # Execute ceph-bluestore-tool allocmap --path <osd_path>
+                osd_id = random.choice(osd_list)
+                log.info(
+                    f"\n --------------------"
+                    f"\n Fetching allocmap for OSD {osd_id}"
+                    f"\n ---------------------"
+                )
+                out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+                log.info(out)
+                assert "success" in out
 
-        # Execute ceph-bluestore-tool bluefs-export --out-dir <dir> --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Exporting BlueFS contents to an output directory for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.do_bluefs_export(osd_id=osd_id, output_dir="/tmp/")
-        log.info(out)
-        assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+            # Execute ceph-bluestore-tool repair --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Run BlueFS repair for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.repair(osd_id=osd_id)
+            log.info(out)
+            assert "success" in out
 
-        # Execute ceph-bluestore-tool bluefs-bdev-sizes --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Print the device sizes, as understood by BlueFS, to stdout for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.block_device_sizes(osd_id=osd_id)
-        log.info(out)
-        assert "device size" in out
+            """
+            # Execute ceph-bluestore-tool restore_cfb --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(f"\n --------------------"
+                     f"\n Restoring Column-Family B for OSD {osd_id}"
+                     f"\n --------------------")
+            out = bluestore_obj.restore_cfb(osd_id=osd_id)
+            log.info(out)
 
-        # Execute ceph-bluestore-tool bluefs-bdev-expand --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Checking if size of block device is expanded for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.block_device_expand(osd_id=osd_id)
-        log.info(out)
-        assert "device size" in out and "Expanding" in out
+            Execution failed with below msg -
+            restore_cfb failed: (1) Operation not permitted
+            7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::cct->_conf->bluestore_allocation_from_file
+            must be cleared first
+            7fe3c5c80600 -1 bluestore::NCB::push_allocation_to_rocksdb::please
+             change default to false in ceph.conf file>
+            *** Needs further investigation as upstream documentation says this command is supposed to reserve changes
+            done by the new NCB code | restore_cfb: Reverses changes done by the new NCB code (either through
+             ceph restart or when running allocmap command) and restores RocksDB B Column-Family (allocator-map).
+            The failure may only be applicable in certain scenarios, BZ will be raised if found otherwise.
+            https://docs.ceph.com/en/quincy/man/8/ceph-bluestore-tool/#commands
+            """
 
-        # Execute ceph-bluestore-tool show-label
-        log.info(
-            f"\n --------------------"
-            f"\n Dump label content for block device for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.show_label(osd_id=osd_id)
-        log.info(out)
-        assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+            # Execute ceph-bluestore-tool bluefs-export --out-dir <dir> --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Exporting BlueFS contents to an output directory for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.do_bluefs_export(osd_id=osd_id, output_dir="/tmp/")
+            log.info(out)
+            assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
 
-        # Execute ceph-bluestore-tool show-label --dev <device>
-        for device in ["block", "db", "wal"]:
+            # Execute ceph-bluestore-tool bluefs-bdev-sizes --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Print the device sizes, as understood by BlueFS, to stdout for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.block_device_sizes(osd_id=osd_id)
+            log.info(out)
+            assert "device size" in out
+
+            # Execute ceph-bluestore-tool bluefs-bdev-expand --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Checking if size of block device is expanded for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.block_device_expand(osd_id=osd_id)
+            log.info(out)
+            assert "device size" in out and "Expanding" in out
+
+            # Execute ceph-bluestore-tool show-label
+            log.info(
+                f"\n --------------------"
+                f"\n Dump label content for block device for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.show_label(osd_id=osd_id)
+            log.info(out)
+            assert f"/var/lib/ceph/osd/ceph-{osd_id}/" in out
+
+            # Execute ceph-bluestore-tool show-label --dev <device>
+            for device in ["block", "db", "wal"]:
+                osd_id = random.choice(osd_list)
+                osd_node = rados_obj.fetch_host_node(
+                    daemon_type="osd", daemon_id=str(osd_id)
+                )
+                lvm_list, _ = osd_node.exec_command(
+                    sudo=True,
+                    cmd=f"cephadm shell -- ceph-volume lvm list {osd_id} --format json",
+                )
+                lvm_json = json.loads(lvm_list)
+                dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
+                device_type = lvm_json[f"{osd_id}"][0]["type"]
+                if device in device_type:
+                    log.info(
+                        f"\n --------------------"
+                        f"\n Dump label content for {device_type} device {dev} for OSD {osd_id}"
+                        f"\n --------------------"
+                    )
+                    out = bluestore_obj.show_label(osd_id=osd_id, device=dev)
+                    log.info(out)
+                    assert dev in out
+
+            # Execute ceph-bluestore-tool prime-osd-dir --dev <main_device> --path <osd_path>
             osd_id = random.choice(osd_list)
             osd_node = rados_obj.fetch_host_node(
                 daemon_type="osd", daemon_id=str(osd_id)
@@ -191,107 +383,103 @@ def run(ceph_cluster, **kw):
             )
             lvm_json = json.loads(lvm_list)
             dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
-            device_type = lvm_json[f"{osd_id}"][0]["type"]
-            if device in device_type:
-                log.info(
-                    f"\n --------------------"
-                    f"\n Dump label content for {device_type} device {dev} for OSD {osd_id}"
-                    f"\n --------------------"
-                )
-                out = bluestore_obj.show_label(osd_id=osd_id, device=dev)
-                log.info(out)
-                assert dev in out
+            log.info(
+                f"\n --------------------"
+                f"\n Generate the content for an OSD data directory "
+                f"that can start up a BlueStore OSD for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.generate_prime_osd_dir(osd_id=osd_id, device=dev)
+            log.info(out)
 
-        # Execute ceph-bluestore-tool prime-osd-dir --dev <main_device> --path <osd_path>
-        osd_id = random.choice(osd_list)
-        osd_node = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=str(osd_id))
-        lvm_list, _ = osd_node.exec_command(
-            sudo=True,
-            cmd=f"cephadm shell -- ceph-volume lvm list {osd_id} --format json",
-        )
-        lvm_json = json.loads(lvm_list)
-        dev = lvm_json[f"{osd_id}"][0]["tags"]["ceph.block_device"]
-        log.info(
-            f"\n --------------------"
-            f"\n Generate the content for an OSD data directory "
-            f"that can start up a BlueStore OSD for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.generate_prime_osd_dir(osd_id=osd_id, device=dev)
-        log.info(out)
+            # ceph-bluestore-tool free-dump --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Dump all free regions in allocator for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = (
+                bluestore_obj.get_free_dump(osd_id=osd_id)
+                if rhbuild.split(".")[0] >= "6"
+                else bluestore_obj.get_free_dump(osd_id=osd_id, allocator_type="block")
+            )
+            log.debug(out)
+            assert "alloc_name" in out and "extents" in out
 
-        # Execute ceph-bluestore-tool free-dump --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Dump all free regions in allocator for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = (
-            bluestore_obj.get_free_dump(osd_id=osd_id)
-            if rhbuild.split(".")[0] >= "6"
-            else bluestore_obj.get_free_dump(osd_id=osd_id, allocator_type="block")
-        )
-        log.debug(out)
-        assert "alloc_name" in out and "extents" in out
+            # ceph-bluestore-tool free-score --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Get fragmentation score for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = (
+                bluestore_obj.get_free_score(osd_id=osd_id)
+                if rhbuild.split(".")[0] >= "6"
+                else bluestore_obj.get_free_score(osd_id=osd_id, allocator_type="block")
+            )
+            log.info(out)
+            assert "fragmentation_rating" in out
 
-        # Execute ceph-bluestore-tool free-score --path <osd_path> [--allocator block/bluefs-wal/bluefs-db/bluefs-slow]
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Get fragmentation score for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = (
-            bluestore_obj.get_free_score(osd_id=osd_id)
-            if rhbuild.split(".")[0] >= "6"
-            else bluestore_obj.get_free_score(osd_id=osd_id, allocator_type="block")
-        )
-        log.info(out)
-        assert "fragmentation_rating" in out
+            # Execute ceph-bluestore-tool show-sharding --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Show sharding that is currently applied to "
+                f"BlueStore's RocksDB for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.show_sharding(osd_id=osd_id)
+            log.info(out)
+            assert "block_cache" in out
 
-        # Execute ceph-bluestore-tool show-sharding --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Show sharding that is currently applied to "
-            f"BlueStore's RocksDB for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.show_sharding(osd_id=osd_id)
-        log.info(out)
-        assert "block_cache" in out
+            # Execute ceph-bluestore-tool --sharding="<>" reshard --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n -----------------------------------------"
+                f"\n Reshard with custom value for for OSD {osd_id}"
+                f"\n -----------------------------------------"
+            )
+            new_shard = "m(3) p(3,0-12) O(3,0-13)=block_cache={type=binned_lru} L P"
+            log.info(f"New shard: {new_shard}")
+            out = bluestore_obj.do_reshard(osd_id=osd_id, new_shard=new_shard)
+            log.info(out)
+            assert "reshard success" in out
+            out = bluestore_obj.show_sharding(osd_id=osd_id)
+            log.info(f"Output of show_sharding after new shard was applied: \n {out}")
+            assert new_shard in out
 
-        # Execute ceph-bluestore-tool bluefs-stats --path <osd_path>
-        osd_id = random.choice(osd_list)
-        log.info(
-            f"\n --------------------"
-            f"\n Display BlueFS statistics for OSD {osd_id}"
-            f"\n --------------------"
-        )
-        out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
-        log.info(out)
-        if rhbuild.split(".")[0] >= "7":
-            for pattern in [
-                "device size",
-                "DEV/LEV",
-                "LOG",
-                "WAL",
-                "DB",
-                "SLOW",
-                "MAXIMUMS",
-                "TOTAL",
-            ]:
-                assert pattern in out
-        else:
-            for pattern in ["device size", "wal_total", "db_total", "slow_total"]:
-                assert pattern in out
+            # Execute ceph-bluestore-tool bluefs-stats --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Display BlueFS statistics for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
+            log.info(out)
+            if rhbuild.split(".")[0] >= "7":
+                for pattern in [
+                    "device size",
+                    "DEV/LEV",
+                    "LOG",
+                    "WAL",
+                    "DB",
+                    "SLOW",
+                    "MAXIMUMS",
+                    "TOTAL",
+                ]:
+                    assert pattern in out
+            else:
+                for pattern in ["device size", "wal_total", "db_total", "slow_total"]:
+                    assert pattern in out
 
-        # restart OSD services
-        osd_services = rados_obj.list_orch_services(service_type="osd")
-        for osd_service in osd_services:
-            cephadm.shell(args=[f"ceph orch restart {osd_service}"])
-        time.sleep(30)
+            # restart OSD services
+            osd_services = rados_obj.list_orch_services(service_type="osd")
+            for osd_service in osd_services:
+                cephadm.shell(args=[f"ceph orch restart {osd_service}"])
+            time.sleep(30)
 
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")

--- a/utility/lvm_utils.py
+++ b/utility/lvm_utils.py
@@ -1,5 +1,5 @@
 def pvcreate(osd, devices):
-    osd.exec_command(cmd="sudo pvcreate %s" % devices)
+    osd.exec_command(cmd="sudo pvcreate -ff %s" % devices)
 
 
 def vgcreate(osd, vg_name, devices):


### PR DESCRIPTION
Previous PR - #3502 

[CEPH-83571692](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83571692l): Automation of ceph-bluestore-tool functionalities and workflows for non-collocated operations

This PR extends the existing automation to cover addition of WAL, addition of dedicated DB and resharding, all three of which were not covered in the parent PR #2634 

Jira - [RHCEPHQE-9439](https://issues.redhat.com/browse/RHCEPHQE-9439)

Test modules modified:
- `ceph/rados/bluestoretool_workflows.py`
- `tests/rados/test_bluestoretool_workflows.py`
- `ceph/rados/core_workflows.py`

Test suites modified:
- `suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/reef/rados/tier-2_rados_test_cot_cbt.yaml`

ceph-bluestore-tool commands covered:
 - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
 - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
 - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
 
Logs:
RHCS 5.3 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6VVCKY
RHCS 6.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1WWU6V/
RHCS 7.0 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PX1J7G/
RHCS 7.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M49EUK

Signed-off-by: Harsh Kumar <hakumar@redhat.com>