### PR TITLE
[TFA-Fix] Enable log to console in run.py of cephci

### DIFF
--- a/run.py
+++ b/run.py
@@ -401,6 +401,10 @@ def run(args):
     run_dir = create_run_dir(run_id, log_directory)
 
     log.configure_logger("startup", run_dir, disable_console_log)
+
+    if console_log_level:
+        log.logger.setLevel(console_log_level.upper())
+
     run_start_time = datetime.datetime.now()
     trigger_user = getuser()
 


### PR DESCRIPTION
# Description
Log_to_console was removed in previous prs: https://github.com/red-hat-storage/cephci/pull/3517, due to this we are not seeing any console log in testcase runs : log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.1-67/Weekly/rgw/29/tier-2_rgw_ms-archive/test_multipart_download_at_remote_site_0.log

log having console logs with this changes : http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-A15BIY/enable_bucket_versioning_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
