### PR TITLE
[Hardware Monitoring] [Baremetal] Add support for hardware monitoring

### DIFF
--- a/cephci/stats.py
+++ b/cephci/stats.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timezone
+
+from docopt import docopt
+from utils.configs import get_cloud_credentials, get_configs, get_database_credentials
+from utils.utility import set_logging_env
+
+from cli.cloudproviders import CloudProvider
+from cli.exceptions import ConfigError
+from cli.reports.database import Database
+from utility.log import Log
+
+# Set logging env
+LOG = Log(__name__)
+
+# Table names corresponding to different usecases
+HARDWARE_MONITORING_TABLE = "hardware_monitoring"
+
+doc = """
+Utility to get Cluster Stats
+
+    Usage:
+        cephci/stats.py --report <STR>
+            [--owner <STR>]
+            [--log-level <LOG>]
+            [--log-dir <PATH>]
+
+        cephci/provision.py --help
+
+    Options:
+        -h --help               Help
+        --report <STR>          Report type [bm-hardware-status|cpu-memory-usage|nfs-scale-report]
+        --owner <STR>           Baremetal node owner
+        --config <YAML>         Config file with cloud credentials
+        --log-level <LOG>       Log level for log utility Default: DEBUG
+        --log-dir <PATH>        Log directory for logs
+"""
+
+
+def get_baremetal_hardware_status(node_stats):
+    # Get the creds specific to the database
+    credentials = get_database_credentials(config, "database")
+    credentials["table"] = HARDWARE_MONITORING_TABLE
+    reporting = Database(**credentials)
+
+    # Indentify the cols
+    cols = []
+    for key, _ in node_stats[0]:
+        cols.append(key)
+    cols.append("locked_days")
+    cols = " ,".join(cols)
+
+    # For each node identify the required data and push to db
+    for node in node_stats:
+        data = []
+        opendays = "NA"
+
+        # Find open since days
+        dt = node.get("locked_since")
+        if dt:
+            dt = datetime.strptime(dt, "%Y-%m-%d %H:%M:%S.%f").replace(
+                tzinfo=timezone.utc
+            )
+            opendays = (datetime.now(timezone.utc) - dt).days
+
+        # For some fields, teuthology returns Attribute Error with long error message or empty value
+        # In such cases, add custom value (Info Not Available or AttributeError) to the db
+        for _, val in node.items():
+            val = str(val) if val else "Info Not Available"
+            if (
+                "AttributeError" in val
+            ):  # Teuthology returns Attribute error for some cols
+                val = "AttributeError"
+            data.append(f"'{val}'")
+
+        data.append(f"'{str(opendays)}'")
+        data = " ,".join(data)
+
+        # Append the data to the database
+        reporting.insert(table=HARDWARE_MONITORING_TABLE, cols=cols, data=data)
+
+    # Close the db connection
+    reporting.db_conn.close()
+
+
+if __name__ == "__main__":
+    # Set configs
+    cloud_configs, global_configs = {}, []
+
+    # Set user parameters
+    args = docopt(doc)
+
+    # Get user parameters
+    report = args.get("--report")
+    owner = args.get("--owner")
+    config = args.get("--config")
+    log_level = args.get("--log-level")
+    log_dir = args.get("--log-dir")
+
+    # Set log level
+    LOG = set_logging_env(level=log_level, path=log_dir)
+
+    # Read configuration for cloud
+    get_configs(config)
+
+    # Check for mandatory baremetal paramters
+    if report == "bm-hardware-status":
+        if not owner:
+            raise ConfigError("Mandatory owner are not provided")
+        # Set cloud owner
+        cloud_configs["owner"] = owner
+
+        # Read cloud configurations
+        cloud_configs.update(get_cloud_credentials(report))
+
+        # Get timeout and interval
+        timeout, retry = cloud_configs.pop("timeout"), cloud_configs.pop("retry")
+
+        # Connect to cloud
+        cloud = CloudProvider(report, **cloud_configs)
+
+        # Get the Hardware Stats
+        node_stats = cloud.get_node_details()
+
+        # Get the baremetal hardware status
+        get_baremetal_hardware_status(node_stats)

--- a/cephci/utils/configs.py
+++ b/cephci/utils/configs.py
@@ -267,3 +267,27 @@ def get_reports(service):
         return _dict
     except KeyError:
         raise ConfigError(f"Insufficient config for '{service}'")
+
+
+def get_database_credentials(config, database):
+    """
+    Gets the credentials of the database
+    Args:
+        config (conf): User specified config
+        database (str): Name of the database
+    """
+    get_configs(config)
+    if not CONFIG:
+        raise ConfigError("Configuration is not passed")
+    _dict = {}
+    try:
+        log.info(f"Loading credentials for reporting service '{database}'")
+        credentials = CONFIG["reports"][database]
+        _dict["name"] = credentials["name"]
+        _dict["user"] = credentials["user"]
+        _dict["pwd"] = credentials["pwd"]
+        _dict["host"] = credentials["host"]
+        _dict["port"] = credentials["port"]
+        return _dict
+    except KeyError:
+        raise ConfigError(f"Insufficient config for '{database}'")

--- a/cli/reports/database.py
+++ b/cli/reports/database.py
@@ -1,0 +1,52 @@
+import psycopg
+
+from cli.exceptions import ConfigError
+
+
+class Database:
+    def __init__(self, **creds):
+        """Initialize instance using provided details
+
+        **Kwargs:
+            name(str): Name of DB
+            user(str): Username
+            pwd(str): db Password
+            host(str): host ip/ hostname
+            port(str): Port no.
+            table(str): db Table name
+        """
+        try:
+            self.name = creds["name"]
+            self.user = creds["user"]
+            self.pwd = creds["pwd"]
+            self.host = creds["host"]
+            self.port = creds["port"]
+        except KeyError:
+            raise ConfigError("Mandatory parameters are missing")
+        self.conn = self._establish_db_conn()
+
+    def _establish_db_conn(self):
+        return psycopg.connect(
+            dbname=self.name,
+            user=self.user,
+            password=self.pwd,
+            host=self.host,
+            port=self.port,
+        )
+        self.conn.autocommit = True
+
+    def insert(self, table, cols, data):
+        insert_query = f"""INSERT INTO {table} ({cols}) VALUES ({data})"""
+        self._execute(insert_query)
+
+    def update(self):
+        update_query = """<cmd here>"""
+        self._execute(update_query)
+
+    def delete(self):
+        delete_query = """<cmd here>"""
+        self._execute(delete_query)
+
+    def _execute(self, cmd):
+        self.conn.cursor().execute(cmd)
+        self.conn.commit()


### PR DESCRIPTION
Problem:
Need to have a single destination for hardware monitoring which can give the details of the machines available, current status, locked status etc.

Solution:
Design and implement a standalone utility that can connect to teuthology and get the information, push the data to a db. This will help us in visualising the data using grafana

Usage:

Add the below details in the config_file
```
reports:
  grafana:
    db_name: xxx
    db_user: xxx
    db_pwd: xxx
    db_host: xxx.xxx.xxx.xxx
    db_port: xxxx
    db_table: xxx
```
run the utility
python3 cephci/stats.py --cloud-type baremetal --owner <owner>@magna002 --config ~/.cephci_baremetal.yaml --log-level DEBUG --log-dir .

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
