### PR TITLE
Nvmeof code changes to adopt few new CLIS

### DIFF
--- a/ceph/nvmegw_cli/__init__.py
+++ b/ceph/nvmegw_cli/__init__.py
@@ -31,3 +31,10 @@ class NVMeGWCLI(ExecuteCommandMixin):
         _, out = self.gateway.info(**gwinfo)
         out = loads(out)
         return out["load_balancing_group"]
+
+    def fetch_gateway_hostname(self):
+        """Return Gateway load balancing group host name"""
+        gwinfo = {"base_cmd_args": {"format": "json"}}
+        _, out = self.gateway.info(**gwinfo)
+        out = loads(out)
+        return out["hostname"]

--- a/ceph/nvmegw_cli/common.py
+++ b/ceph/nvmegw_cli/common.py
@@ -20,6 +20,11 @@ def find_client_daemon_id(node, port=5500):
     return NVMeGWCLI(node, port).fetch_gateway_client_name()
 
 
+def find_gateway_hostname(node, port=5500):
+    """Find client daemon Id."""
+    return NVMeGWCLI(node, port).fetch_gateway_hostname()
+
+
 class NVMeCLI:
     """NVMeCLI class for managing NVMeoF Gateway entities."""
 

--- a/tests/cephadm/test_nvmeof.py
+++ b/tests/cephadm/test_nvmeof.py
@@ -28,5 +28,6 @@ def run(ceph_cluster, **kw):
         method(config)
     finally:
         # Get cluster state
-        get_cluster_state(nvmeof)
+        if kw.get("no_cluster_state", True):
+            get_cluster_state(nvmeof)
     return 0

--- a/tests/cephadm/test_orch.py
+++ b/tests/cephadm/test_orch.py
@@ -37,5 +37,6 @@ def run(ceph_cluster, **kw):
         method(config)
     finally:
         # Get cluster state
-        get_cluster_state(orch)
+        if kw.get("no_cluster_state", True):
+            get_cluster_state(orch)
     return 0

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -23,7 +23,7 @@ def configure_subsystems(rbd, pool, subsystem, config):
     )
 
     listener_cfg = {
-        "gateway-name": subsystem.fetch_gateway_client_name(),
+        "host-name": subsystem.fetch_gateway_hostname(),
         "traddr": subsystem.node.ip_address,
         "trsvcid": config["listener_port"],
     }

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -27,7 +27,7 @@ def configure_subsystems(rbd, pool, subsystem, config):
     )
 
     listener_cfg = {
-        "gateway-name": subsystem.fetch_gateway_client_name(),
+        "host-name": subsystem.fetch_gateway_hostname(),
         "traddr": subsystem.node.ip_address,
         "trsvcid": config["listener_port"],
     }

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -164,11 +164,12 @@ def teardown(ceph_cluster, rbd_obj, config):
     # Delete the gateway
     if "gateway" in config["cleanup"]:
         cfg = {
+            "no_cluster_state": False,
             "config": {
                 "command": "remove",
                 "service": "nvmeof",
                 "args": {"service_name": f"nvmeof.{config['rbd_pool']}"},
-            }
+            },
         }
         test_orch.run(ceph_cluster, **cfg)
 
@@ -260,12 +261,13 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
         subsystem = Subsystem(gw_node, gw_port)
         if config.get("install"):
             cfg = {
+                "no_cluster_state": False,
                 "config": {
                     "command": "apply",
                     "service": "nvmeof",
                     "args": {"placement": {"nodes": [gw_node.hostname]}},
                     "pos_args": [rbd_pool],
-                }
+                },
             }
             test_nvmeof.run(ceph_cluster, **cfg)
 

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
@@ -106,7 +106,7 @@ def configure_listeners(config, _cls, command, ceph_cluster):
             config["args"].update(
                 {
                     "subsystem": f"nqn.2016-06.io.spdk:cnode{num}",
-                    "gateway-name": listener_node.hostname,
+                    "host-name": listener_node.hostname,
                     "traddr": listener_node.ip_address,
                     "trsvcid": port,
                 }

--- a/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from ceph.ceph import Ceph
 from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.common import fetch_method
-from ceph.nvmegw_cli.common import NVMeCLI, find_client_daemon_id
+from ceph.nvmegw_cli.common import NVMeCLI, find_gateway_hostname
 from ceph.nvmeof.initiator import Initiator
 from ceph.utils import get_node_by_id
 from tests.rbd.rbd_utils import initial_rbd_config
@@ -158,9 +158,9 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                                 "subnqn": f"nqn.2016-06.io.spdk:cnode{num}",
                                 "port": listener_port,
                             }
-                            client_id = find_client_daemon_id(node)
+                            hostname = find_gateway_hostname(node)
                             listener.update(
-                                {"gateway-name": client_id, "traddr": node.ip_address}
+                                {"host-name": hostname, "traddr": node.ip_address}
                             )
                             listener_func = fetch_method(nvme_cli, command)
                             listener_func(**listener)

--- a/tests/nvmeof/test_nvme_cli.py
+++ b/tests/nvmeof/test_nvme_cli.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 from ceph.ceph import Ceph
 from ceph.ceph_admin.common import fetch_method
-from ceph.nvmegw_cli.common import find_client_daemon_id
+from ceph.nvmegw_cli.common import find_gateway_hostname
 from ceph.nvmegw_cli.connection import Connection
 from ceph.nvmegw_cli.gateway import Gateway
 from ceph.nvmegw_cli.host import Host
@@ -92,9 +92,9 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 _cls.NVMEOF_CLI_IMAGE = cli_image
             if service in "listener" and command in ["add", "delete"]:
                 gw_node = get_node_by_id(ceph_cluster, cfg["args"]["gateway-name"])
-                client_id = find_client_daemon_id(gw_node)
+                hostname = find_gateway_hostname(gw_node)
                 cfg["args"].update(
-                    {"gateway-name": client_id, "traddr": gw_node.ip_address}
+                    {"host-name": hostname, "traddr": gw_node.ip_address}
                 )
             func = fetch_method(_cls, command)
             func(**cfg)


### PR DESCRIPTION
# Description
- [replace gw-client-id with gw hostname in listener addition](https://github.com/red-hat-storage/cephci/commit/a94a41d4cbdc18ee81cf698f886156d71d8d1a36)
   - Replace the Old gateway Client Id with new attribute hostname, basically GW hostname.
- [suppress cluster state calls](https://github.com/red-hat-storage/cephci/commit/5954298c4a8867e059c4d1a72d014959e6f3e13b)
   - Suppress unneccessary cluster state calls.

Results:
```
2024-04-15 16:42:52,940 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.run.py:891 - Test <module 'test_ceph_nvmeof_gateway' from '/Users/sunilkumarn/workspace/cephci/tests/nvmeof/test_ceph_nvmeof_gateway.py'> passed
Test <module 'test_ceph_nvmeof_gateway' from '/Users/sunilkumarn/workspace/cephci/tests/nvmeof/test_ceph_nvmeof_gateway.py'> passed
2024-04-15 16:42:52,941 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.run.py:946 -
All test logs located here: /Users/sunilkumarn/logs/Sanity-test-01

All test logs located here: /Users/sunilkumarn/logs/Sanity-test-01

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:06:21.368740                   Pass
deploy cluster                   RHCS cluster deployment using cephadm                          0:14:00.481012                   Pass
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:00:41.858730                   Pass
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:02:24.191980                   Pass
Basic E2ETest Ceph NVMEoF GW s   E2E-Test NVMEoF Gateway on dedicated node and Run IOs on tar   0:15:27.233712                   Pass
```
