### PR TITLE
Integration of assume-role test at multisite.

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -539,3 +539,15 @@ tests:
       polarion-id: CEPH-83581973 #CEPH-83581975
       module: sanity_rgw_multisite.py
       name: test LC cloud transition to IBM cos with retain false
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sts_using_boto.py
+            config-file-name: test_sts_multisite.yaml
+            timeout: 30
+      desc: test assume role at secondary, with s3 ops
+      polarion-id: CEPH-83575592
+      module: sanity_rgw_multisite.py
+      name: test assume role at secondary, with s3 ops


### PR DESCRIPTION
# Description

CEPH-83575592:sts assume-role at multisite.
ceph-qe-scripts pr :https://github.com/red-hat-storage/ceph-qe-scripts/pull/580

Currently with this automation, we saw that the s3 bucket operations fails on the secondary (https://bugzilla.redhat.com/show_bug.cgi?id=2271399)

logs: will fail at bucket creation (expected)
http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/580/logs_stst_assumerole_ms

