### PR TITLE
[Tier-3] CEPH-83575074: cleanup workload bi-directional object workload

### DIFF
--- a/suites/quincy/baremetal_pipeline/tier-1_rgw_ms.yaml
+++ b/suites/quincy/baremetal_pipeline/tier-1_rgw_ms.yaml
@@ -448,3 +448,47 @@ tests:
             module: push_cosbench_workload.py
             name: push cosbench push workload from secondary
             polarion-id: CEPH-83575073
+
+  - test:
+      name: Parallel delete of objects from bucket
+      desc: Parallel delete of objects from bucket
+      module: test_parallel.py
+      parallel:
+        - test:
+            abort-on-fail: true
+            clusters:
+              ceph-pri:
+                config:
+                  controllers:
+                    - folio01
+                  drivers:
+                    - folio01
+                    - folio02
+                    - folio03
+                  workload_type: cleanup
+                  record_sync_on_site: ceph-sec
+                  bucket_prefix: cosbench01-bkt-
+                  number_of_buckets: 1
+            desc: initiate cosbench cleanup workload from primary
+            module: push_cosbench_workload.py
+            name: push cosbench cleanup workload from primary
+            polarion-id: CEPH-83575074
+        - test:
+            abort-on-fail: true
+            clusters:
+              ceph-sec:
+                config:
+                  controllers:
+                    - folio04
+                  drivers:
+                    - folio04
+                    - folio05
+                    - folio06
+                  workload_type: cleanup
+                  record_sync_on_site: ceph-pri
+                  bucket_prefix: cosbench01-bkt-
+                  number_of_buckets: 1
+            desc: initiate cosbench cleanup workload from secondary
+            module: push_cosbench_workload.py
+            name: push cosbench cleanup workload from secondary
+            polarion-id: CEPH-83575074


### PR DESCRIPTION
# Description

Initiate cleanup workload parallely, bidirectional
log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-ROSV1H/Parallel_delete_of_objects_from_bucket_0.log

latest log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-KHKL0J/Parallel_delete_of_objects_from_bucket_0.log
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
