### PR TITLE
NVMe HA automation support

### DIFF
--- a/ceph/nvmegw_cli/__init__.py
+++ b/ceph/nvmegw_cli/__init__.py
@@ -45,27 +45,28 @@ class NVMeGWCLI(ExecuteCommandMixin):
             password = registry_details.get("registry-password")
             Registry(self.node).login(url, username, password)
 
-    def fetch_gateway_client_name(self):
-        """Return Gateway Client name/id."""
+    def fetch_gateway(self):
+        """Return Gateway info"""
         gwinfo = {"base_cmd_args": {"format": "json"}}
         _, out = self.gateway.info(**gwinfo)
         out = loads(out)
+        return out
+
+    def fetch_gateway_client_name(self):
+        """Return Gateway Client name/id."""
+        out = self.fetch_gateway()
         return out["name"]
 
     def fetch_gateway_lb_group_id(self):
         """Return Gateway Load balancing group Id."""
-        gwinfo = {"base_cmd_args": {"format": "json"}}
-        _, out = self.gateway.info(**gwinfo)
-        out = loads(out)
+        out = self.fetch_gateway()
         return out["load_balancing_group"]
 
     def fetch_gateway_hostname(self):
         """Return Gateway load balancing group host name"""
-        gwinfo = {"base_cmd_args": {"format": "json"}}
-        _, out = self.gateway.info(**gwinfo)
-        out = loads(out)
+        out = self.fetch_gateway()
         return out["hostname"]
 
     def get_subsystems(self, **kwargs):
         """Nvme CLI get_subsystems"""
-        return self.run_nvme_cli(**kwargs)
+        return self.run_nvme_cli("get_subsystems", **kwargs)

--- a/ceph/nvmegw_cli/connection.py
+++ b/ceph/nvmegw_cli/connection.py
@@ -2,8 +2,8 @@ from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
 class Connection(ExecuteCommandMixin):
-    def __init__(self, port, node) -> None:
-        super().__init__(port, node)
+    def __init__(self, node, port) -> None:
+        super().__init__(node, port)
         self.name = "connection"
 
     def list(self, **kwargs):

--- a/ceph/nvmegw_cli/execute.py
+++ b/ceph/nvmegw_cli/execute.py
@@ -5,7 +5,7 @@ LOG = Log(__name__)
 
 
 class ExecuteCommandMixin:
-    BASE_CMD = "podman run --rm"
+    BASE_CMD = "podman run --quiet --rm"
     NVMEOF_CLI_IMAGE = "quay.io/ceph/nvmeof-cli:1.1.0"
 
     def __init__(self, node, port=5500) -> None:

--- a/ceph/nvmegw_cli/gateway.py
+++ b/ceph/nvmegw_cli/gateway.py
@@ -2,8 +2,8 @@ from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
 class Gateway(ExecuteCommandMixin):
-    def __init__(self, port, node) -> None:
-        super().__init__(port, node)
+    def __init__(self, node, port) -> None:
+        super().__init__(node, port)
         self.name = "gw"
 
     def info(self, **kwargs):

--- a/ceph/nvmegw_cli/listener.py
+++ b/ceph/nvmegw_cli/listener.py
@@ -2,8 +2,8 @@ from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
 class Listener(ExecuteCommandMixin):
-    def __init__(self, port, node) -> None:
-        super().__init__(port, node)
+    def __init__(self, node, port) -> None:
+        super().__init__(node, port)
         self.name = "listener"
 
     def add(self, **kwargs):

--- a/ceph/nvmegw_cli/log_level.py
+++ b/ceph/nvmegw_cli/log_level.py
@@ -2,8 +2,8 @@ from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
 class LogLevel(ExecuteCommandMixin):
-    def __init__(self, port, node) -> None:
-        super().__init__(port, node)
+    def __init__(self, node, port) -> None:
+        super().__init__(node, port)
         self.name = "log_level"
 
     def get(self, **kwargs):

--- a/ceph/nvmegw_cli/version.py
+++ b/ceph/nvmegw_cli/version.py
@@ -2,8 +2,8 @@ from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
 class Version(ExecuteCommandMixin):
-    def __init__(self, port, node) -> None:
-        super().__init__(port, node)
+    def __init__(self, node, port) -> None:
+        super().__init__(node, port)
         self.name = str()
 
     def version(self, **kwargs):

--- a/ceph/nvmeof/nvme_cli.py
+++ b/ceph/nvmeof/nvme_cli.py
@@ -93,3 +93,9 @@ class NVMeCLI(Cli):
     def disconnect_all(self):
         """Disconnects all controllers connected to subsystems."""
         return self.execute(cmd="nvme disconnect-all", sudo=True)
+
+    def connect_all(self, **kwargs):
+        """Connects all controllers connected to subsystems."""
+        return self.execute(
+            cmd=f"nvme connect-all {config_dict_to_string(kwargs)}", sudo=True
+        )

