### PR TITLE
Adding trash operations at scale

### DIFF
--- a/ceph/rbd/workflows/cleanup.py
+++ b/ceph/rbd/workflows/cleanup.py
@@ -138,7 +138,7 @@ def device_cleanup(rbd, client, **kw):
             flag = 1
 
     if kw.get("device_name"):
-        if kw.get("device-type"):
+        if kw.get("device_type"):
             # RBD image map cleanup with device map
             map_config = {
                 "image-snap-or-device-spec": kw["device_name"],

--- a/ceph/rbd/workflows/krbd_io_handler.py
+++ b/ceph/rbd/workflows/krbd_io_handler.py
@@ -194,7 +194,7 @@ def krbd_io_handler(**kw):
                     }
                     if operations.get("device_map"):
                         cleanup_config.update(
-                            {"device-type": config.get("device_type", "nbd")}
+                            {"device_type": config.get("device_type", "nbd")}
                         )
                     return_flag = device_cleanup(**cleanup_config)
     kw["config"]["device_names"] = device_names

--- a/ceph/rbd/workflows/rbd.py
+++ b/ceph/rbd/workflows/rbd.py
@@ -649,7 +649,7 @@ def check_rbd_status(rbd, pool, image, timeout):
     starttime = datetime.datetime.now()
 
     out = str()
-    sleep(5)
+    sleep(15)
     while datetime.datetime.now() - starttime <= timeout:
         out, err = rbd.status(pool=pool, image=image, format="json")
         if err:

