### PR TITLE
Adding upgrade suites from 7.0 to 7.1

### DIFF
--- a/suites/quincy/cephfs/tier-4_cephfs_recovery.yaml
+++ b/suites/quincy/cephfs/tier-4_cephfs_recovery.yaml
@@ -193,6 +193,7 @@ tests:
       module: cephfs_recovery.fs_down_flag.py
       polarion-id: CEPH-83573264
       name: "Taking the cephfs down with down flag"
+      comments: "Product bug - BZ-2225891"
   - test:
       abort-on-fail: false
       desc: "Execute FS Scrub Commands on cephfs"
@@ -213,3 +214,4 @@ tests:
       polarion-id: CEPH-11264
       desc: Move data and meta_data pool to different root level bucket in OSD tree.
       abort-on-fail: false
+      comments: "Unable to install ceph-base"

--- a/suites/reef/cephfs/tier-0_cephfs_mirrror_upgrade_70_to_71.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_mirrror_upgrade_70_to_71.yaml
@@ -1,0 +1,198 @@
+---
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 7.0
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+              - config:
+                  command: apply
+                  service: cephfs-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node6
+        ceph2:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    rhcs-version: 6.1
+                    release: rc
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: shell
+                  args:
+                    - ceph fs volume create cephfs
+              - config:
+                  command: apply
+                  service: mds
+                  base_cmd_args:
+                    verbose: true
+                  pos_args:
+                    - cephfs
+                  args:
+                    placement:
+                      nodes:
+                        - node4
+                        - node5
+      desc: CephFS Mirror cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      polarion-id: CEPH-83574114
+      name: deploy cephfs-mirror
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph1:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node7
+        ceph2:
+          config:
+            command: add
+            copy_admin_keyring: true
+            id: client.1
+            install_packages:
+              - ceph-common
+              - ceph-fuse
+            node: node6
+      desc: Configure the Cephfs client system 1
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            clusters:
+              ceph1:
+                config:
+                  command: start
+                  service: upgrade
+                  base_cmd_args:
+                    verbose: true
+                  benchmark:
+                    type: rados
+                    pool_per_client: true
+                    pg_num: 128
+                    duration: 10
+                  verify_cluster_health: false
+            destroy-cluster: false
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validate the Synchronisation is successful upon upgrade
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon upgrade
+      module: cephfs_mirror_upgrade.post_upgrade_validate.py
+      name: Validate the Synchronisation is successful upon upgrade.
+      polarion-id: CEPH-83575336

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_70_to_71.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_70_to_71.yaml
@@ -1,0 +1,237 @@
+#===============================================================================================
+# Cluster Configuration:
+#    conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
+#
+# Test Steps:
+#   (1) Bootstrap cluster using latest released ceph 6.x with below options,
+#       - rhcs-version: 6.1 in this suite, but it can be changed to 6.x for upgrade start version as needed
+#       - release: ga in this suite but it can be changed to  <ga | z1 | z1-async1>
+#       - registry-url: <registry-URL>
+#       - mon-ip: <monitor address, Required>
+#   (2) Copy SSH keys to nodes and Add it to cluster with address and role labels attached to it.
+#   (3) Upgrade to distro build(N) by provided Ceph image version.
+#===============================================================================================
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        steps:
+          -
+            config:
+              args:
+                rhcs-version: 7.0
+                release: rc
+                mon-ip: node1
+                orphan-initial-daemons: true
+                registry-url: registry.redhat.io
+                skip-monitoring-stack: true
+              base_cmd_args:
+                verbose: true
+              command: bootstrap
+              service: cephadm
+          -
+            config:
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+              command: add_hosts
+              service: host
+          -
+            config:
+              args:
+                placement:
+                  label: mgr
+              command: apply
+              service: mgr
+          -
+            config:
+              args:
+                placement:
+                  label: mon
+              command: apply
+              service: mon
+          -
+            config:
+              args:
+                all-available-devices: true
+              command: apply
+              service: osd
+          -
+            config:
+              args:
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+              command: shell
+          -
+            config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+        verify_cluster_health: true
+      desc: "Execute the cluster deployment workflow with label placement."
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: "cluster deployment"
+      polarion-id: CEPH-83573777
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: false
+      desc: Creates all the fs related components before upgrade
+      module: cephfs_upgrade.upgrade_pre_req.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575312
+  -
+    test:
+      abort-on-fail: false
+      desc: Collects all the info required for validating the upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "Metadata validation for Upgrade"
+      polarion-id: CEPH-83575313
+
+  - test:
+      name: Upgrade along with IOs
+      module: test_parallel.py
+      parallel:
+        -
+          test:
+            abort-on-fail: false
+            config:
+              timeout: 30
+            desc: Runs IOs in parallel with upgrade process
+            module: cephfs_upgrade.cephfs_io.py
+            name: "creation of Prerequisites for Upgrade"
+            polarion-id: CEPH-83575315
+
+        - test:
+            name: Upgrade ceph
+            desc: Upgrade cluster to latest version
+            module: cephadm.test_cephadm_upgrade.py
+            polarion-id: CEPH-83574638
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+              benchmark:
+                type: rados                      # future-use
+                pool_per_client: true
+                pg_num: 128
+                duration: 10
+              verify_cluster_health: true
+            destroy-cluster: false
+        - test:
+            abort-on-fail: false
+            desc: Fail MDS while Upgrade is going on
+            module: cephfs_upgrade.cephfs_mds_failover.py
+            name: "Fail MDS while Upgrade is in Progress"
+            polarion-id: CEPH-83575628
+      desc: Running upgrade, mds Failure and i/o's parallelly
+      abort-on-fail: true
+  - test:
+      abort-on-fail: false
+      desc: Validates the data after upgrade
+      module: cephfs_upgrade.metadata_version_validation.py
+      name: "creation of Prerequisites for Upgrade"
+      polarion-id: CEPH-83575313
+  - test:
+      abort-on-fail: false
+      desc: Validates nfs after upgrade
+      module: cephfs_upgrade.cephfs_post_upgrade_validation.py
+      name: "Validates NFS after upgrade"
+      polarion-id: CEPH-83575098
+      comments: product bug bz-2271641
+  - test:
+      name: cephfs_volume_management
+      module: cephfs_volume_management.py
+      polarion-id: CEPH-83573446
+      desc: cephfs volume management
+      abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+  - test:
+      name: cephfs_snapshot_management
+      module: cephfs_snapshot_management.py
+      polarion-id: CEPH-83573259
+      desc: cephfs snapshot management
+      abort-on-fail: false
+  - test:
+        name: cephfs_tier1_ops
+        module: cephfs_tier1_ops.py
+        polarion-id: CEPH-83573447
+        desc: cephfs tier1 operations
+        abort-on-fail: false
+  - test:
+      name: Clone Operations
+      module: bug-1980920.py
+      desc: Cancel the clone operation and validate error message
+      polarion-id: CEPH-83574681
+      abort-on-fail: false
+  - test:
+       name: Files-quota-test
+       module: quota.quota_files.py
+       polarion-id: CEPH-83573399
+       desc: Tests the file attributes on the directory
+       abort-on-fail: false
+  - test:
+       name: Bytes-quota-test
+       module: quota.quota_bytes.py
+       polarion-id: CEPH-83573399
+       desc: Tests the Byte attr

