### PR TITLE
Fix for upgrade test cases not adding right repo to cluster nodes

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -134,6 +134,9 @@ class CephAdmin(BootstrapMixin, ShellMixin):
                 base_url += "Tools"
             else:
                 base_url += "compose/Tools/x86_64/os/"
+            cmd = f"yum-config-manager --add-repo {base_url}"
+            for node in self.cluster.get_nodes():
+                node.exec_command(sudo=True, cmd=cmd)
 
     def set_cdn_tool_repo(self):
         """


### PR DESCRIPTION
# Description

Upgrade test cases were not adding the right repo to cluster nodes. 
Added yum config manager for missing if condition.

logs:

2024-04-15 14:13:46,420 (cephci.utility.xunit) [DEBUG] - cephci.utility.log.py:245 - Completed log configuration
2024-04-15 14:13:46,456 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.run.py:720 - Running test cephadm.test_cephadm_upgrade.py
2024-04-15 14:13:46,462 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.tests.cephadm.test_cephadm_upgrade.py:41 - Upgrade Ceph cluster...
2024-04-15 14:13:46,463 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph_admin.__init__.py:102 - cloud type is baremetal
2024-04-15 14:13:46,464 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.129.230 timeout 600
2024-04-15 14:13:48,391 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:13:48,393 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.129.232 timeout 600
2024-04-15 14:13:50,298 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:13:50,299 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.128.10 timeout 600
2024-04-15 14:13:52,931 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:13:52,932 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.128.8 timeout 600
2024-04-15 14:13:55,616 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:13:55,617 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.128.60 timeout 600
2024-04-15 14:13:58,269 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:13:58,270 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.128.12 timeout 600
2024-04-15 14:14:00,880 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:14:00,881 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.129.226 timeout 600
2024-04-15 14:14:03,046 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-15 14:14:03,047 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1563 - Running command yum-config-manager --add-repo http://download.eng.bos.redhat.com/rhel-9/composes/auto/ceph-7.1-rhel-9/RHCEPH-7.1-RHEL-9-20240410.ci.3/compose/Tools/x86_64/os/ on 10.8.129.228 timeout 600
2024-04-15 14:14:05,221 (cephci.cephadm.test_cephadm_upgrade) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