--- a/ceph/rbd/workflows/rbd_trash.py
+++ b/ceph/rbd/workflows/rbd_trash.py
@@ -1,0 +1,211 @@
+import json
+
+from ceph.rbd.workflows.rbd import list_images_and_verify_with_input
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def get_trash_list(**kw):
+    """
+    Get all images in trash for a given pool
+    kw:{
+        "rbd": <>,
+        "pool": <>,
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    out, err = rbd.trash.ls(pool=pool, format="json")
+    if err:
+        log.error(f"Listing images in trash failed for pool {pool} with err {err}")
+        return []
+
+    trash_list = json.loads(out)
+    return trash_list
+
+
+def is_image_present_in_trash(**kw):
+    """
+    Check if given image is present in trash
+    kw:{
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "test_ops_parallely": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    test_ops_parallely = kw.get("test_ops_parallely", False)
+
+    trash_list = get_trash_list(rbd=rbd, pool=pool)
+    if not trash_list:
+        log.info(f"No images present in trash/trash ls failed for pool {pool}")
+        return False
+
+    images_in_trash = [trash_image.get("name") for trash_image in trash_list]
+    if image in images_in_trash:
+        log.info(f"Image {pool}/{image} is moved to trash successfully")
+        return True
+    else:
+        log.error(f"Image {pool}/{image} is not present in trash")
+        if test_ops_parallely:
+            raise Exception(f"Image {pool}/{image} is not present in trash")
+        return False
+
+
+def move_image_to_trash_and_verify(**kw):
+    """
+    Move the specified image to trash and verify that
+    the image is present in trash
+    kw:{
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "image_conf": <>,
+        "test_ops_parallely": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    test_ops_parallely = kw.get("test_ops_parallely", False)
+    image_conf = kw.get("image_conf", {})
+    expires_at = image_conf.get("expires-at", None)
+
+    log.info(f"Moving image {pool}/{image} to trash")
+    trash_conf = {"pool": pool, "image": image}
+    if expires_at:
+        trash_conf.update({"expires-at": f'"{expires_at}"'})
+    out, err = rbd.trash.mv(**trash_conf)
+    if (out or err) and f"image {image} will expire at" not in out + err:
+        log.error(f"Moving image {pool}/{image} to trash failed with err {out} {err}")
+        if test_ops_parallely:
+            raise Exception(
+                f"Moving image {pool}/{image} to trash failed with err {out} {err}"
+            )
+        return 1
+
+    log.info(f"Verifying whether image {pool}/{image} is present in trash")
+
+    if is_image_present_in_trash(rbd=rbd, pool=pool, image=image):
+        log.info(f"Image {pool}/{image} is present in trash")
+    else:
+        log.error(f"Image {pool}/{image} not present in trash")
+        if test_ops_parallely:
+            raise Exception(f"Image {pool}/{image} not present in trash")
+        return 1
+
+    return 0
+
+
+def restore_image_from_trash_and_verify(**kw):
+    """
+    Restore the specified image from trash and verify that
+    the image is not present in trash instead present in rbd ls
+    kw:{
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "image_conf": <>,
+        "test_ops_parallely": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    test_ops_parallely = kw.get("test_ops_parallely", False)
+
+    log.info(f"Get image id for {pool}/{image} from trash list")
+
+    out, err = rbd.trash.ls(pool=pool, format="json")
+    if err:
+        log.error(f"Listing images in trash failed for pool {pool} with err {err}")
+        if test_ops_parallely:
+            raise Exception(
+                f"Listing images in trash failed for pool {pool} with err {err}"
+            )
+        return 1
+
+    trash_list = json.loads(out)
+    image_id = [
+        trash_image.get("id")
+        for trash_image in trash_list
+        if trash_image.get("name") == image
+    ][0]
+
+    log.info(f"Restoring image {pool}/{image} with id {image_id} from trash")
+
+    restore_conf = {"pool": pool, "image-id": image_id}
+    out, err = rbd.trash.restore(**restore_conf)
+    if out or err:
+        log.error(f"Restore image {pool}/{image} failed with err {out} {err}")
+        if test_ops_parallely:
+            raise Exception(f"Restore image {pool}/{image} failed with err {out} {err}")
+        return 1
+
+    if not is_image_present_in_trash(rbd=rbd, pool=pool, image=image):
+        log.info(f"Image {pool}/{image} is not present in trash after restore")
+    else:
+        log.error(f"Image {pool}/{image} is present in trash after restore")
+        if test_ops_parallely:
+            raise Exception(f"Image {pool}/{image} is present in trash after restore")
+        return 1
+
+    rc = list_images_and_verify_with_input(rbd=rbd, pool=pool, images=[image])
+    if rc:
+        log.error(f"Image {image} is not present in pool {pool}")
+        if test_ops_parallely:
+            raise Exception(f"Image {image} is not present in pool {pool}")
+        return 1
+    log.info(f"Image {image} is present in pool {pool} after restore")
+
+    return 0
+
+
+def purge_images_and_verify(**kw):
+    """Purge all images in a pool and verify that all images without snaps and clones are purged
+    Args: kw:{
+        "rbd":<>,
+        "pool":<>,
+        "snap_count_per_image": <>,
+        "test_ops_parallely":<>,
+        "images_to_be_purged":<>
+    }
+    """
+    purge_err_msg = "some expired images could not be removed\nEnsure that they are closed/unmapped, "
+    purge_err_msg += (
+        "do not have snapshots (including trashed snapshots with linked clones), are "
+    )
+    purge_err_msg += "not in a group and were moved to the trash successfully"
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    test_ops_parallely = kw.get("test_ops_parallely")
+    images_to_be_purged = kw.get("images_to_be_purged", [])
+    expired_before = kw.get("expired_before", None)
+
+    purge_conf = {"pool": pool}
+    if expired_before:
+        purge_conf.update({"expired-before": f'"{expired_before}"'})
+    out, err = rbd.trash.purge(**purge_conf)
+    if (
+        out
+        or err
+        and purge_err_msg not in out + err
+        and "100% complete" not in out + err
+    ):
+        log.error(f"Trash purge failed for pool {pool}")
+        if test_ops_parallely:
+            raise Exception(f"Trash purge failed for pool {pool}")
+        return 1
+
+    for image in images_to_be_purged:
+        if is_image_present_in_trash(rbd=rbd, pool=pool, image=image):
+            log.error(f"Image {pool}/{image} is present in trash after purge")
+            if test_ops_parallely:
+                raise Exception(f"Image {pool}/{image} is present in trash after purge")
+            return 1
+
+    return 0

--- a/ceph/rbd/workflows/snap_clone_operations.py
+++ b/ceph/rbd/workflows/snap_clone_operations.py
@@ -596,3 +596,255 @@ def wrapper_for_image_snap_ops(**kw):
                 )
                 return 1
     return 0
+
+
+def create_clone_and_verify(**kw):
+    """
+    Create a single snap and clone for the given image
+    Args: kw{
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "snap": <>,
+        "clone": <>,
+        "test_ops_parallely": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    snap_name = kw.get("snap")
+    clone = kw.get("clone")
+    test_ops_parallely = kw.get("test_ops_parallely")
+    clone_spec = {
+        "source-snap-spec": f"{pool}/{image}@{snap_name}",
+        "dest-image-spec": f"{pool}/{clone}",
+    }
+    out, err = rbd.clone(**clone_spec)
+    if out or err and "100% complete" not in out + err:
+        log.error(f"Clone creation failed for {pool}/{clone}")
+        if test_ops_parallely:
+            raise Exception(f"Clone creation failed for {pool}/{clone}")
+        return 1
+
+    out, err = rbd.children(pool=pool, image=image, snap=snap_name, format="json")
+    if err:
+        log.error(f"Fetching children for snap {pool}/{image}@{snap_name} failed")
+        if test_ops_parallely:
+            raise Exception(
+                f"Fetching children for snap {pool}/{image}@{snap_name} failed"
+            )
+        return 1
+
+    children = json.loads(out)
+    if not [child.get("image") for child in children if child.get("image") == clone]:
+        log.error(f"Clone {pool}/{clone} doesn't exist after creation")
+        if test_ops_parallely:
+            raise Exception(f"Clone {pool}/{clone} doesn't exist after creation")
+        return 1
+
+    log.info(f"Clone {pool}/{clone} creation successful")
+    return 0
+
+
+def create_snap_and_clones(**kw):
+    """
+    Create snap and clones based on the input specified for the given image
+    Args: kw{
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "snap_spec": <snaps and clones to be created>
+                        Ex: {
+                            "snap_1": ["clone_11", "clone_12",..],
+                        }
+        "test_parallely": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    snap_spec = kw.get("snap_spec")
+    test_ops_parallely = kw.get("test_ops_parallely")
+
+    snap_name = list(snap_spec.keys())[0]
+    clones = snap_spec.get(snap_name)
+
+    out, err = rbd.snap.create(pool=pool, image=image, snap=snap_name)
+    if out or err and "100% complete" not in out + err:
+        log.error(f"Snap creation failed for {pool}/{image}@{snap_name}")
+        if test_ops_parallely:
+            raise Exception(f"Snap creation failed for {pool}/{image}@{snap_name}")
+        return 1
+
+    if not snap_exists(rbd=rbd, pool=pool, image=image, snap_name=snap_name):
+        log.error(f"Snapshot {snap_name} does not exist in snap ls for {pool}/{image}")
+        return 1
+
+    if clones:
+        out, err = rbd.snap.protect(pool=pool, image=image, snap=snap_name)
+        if out or err and "100% complete" not in out + err:
+            log.error(f"Snap protect failed for {pool}/{image}@{snap_name}")
+            if test_ops_parallely:
+                raise Exception(f"Snap protect failed for {pool}/{image}@{snap_name}")
+            return 1
+
+    if test_ops_parallely:
+        with parallel() as p:
+            for clone in clones:
+                p.spawn(
+                    create_clone_and_verify,
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap=snap_name,
+                    clone=clone,
+                    test_ops_parallely=test_ops_parallely,
+                )
+    else:
+        for clone in clones:
+            rc = create_clone_and_verify(
+                rbd=rbd, pool=pool, image=image, snap=snap_name, clone=clone
+            )
+            if rc:
+                log.error(f"Clone creation failed for {pool}/{clone}")
+                return 1
+
+    return 0
+
+
+def create_snaps_and_clones(**kw):
+    """
+    Create snap and clones based on the input specified for the given image
+    Args: kw{
+        "rbd": <>,
+        "pool": <>,
+        "image": <>,
+        "image_conf": <snaps and clones to be created>
+                        Ex: {
+                            "snap_1": ["clone_11", "clone_12",..],
+                        }
+        "test_parallely": <>
+    }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    snaps_spec = kw.get("image_conf", {}).get("snap_spec")
+    test_ops_parallely = kw.get("test_ops_parallely")
+
+    if test_ops_parallely:
+        with parallel() as p:
+            for snap, clones in snaps_spec.items():
+                p.spawn(
+                    create_snap_and_clones,
+                    rbd=rbd,
+                    pool=pool,
+                    image=image,
+                    snap_spec={snap: clones},
+                    test_ops_parallely=test_ops_parallely,
+                )
+    else:
+        for snap, clones in snaps_spec.items():
+            rc = create_snap_and_clones(
+                rbd=rbd, pool=pool, image=image, snap_spec={snap: clones}
+            )
+            if rc:
+                log.error(f"Creation of snaps and clones failed for {pool}/{image}")
+                return 1
+
+    return 0
+
+
+def is_snap_present(**kw):
+    """
+    Check if the given image has atleast one snapshot
+    Args:
+        kw:{
+            "rbd": <>,
+            "pool": <>,
+            "image": <>,
+            "test_ops_parallely": <>
+        }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    test_ops_parallely = kw.get("test_ops_parallely")
+
+    out, err = rbd.snap.ls(pool=pool, image=image, format="json")
+    if err:
+        log.error(f"Error while fetching snapshots for image {pool}/{image}")
+        if test_ops_parallely:
+            raise Exception(f"Error while fetching snapshots for image {pool}/{image}")
+        return 1
+
+    snaps = json.loads(out)
+    if len(snaps) > 0:
+        return True
+    else:
+        return False
+
+
+def is_children_present(**kw):
+    """
+    Check if the given image has atleast one child
+    Args:
+        kw: {
+            "rbd": <>,
+            "pool": <>,
+            "image": <>,
+            "test_ops_parallely": <>
+        }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    image = kw.get("image")
+    test_ops_parallely = kw.get("test_ops_parallely")
+
+    out, err = rbd.children(pool=pool, image=image, format="json")
+    if err:
+        log.error(f"Error while fetching children for image {pool}/{image}")
+        if test_ops_parallely:
+            raise Exception(f"Error while fetching children for image {pool}/{image}")
+        return 1
+
+    children = json.loads(out)
+    if len(children) > 0:
+        return True
+    else:
+        return False
+
+
+def get_images_without_snap_and_or_clone(**kw):
+    """
+    Get all images in a pool having zero snaps and/or clones
+    Args:
+        kw: {
+            "rbd": <>,
+            "pool": <>,
+            "test_ops_parallely": <>
+        }
+    """
+    rbd = kw.get("rbd")
+    pool = kw.get("pool")
+    test_ops_parallely = kw.get("test_ops_parallely")
+    req_images = []
+
+    out, err = rbd.ls(pool=pool, format="json")
+    if err:
+        log.error(f"Error while fetching images from pool {pool}: {err}")
+        return 1
+    images_in_pool = json.loads(out)
+    for image in images_in_pool:
+        if not (
+            is_snap_present(
+                rbd=rbd, pool=pool, image=image, test_ops_parallely=test_ops_parallely
+            )
+            or is_children_present(
+                rbd=rbd, pool=pool, image=image, test_ops_parallely=test_ops_parallely
+            )
+        ):
+            req_images.append(image)
+
+    return req_images

--- a/cli/rbd/rbd.py
+++ b/cli/rbd/rbd.py
@@ -12,6 +12,7 @@ from .mirror.mirror import Mirror
 from .namespace import Namespace
 from .pool import Pool
 from .snap import Snap
+from .trash.trash import Trash
 
 
 class Rbd(Cli):
@@ -27,6 +28,7 @@ class Rbd(Cli):
         self.config = Config(nodes, self.base_cmd)
         self.namespace = Namespace(nodes, self.base_cmd)
         self.group = Group(nodes, self.base_cmd)
+        self.trash = Trash(nodes, self.base_cmd)
 
     def create(self, **kw):
         """

--- a/cli/rbd/trash/trash.py
+++ b/cli/rbd/trash/trash.py
@@ -1,0 +1,240 @@
+from copy import deepcopy
+
+from cli import Cli
+from cli.utilities.utils import build_cmd_from_args
+
+# from .trash_purge_schedule import TrashPurgeSchedule
+
+
+class Trash(Cli):
+    """
+    This module provides CLI interface to manage snapshots from images in pool.
+    """
+
+    def __init__(self, nodes, base_cmd):
+        super(Trash, self).__init__(nodes)
+        self.base_cmd = base_cmd + " trash"
+        # self.trash_purge_schedule = TrashPurgeSchedule(nodes, self.base_cmd)
+
+    def list(self, **kw):
+        """
+        Lists images in trash.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    See rbd help trash list for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} list {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def ls(self, **kw):
+        """
+        Lists images in trash.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    See rbd help trash ls for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} ls {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def move(self, **kw):
+        """
+        Moves image to trash.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    image(str) : name of the image
+                    expires-at(str) : set the expiration time of an image so it can be
+                          purged when it is stale
+                    image-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                    See rbd help trash move for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} move {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def mv(self, **kw):
+        """
+        Moves image to trash.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    image(str) : name of the image
+                    expires-at(str) : set the expiration time of an image so it can be
+                          purged when it is stale
+                    image-spec(str) : [<pool-name>/[<namespace>/]]<image-name>
+                    See rbd help trash move for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        image_spec = kw_copy.pop("image-spec", "")
+        cmd = f"{self.base_cmd} mv {image_spec} {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def purge(self, **kw):
+        """
+        Purges all images in a pool to trash.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    expired-before(str) : purges images that expired before the
+                        given date
+                    threshold(str) : purges images until the current pool data usage
+                        is reduced to X%, value range: 0.0-1.0
+                    See rbd help trash purge for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} purge {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def purge_schedule_add(self, **kw):
+        """
+        Add trash purge schedule to all images in a pool.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    interval(str) : schedule interval
+                    start-time(str) : schedule start time
+                    See rbd help trash purge schedule add for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} purge schedule add {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def purge_schedule_list(self, **kw):
+        """
+        List trash purge schedule to all images in a pool.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    recursive(str) : list all schedules
+                    See rbd help trash purge schedule list for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} purge schedule list {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def purge_schedule_ls(self, **kw):
+        """
+        List trash purge schedule to all images in a pool.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    recursive(str) : list all schedules
+                    See rbd help trash purge schedule ls for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} purge schedule ls {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def purge_schedule_remove(self, **kw):
+        """
+        Remove trash purge schedule to all images in a pool.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    interval(str) : schedule interval
+                    start-time(str) : schedule start time
+                    See rbd help trash purge schedule add for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} purge schedule remove {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def purge_schedule_rm(self, **kw):
+        """
+        Remove trash purge schedule to all images in a pool.
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    interval(str) : schedule interval
+                    start-time(str) : schedule start time
+                    See rbd help trash purge schedule add for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} purge schedule rm {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def remove(self, **kw):
+        """
+        Remove an image from trash
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    image-id(str) : image id
+                    image(str) : image name
+                    See rbd help trash remove for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} remove {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def rm(self, **kw):
+        """
+        Remove an image from trash
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    image-id(str) : image id
+                    image(str) : image name
+                    See rbd help trash rm for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} rm {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)
+
+    def restore(self, **kw):
+        """
+        Restore an image from trash
+        Args:
+            kw(dict): Key/value pairs that needs to be provided to the installer
+                Example::
+                Supported keys:
+                    pool(str) : name of the pool
+                    image-id(str) : image id
+                    image(str) : image name
+                    See rbd help trash restore for more supported keys
+        """
+        kw_copy = deepcopy(kw)
+        cmd = f"{self.base_cmd} restore {build_cmd_from_args(**kw_copy)}"
+
+        return self.execute(cmd=cmd)

--- a/suites/quincy/rbd/tier-3_rbd_operations.yaml
+++ b/suites/quincy/rbd/tier-3_rbd_operations.yaml
@@ -93,3 +93,24 @@ tests:
           test_ops_parallely: true
         fio:
           size: 100M
+
+  - test:
+        desc: Run all image trash operations in scale
+        module: test_rbd_trash_operations.py
+        name: RBD image trash operations in scale
+        polarion-id: CEPH-83582444
+        config:
+          rep_pool_config:
+            num_pools: 10
+            num_images: 100
+            size: 4G
+            create_pool_parallely: true
+            create_image_parallely: true
+            test_ops_parallely: true
+          ec_pool_config:
+            num_pools: 10
+            num_images: 100
+            size: 4G
+            create_pool_parallely: true
+            create_image_parallely: true
+            test_ops_parallely: true

--- a/suites/reef/rbd/tier-3_rbd_operations.yaml
+++ b/suites/reef/rbd/tier-3_rbd_operations.yaml
@@ -51,7 +51,7 @@ tests:
       config:
         command: add
         id: client.1
-        node: node10
+        node: node4
         install_packages:
           - ceph-common
           - fio
@@ -93,3 +93,24 @@ tests:
           test_ops_parallely: true
         fio:
           size: 100M
+
+  - test:
+        desc: Run all image trash operations in scale
+        module: test_rbd_trash_operations.py
+        name: RBD image trash operations in scale
+        polarion-id: CEPH-83582444
+        config:
+          rep_pool_config:
+            num_pools: 10
+            num_images: 100
+            size: 4G
+            create_pool_parallely: true
+            create_image_parallely: true
+            test_ops_parallely: true
+          ec_pool_config:
+            num_pools: 10
+            num_images: 100
+            size: 4G
+            create_pool_parallely: true
+            create_image_parallely: true
+            test_ops_parallely: true

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,3 +6,4 @@ tox
 isort
 black==23.12.0
 yamllint
+pytz

--- a/tests/rbd/test_rbd_trash_operations.py
+++ b/tests/rbd/test_rbd_trash_operations.py
@@ -1,0 +1,276 @@
+"""RBD Image trash operations at scale
+Test Case Covered:
+CEPH-83582444 - [Baremetal] [ScaleTest] - Test all rbd trash operations at scale
+Steps:
+1) Create an RHCS cluster on baremetal nodes as specified in setup. Execute IOs to
+fill the cluster to a decent percentage
+2) Create 10 RBD pools and 100 images per pool parallely on this cluster
+3) Create snaps and clones for half of the images
+4) Run IOs on clones
+5) Move all images to trash parallely and verify
+6) Restore all images back from trash parallely and verify
+7) Trash purge all images parallely and verify
+8) Restore all images back and verify
+9) Enable rbd_move_to_trash_on_remove in client config and remove all images
+10) Restore all images back and verify
+11) Define a trash purge schedule and verify that all images adhere to this schedule
+12) Restore all images back and remove trash purge schedule and verify
+13) Disable rbd_move_to_trash_on_remove in client config and remove all images
+Pre-requisites :
+- need client node with ceph-common package, conf and keyring files
+- FIO should be installed on the client.
+Environment and limitations:
+- The cluster should have enough storage to create atleast 1000 images with 4G each
+- cluster/global-config-file: config/reef/baremetal/mero_conf.yaml
+- Should be Bare-metal.
+"""
+
+from ceph.parallel import parallel
+from ceph.rbd.initial_config import initial_rbd_config
+from ceph.rbd.utils import getdict
+from ceph.rbd.workflows.cleanup import cleanup
+from ceph.rbd.workflows.rbd import create_images, wrapper_for_image_ops
+from ceph.rbd.workflows.rbd_trash import purge_images_and_verify
+from ceph.utils import get_node_by_id
+from cli.rbd.rbd import Rbd
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def restore_and_create_new_image(
+    rbd,
+    pool,
+    pool_type,
+    pool_config,
+    image_config,
+    client,
+    multi_image_config,
+    images_without_snaps_and_clones,
+    test_ops_parallely,
+    **kw,
+):
+    """ """
+    log.info(f"Restore images from trash and verify for pool {pool}")
+    rc = wrapper_for_image_ops(
+        rbd=rbd,
+        pool=pool,
+        image_config=image_config,
+        client=client,
+        ops_module="ceph.rbd.workflows.rbd_trash",
+        ops_method="restore_image_from_trash_and_verify",
+        test_ops_parallely=test_ops_parallely,
+    )
+    if rc:
+        log.error(f"Restore images from trash and verify failed for pool {pool}")
+        return 1
+
+    image_create_config = {
+        image: multi_image_config.get(image)
+        for image in images_without_snaps_and_clones
+    }
+
+    rc = create_images(
+        config=kw.get("config"),
+        cluster="ceph",
+        rbd=rbd,
+        pool=pool,
+        pool_config=pool_config,
+        image_config=image_create_config,
+        is_ec_pool=True if "ec" in pool_type else False,
+        create_image_parallely=kw["config"][pool_type].get("create_image_parallely"),
+    )
+
+    if rc:
+        log.error(f"Image creation failed for pool {pool}")
+        return 1
+
+    return 0
+
+
+def test_rbd_trash_operations_for_pool(
+    rbd, pool, pool_config, test_ops_parallely, client, pool_type, **kw
+):
+    """Test image trash operations like trash, restore, purge, trash purge schedule
+    and remove for all images with and without snaps and clones in the given pool type
+    Args:
+        rbd: rbd object
+        pool: pool name
+        pool_config: config specifying all images in pool
+        test_ops_parallely: test operations in parallel/sequential
+        client: client node
+        pool_type: replicated or ec pool
+        **kw: any other args
+    """
+    try:
+        multi_image_config = getdict(pool_config)
+        images = list(multi_image_config.keys())
+
+        log.info(f"Run IOs and verify rbd status for images in pool {pool}")
+        rc = wrapper_for_image_ops(
+            rbd=rbd,
+            pool=pool,
+            image_config=multi_image_config,
+            client=client,
+            ops_module="ceph.rbd.workflows.rbd",
+            ops_method="run_io_and_check_rbd_status",
+            test_ops_parallely=test_ops_parallely,
+        )
+        if rc:
+            log.error(f"Run IOs and verify rbd status failed for pool {pool}")
+            return 1
+
+        image_config = dict()
+        for index, image in enumerate(images):
+            if index % 2 == 0:
+                snap_spec = {f"{image}_snap": [f"{image}_clone"]}
+                image_config.update({image: {"snap_spec": snap_spec}})
+
+        log.info(
+            f"Creating snaps and clones for every alternate image in the pool {pool}"
+        )
+        rc = wrapper_for_image_ops(
+            rbd=rbd,
+            pool=pool,
+            image_config=image_config,
+            client=client,
+            ops_module="ceph.rbd.workflows.snap_clone_operations",
+            ops_method="create_snaps_and_clones",
+            test_ops_parallely=test_ops_parallely,
+        )
+        if rc:
+            log.error(
+                f"Create snaps and clones for every alternate image failed for pool {pool}"
+            )
+            return 1
+
+        log.info(f"Move images to trash and verify for pool {pool}")
+        rc = wrapper_for_image_ops(
+            rbd=rbd,
+            pool=pool,
+            image_config=multi_image_config,
+            client=client,
+            ops_module="ceph.rbd.workflows.rbd_trash",
+            ops_method="move_image_to_trash_and_verify",
+            test_ops_parallely=test_ops_parallely,
+        )
+        if rc:
+            log.error(f"Move images to trash and verify failed for pool {pool}")
+            return 1
+
+        log.info(f"Trash purge all images in pool {pool} and verify")
+        images_without_snaps_and_clones = [
+            image for image in images if image not in image_config.keys()
+        ]
+        rc = purge_images_and_verify(
+            rbd=rbd,
+            pool=pool,
+            test_ops_parallely=test_ops_parallely,
+            images_to_be_purged=images_without_snaps_and_clones,
+        )
+        if rc:
+            log.error(f"Purge images in trash failed for pool {pool}")
+            return 1
+
+        log.info(
+            f"Restore images from trash, create new images and verify for pool {pool}"
+        )
+        rc = restore_and_create_new_image(
+            rbd,
+            pool,
+            pool_type,
+            pool_config,
+            image_config,
+            client,
+            multi_image_config,
+            images_without_snaps_and_clones,
+            test_ops_parallely,
+            **kw,
+        )
+
+        if rc:
+            log.error(
+                f"Restore images from trash and create new images failed for pool {pool}"
+            )
+            return 1
+    except Exception as e:
+        log.error(
+            f"Testing image trash operations failed for pool {pool} with error {e}"
+        )
+        if test_ops_parallely:
+            raise Exception(
+                f"Testing image trash operations failed for pool {pool} with error {e}"
+            )
+        return 1
+
+
+def test_rbd_trash_operations(rbd_obj, client, **kw):
+    """
+    Test all image trash operations on each pool created
+    Args:
+        rbd_obj: rbd object
+        client: client node
+        **kw: key word arguments
+    """
+    log.info(f"Performing image trash operations for pool type {rbd_obj['pool_types']}")
+    rbd = rbd_obj.get("rbd")
+    for pool_type in rbd_obj.get("pool_types"):
+        rbd_config = kw.get("config", {}).get(pool_type, {})
+        multi_pool_config = getdict(rbd_config)
+        test_ops_parallely = rbd_config.get("test_ops_parallely", False)
+        if test_ops_parallely:
+            with parallel() as p:
+                for pool, pool_config in multi_pool_config.items():
+                    p.spawn(
+                        test_rbd_trash_operations_for_pool,
+                        rbd=rbd,
+                        pool=pool,
+                        pool_config=pool_config,
+                        test_ops_parallely=test_ops_parallely,
+                        client=client,
+                        pool_type=pool_type,
+                        **kw,
+                    )
+        else:
+            for pool, pool_config in multi_pool_config.items():
+                rc = test_rbd_trash_operations_for_pool(
+                    rbd=rbd,
+                    pool=pool,
+                    pool_config=pool_config,
+                    test_ops_parallely=test_ops_parallely,
+                    client=client,
+                    pool_type=pool_type,
+                    **kw,
+                )
+                if rc:
+                    log.error(f"Image trash operations testing failed for pool {pool}")
+                    return 1
+    return 0
+
+
+def run(**kw):
+    """RBD image trash operations testing.
+    Args:
+        **kw: test data
+    """
+    log.info("Running test CEPH-83582444 - Testing RBD image trash operations.")
+
+    ret_val = 0
+    try:
+        if kw.get("client_node"):
+            client = get_node_by_id(kw.get("ceph_cluster"), kw.get("client_node"))
+        else:
+            client = kw.get("ceph_cluster").get_nodes(role="client")[0]
+        rbd_obj = initial_rbd_config(**kw)
+        pool_types = rbd_obj.get("pool_types")
+        ret_val = test_rbd_trash_operations(rbd_obj=rbd_obj, client=client, **kw)
+    except Exception as e:
+        log.error(f"Testing RBD image trash operations failed with the error {str(e)}")
+        ret_val = 1
+    finally:
+        cluster_name = kw.get("ceph_cluster", {}).name
+        if "rbd_obj" not in locals():
+            rbd_obj = Rbd(client)
+        obj = {cluster_name: rbd_obj}
+        cleanup(pool_types=pool_types, multi_cluster_obj=obj, **kw)
+    return ret_val


### PR DESCRIPTION
Adding trash operations at scale. Automating test case - CEPH-83582444
Automated only a part of the above polarion test case in this PR since it is a pretty big change.
The steps automated for this are

1. Run IOs on images, create snaps and clones for few of the images created (this is useful while doing trash purge)
2. Move images to trash and verify that its present in trash list
3. Purge trash for the pool, verify that all images which don't have snaps or clones are deleted permanently from trash
4. Restore rest of the images from trash and verify that they are present in rbd ls.

Success Logs

Sequential execution - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M9F1I4/
Parallel execution - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-E5GA9C/