### PR TITLE
adding right yaml for kafka_none_persistent in notification suites

### DIFF
--- a/suites/nautilus/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/nautilus/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -102,13 +102,13 @@ tests:
         timeout: 300
 
   - test:
-      name: bucket notification with kafka endpoint
+      name: bucket notification with kafka_none_persistent
       desc: notify on multipart upload events with kafka_none_persistent
       polarion-id: CEPH-83574070
       module: sanity_rgw.py
       config:
         script-name: test_bucket_notifications.py
-        config-file-name: test_bucket_notification_kafka_none_multipart.yaml
+        config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
         timeout: 300
 
   # kafka broker type none

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -162,7 +162,7 @@ tests:
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
-        config-file-name: test_bucket_notification_kafka_none_multipart.yaml
+        config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
         timeout: 300
 
   # kafka broker type none

--- a/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -118,7 +118,7 @@ tests:
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
-        config-file-name: test_bucket_notification_kafka_none_multipart.yaml
+        config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
         timeout: 300
 
   # kafka broker type none

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -119,7 +119,7 @@ tests:
       config:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
-        config-file-name: test_bucket_notification_kafka_none_multipart.yaml
+        config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
         timeout: 300
 
   # kafka broker type none


### PR DESCRIPTION
test_bucket_notification_kafka_none_multipart.yaml is the yaml present for kafka_none_persistent tests also
so fixing it with the correct yaml: test_bucket_notification_kafka_none_persistent_multipart.yaml
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
