### PR TITLE
[TFA] Removing abort-on-failure from baremetal

### DIFF
--- a/suites/quincy/baremetal_pipeline/tier-1_rgw_ms.yaml
+++ b/suites/quincy/baremetal_pipeline/tier-1_rgw_ms.yaml
@@ -342,7 +342,6 @@ tests:
       name: deploy cosbench
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -359,7 +358,6 @@ tests:
       polarion-id: CEPH-83574428
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -411,7 +409,6 @@ tests:
       module: test_parallel.py
       parallel:
         - test:
-            abort-on-fail: true
             clusters:
               ceph-pri:
                 config:
@@ -431,7 +428,6 @@ tests:
             name: push cosbench push workload from primary
             polarion-id: CEPH-83575073
         - test:
-            abort-on-fail: true
             clusters:
               ceph-sec:
                 config:
@@ -452,7 +448,6 @@ tests:
             polarion-id: CEPH-83575073
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -474,7 +469,6 @@ tests:
       polarion-id: CEPH-83575077
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -492,7 +486,6 @@ tests:
       module: test_parallel.py
       parallel:
         - test:
-            abort-on-fail: true
             clusters:
               ceph-pri:
                 config:
@@ -511,7 +504,6 @@ tests:
             name: push cosbench cleanup workload from primary
             polarion-id: CEPH-83575074
         - test:
-            abort-on-fail: true
             clusters:
               ceph-sec:
                 config:

--- a/suites/reef/rgw/baremetal/scale_rgw_multi_site.yaml
+++ b/suites/reef/rgw/baremetal/scale_rgw_multi_site.yaml
@@ -13,7 +13,6 @@
 tests:
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -29,7 +28,6 @@ tests:
       polarion-id: CEPH-83574428
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -80,7 +78,6 @@ tests:
       module: test_parallel.py
       parallel:
         - test:
-            abort-on-fail: true
             clusters:
               ceph-pri:
                 config:
@@ -99,7 +96,6 @@ tests:
             name: push cosbench push workload from primary
             polarion-id: CEPH-83575073
         - test:
-            abort-on-fail: true
             clusters:
               ceph-sec:
                 config:
@@ -119,7 +115,6 @@ tests:
             polarion-id: CEPH-83575073
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -140,7 +135,6 @@ tests:
       polarion-id: CEPH-83575077
 
   - test:
-      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -158,7 +152,6 @@ tests:
       module: test_parallel.py
       parallel:
         - test:
-            abort-on-fail: true
             clusters:
               ceph-pri:
                 config:
@@ -176,7 +169,6 @@ tests:
             name: push cosbench cleanup workload from primary
             polarion-id: CEPH-83575074
         - test:
-            abort-on-fail: true
             clusters:
               ceph-sec:
                 config:

--- a/suites/reef/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/reef/rgw/baremetal/scale_rgw_single_site.yaml
@@ -105,7 +105,6 @@ tests:
       name: deploy cosbench
 
   - test:
-      abort-on-fail: true
       config:
         controllers:
           - node10
@@ -119,7 +118,6 @@ tests:
       polarion-id: CEPH-83574428
 
   - test:
-      abort-on-fail: true
       config:
         controllers:
           - node10


### PR DESCRIPTION
# Description
http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/baremetal/RH/7.1/rhel-9/18.2.1-135/rgw/19/scale_rgw_multi_site/push_cosbench_fill_workload_0.log

failure is due to cosbench workload failure (http://10.8.130.210:19088/controller/workload.html?id=w1 ), since we had "abort-on-fail: true" next test case did not trigger so removing the abort-on-fail


server was down:
obj2438909, pri-bkt5/pri-obj2151395, pri-bkt6/pri-obj2342581, pri-bkt6/pri-obj2339548, pri-bkt6/pri-obj2330913, pri-bkt6/pri-obj2444186, pri-bkt6/pri-obj2157358, pri-bkt6/pri-obj2432588, pri-bkt6/pri-obj2264418, pri-bkt6/pri-obj2175718, pri-bkt6/pri-obj2245967
com.intel.cosbench.api.storage.StorageException: com.amazonaws.services.s3.model.AmazonS3Exception: Gateway Time-out (Service: Amazon S3; Status Code: 504; Error Code: 504 Gateway Time-out; Request ID: null), S3 Extended Request ID: null
	at com.intel.cosbench.api.S3Stor.S3Storage.createObject(S3Storage.java:170)
	at com.intel.cosbench.driver.operator.Writer.doWrite(Writer.java:98)
	at com.intel.cosbench.driver.operator.Preparer.operate(Preparer.java:97)
	at com.intel.cosbench.driver.operator.AbstractOperator.operate(AbstractOperator.java:76)
	at com.intel.cosbench.driver.agent.WorkAgent.performOperation(WorkAgent.java:197)
	at com.intel.cosbench.driver.agent.WorkAgent.doWork(WorkAgent.java:177)
	at com.intel.cosbench.driver.agent.WorkAgent.execute(WorkAgent.java:134)
	at com.intel.cosbench.driver.agent.AbstractAgent.call(AbstractAgent.java:44)
	at com.intel.cosbench.driver.agent.AbstractAgent.call(AbstractAgent.java:1)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: Gateway Time-out (Service: Amazon S3; Status Code: 504; Error Code: 504 Gateway Time-out; Request ID: null), S3 Extended Request ID: null
	at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:1389)
	at com.amazonaws.http.AmazonHttpClient.executeOneRequest(AmazonHttpClient.java:902)
	at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:607)
	at com.amazonaws.http.AmazonHttpClient.doExecute(AmazonHttpClient.java:376)
	at com.amazonaws.http.AmazonHttpClient.executeWithTimer(AmazonHttpClient.java:338)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:287)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3826)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1405)
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1270)
	at com.intel.cosbench.api.S3Stor.S3Storage.createObject(S3Storage.java:167)
	... 12 more

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
