### PR TITLE
CEPH-83582326 - Deploy the cluster with the RocksDB compress enabled with the LZ4compression and perform regression tests

### DIFF
--- a/suites/reef/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/reef/rados/tier-2_rados_test_parameters.yaml
@@ -91,3 +91,10 @@ tests:
       config:
         scenario: mclock_chg_chk
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+  - test:
+      name: Check RocksDB compression default value
+      desc: Check that RocksDB compression value is kLZ4Compression
+      polarion-id: CEPH-83582326
+      module: test_config_parameter_chk.py
+      config:
+        scenario: rocksdb_compression


### PR DESCRIPTION

# Description

Earlier to the 7.1 the RocksDB(Metadata) was not compressed. From 7.1  the compression of the RocksDB is made as default. LZ4 algorithm is the default algorithm to compress the RocksDB data.

Polarion Testcase:  https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582326

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
