### PR TITLE
[tfa-fix] Add support for s3.upshift repo for RC builds

### DIFF
--- a/cli/ops/cephadm_ansible.py
+++ b/cli/ops/cephadm_ansible.py
@@ -138,7 +138,7 @@ def exec_cephadm_preflight(node, build_type, ibm_build=False, repo=None):
     extra_vars = {"ceph_origin": build_type}
 
     # Set custom repository
-    if repo:
+    if repo and "s3.upshift.redhat.com" not in repo:
         if ibm_build and repo.endswith(".repo") and "public.dhe.ibm.com" in repo:
             if "rhel9" in repo:
                 repo = repo.replace(repo.split("/")[-1], "rhel9/x86_64/")


### PR DESCRIPTION
# Description

### Problem:
Ansible-wrapper related tests fail while running the preflight playbook if the repo provided is the `s3.upshift.redhat.com` repo.

### Reason for Failure:
The `s3.upshift.redhat.com` repo's baseurl contains xml data which does not include the repodata dir that is required for the packages to be installed.

### Solution:
Since the repo's are being added at the start of the test with `yum-config-manager --add-repo` command, there is no need to add the `s3.upshift.redhat.com` repo in the custom-options for preflight playbook.

### Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U7Y4W2
