### PR TITLE
Remove known issue of aws-etag empty issue from reef

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -180,7 +180,6 @@ tests:
       desc: Test Etag not empty for complete multipart upload in aws
       polarion-id: CEPH-9801
       module: sanity_rgw.py
-      comments: known issue (bz-2266579)
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml


### PR DESCRIPTION
# Description
Remove known issue of aws-etag empty issue from reef

since issue fixed for reef, i.e 7.1 and 7.0z2

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
