### PR TITLE
Changing order of the 5000 full sync test in the suite

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -571,6 +571,32 @@ tests:
       comments: workaround sync fail [bz-2262400]
       name: test M buckets multipart uploads on haproxy node
       polarion-id: CEPH-83575433
+  - test:
+      clusters:
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph orch stop rgw.shared.arc"
+            timeout: 120
+      desc: Test full sync at archive, power off archive zone with IOs in active zone
+      module: exec.py
+      name: Test full sync at archive, power off archive zone with IOs in active zone
+      polarion-id: CEPH-83575917
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd.yaml
+            run-on-haproxy: true
+            timeout: 300
+      desc: Upload 5000 objects via s3cmd to test full sync at archive
+      polarion-id: CEPH-83575917
+      module: sanity_rgw_multisite.py
+      name: Upload 5000 objects via s3cmd to test full sync at archive
+      comments: Known issue in 7.1, Bug 2262400
 
   - test:
       clusters:
@@ -612,32 +638,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: test versioning suspend on archive
       polarion-id: CEPH-83575578
-  - test:
-      clusters:
-        ceph-arc:
-          config:
-            cephadm: true
-            commands:
-              - "ceph orch stop rgw.shared.arc"
-            timeout: 120
-      desc: Test full sync at archive, power off archive zone with IOs in active zone
-      module: exec.py
-      name: Test full sync at archive, power off archive zone with IOs in active zone
-      polarion-id: CEPH-83575917
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            set-env: true
-            script-name: ../s3cmd/test_s3cmd.py
-            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd.yaml
-            run-on-haproxy: true
-            timeout: 300
-      desc: Upload 5000 objects via s3cmd to test full sync at archive
-      polarion-id: CEPH-83575917
-      module: sanity_rgw_multisite.py
-      name: Upload 5000 objects via s3cmd to test full sync at archive
-      comments: Known issue in 7.1, Bug 2262400
   - test:
       clusters:
         ceph-pri:


### PR DESCRIPTION
# Description

Changing the order of the 5000 objects full sync test to the archive zone. The motivation is to have the test executed after changing the configuration for the archive zone to only sync from the primary zone.

The above is for tracking the workaround [bz-2262400] which should not fail on latest 7.1

We already have a test in the suite that tracks bug-2213138, a known failure which is at https://github.com/red-hat-storage/cephci/blob/master/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml#L530C17-L530C43

