### PR TITLE
Unify all NVMe GW CLI command options

### DIFF
--- a/ceph/nvmegw_cli/__init__.py
+++ b/ceph/nvmegw_cli/__init__.py
@@ -3,19 +3,37 @@ from json import loads
 from ceph.nvmegw_cli.connection import Connection
 from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 from ceph.nvmegw_cli.gateway import Gateway
+from ceph.nvmegw_cli.host import Host
+from ceph.nvmegw_cli.listener import Listener
 from ceph.nvmegw_cli.log_level import LogLevel
+from ceph.nvmegw_cli.namespace import Namespace
+from ceph.nvmegw_cli.subsystem import Subsystem
 from ceph.nvmegw_cli.version import Version
 
 
 class NVMeGWCLI(ExecuteCommandMixin):
     def __init__(self, node, port=5500) -> None:
         super().__init__(node, port)
-        self.loglevel = LogLevel(node, port)
-        self.gateway = Gateway(node, port)
-        self.version = Version(node, port)
         self.connection = Connection(node, port)
+        self.gateway = Gateway(node, port)
+        self.host = Host(node, port)
+        self.loglevel = LogLevel(node, port)
+        self.listener = Listener(node, port)
+        self.namespace = Namespace(node, port)
+        self.subsystem = Subsystem(node, port)
+        self.version = Version(node, port)
+
         self.name = " "
-        for clas in [self.loglevel, self.gateway, self.version, self.connection]:
+        for clas in [
+            self.loglevel,
+            self.gateway,
+            self.version,
+            self.connection,
+            self.host,
+            self.subsystem,
+            self.namespace,
+            self.listener,
+        ]:
             clas.NVMEOF_CLI_IMAGE = self.NVMEOF_CLI_IMAGE
 
     def fetch_gateway_client_name(self):
@@ -38,3 +56,7 @@ class NVMeGWCLI(ExecuteCommandMixin):
         _, out = self.gateway.info(**gwinfo)
         out = loads(out)
         return out["hostname"]
+
+    def get_subsystems(self, **kwargs):
+        """Nvme CLI get_subsystems"""
+        return self.run_nvme_cli(**kwargs)

--- a/ceph/nvmegw_cli/host.py
+++ b/ceph/nvmegw_cli/host.py
@@ -1,7 +1,7 @@
-from ceph.nvmegw_cli import NVMeGWCLI
+from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
-class Host(NVMeGWCLI):
+class Host(ExecuteCommandMixin):
     def __init__(self, node, port) -> None:
         super().__init__(node, port)
         self.name = "host"

--- a/ceph/nvmegw_cli/listener.py
+++ b/ceph/nvmegw_cli/listener.py
@@ -1,7 +1,7 @@
-from ceph.nvmegw_cli import NVMeGWCLI
+from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
-class Listener(NVMeGWCLI):
+class Listener(ExecuteCommandMixin):
     def __init__(self, port, node) -> None:
         super().__init__(port, node)
         self.name = "listener"

--- a/ceph/nvmegw_cli/namespace.py
+++ b/ceph/nvmegw_cli/namespace.py
@@ -1,9 +1,9 @@
 import re
 
-from ceph.nvmegw_cli import NVMeGWCLI
+from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
-class Namespace(NVMeGWCLI):
+class Namespace(ExecuteCommandMixin):
     def __init__(self, node, port) -> None:
         super().__init__(node, port)
         self.name = "namespace"

--- a/ceph/nvmegw_cli/subsystem.py
+++ b/ceph/nvmegw_cli/subsystem.py
@@ -1,18 +1,10 @@
-from ceph.nvmegw_cli import NVMeGWCLI
-from ceph.nvmegw_cli.host import Host
-from ceph.nvmegw_cli.listener import Listener
-from ceph.nvmegw_cli.namespace import Namespace
+from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
-class Subsystem(NVMeGWCLI):
+class Subsystem(ExecuteCommandMixin):
     def __init__(self, node, port) -> None:
         super().__init__(node, port)
         self.name = "subsystem"
-        self.listener = Listener(node, port)
-        self.namespace = Namespace(node, port)
-        self.host = Host(node, port)
-        for clas in [self.listener, self.namespace, self.host]:
-            clas.NVMEOF_CLI_IMAGE = self.NVMEOF_CLI_IMAGE
 
     def add(self, **kwargs):
         return self.run_nvme_cli("add", **kwargs)


### PR DESCRIPTION
# Description

Unify all NVMe GW CLI command options
- NVMeGWCLI
   - subsystem
   - listener
   - host
   - namespace
   - gateway
   - log-level

![image](https://github.com/red-hat-storage/cephci/assets/31158377/9ed2048a-91e8-4c66-9b3f-13089ad01000)


