### PR TITLE
Include log-to-file for nvme suites

### DIFF
--- a/suites/reef/nvmeof/tier-1_nvmeof_qos.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_qos.yaml
@@ -19,6 +19,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
@@ -20,6 +20,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-1_nvmeof_vmware_esx_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_vmware_esx_sanity.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-2_nvmeof_e2e_fips.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_e2e_fips.yaml
@@ -20,6 +20,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -16,6 +16,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -20,6 +20,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_1-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_1-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_16-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_16-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_2-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_4-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_4-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_2-nvmeof-gw_8-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_2-nvmeof-gw_8-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_4-nvmeof-gw_1-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_4-nvmeof-gw_1-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_4-nvmeof-gw_16-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_4-nvmeof-gw_16-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_4-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_4-nvmeof-gw_2-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_4-nvmeof-gw_4-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_4-nvmeof-gw_4-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_4-nvmeof-gw_8-sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_4-nvmeof-gw_8-sub_ns.yaml
@@ -32,6 +32,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
@@ -20,6 +20,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
@@ -21,6 +21,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_namespace_limit.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_namespace_limit.yaml
@@ -34,6 +34,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_restart_operations.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_restart_operations.yaml
@@ -20,6 +20,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_scale_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_scale_ns.yaml
@@ -31,6 +31,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-3_nvmeof_scale_sub_ns.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_scale_sub_ns.yaml
@@ -34,6 +34,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-4_nvmeof_namespace_operations.yaml
+++ b/suites/reef/nvmeof/tier-4_nvmeof_namespace_operations.yaml
@@ -20,6 +20,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host

--- a/suites/reef/nvmeof/tier-4_nvmeof_neg_tests.yaml
+++ b/suites/reef/nvmeof/tier-4_nvmeof_neg_tests.yaml
@@ -19,6 +19,7 @@ tests:
                 mon-ip: node1
                 registry-url: registry.redhat.io
                 allow-fqdn-hostname: true
+                log-to-file: true
           - config:
               command: add_hosts
               service: host


### PR DESCRIPTION
# Description

Including `log-to-file` bootstrap option to automatically enable log files for each dameon for ceph created.

```
  --log-to-file         configure cluster to log to traditional log files in /var/log/ceph/$fsid
```