--- a/conf/reef/nvmeof/ceph_nvmeof_ha_cluster.yaml
+++ b/conf/reef/nvmeof/ceph_nvmeof_ha_cluster.yaml
@@ -1,0 +1,43 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      vm-size: ci.standard.xl
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - mds
+          - osd
+          - rgw
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - nvmeof-gw
+      node7:
+        role:
+          - nvmeof-gw
+      node8:
+        id: node10
+        role:
+          - client

--- a/suites/reef/nvmeof/tier-1_nvmeof_ha_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_ha_sanity.yaml
@@ -1,0 +1,121 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  #  Configure Ceph NVMeoF gateway
+  #  Configure Initiators
+  #  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 2G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+            - count: 2
+              size: 2G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node6
+      desc: E2E-Test NVMEoF 2GW test with mutliple subsystems
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: E2E Ceph NVMeoF 2-GW HA sanity test

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -1,0 +1,231 @@
+"""
+Test suite that verifies the deployment of Ceph NVMeoF Gateway HA
+ with supported entities like subsystems , etc.,
+
+"""
+from copy import deepcopy
+
+from ceph.ceph import Ceph
+from ceph.nvmegw_cli import NVMeGWCLI
+from ceph.nvmeof.initiator import Initiator
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id, get_nodes_by_ids
+from tests.cephadm import test_nvmeof, test_orch
+from tests.nvmeof.workflows.ha import HighAvailability
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+from utility.utils import generate_unique_id
+
+LOG = Log(__name__)
+
+
+def configure_listeners(cluster, nodes, config):
+    """Configure Listeners on subsystem."""
+    listeners = get_nodes_by_ids(cluster, nodes)
+    lb_group_ids = {}
+    for node in listeners:
+        nvmegwcli = NVMeGWCLI(node)
+        listener_config = {
+            "args": {
+                "subsystem": config["nqn"],
+                "traddr": node.ip_address,
+                "trsvcid": config["listener_port"],
+                "host-name": nvmegwcli.fetch_gateway_hostname(),
+            }
+        }
+        nvmegwcli.listener.add(**listener_config)
+        lb_group_ids.update({node.hostname: nvmegwcli.fetch_gateway_lb_group_id()})
+    return lb_group_ids
+
+
+def configure_subsystems(rbd, pool, nvmegwcli, config):
+    """Configure Ceph-NVMEoF Subsystems."""
+    sub_args = {"subsystem": config["nqn"]}
+    ceph_cluster = config["ceph_cluster"]
+
+    # Add Subsystem
+    nvmegwcli.subsystem.add(
+        **{
+            "args": {
+                **sub_args,
+                **{
+                    "max-namespaces": config.get("max_ns", 32),
+                    "enable-ha": config.get("enable_ha", False),
+                },
+            }
+        }
+    )
+
+    # Add Listeners
+    listeners = [nvmegwcli.node.hostname]
+    if config.get("listeners"):
+        listeners = config["listeners"]
+    lb_groups = configure_listeners(ceph_cluster, listeners, config)
+
+    # Add Host access
+    nvmegwcli.host.add(**{"args": {**sub_args, **{"host": repr(config["allow_host"])}}})
+
+    # Add Namespaces
+    if config.get("bdevs"):
+        bdev_configs = config["bdevs"]
+        if isinstance(config["bdevs"], dict):
+            bdev_configs = [config["bdevs"]]
+        for bdev_cfg in bdev_configs:
+            name = generate_unique_id(length=4)
+            namespace_args = {
+                **sub_args,
+                **{
+                    "rbd-pool": pool,
+                    "rbd-create-image": True,
+                    "size": bdev_cfg["size"],
+                },
+            }
+            with parallel() as p:
+                # Create namespace in gateway
+                for num in range(bdev_cfg["count"]):
+                    ns_args = deepcopy(namespace_args)
+                    ns_args["rbd-image"] = f"{name}-image{num}"
+                    if bdev_cfg.get("lb_group"):
+                        lbgid = lb_groups[
+                            get_node_by_id(ceph_cluster, bdev_cfg["lb_group"]).hostname
+                        ]
+                        ns_args["load-balancing-group"] = lbgid
+                    ns_args = {"args": ns_args}
+                    p.spawn(nvmegwcli.namespace.add, **ns_args)
+
+
+def disconnect_initiator(ceph_cluster, node):
+    """Disconnect Initiator."""
+    node = get_node_by_id(ceph_cluster, node)
+    initiator = Initiator(node)
+    initiator.disconnect_all()
+
+
+def teardown(ceph_cluster, rbd_obj, config):
+    """Cleanup the ceph-nvme gw entities.
+
+    Args:
+        ceph_cluster: Ceph Cluster
+        rbd_obj: RBD object
+        config: test config
+    """
+    # Delete the multiple Initiators across multiple gateways
+    if "initiators" in config["cleanup"]:
+        for initiator_cfg in config["initiators"]:
+            disconnect_initiator(ceph_cluster, initiator_cfg["node"])
+
+    # Delete the gateway
+    if "gateway" in config["cleanup"]:
+        cfg = {
+            "no_cluster_state": False,
+            "config": {
+                "command": "remove",
+                "service": "nvmeof",
+                "args": {
+                    "service_name": f"nvmeof.{config['rbd_pool']}",
+                    "verify": True,
+                },
+            },
+        }
+        test_orch.run(ceph_cluster, **cfg)
+
+    # Delete the pool
+    if "pool" in config["cleanup"]:
+        rbd_obj.clean_up(pools=[config["rbd_pool"]])
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Return the status of the Ceph NVMEof HA test execution.
+
+    - Configure Gateways
+    - Configures Initiators and Run FIO on NVMe targets.
+    - Perform failover and failback.
+    - Validate the IO continuation prior and after to failover and failback
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        kwargs: Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+
+    Example:
+
+        # Execute the nvmeof GW test
+            - test:
+                name: Ceph NVMeoF deployment
+                desc: Configure NVMEoF gateways and initiators
+                config:
+                    gw_nodes:
+                     - node6
+                    rbd_pool: rbd
+                    do_not_create_image: true
+                    rep-pool-only: true
+                    cleanup-only: true                          # only for cleanup
+                    rep_pool_config:
+                      pool: rbd
+                    install: true                               # Run SPDK with all pre-requisites
+                    subsystems:                                 # Configure subsystems with all sub-entities
+                      - nqn: nqn.2016-06.io.spdk:cnode3
+                        serial: 3
+                        bdevs:
+                          count: 1
+                          size: 100G
+                        listener_port: 5002
+                        allow_host: "*"
+                    initiators:                             # Configure Initiators with all pre-req
+                      - nqn: connect-all
+                        listener_port: 4420
+                        node: node10
+                    fault-injection-methods:                # fail-tool: systemctl, nodes-to-be-failed: node names
+                      - tool: systemctl
+                        nodes: node6
+    """
+    LOG.info("Starting Ceph Ceph NVMEoF deployment.")
+    config = kwargs["config"]
+    rbd_pool = config["rbd_pool"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeGWCLI.NVMEOF_CLI_IMAGE = value
+            break
+    gw_nodes = get_nodes_by_ids(ceph_cluster, config["gw_nodes"])
+
+    try:
+        if config.get("install"):
+            cfg = {
+                "no_cluster_state": False,
+                "config": {
+                    "command": "apply",
+                    "service": "nvmeof",
+                    "args": {"placement": {"nodes": [i.hostname for i in gw_nodes]}},
+                    "pos_args": [rbd_pool],
+                },
+            }
+            test_nvmeof.run(ceph_cluster, **cfg)
+
+        ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
+        nvmegwcli = ha.gateways[0]
+
+        # Configure Subsystem
+        if config.get("subsystems"):
+            with parallel() as p:
+                for subsys_args in config["subsystems"]:
+                    subsys_args["ceph_cluster"] = ceph_cluster
+                    p.spawn(
+                        configure_subsystems, rbd_obj, rbd_pool, nvmegwcli, subsys_args
+                    )
+
+        # HA failover and failback
+        ha.run()
+
+        return 0
+    except Exception as err:
+        LOG.error(err)
+    finally:
+        if config.get("cleanup"):
+            teardown(ceph_cluster, rbd_obj, config)
+
+    return 1

--- a/tests/nvmeof/workflows/ha.py
+++ b/tests/nvmeof/workflows/ha.py
@@ -1,0 +1,464 @@
+"""
+NVMe High Availability Module.
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from ceph.ceph_admin.orch import Orch
+from ceph.parallel import parallel
+from ceph.utils import get_node_by_id
+from ceph.waiter import WaitUntil
+from tests.nvmeof.workflows.initiator import NVMeInitiator
+from tests.nvmeof.workflows.nvme_gateway import NVMeGateway
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+def log_json_dump(data):
+    return json.dumps(data, indent=4)
+
+
+def get_current_timestamp():
+    return time.perf_counter(), time.asctime()
+
+
+class HighAvailability:
+    def __init__(self, ceph_cluster, gateways, **config):
+        """Initialize NVMeoF Gateway High Availability class.
+
+        Args:
+            cluster: Ceph cluster
+            gateways: Gateway node Ids
+            config: HA config
+        """
+        self.cluster = ceph_cluster
+        self.config = config
+        self.gateways = []
+        self.orch = Orch(cluster=self.cluster, **{})
+        self.nvme_pool = config["rbd_pool"]
+        self.clients = []
+
+        for gateway in gateways:
+            gw_node = get_node_by_id(self.cluster, gateway)
+            self.gateways.append(NVMeGateway(gw_node))
+
+        self.ana_ids = [i.ana_group_id for i in self.gateways]
+
+    def check_gateway(self, node_id):
+        """Check node is NVMeoF Gateway node.
+
+        Args:
+            node_id: Ceph node Id (ex., node6)
+        """
+        for gw in self.gateways:
+            if gw.node.id == node_id:
+                LOG.info(f"[{node_id}] {gw.node.hostname} is NVMeoF Gateway node.")
+                return gw
+        raise Exception(f"{node_id} doesn't match to any gateways provided...")
+
+    def catogorize(self, gws):
+        """Categorize to-be failed and running GWs.
+
+        Args:
+            gws: gateways to be failed/stopped
+
+        Returns:
+            list of,
+             - to-be failed gateways
+             - rest of the gateways
+        """
+        fail_gws = []
+        running_gws = []
+
+        # collect impending Gateways to be failed.
+        if isinstance(gws, str):
+            gws = [gws]
+        for gw_id in gws:
+            fail_gws.append(self.check_gateway(gw_id))
+
+        # Collect rest of the Gateways
+        for gw in self.gateways:
+            if gw.node.id not in gws:
+                running_gws.append(gw)
+
+        return fail_gws, running_gws
+
+    @staticmethod
+    def string_to_dict(string):
+        """Parse ANA states from the string."""
+        states = string.replace(" ", "").split(",")
+        dict = {}
+        for state in states:
+            if not state:
+                continue
+            _id, _state = state.split(":")
+            dict[int(_id)] = _state
+        return dict
+
+    def ana_states(self, gw_group=""):
+        """Fetch ANA states and convert into python dict."""
+
+        out, _ = self.orch.shell(
+            args=["ceph", "nvme-gw", "show", self.nvme_pool, repr(gw_group)]
+        )
+        states = {}
+        for data in out.split("}"):
+            data = data.strip()
+            if not data:
+                continue
+            data = json.loads(f"{data}}}")
+            if data.get("ana states"):
+                gw = data["gw-id"]
+                states[gw] = data
+                states[gw].update(self.string_to_dict(data["ana states"]))
+
+        return states
+
+    def check_gateway_availability(self, ana_id, state="AVAILABLE", ana_states=None):
+        """Check for failed ANA GW become unavailable.
+
+        Args:
+            ana_id: Gateway ANA group id.
+            state: Gateway availability state
+            ana_states: Overall ana state. (output from self.ana_states)
+        Return:
+            True if Gateway availability is in expected state, else False
+        """
+        # get ANA states
+        if not ana_states:
+            ana_states = self.ana_states()
+
+        # Check Availability of ANA Group Gateway
+        for _, _state in ana_states.items():
+            if _state["anagrp-id"] == ana_id:
+                if _state["Availability"] == state:
+                    return True
+                return False
+        return False
+
+    def get_optimized_state(self, failed_ana_id):
+        """Fetch the Optimized ANA states for failed gateway.
+
+        Args:
+            gateway: The gateway which is operational.
+            failed_ana_id: failed gateway ANA Group Id.
+
+        Returns:
+            gateways which shows ACTIVE state for failed ANA Group Id
+        """
+        # get ANA states
+        ana_states = self.ana_states()
+
+        # Fetch failed ANA Group Id in ACTIVE state
+        found = []
+
+        for ana_gw_id, state in ana_states.items():
+            if (
+                state["Availability"] == "AVAILABLE"
+                and state.get(failed_ana_id) == "ACTIVE"
+            ):
+                found.append({ana_gw_id: state})
+
+        return found
+
+    def system_control(self, gateway, state="is_active"):
+        # todo: handling failure injection via systemctl
+        pass
+
+    def ceph_daemon(self, gateway, state="running"):
+        # todo: handling failure injection via systemctl
+        pass
+
+    def failover(self, gateway, fail_tool="systemctl"):
+        """HA Failover on the NVMeoF Gateways.
+
+        Initiate Failover
+        - List the gateways which not have failures.
+        - Initiate failures on GWs which has to be down systemctl/daemon stop
+        - Validate the ANA states of failed GWs are optimized in one of the other working GWs.
+
+        Post Failover Validation
+        - List out namespaces associated with the failed Gateways using ANA group ids.
+        - Check for 5 Consecutive times for the increments in write/read to validate IO continuation.
+        """
+        LOG.info(f"[ {gateway.hostname} ] Failing over Gateway")
+
+        # Initiate Failover
+        LOG.info(f"[ {gateway.hostname} ]: Failing NVMe Service {fail_tool} command")
+        service = gateway.system_unit_id
+        gateway.systemctl.stop(service)
+
+        start_counter = float()
+        start_time = str()
+        end_counter = float()
+        end_time = str()
+
+        # Wait until 60 seconds
+        for w in WaitUntil():
+            # Check for service/daemon failure
+            if not gateway.systemctl.is_active(service):
+                LOG.info(f"[ {service} ] NVMeofGW service Stopped successfully.")
+                if not start_counter:
+                    start_counter, start_time = get_current_timestamp()
+
+                # Check for gateway unavailability
+                if self.check_gateway_availability(
+                    gateway.ana_group_id, state="UNAVAILABLE"
+                ):
+                    LOG.info(f"[ {service} ] NVMeofGW service is UNAVAILABLE.")
+                    active = self.get_optimized_state(gateway.ana_group_id)
+
+                    # Find optimized path
+                    # Condidtion to fail if multiple Active path exists for a gateway.
+                    if active and 1 <= len(active) < 2:
+                        end_counter, end_time = get_current_timestamp()
+                        LOG.info(
+                            f"{list(active[0])} is new and only Active GW for failed {gateway.hostname}"
+                        )
+                        break
+
+                    if len(active) > 1:
+                        raise Exception(
+                            f"[ {gateway.hostname} ] Found more than one Active path - {log_json_dump(active)}"
+                        )
+                LOG.warning(f"[ {service} ] is still in AVAILABLE state..")
+                continue
+
+            LOG.warning(
+                f"[ {service} ] Stopping NVMeofGW service Failed. try again!!!!"
+            )
+
+        if w.expired:
+            raise TimeoutError(
+                f"[ {gateway.hostname} ] Failover of NVMeofGW service failed after 60s timeout.."
+            )
+
+        LOG.info(
+            f"[ {gateway.hostname} ] Total time taken to failover - {end_counter - start_counter}s"
+        )
+        return {
+            "failover-start-time": start_time,
+            "failover-end-time": end_time,
+            "failover-start-counter-time": start_counter,
+            "failover-end-counter-time": end_counter,
+        }
+
+    def failback(self, gateway, fail_tool="systemctl"):
+        """Failback the Gateways.
+
+        Args:
+            gateway: Gateway to be fail-back.
+            fail_tool: tool to fail the GW service
+        """
+        LOG.info(f"[ {gateway.hostname} ] Failback / Restore Gateway")
+
+        # Initiate Fail-back
+        LOG.info(f"[ {gateway.hostname} ]: Starting NVMe Service {fail_tool} command")
+        service = gateway.system_unit_id
+        gateway.systemctl.start(service)
+
+        start_counter = float()
+        start_time = str()
+        end_counter = float()
+        end_time = str()
+
+        for w in WaitUntil():
+            # Check for service/daemon running satte
+            if gateway.systemctl.is_active(service):
+                LOG.info(f"[ {service} ] NVMeofGW service Started successfully.")
+                if not start_counter:
+                    start_counter, start_time = get_current_timestamp()
+
+                # Check for gateway availability
+                if self.check_gateway_availability(gateway.ana_group_id):
+                    LOG.info(f"[ {service} ] NVMeofGW service is AVAILABLE.")
+
+                    active = self.get_optimized_state(gateway.ana_group_id)
+                    if active and 1 <= len(active) < 2:
+                        state = active[0]
+
+                        # check gateway for its own original path.
+                        if gateway.ana_group["name"] in state:
+                            end_counter, end_time = get_current_timestamp()
+                            LOG.info(
+                                f"{gateway.hostname} restored to original path - {log_json_dump(state)}"
+                            )
+                            break
+
+                    if len(active) > 1:
+                        raise Exception(
+                            f"[ {gateway.hostname} ] More than one Active path found - {log_json_dump(active)}"
+                        )
+                    LOG.warning(f"[ {gateway.hostname} ] No Active path found")
+                    continue
+
+                LOG.warning(f"[ {service} ] is still not in AVAILABLE state..")
+                continue
+
+            LOG.warning(
+                f"[ {service} ] NVMeofGW service START still in Failed State. try again !!!!"
+            )
+
+        if w.expired:
+            raise TimeoutError(
+                f"[ {gateway.hostname} ] Fail-back of NVMeofGW service failed after 60s timeout.."
+            )
+        LOG.info(
+            f"[ {gateway.hostname} ] Time taken to Failback - {end_counter - start_counter} seconds"
+        )
+        return {
+            "failback-start-time": start_time,
+            "failback-end-time": end_time,
+            "failback-start-counter-time": start_counter,
+            "failback-end-counter-time": end_counter,
+        }
+
+    def prepare_io_execution(self, io_clients):
+        """Prepare FIO Execution.
+
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        """
+        for io_client in io_clients:
+            node = get_node_by_id(self.cluster, io_client["node"])
+            client = NVMeInitiator(node, self.gateways[0])
+            client.connect_targets(io_client)
+            self.clients.append(client)
+
+    def fetch_namespaces(self, gateway, failed_ana_grp_ids):
+        """Fetch all namespaces for failed gateways.
+
+        Args:
+            gateway: Operational gateway
+            failed_ana_grp_ids: Failed or to-be failed gateway ids
+        Returns:
+            list of namespaces
+        """
+        args = {"base_cmd_args": {"format": "json"}}
+        _, subsystems = gateway.subsystem.list(**args)
+        subsystems = json.loads(subsystems)
+
+        namespaces = []
+        for subsystem in subsystems["subsystems"]:
+            sub_name = subsystem["nqn"]
+            cmd_args = {"args": {"subsystem": subsystem["nqn"]}}
+            _, nspaces = gateway.namespace.list(**{**args, **cmd_args})
+            nspaces = json.loads(nspaces)
+
+            for ns in nspaces["namespaces"]:
+                if ns["load_balancing_group"] in failed_ana_grp_ids:
+                    # <subsystem>|<nsid>|<pool_name>|<image>
+                    ns_info = f"nsid-{ns['nsid']}|{ns['rbd_pool_name']}|{ns['rbd_image_name']}"
+                    namespaces.append(f"{sub_name}|{ns_info}")
+
+        LOG.info(
+            f"Namespaces found for ANA-grp-id [{failed_ana_grp_ids}]: {log_json_dump(namespaces)}"
+        )
+        return namespaces
+
+    def validate_io(self, namespaces):
+        """Validate Continuous IO on namespaces.
+
+        - Collect rbd disk usage info for each rbd image.
+        - Validate written bytes value is incremental.
+
+        Args:
+            namespaces: list of namespaces
+        """
+
+        def io_value(ns):
+            sub_ns, pool, image = ns.rsplit("|", 2)
+            count = 3
+            samples = []
+            for _ in range(count):
+                out, _ = self.orch.shell(args=[f"rbd --format json du {pool}/{image}"])
+                out = json.loads(out)["images"][0]
+                samples.append(out)
+                time.sleep(3)
+            return sub_ns, samples
+
+        def validate_incremetal_io(write_samples):
+            for i in range(len(write_samples) - 1):
+                if write_samples[i] >= write_samples[i + 1]:
+                    return False
+            return True
+
+        with parallel() as p:
+            for namespace in namespaces:
+                p.spawn(io_value, namespace)
+
+            for result in p:
+                subsys, samples = result
+                res = [i["used_size"] for i in samples]
+
+                LOG.info(f"[ {subsys} ] RBD Disk Usage samples - {res}")
+                if not validate_incremetal_io(res):
+                    raise Exception(f"[ {subsys} ] IO is not progressing - {res}")
+                LOG.info(
+                    f"IO validation for {subsys} is successful. {log_json_dump(samples)}"
+                )
+
+        LOG.info("IO Validation is Successfull on all RBD images..")
+
+    def run(self):
+        """Execute the HA failover and failback with IO validation."""
+        fail_methods = self.config["fault-injection-methods"]
+        initiators = self.config["initiators"]
+        executor = ThreadPoolExecutor()
+        io_tasks = []
+
+        try:
+            # Prepare FIO Execution
+            self.prepare_io_execution(initiators)
+
+            # Start IO Execution
+            for initiator in self.clients:
+                io_tasks.append(executor.submit(initiator.start_fio))
+            time.sleep(20)  # time sleep for IO to Kick-in
+
+            # Failover and Failback
+            for fail_method in fail_methods:
+                fail_tool = fail_method.get("fail_tool", "systemctl")
+                nodes = fail_method["nodes"]
+                if not isinstance(nodes, list):
+                    nodes = [nodes]
+
+                LOG.info(
+                    f"Failover and Failback execution on {nodes} using {fail_tool}"
+                )
+                log_json_dump(fail_method)
+
+                fail_gws, operational_gws = self.catogorize(nodes)
+                fail_gw_ana_ids = [gw.ana_group_id for gw in fail_gws]
+                gateway = operational_gws[0]
+
+                # Primary check - validate IO continuation
+                namespaces = self.fetch_namespaces(gateway, fail_gw_ana_ids)
+                self.validate_io(namespaces)
+
+                # Fail Over
+                with parallel() as p:
+                    for gw in fail_gws:
+                        p.spawn(self.failover, gw, fail_tool)
+                    for result in p:
+                        LOG.info(log_json_dump(result))
+                    self.validate_io(namespaces)
+
+                # Fail Back
+                with parallel() as p:
+                    for gw in fail_gws:
+                        p.spawn(self.failback, gw, fail_tool)
+                    for result in p:
+                        LOG.info(log_json_dump(result))
+                    self.validate_io(namespaces)
+
+        except BaseException as err:  # noqa
+            raise Exception(err)
+        finally:
+            if io_tasks:
+                executor.shutdown(wait=True, cancel_futures=True)

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -1,0 +1,95 @@
+import json
+
+from ceph.nvmeof.initiator import Initiator
+from ceph.parallel import parallel
+from utility.log import Log
+from utility.utils import run_fio
+
+LOG = Log(__name__)
+
+
+class NVMeInitiator(Initiator):
+    def __init__(self, node, gateway):
+        super().__init__(node)
+        self.gateway = gateway
+        self.discovery_port = 8009
+
+    def connect_targets(self, config):
+        if not config:
+            config = self.config
+
+        # Discover the subsystem endpoints
+        cmd_args = {
+            "transport": "tcp",
+            "traddr": self.gateway.node.ip_address,
+        }
+        json_format = {"output-format": "json"}
+
+        discovery_port = {"trsvcid": self.discovery_port}
+        _disc_cmd = {**cmd_args, **discovery_port, **json_format}
+
+        # connect-all
+        connect_all = {}
+        if config["nqn"] == "connect-all":
+            connect_all = {"ctrl-loss-tmo": 3600}
+            cmd = {**discovery_port, **cmd_args, **connect_all}
+            self.connect_all(**cmd)
+            return
+
+        # Connect to individual targets of a subsystem
+        nqns_discovered, _ = self.discover(**_disc_cmd)
+        subsystem = config["nqn"]
+        LOG.debug(nqns_discovered)
+        sub_endpoints = []
+
+        for nqn in json.loads(nqns_discovered)["records"]:
+            if nqn["subnqn"] == subsystem and nqn["trsvcid"] == str(
+                config["listener_port"]
+            ):
+                sub_endpoints.append(nqn)
+
+        if not sub_endpoints:
+            raise Exception(f"Subsystem not found -- {cmd_args}")
+
+        for sub_endpoint in sub_endpoints:
+            conn_port = {"trsvcid": config["listener_port"]}
+            sub_args = {"nqn": sub_endpoint["subnqn"]}
+            cmd_args.update({"traddr": sub_endpoint["traddr"]})
+            _conn_cmd = {**cmd_args, **conn_port, **sub_args}
+            LOG.debug(self.connect(**_conn_cmd))
+
+    def list_devices(self):
+        """List NVMe targets."""
+        targets = self.list_spdk_drives()
+        if not targets:
+            raise Exception(f"NVMe Targets not found on {self.node.hostname}")
+        LOG.debug(targets)
+        return targets
+
+    def start_fio(self):
+        """Start FIO on the all targets on client node."""
+        targets = self.list_devices()
+        results = []
+        io_args = {"size": "100%"}
+        with parallel() as p:
+            for target in targets:
+                _io_args = {}
+                if io_args.get("test_name"):
+                    test_name = (
+                        f"{io_args['test_name']}-"
+                        f"{target['DevicePath'].replace('/', '_')}"
+                    )
+                    _io_args.update({"test_name": test_name})
+                _io_args.update(
+                    {
+                        "device_name": target["DevicePath"],
+                        "client_node": self.node,
+                        "long_running": True,
+                        "cmd_timeout": "notimeout",
+                    }
+                )
+                _io_args = {**io_args, **_io_args}
+                p.spawn(run_fio, **_io_args)
+            for op in p:
+                results.append(op)
+        return results

