### PR TITLE
CEPH-83582009 | CEPH-83582010: EIO flag on a replica-1 pool

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -267,10 +267,8 @@ class RadosOrchestrator:
             log.error(f"requested pool {pool} is not present on the cluster")
             return False
 
-        cmd = f"ceph osd pool get {pool} {props} -f json"
-        out, err = self.node.shell([cmd])
-        prop_details = json.loads(out)
-        return prop_details
+        cmd = f"ceph osd pool get {pool} {props}"
+        return self.run_ceph_command(cmd=cmd, client_exec=True)
 
     def get_pool_details(self, pool) -> dict:
         """

--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -104,6 +104,7 @@ class PoolFunctions:
                 self.rados_obj.change_osd_state(action="restart", target=primary_osd)
                 pool_stat = self.rados_obj.get_ceph_pg_dump_pools(pool_id=pool_id)
                 omap_keys = pool_stat["stat_sum"]["num_omap_keys"]
+                log.info(f"Current value of OMAP keys: {omap_keys}")
                 if omap_keys < expected_omap_keys:
                     log.error(
                         f"OMAP key yet to reach expected value of {expected_omap_keys} for pool {pool_name} "
@@ -698,3 +699,17 @@ class PoolFunctions:
 
         log.info(f"Executing command: {_cmd}")
         return self.node.shell([_cmd])
+
+    def fetch_pool_stats(self, pool: str) -> dict:
+        """
+        Fetch pool statistics using ceph osd pool stats <pool-name>
+        Args:
+            pool: name of the pool in string format
+        Returns:
+            dictionary output of ceph osd pool stats command
+            e.g. [{"pool_name":"replica1_zone2","pool_id":9,"recovery":{},"recovery_rate":{},
+            "client_io_rate":{"write_bytes_sec":1255027894,"read_op_per_sec":0,"write_op_per_sec":299}}]
+        """
+        _cmd = f"ceph osd pool stats {pool}"
+        pool_stat = self.rados_obj.run_ceph_command(cmd=_cmd, client_exec=True)
+        return pool_stat[0]

--- a/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -249,3 +249,4 @@ tests:
       module: test_crash_daemon.py
       polarion-id: CEPH-83573855
       desc: Verify crash warning in ceph health upon crashing a daemon
+      comments: Active BZ-2253394

--- a/suites/quincy/rados/tier-2_rados_test-replica1.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-replica1.yaml
@@ -1,4 +1,5 @@
 # Suite contains tests for replica-1 non-resilient pool
+# conf: conf/quincy/rados/11-node-replica1-cluster.yaml
 tests:
   - test:
       name: setup install pre-requisistes
@@ -109,4 +110,16 @@ tests:
       name: replica-1 non-resilient pools
       module: test_replica1.py
       polarion-id: CEPH-83575297
+      config:
+       replica-1: true
       desc: Test replica-1 non-resilient pools
+
+# test should run in succession with previous test(replica-1 non-resilient pools)
+# as it needs replica-1 pools to be present on the cluster
+  - test:
+      name: EIO flag on replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83582009
+      config:
+        eio: true
+      desc: Test EIO flag on replica-1 non-resilient pools

--- a/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -248,3 +248,4 @@ tests:
       module: test_crash_daemon.py
       polarion-id: CEPH-83573855
       desc: Verify crash warning in ceph health upon crashing a daemon
+      comments: Active BZ-2253394

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -105,7 +105,6 @@ tests:
       polarion-id: CEPH-83580881
       config:
         host_level: true
-      comments: Fix isn't included in 7.0
 
   - test:
       name: ceph osd df stats

--- a/suites/reef/rados/tier-2_rados_test-replica1.yaml
+++ b/suites/reef/rados/tier-2_rados_test-replica1.yaml
@@ -1,4 +1,5 @@
 # Suite contains tests for replica-1 non-resilient pool
+# conf: conf/reef/rados/11-node-replica1-cluster.yaml
 tests:
   - test:
       name: setup install pre-requisistes
@@ -109,4 +110,16 @@ tests:
       name: replica-1 non-resilient pools
       module: test_replica1.py
       polarion-id: CEPH-83575297
+      config:
+       replica-1: true
       desc: Test replica-1 non-resilient pools
+
+# test should run in succession with previous test(replica-1 non-resilient pools)
+# as it needs replica-1 pools to be present on the cluster
+  - test:
+      name: EIO flag on replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83582009
+      config:
+        eio: true
+      desc: Test EIO flag on replica-1 non-resilient pools

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -171,3 +171,4 @@ tests:
               pool_type: replicated
               pg_num: 16
         delete_pool: true
+      comments: Active BZ-2269089

--- a/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -248,3 +248,4 @@ tests:
       module: test_crash_daemon.py
       polarion-id: CEPH-83573855
       desc: Verify crash warning in ceph health upon crashing a daemon
+      comments: Active BZ-2253394

--- a/tests/rados/test_osd_memory_target.py
+++ b/tests/rados/test_osd_memory_target.py
@@ -22,7 +22,6 @@ def run(ceph_cluster, **kw):
     """
     log.info(run.__doc__)
     config = kw["config"]
