### PR TITLE
cephci integration of CEPH-83574044

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -992,3 +992,24 @@ tests:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
         timeout: 500
+
+  - test:
+      name: Test LC transition with rule by lc process
+      desc: Test LC transition with rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      comments: known issue (BZ-2269490)
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_transition_with_lc_process.yaml
+        timeout: 500
+
+  - test:
+      name: Test LC transition without rule by lc process
+      desc: Test LC transition without rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_process_without_applying_rule.yaml
+        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
@@ -188,3 +188,24 @@ tests:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_aws_non_ascii.yaml
         timeout: 500
+
+  - test:
+      name: Test LC transition with rule by lc process
+      desc: Test LC transition with rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      comments: known issue (BZ-2269490)
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_transition_with_lc_process.yaml
+        timeout: 500
+
+  - test:
+      name: Test LC transition without rule by lc process
+      desc: Test LC transition without rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_process_without_applying_rule.yaml
+        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -198,3 +198,25 @@ tests:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_aws_non_ascii.yaml
         timeout: 500
+
+  - test:
+      name: Test LC transition with rule by lc process
+      desc: Test LC transition with rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      comments: known issue (BZ-2269490)
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_transition_with_lc_process.yaml
+        timeout: 500
+
+  - test:
+      name: Test LC transition without rule by lc process
+      desc: Test LC transition without rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      comments: known issue (BZ-2270402)
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_process_without_applying_rule.yaml
+        timeout: 500


### PR DESCRIPTION
# Description
cephci integration of:
Polarian: CEPH-83574044: Test LC process (perform radosgw-admin lc process) with and without applying LC rule

Logs:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-0PHI69/
Both failures are known product issue.
added know issue comment in suite.

ceph-qe-script: https://github.com/red-hat-storage/ceph-qe-scripts/pull/574


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
