### PR TITLE
[TFA issue fix] include datalog trim testcase in reef and run from primary

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -560,17 +560,17 @@ tests:
             verify-io-on-site: ["ceph-sec"]
 
   - test:
-      name: Datalog trimming test on secondary
-      desc: test datalog trimming on secondary
+      name: Datalog trimming test on primary
+      desc: test datalog trimming on primary
       polarion-id: CEPH-10540 #CEPH-10722, CEPH-10547
       module: sanity_rgw_multisite.py
       clusters:
-        ceph-sec:
+        ceph-pri:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_datalog_trimming.yaml
             timeout: 300
-            verify-io-on-site: ["ceph-pri"]
+            verify-io-on-site: ["ceph-sec"]
 
 
   - test:

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -491,6 +491,46 @@ tests:
             timeout: 300
             verify-io-on-site: ["ceph-pri"]
 
+# Log trimming tests
+  - test:
+      name: Mdlog trimming test on primary
+      desc: test mdlog trimming on primary
+      polarion-id: CEPH-10544 #CEPH-10722, CEPH-10547
+      module: sanity_rgw_multisite.py
+      comments: Known issue BZ-2230359
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bilog_trimming.py
+            config-file-name: test_mdlog_trimming.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-sec"]
+
+  - test:
+      name: Datalog trimming test on primary
+      desc: test datalog trimming on primary
+      polarion-id: CEPH-10540 #CEPH-10722, CEPH-10547
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bilog_trimming.py
+            config-file-name: test_datalog_trimming.yaml
+            timeout: 300
+            verify-io-on-site: ["ceph-sec"]
+
+  - test:
+      name: Bilog trimming test on primary
+      desc: test bilog trimming on primary
+      polarion-id: CEPH-83572658 #CEPH-10722, CEPH-10547
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bilog_trimming.py
+            config-file-name: test_bilog_trimming.yaml
+            timeout: 300
+
   - test:
       name: bucket request payer
       desc: Basic test for bucket request payer


### PR DESCRIPTION
# Description
pr includes 2 changes:
1. while running datalog trim from secondary saw issue related to user_details.json not found in secondary, so runing testcase from primary 
     issue log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/17.2.6-212/Weekly/rgw/29/tier-2_rgw_singlesite_to_multisite/Datalog_trimming_test_on_secondary_0.log
2.  testcase was not found in reef so included in reef

log: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-R4QVL6/Datalog_trimming_test_on_primary_0.log


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