-    rhbuild = config.get("rhbuild")
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
@@ -140,6 +139,7 @@ def run(ceph_cluster, **kw):
         # BZ-2213873 | Quincy (6.1z3)
         # BZ-2249014 | Pacific (5.3z6)
         # BZ-2244604 | Reef (7.1)
+        # BZ-2270263 | Reef (7.0)
         This test is to verify the propagation of osd_memory_target parameter
         set at HOST level to individual OSDs
         1. Create cluster with default configuration
@@ -155,11 +155,6 @@ def run(ceph_cluster, **kw):
         9. osd_memory_target value for the 2nd random OSD should get updated
         """
         log.info(doc)
-        if "7.0" in rhbuild:
-            log.info(
-                "Fix is yet to be back-ported to RHCS 7.0, passing without execution"
-            )
-            return 0
 
         try:
             osd_node = random.choice(osd_nodes)

--- a/tests/rados/test_replica1.py
+++ b/tests/rados/test_replica1.py
@@ -1,8 +1,11 @@
 """ Test module to verify replica-1 non-resilient pool functionalities"""
+import time
+from copy import deepcopy
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.crushtool_workflows import CrushToolWorkflows
+from ceph.rados.pool_workflows import PoolFunctions
 from tests.rados.monitor_configurations import MonConfigMethods
 from tests.rbd.rbd_utils import Rbd
 from utility.log import Log
@@ -13,160 +16,336 @@ log = Log(__name__)
 
 def run(ceph_cluster, **kw):
     """
