### PR TITLE
Cephci integration: CEPH-83574088:Changing the value of rgw_data_log_…

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
@@ -347,3 +347,15 @@ tests:
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
             timeout: 300
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
+
+  - test:
+      name: Test Changing datalog num shards not cause any crash
+      desc: Test Changing datalog num shards not cause any crash
+      polarion-id: CEPH-83574088
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_changing_data_log_num_shards_cause_no_crash.yaml
+            timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -346,3 +346,15 @@ tests:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_forbidden.yaml
             timeout: 300
+
+  - test:
+      name: Test Changing datalog num shards not cause any crash
+      desc: Test Changing datalog num shards not cause any crash
+      polarion-id: CEPH-83574088
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_changing_data_log_num_shards_cause_no_crash.yaml
+            timeout: 300


### PR DESCRIPTION
…num_shards parameter should not cause rgw daemon crash

CEPH-83574088:Changing the value of rgw_data_log_num_shards parameter should not cause rgw daemon crash

Log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-PIBKUK/

depends on: https://github.com/red-hat-storage/ceph-qe-scripts/pull/583

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
