### PR TITLE
Disable sync between zones in case of multizone configuration

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
@@ -181,6 +181,27 @@ tests:
       polarion-id: CEPH-83573815
 
   - test:
+      abort-on-fail: true
+      config:
+        node: node7
+        sudo: True
+        commands:
+          - "yum install -y jq"
+          - "radosgw-admin zonegroup get --rgw-zonegroup=south > /tmp/zonegroup_south_backup.json"
+          - "jq -r '.zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_south_backup.json > /tmp/zonegroup_south.json"
+          - "radosgw-admin zonegroup set --rgw-zonegroup=south --infile=/tmp/zonegroup_south.json"
+          - "radosgw-admin period update --rgw-realm india --commit"
+          - "radosgw-admin zonegroup get --rgw-zonegroup=east > /tmp/zonegroup_east_backup.json"
+          - "jq -r '.zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_east_backup.json > /tmp/zonegroup_east.json"
+          - "radosgw-admin zonegroup set --rgw-zonegroup=east --infile=/tmp/zonegroup_east.json"
+          - "radosgw-admin period update --rgw-realm us --commit"
+          - "sleep 20"
+      desc: Disabling sync between the zones
+      module: exec.py
+      name: disable sync between zones
+      polarion-id: CEPH-83581229
+
+  - test:
       name: Test the byte ranges with get object
       desc: Test the byte ranges with get_object
       polarion-id: CEPH-83572691

--- a/suites/reef/rgw/tier-1_rgw_with_multi_realm.yaml
+++ b/suites/reef/rgw/tier-1_rgw_with_multi_realm.yaml
@@ -181,6 +181,27 @@ tests:
       polarion-id: CEPH-83573815
 
   - test:
+      abort-on-fail: true
+      config:
+        node: node7
+        sudo: True
+        commands:
+          - "yum install -y jq"
+          - "radosgw-admin zonegroup get --rgw-zonegroup=south > /tmp/zonegroup_south_backup.json"
+          - "jq -r '.zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_south_backup.json > /tmp/zonegroup_south.json"
+          - "radosgw-admin zonegroup set --rgw-zonegroup=south --infile=/tmp/zonegroup_south.json"
+          - "radosgw-admin period update --rgw-realm india --commit"
+          - "radosgw-admin zonegroup get --rgw-zonegroup=east > /tmp/zonegroup_east_backup.json"
+          - "jq -r '.zones[].log_data=false | .zones[].sync_from_all=false' /tmp/zonegroup_east_backup.json > /tmp/zonegroup_east.json"
+          - "radosgw-admin zonegroup set --rgw-zonegroup=east --infile=/tmp/zonegroup_east.json"
+          - "radosgw-admin period update --rgw-realm us --commit"
+          - "sleep 20"
+      desc: Disabling sync between the zones
+      module: exec.py
+      name: disable sync between zones
+      polarion-id: CEPH-83581229
+
+  - test:
       name: Test the byte ranges with get object
       desc: Test the byte ranges with get_object
       polarion-id: CEPH-83572691


### PR DESCRIPTION
# Description

Include testcase to disable sync between the zones,
In case of multi zone configuration present within single realm

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-283KRF/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
