### PR TITLE
integrating s3select query generation tests on csv objects

### DIFF
--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -223,3 +223,24 @@ tests:
         script-name: test_swift_basic_ops.py
         config-file-name: test_s3_and_swift_versioning.yaml
         timeout: 500
+
+  # test s3-select with query generation of incorrect syntax
+  - test:
+      name: test s3select with depth1 queries on csv objects
+      desc: test s3select with depth1 queries of incorrect syntax for checking rgw crashes on csv objects
+      polarion-id: CEPH-83575176
+      module: sanity_rgw.py
+      config:
+        script-name: test_s3select.py
+        config-file-name: test_s3select_query_gen_csv_depth1.yaml
+        timeout: 3600
+
+  - test:
+      name: test s3select with depth2 queries on csv objects
+      desc: test s3select with depth2 queries of incorrect syntax for checking rgw crashes on csv objects
+      polarion-id: CEPH-83575176
+      module: sanity_rgw.py
+      config:
+        script-name: test_s3select.py
+        config-file-name: test_s3select_query_gen_csv_depth2.yaml
+        timeout: 3600


### PR DESCRIPTION
This PR is to automate s3select query generation for checking rgw crashes on csv objects
pass logs on 7.1: http://magna002.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/PR_s3select_query_gen/

ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/570

polarion id: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575176

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