--- a/tests/nvmeof/workflows/nvme_gateway.py
+++ b/tests/nvmeof/workflows/nvme_gateway.py
@@ -1,0 +1,72 @@
+from json import loads
+
+from ceph.nvmegw_cli import NVMeGWCLI
+from cli.utilities.utils import exec_command_on_container, get_running_containers
+from utility.systemctl import SystemCtl
+
+
+class NVMeGateway(NVMeGWCLI):
+    def __init__(self, node):
+        """NVMe Gateway Class"""
+        self.node = node
+        super(NVMeGateway, self).__init__(node)
+        self._ana_group = self.fetch_gateway()
+        self._ana_group_id = self.ana_group["load_balancing_group"]
+        self.systemctl = SystemCtl(node)
+
+    @property
+    def ana_group_id(self):
+        return self._ana_group_id
+
+    @ana_group_id.setter
+    def ana_group_id(self, value):
+        self._ana_group_id = value
+
+    @property
+    def ana_group(self):
+        return self._ana_group
+
+    @ana_group.setter
+    def ana_group(self, value):
+        self._ana_group = value
+
+    @property
+    def system_unit_id(self):
+        return self.systemctl.get_service_unit("*@nvmeof*")
+
+    @property
+    def hostname(self):
+        return self.node.hostname
+
+    def get_io_stats(self, subsystem, namespaces):
+        pass
+
+    def get_nvme_container(self):
+        """Fetch NVMeof GW container id."""
+        args = {"filter": "label=name=ceph-nvmeof", "quite": True}
+        return get_running_containers(self.node, **args)
+
+    def get_ana_states(self, subsystem, ana_groups):
+        """Fetch ANA states from NVMeoF GW container.
+
+        Args:
+            subsystem: Subsytem name
+            ana_groups: ANA Group IDs
+        Returns:
+            lists of optimized and inaccessible ana_group ids.
+        """
+        cmd = f"/usr/libexec/spdk/scripts/rpc.py  nvmf_subsystem_get_listeners {subsystem}"
+        out, _ = exec_command_on_container(self.node, self.get_nvme_container(), cmd)
+        out = loads(out)[0]["ana_states"]
+        optimized = []
+        inaccessible = []
+        for ana_group in out:
+            ana_group_id = ana_group["ana_group"]
+            ana_group_state = ana_group["ana_state"]
+            if ana_group_id in ana_groups:
+                if ana_group_state == "optimized":
+                    optimized.append(ana_group_id)
+                elif ana_group_id == "inaccessible":
+                    inaccessible.append(ana_group_id)
+
+        return optimized, inaccessible

