### PR TITLE
Test archive zone colocation with data zone on same ceph cluster

### DIFF
--- a/conf/reef/rgw/tier-3_archive_zone_colocate_data_zone_conf.yaml
+++ b/conf/reef/rgw/tier-3_archive_zone_colocate_data_zone_conf.yaml
@@ -1,0 +1,77 @@
+#Conf for archive+primary colocation one 1 cluster ‘ceph-pri’
+#and secondary zone on ‘ceph-sec’
+---
+globals:
+  - ceph-cluster:
+      name: ceph-pri
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+      node2:
+        role:
+          - mgr
+          - mon
+      node3:
+        role:
+          - mon
+          - rgw
+      node4:
+        role:
+          - rgw
+          - client
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+      node6:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+      node7:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+      node8:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+  - ceph-cluster:
+      name: ceph-sec
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - mon
+          - osd
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+          - client

--- a/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -1,0 +1,276 @@
+# Test suite for archive colocated scenario, where the archive zone is colocated to the primary zone cluster.
+# This suite deploys a single realm (India) spanning across two RHCS clusters.
+# The first cluster is ceph-pri that has a primary zone(active zone) colocated with an archive zone.
+# The second cluster is Ceph-sec that has a secondary zone(active zone)
+# It has a zonegroup (shared) which also spans across the clusters. There
+# exists a
+# master zone - pri
+# secondary zone - sec
+# archive zone - arc
+
+---
+
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.arc
+                  args:
+                    placement:
+                      nodes:
+                        - node3
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+      desc: RHCS cluster deployment using cephadm.
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+      polarion-id: CEPH-10117
+
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node4
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node4
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node4}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node4}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key colocate123 --secret colocate123 --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key colocate123 --secret colocate123"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node4}:80 --access-key colocate123 --secret colocate123 --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node4}:80 --access-key colocate123 --secret colocate123"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node4}:80 --access-key colocate123 --secret colocate123"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+      desc: Setting up 3-way RGW multisite replication environment
+      module: exec.py
+      name: setup 3-way multisite
+      polarion-id: CEPH-10704
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+              - "ceph osd dump"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on primary
+      polarion-id: CEPH-83575227
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+              - "ceph osd dump"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on secondary
+      polarion-id: CEPH-83575227
+
+# create the archive zone colocated with the primary zone
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node4}:80 --access-key colocate123 --secret colocate123 --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node4}:80 --access-key colocate123 --secret colocate123"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone archive --endpoints http://{node_ip:node3}:80 --access-key colocate123 --secret colocate123 --tier-type=archive"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.shared.arc rgw_realm india"
+              - "ceph config set client.rgw.shared.arc rgw_zonegroup shared"
+              - "ceph config set client.rgw.shared.arc rgw_zone archive"
+              - "ceph orch restart rgw.shared.arc"
+      desc: Colocate the archive zone with primary sone cluster
+      module: exec.py
+      name: Colocate the archive zone with primary sone cluster
+      polarion-id: CEPH-83573389
+
+
+  # Test work flow
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+            timeout: 300
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
+            timeout: 300
+      desc: Perform IOs and test bucket versioned at the colocated archive zone
+      module: sanity_rgw_multisite.py
+      name: Perform IOs and test bucket versioned at the colocated archive zone
+      polarion-id: CEPH-83573389

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -391,7 +391,6 @@ def set_test_env(config, rgw_node):
             )
             rgw_node.exec_command(cmd="python3 -m venv venv")
             rgw_node.exec_command(cmd="venv/bin/pip install --upgrade pip")
-            rgw_node.exec_command(cmd="venv/bin/pip install configobj")
             rgw_node.exec_command(
                 cmd=f"venv/bin/pip install -r {test_folder}/ceph-qe-scripts/rgw/requirements.txt"
             )

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -391,6 +391,7 @@ def set_test_env(config, rgw_node):
             )
             rgw_node.exec_command(cmd="python3 -m venv venv")
             rgw_node.exec_command(cmd="venv/bin/pip install --upgrade pip")
+            rgw_node.exec_command(cmd="venv/bin/pip install configobj")
             rgw_node.exec_command(
                 cmd=f"venv/bin/pip install -r {test_folder}/ceph-qe-scripts/rgw/requirements.txt"
             )


### PR DESCRIPTION
# Description

Test archive zone colocation with data zone on same ceph cluster


Test suite for archive colocated scenario, where the archive zone is colocated to the primary zone cluster.
This suite deploys a single realm (India) spanning across two RHCS clusters.
The first cluster is ceph-pri that has a primary zone(active zone) colocated with an archive zone.
The second cluster is Ceph-sec that has a secondary zone(active zone)
It has a zonegroup (shared) which also spans across the clusters. 
There exists a
 - master zone - pri
 - secondary zone - sec
-  archive zone - arc

test case : [CEPH-83573389](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83573389)

passed logs http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Q1SPQR


ceph-qe-scripts pr https://github.com/red-hat-storage/ceph-qe-scripts/pull/575

