### PR TITLE
Include s3tests tescases in regression execution of reef and quincy

### DIFF
--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -659,17 +659,6 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
-  - test:
-      abort-on-fail: false
-      config:
-        branch: ceph-quincy
-      desc: Run the external S3test suites.
-      destroy-cluster: false
-      module: test_s3.py
-      name: execute s3tests
-      polarion-id: CEPH-83575225
-      comments: Known issue - Ceph tracker 55614
-
   # Index-less buckets
   - test:
       name: Indexless buckets

--- a/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
@@ -209,3 +209,14 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
         timeout: 500
+
+  - test:
+      abort-on-fail: false
+      config:
+        branch: ceph-quincy
+      desc: Run the external S3test suites.
+      destroy-cluster: false
+      module: test_s3.py
+      name: execute s3tests
+      polarion-id: CEPH-83575225
+      comments: Known issue - Ceph tracker 55614

--- a/suites/reef/rgw/sanity_rgw.yaml
+++ b/suites/reef/rgw/sanity_rgw.yaml
@@ -241,16 +241,7 @@ tests:
       module: sanity_rgw.py
       name: test bucket quota max objects
       polarion-id: CEPH-83575330
-  - test:
-      abort-on-fail: false
-      config:
-        branch: ceph-reef
-      desc: Run the external S3test suites.
-      destroy-cluster: false
-      module: test_s3.py
-      name: execute s3tests
-      polarion-id: CEPH-83575225
-      comments: BZ2266411 - anon_put_write_access, BZ2268234 - list_buckets_bad_auth
+
   - test:
       name: versioned object deletion with mfa token
       desc: test versioned object deletion with mfa token

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -217,3 +217,14 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
         timeout: 500
+
+  - test:
+      abort-on-fail: false
+      config:
+        branch: ceph-reef
+      desc: Run the external S3test suites.
+      destroy-cluster: false
+      module: test_s3.py
+      name: execute s3tests
+      polarion-id: CEPH-83575225
+      comments: BZ2266411 - anon_put_write_access, BZ2268234 - list_buckets_bad_auth


### PR DESCRIPTION
# Description
Include s3tests tescases in regression execution of reef and quincy

Since currently we are aving s3tests execution only in weekly run

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