--- a/utility/systemctl.py
+++ b/utility/systemctl.py
@@ -1,0 +1,65 @@
+from json import loads
+
+from cli.utilities.utils import config_dict_to_string
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+class SystemCtl:
+    BASE_CMD = "systemctl"
+
+    def __init__(self, node):
+        self.node = node
+
+    def get_service(self, regex):
+        """Fetch Service info.
+
+        Provide regex which could match required services.
+
+        Args:
+            regex: regex pattern matches single service
+        Returns:
+            list of unit.services matches regex
+        """
+        # systemctl list-units --type=service --state=running --no-legend *@nvmeof* --output json-pretty
+        base_cmd = [
+            self.BASE_CMD,
+            "list-units",
+            "--type=service",
+            "--no-legend",
+            "--no-pager",
+            repr(regex),
+            "--output=json-pretty",
+        ]
+
+        out, _ = self.node.exec_command(cmd=" ".join(base_cmd), sudo=True)
+        return loads(out)
+
+    def get_service_unit(self, regex):
+        return self.get_service(regex)[0]["unit"]
+
+    def is_active(self, unit_name):
+        base_cmd = [self.BASE_CMD, "is-active", unit_name]
+        out, _ = self.node.exec_command(
+            cmd=" ".join(base_cmd), sudo=True, check_ec=False
+        )
+        LOG.info(f"{unit_name} is {out}")
+        if out.strip() in ["inactive", "failed"]:
+            return False
+        return True
+
+    def start(self, unit_name, **args):
+        base_cmd = [self.BASE_CMD, "start", unit_name, config_dict_to_string(args)]
+        out, _ = self.node.exec_command(cmd=" ".join(base_cmd), sudo=True)
+        return out
+
+    def stop(self, unit_name, **args):
+        base_cmd = [self.BASE_CMD, "stop", unit_name, config_dict_to_string(args)]
+        out, _ = self.node.exec_command(cmd=" ".join(base_cmd), sudo=True)
+        return out
+
+    def status(self, unit_name, **args):
+        base_cmd = [self.BASE_CMD, "status", unit_name, config_dict_to_string(args)]
+        out, _ = self.node.exec_command(cmd=" ".join(base_cmd), sudo=True)
+        return out