-    # CEPH-83575297
-    1. Deploy ceph cluster with one OSD per host
-    2. Remove the crush device for all OSDs
-    3. Set unique device class for few OSDs and replicated device
-    class for all others.
-    4. Divide the hosts into different zones
-    5. Create unique crush rule for each unique device class
-    6. Set MON Config mon_allow_pool_size_one to true
-    7. Create replia-1 pool for each zone device class OSD
-    8. Ensure proper health warning is generated.
-    9. Perform scrubbing, deep-scrubbing and repair on replica-1 pools
-    10. Create RBD images on replica-1 pool
-    11. Enable compression of replica-1 pool
+    Test to verify scenarios related to replica-1
+        # CEPH-83575297: replica-1 pool creation and regression
+        # CEPH-83582009: EIO flag positive checks
+        # CEPH-83582010: EIO flag negative checks
     """
     log.info(run.__doc__)
     config = kw["config"]
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
     crush_obj = CrushToolWorkflows(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
     rbd_obj = Rbd(**kw)
     repli_pools = []
     zone_unique = generate_unique_id(length=4)
 
-    log.info("Running test case to verify replica-1 non-resilient pool")
+    def set_eio_flag(_pool: str, val: str):
+        log.info(f"Setting eio flag for pool {_pool} to {val}")
+        assert rados_obj.set_pool_property(pool=_pool, props="eio", value=val)
+        time.sleep(5)
+        _pool_prop = rados_obj.get_pool_property(pool=_pool, props="eio")
+        _eio_flag = _pool_prop["eio"]
+
+        log.info(f"EIO flag for pool {_pool} is {_eio_flag} | Expected - {val}")
+        return _eio_flag
 
     try:
-        # Fetch all the OSDs on the cluster
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
-        log.debug(f"List of OSDs: {osd_list}")
+        if config.get("replica-1"):
+            doc_text = """
+            # CEPH-83575297
+            1. Deploy ceph cluster with one OSD per host
+            2. Remove the crush device for all OSDs
+            3. Set unique device class for few OSDs and replicated device
+            class for all others.
+            4. Divide the hosts into different zones
+            5. Create unique crush rule for each unique device class
+            6. Set MON Config mon_allow_pool_size_one to true
+            7. Create replia-1 pool for each zone device class OSD
+            8. Ensure proper health warning is generated.
+            9. Perform scrubbing, deep-scrubbing and repair on replica-1 pools
+            10. Create RBD images on replica-1 pool
+            11. Enable compression of replica-1 pool
+            """
+            log.info(doc_text)
+            log.info("Running test case to verify replica-1 non-resilient pool")
 
-        # remove the device class for all the OSDs
-        assert crush_obj.remove_device_class(osd_list=osd_list)
+            # Fetch all the OSDs on the cluster
+            out, _ = cephadm.shell(args=["ceph osd ls"])
+            osd_list = out.strip().split("\n")
+            log.debug(f"List of OSDs: {osd_list}")
 
-        # divide OSDs into different device classes(zones) and their respective
-        # hosts into unique zones
-        for osd_id in osd_list:
-            if int(osd_id) % 2 == 0:
-                zone_name = f"zone{osd_id}-{zone_unique}"
-                cephadm.shell(
-                    [f"ceph osd crush set-device-class zone{osd_id} {osd_id}"]
-                )
-                cephadm.shell([f"ceph osd crush add-bucket {zone_name} zone"])
-                cephadm.shell([f"ceph osd crush move {zone_name} root=default"])
-                osd_node = rados_obj.fetch_host_node(
-                    daemon_type="osd", daemon_id=osd_id
-                )
-                cephadm.shell(
-                    [f"ceph osd crush move {osd_node.hostname} zone={zone_name}"]
-                )
+            # remove the device class for all the OSDs
+            assert crush_obj.remove_device_class(osd_list=osd_list)
 
-        # divide OSDs into different device classes(replicated)
-        replicated_osd = " ".join(
-            [osd_id for osd_id in osd_list if int(osd_id) % 2 != 0]
-        )
-        cephadm.shell([f"ceph osd crush set-device-class replicated {replicated_osd}"])
+            # divide OSDs into different device classes(zones) and their respective
+            # hosts into unique zones
+            for osd_id in osd_list:
+                if int(osd_id) % 2 == 0:
+                    zone_name = f"zone{osd_id}-{zone_unique}"
+                    cephadm.shell(
+                        [f"ceph osd crush set-device-class zone{osd_id} {osd_id}"]
+                    )
+                    cephadm.shell([f"ceph osd crush add-bucket {zone_name} zone"])
+                    cephadm.shell([f"ceph osd crush move {zone_name} root=default"])
+                    osd_node = rados_obj.fetch_host_node(
+                        daemon_type="osd", daemon_id=osd_id
+                    )
+                    cephadm.shell(
+                        [f"ceph osd crush move {osd_node.hostname} zone={zone_name}"]
+                    )
 
-        # generate replicated crush rule to append cluster crush rule
-        rule_name = "general-replicated"
-        zone_rules = """        id 111
-        type replicated
-        step take default class replicated
-        step chooseleaf firstn 0 type host
-        step emit"""
-        assert crush_obj.add_crush_rule(rule_name=rule_name, rules=zone_rules)
-
-        # generate zone level crush rules to append cluster crush rule
-        for osd_id in osd_list:
-            if int(osd_id) % 2 == 0:
-                rule_name = f"zone{osd_id}"
-                zone_rules = f"""        id 5{osd_id}
-                type replicated
-                step take default class zone{osd_id}
-                step chooseleaf firstn 0 type host
-                step emit"""
-                assert crush_obj.add_crush_rule(rule_name=rule_name, rules=zone_rules)
-
-        # set general replicated crush rule to all existing pools
-        pool_list = rados_obj.list_pools()
-        log.debug(f"List of pools in the cluster: {pool_list}")
-        for pool in pool_list:
-            rados_obj.set_pool_property(
-                pool=pool, props="crush_rule", value="general-replicated"
+            # divide OSDs into different device classes(replicated)
+            replicated_osd = " ".join(
+                [osd_id for osd_id in osd_list if int(osd_id) % 2 != 0]
+            )
+            cephadm.shell(
+                [f"ceph osd crush set-device-class replicated {replicated_osd}"]
             )
 
-        # set mon mon_allow_pool_size_one true
-        assert mon_obj.set_config(
-            section="mon", name="mon_allow_pool_size_one", value=True
-        )
+            # generate replicated crush rule to append cluster crush rule
+            rule_name = "general-replicated"
+            zone_rules = """        id 111
+            type replicated
+            step take default class replicated
+            step chooseleaf firstn 0 type host
+            step emit"""
+            assert crush_obj.add_crush_rule(rule_name=rule_name, rules=zone_rules)
 
-        # create replica-1 pools for each zone device class osd
-        for osd_id in osd_list:
-            if int(osd_id) % 2 == 0:
-                pool_cfg = {
-                    "pool_name": f"replica1_zone{osd_id}",
-                    "pg_num": 1,
-                    "pgp_num": 1,
-                    "crush_rule": f"zone{osd_id}",
-                    "disable_pg_autoscale": True,
-                }
-                assert rados_obj.create_pool(**pool_cfg)
+            # generate zone level crush rules to append cluster crush rule
+            for osd_id in osd_list:
+                if int(osd_id) % 2 == 0:
+                    rule_name = f"zone{osd_id}"
+                    zone_rules = f"""        id 5{osd_id}
+                    type replicated
+                    step take default class zone{osd_id}
+                    step chooseleaf firstn 0 type host
+                    step emit"""
+                    assert crush_obj.add_crush_rule(
+                        rule_name=rule_name, rules=zone_rules
+                    )
 
-                # set pool size to 1
-                out, _ = cephadm.shell(
-                    [
-                        f"ceph osd pool set {pool_cfg['pool_name']} size 1 --yes-i-really-mean-it"
-                    ]
+            # set general replicated crush rule to all existing pools
+            pool_list = rados_obj.list_pools()
+            log.debug(f"List of pools in the cluster: {pool_list}")
+            for pool in pool_list:
+                rados_obj.set_pool_property(
+                    pool=pool, props="crush_rule", value="general-replicated"
                 )
-                log.info(out)
-                repli_pools.append(pool_cfg["pool_name"])
 
-        # check ceph status to confirm replica pools have been created.
-        health_detail, _ = cephadm.shell(["ceph health detail"])
-        assert "pool(s) have no replicas configured" in health_detail
+            # set mon mon_allow_pool_size_one true
+            assert mon_obj.set_config(
+                section="mon", name="mon_allow_pool_size_one", value=True
+            )
 
-        # print the pool detail for each replica-1 pool
-        for _pool in repli_pools:
-            pool_detail = rados_obj.get_pool_details(pool=_pool)
-            log.info(f"{_pool} Pool details: ")
-            log.info(pool_detail)
+            # create replica-1 pools for each zone device class osd
+            for osd_id in osd_list:
+                if int(osd_id) % 2 == 0:
+                    pool_cfg = {
+                        "pool_name": f"replica1_zone{osd_id}",
+                        "pg_num": 1,
+                        "pgp_num": 1,
+                        "crush_rule": f"zone{osd_id}",
+                        "disable_pg_autoscale": True,
+                    }
+                    assert rados_obj.create_pool(**pool_cfg)
 
-        # perform scrub, deep-scrub and repairs on the replica1 pool pg
-        for _pool in repli_pools:
-            pg_id = rados_obj.get_pgid(pool_name=_pool)[0]
-            # trigger repair
-            cephadm.shell([f"ceph pg repair {pg_id}"])
-            rados_obj.run_scrub(pool=_pool)
-            rados_obj.run_deep_scrub(pool=_pool)
+                    # set pool size to 1
+                    out, _ = cephadm.shell(
+                        [
+                            f"ceph osd pool set {pool_cfg['pool_name']} size 1 --yes-i-really-mean-it"
+                        ]
+                    )
+                    log.info(out)
+                    repli_pools.append(pool_cfg["pool_name"])
 
-        # ensure acting set of each replica1 pool has only one OSD
-        for _pool in repli_pools:
-            pg_acting_set = rados_obj.get_pg_acting_set(pool_name=_pool)
-            assert len(pg_acting_set) == 1
-            log.info(f"Acting set of {_pool}: {pg_acting_set}")
+            # check ceph status to confirm replica pools have been created.
+            health_detail, _ = cephadm.shell(["ceph health detail"])
+            assert "pool(s) have no replicas configured" in health_detail
 
-        # create and map rbd images
-        for _pool in repli_pools:
-            if rbd_obj.create_image(
-                pool_name=_pool, image_name=f"img-{_pool}", size="4M"
-            ):
-                raise Exception(f"RBD image creation failed on pool: {_pool}")
-            log.info(f"RBD image creation success on pool: {_pool}")
+            # print the pool detail for each replica-1 pool
+            for _pool in repli_pools:
+                pool_detail = rados_obj.get_pool_details(pool=_pool)
+                log.info(f"{_pool} Pool details: ")
+                log.info(pool_detail)
 
-        # enable compression and compression ratios for each replica 1 pool
-        compress_cfg = {
-            "compression_algorithm": "snappy",
-            "compression_mode": "force",
-            "compression_required_ratio": 0.5,
-        }
-        for _pool in repli_pools:
-            assert rados_obj.pool_inline_compression(pool_name=_pool, **compress_cfg)
+            # perform scrub, deep-scrub and repairs on the replica1 pool pg
+            for _pool in repli_pools:
+                pg_id = rados_obj.get_pgid(pool_name=_pool)[0]
+                # trigger repair
+                cephadm.shell([f"ceph pg repair {pg_id}"])
+                rados_obj.run_scrub(pool=_pool)
+                rados_obj.run_deep_scrub(pool=_pool)
+
+            # ensure acting set of each replica1 pool has only one OSD
+            for _pool in repli_pools:
+                pg_acting_set = rados_obj.get_pg_acting_set(pool_name=_pool)
+                assert len(pg_acting_set) == 1
+                log.info(f"Acting set of {_pool}: {pg_acting_set}")
+
+            # create and map rbd images
+            for _pool in repli_pools:
+                if rbd_obj.create_image(
+                    pool_name=_pool, image_name=f"img-{_pool}", size="4M"
+                ):
+                    raise Exception(f"RBD image creation failed on pool: {_pool}")
+                log.info(f"RBD image creation success on pool: {_pool}")
+
+            # enable compression and compression ratios for each replica 1 pool
+            compress_cfg = {
+                "compression_algorithm": "snappy",
+                "compression_mode": "force",
+                "compression_required_ratio": 0.5,
+            }
+            for _pool in repli_pools:
+                assert rados_obj.pool_inline_compression(
+                    pool_name=_pool, **compress_cfg
+                )
+
+            log.info("replica-1 pool tests completed successfully")
+
+        if config.get("eio"):
+            doc_text = """
+                # CEPH-83582009 | CEPH-83582010
+                1. On a cluster with replica-1 pools configured
+                2. Perform sanity check for EIO flag
+                3. Trigger IOs using rados bench and set EIO flag during active IOPS
+                4. With EIO flag already set on a pool, try writing data to it
+            """
+            log.info(doc_text)
+
+            log.info(
+                "Running test case to verify EIO flag on replica-1 non-resilient pool"
+            )
+
+            pool_list = rados_obj.list_pools()
+            repli_pools = [pool for pool in pool_list if "replica1" in pool]
+            repli_pools_org = deepcopy(repli_pools)
+            log.info(f"List of replica-1 pools on the cluster: {repli_pools}")
+
+            # choose a replica-1 pool to do sanity checks
+            pool_name = repli_pools.pop()
+            log.info(
+                f"Pool on which EIO flag sanity test will be performed: {pool_name}"
+            )
+
+            # fetch default value of eio flag for the chosen pool
+            pool_prop = rados_obj.get_pool_property(pool=pool_name, props="eio")
+            eio_flag = pool_prop["eio"]
+
+            # default value of eio flag should be false
+            # {"pool":"replica1_zone4","pool_id":10,"eio":false}
+            if eio_flag:
+                log.error(
+                    f"Default value of EIO flag for replica-1 pool {pool_name} expected to be false"
+                )
+                log.error(f"Actual value: {eio_flag}")
+                raise AssertionError(
+                    f"Expected eio flag to be false, actual value: {eio_flag}"
+                )
+
+            log.info(f"Default value of EIO flag has been verified: {eio_flag}")
+
+            # positive check | True
+            eio_flag = set_eio_flag(_pool=pool_name, val="true")
+            assert eio_flag is True
+
+            # positive check | False
+            eio_flag = set_eio_flag(_pool=pool_name, val="false")
+            assert eio_flag is False
+
+            # positive check | 1
+            eio_flag = set_eio_flag(_pool=pool_name, val="1")
+            assert eio_flag is True
+
+            # positive check | 0
+            eio_flag = set_eio_flag(_pool=pool_name, val="0")
+            assert eio_flag is False
+
+            # invalid input check
+            for value in ["111", "text", "-1"]:
+                try:
+                    cmd = f"ceph osd pool set {pool_name} eio {value}"
+                    out, _ = cephadm.shell(args=[cmd])
+                except Exception as err:
+                    log.info(f"Expected to fail: {err}")
+                    assert "expecting value" in str(err)
+
+            log.info(
+                f"Sanity checks for EIO flag on pool {pool_name} have been completed"
+            )
+
+            # choose a replica-1 pool to do in flight IOPs check
+            pool_name = repli_pools.pop()
+            log.info(f"Pool on which in-flight IOs test will be performed: {pool_name}")
+
+            # start ios using rados bench
+            rados_obj.bench_write(pool_name=pool_name, background=True)
+            time.sleep(5)
+
+            # ensure ios have started on the pool
+            pool_stat = pool_obj.fetch_pool_stats(pool=pool_name)
+            log.info(f"Pool stats after IOs have started: {pool_stat}")
+            if not pool_stat["client_io_rate"]:
+                log.error(f"Expected to have client IOs on pool {pool_name}")
+                raise Exception(f"Expected to have client IOs on pool {pool_name}")
+
+            log.info(
+                f"Client IOs started successfully on {pool_name}, proceeding to set EIO flag"
+            )
+
+            eio_flag = set_eio_flag(_pool=pool_name, val="true")
+            assert eio_flag is True
+            time.sleep(10)
+
+            # ensure in-flight ios have halted on the pool
+            pool_stat = pool_obj.fetch_pool_stats(pool=pool_name)
+            log.info(
+                f"Pool stats after EIO flag during acting background IOs: {pool_stat}"
+            )
+            if pool_stat["client_io_rate"]:
+                log.error(f"Expected client IOs to halt on pool {pool_name}")
+                raise Exception(f"Expected client IOs to halt on pool {pool_name}")
+
+            log.info(
+                f"In-flight IOs stopped once EIO flag was set on the pool {pool_name}"
+            )
+
+            # the recovery of IOs cannot be verified with rados bench, as the process
+            # stops as soon as it receives the EIO signal
+            # Future scope: Figure out an IO tool with which IO recovery can be verified
+            if False:
+                log.info("proceeding to unset EIO flag to resume IOs after 15 secs")
+                time.sleep(15)
+
+                eio_flag = set_eio_flag(_pool=pool_name, val="false")
+                assert eio_flag is False
+                time.sleep(5)
+
+                # ensure ios have resumed on the pool
+                pool_stat = pool_obj.fetch_pool_stats(pool=pool_name)
+                log.info(f"Pool stats after EIO flag is removed: {pool_stat}")
+                if not pool_stat["client_io_rate"]:
+                    log.error(f"Expected to have client IOs resume on pool {pool_name}")
+                    raise Exception(
+                        f"Expected to have client IOs resume on pool {pool_name}"
+                    )
+
+                log.info(
+                    f"Client IOs resumed successfully on {pool_name}, proceeding to set EIO flag"
+                )
+
+            # Perform IOs on a pool on which EIO flag is already set
+            log.info("Running client IOs on a pool with active EIO flag")
+            log.info(f"Pool on which EIO flag is already set: {pool_name}")
+
+            if rados_obj.bench_write(pool_name=pool_name):
+                log.error(f"Expected rados bench to fail on pool {pool_name}")
+                raise Exception(f"Expected rados bench to fail on pool {pool_name}")
+
+            log.info(f"Client IOs could not run on pool {pool_name} as expected")
+            log.info("All relevant tests around EIO have been verified")
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
         return 1
+    finally:
+        log.info("************* Execution of finally block starts ***********")
+        if config.get("eio"):
+            # unset eio flag on all replica-1 pools
+            for pool in repli_pools_org:
+                set_eio_flag(_pool=pool, val="false")
+
     return 0

--- a/tests/rados/test_upgrade_warn.py
+++ b/tests/rados/test_upgrade_warn.py
@@ -48,7 +48,7 @@ def run(ceph_cluster, **kw):
         warn_flag = False
         upgrade_complete = False
         # Monitor upgrade status, till completion, checking for the warning to be generated
-        end_time = datetime.datetime.now() + datetime.timedelta(seconds=14400)
+        end_time = datetime.datetime.now() + datetime.timedelta(seconds=3600)
         while end_time > datetime.datetime.now():
             cmd = "ceph orch upgrade status"
             out = rados_obj.run_ceph_command(cmd=cmd, client_exec=True)


### PR DESCRIPTION
[CEPH-83582009](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582009): EIO flag set in a replica-1 deployment [positive scenarios]

[CEPH-83582010](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582010): EIO flag set in a replica-1 deployment [negative scenarios]

Jira: [RHCEPHQE-13626](https://issues.redhat.com/browse/RHCEPHQE-13626)

EIO brief introduction:
- There are use cases where data safety is assured by external mechanism and Ceph is being used basically as a provider of RADOS / S3 / Swift / * API.
- In such deployments there will be a need for signaling the “disk unplugged” condition to Ceph clients. 


Test modules modified:
- `get_pool_property` in `ceph/rados/core_workflows.py`
- `tests/rados/test_replica1.py`

Test modules added:
- `fetch_pool_stats` in `ceph/rados/pool_workflows.py`

Test suites modified:
- suites/quincy/rados/tier-2_rados_test-replica1.yaml
- suites/reef/rados/tier-2_rados_test-replica1.yaml

Steps:
1. Deploy a cluster and configure replica-1 pools
2. Perform sanity check for EIO flag
3. Trigger IOs using rados bench and set EIO flag during active IOPS
4. With EIO flag already set on a pool, try writing data to it

Logs-
RHCS 6.1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ECU4KN
RHCS 7.0: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FDC0IV
RHCS 7.1: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YMIL4P
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W7K311

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