--- a/suites/reef/cephfs/tier-2_cephfs_test-nfs.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test-nfs.yaml
@@ -281,12 +281,14 @@ tests:
       module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
       name: "nfs ls export verification and info with cluster_id"
       polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
   - test:
       abort-on-fail: false
       desc: "Apply various number of hosts to nfs cluster and verify the changes"
       module: cephfs_nfs.nfs_update_cluster_node_changes.py
       name: "nfs cluster host changes and verification"
       polarion-id: "CEPH-83574013"
+      comments: "Product Bug BZ-2238301"
   - test:
       abort-on-fail: false
       desc: "test cephfs nfs with io and network failures"

--- a/suites/reef/cephfs/tier-4_cephfs_recovery.yaml
+++ b/suites/reef/cephfs/tier-4_cephfs_recovery.yaml
@@ -193,6 +193,7 @@ tests:
       module: cephfs_recovery.fs_down_flag.py
       polarion-id: CEPH-83573264
       name: "Taking the cephfs down with down flag"
+      comments: "Product bug - BZ-2225891"
   - test:
       abort-on-fail: false
       desc: "Execute FS Scrub Commands on cephfs"
@@ -213,4 +214,5 @@ tests:
       polarion-id: CEPH-11264
       desc: Move data and meta_data pool to different root level bucket in OSD tree.
       abort-on-fail: false
+      comments: "Unable to install ceph-base"
 


### PR DESCRIPTION
# Description
Adding upgrade suites from 7.0 to 7.1 

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4W0MK7/

We are having a problem in this regarding the schedule.
In 7.0 We have M for mins
In 7.1 we have M for months

Raised BZ for backporting 
https://bugzilla.redhat.com/show_bug.cgi?id=2271641

One test case is failing for that reason
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