### PR DESCRIPTION
# Description
- NVMeoF Gateway HA automation support with IO.

Initial code, so happy to improvise with more review comments and solutions.

http://magna002.ceph.redhat.com/cephci-jenkins/rlepaksh_logs/ha_sanity.log

```
2024-04-19 15:58:55,478 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.ceph.ceph.py:1563 - Running command ceph osd pool delete rbd rbd --yes-i-really-really-mean-it on 10.0.209.9 timeout 600
2024-04-19 15:58:57,093 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.ceph.ceph.py:1597 - Command completed successfully
2024-04-19 15:58:57,094 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.tests.rbd.rbd_utils.py:107 - Command execution complete
2024-04-19 15:58:57,097 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.ceph.ceph.py:1563 - Running command podman --version | awk {'print $3'} on 10.0.208.106 timeout 600
2024-04-19 15:58:58,432 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.run.py:1041 - Podman Version 4.6.1
2024-04-19 15:58:58,435 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.ceph.ceph.py:1563 - Running command docker --version | awk {'print $3'} on 10.0.208.106 timeout 600
2024-04-19 15:58:59,843 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.ceph.ceph.py:1563 - Running command ceph --version | awk '{print $3}' on 10.0.209.9 timeout 600
2024-04-19 15:59:00,441 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.run.py:1057 - ceph Version 19.0.0-2511-g12ef028e
2024-04-19 15:59:00,446 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.run.py:892 - Test <module 'test_ceph_nvmeof_high_availability' from '/Users/sunilkumarn/workspace/cephci/tests/nvmeof/test_ceph_nvmeof_high_availability.py'> passed
Test <module 'test_ceph_nvmeof_high_availability' from '/Users/sunilkumarn/workspace/cephci/tests/nvmeof/test_ceph_nvmeof_high_availability.py'> passed
2024-04-19 15:59:00,447 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.run.py:947 -
All test logs located here: /Users/sunilkumarn/logs/HA-Sanity-with-IO-10

All test logs located here: /Users/sunilkumarn/logs/HA-Sanity-with-IO-10

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Basic E2ETest Ceph NVMEoF GW H   E2E-Test NVMEoF Gateway HA                                     0:06:54.926948                   Pass
```

<img width="1720" alt="image" src="https://github.com/red-hat-storage/cephci/assets/31158377/7cd57bcf-ab27-4e34-9c5b-fbbaa6107eed">
