### PR TITLE
[TFA] Introducing small delay before monitor_consistency_via_bucket_stats

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -268,6 +268,7 @@ def run(**kw):
         )
         if monitor_consistency_via_bucket_stats:
             log.info("Monitor sync consistency via bucket stats across sites.")
+            time.sleep(120)
             test_sync_via_bucket_stats(primary_rgw_node, secondary_rgw_node)
 
         test_bucket_stats_at_archive = config.get("test-archive-bucket-stats")


### PR DESCRIPTION
# Description
issue of inconsistency not seen in local run for s3cmd : http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-TX89U3/S3CMD_object_download_on_primary_0.log

but issue seen with different test case so better to include some delay before sync check

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
