### PR TITLE
Fixing Version comparison using looseversion

### DIFF
--- a/tests/misc_env/validate_version.py
+++ b/tests/misc_env/validate_version.py
@@ -1,4 +1,5 @@
 import traceback
+from distutils.version import LooseVersion
 
 from utility.log import Log
 from utility.utils import get_ceph_version_from_cluster, get_ceph_version_from_repo
@@ -13,7 +14,7 @@ def run(ceph_cluster, **kw):
         log.info(kw.get("config"))
         ceph_version_installed = get_ceph_version_from_cluster(clients[0])
         ceph_version = get_ceph_version_from_repo(clients[0], config)
-        if ceph_version <= ceph_version_installed:
+        if LooseVersion(ceph_version) <= LooseVersion(ceph_version_installed):
             log.info(
                 f"Upgrade should not proceeded as installed versions is {ceph_version_installed} "
                 f"greater than or equal to latest Version i.e., {ceph_version}"


### PR DESCRIPTION
# Description
Fixing Version comparison using looseversion

For validation of versions we used string comparison which was not working as expected. replaced it with looseversion
Quick Demo code```
```

>>> from distutils.version import LooseVersion
>>> ceph_version_installed = "18.2.1-76.el9cp"
>>> ceph_version = "18.2.1-111.el9cp"
>>> ceph_version <= ceph_version_installed
True
>>> LooseVersion(ceph_version) <= LooseVersion(ceph_version_installed)
False
>>> ceph_version_installed = "18.2.1-761.el9cp"
>>> LooseVersion(ceph_version) <= LooseVersion(ceph_version_installed)
True
```
```


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
