### PR TITLE
Fix Rados Inconsistent Objects test cases

### DIFF
--- a/suites/pacific/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/pacific/rados/tier-2_rados_trim_tests.yaml
@@ -159,29 +159,6 @@ tests:
             num_keys_obj: 10
         delete_pool: true
 
-# Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2263023
-# Need to identify method to create Inconsistent object without manipulating the omap entries
-#  - test:
-#      name: Inconsistent object pg check for EC pools
-#      desc: Inconsistent object pg check for EC pools
-#      module: test_osd_inconsistency_pg.py
-#      polarion-id: CEPH-83571453
-#      config:
-#        verify_osd_omap_entries:
-#          configurations:
-#            pool-1:
-#              pool_name: Inconsistent_pool_ec
-#              pool_type: erasure
-#              pg_num: 1
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#          omap_config:
-#            obj_start: 0
-#            obj_end: 5
-#            num_keys_obj: 10
-#        delete_pool: true
-
   - test:
       name: Inconsistent object secondary pg check using pool snapshot
       desc: Inconsistent object pg check using pool snapshot for RE pools for secondary OSD in PG

--- a/suites/quincy/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/quincy/rados/tier-2_rados_trim_tests.yaml
@@ -159,29 +159,6 @@ tests:
             num_keys_obj: 10
         delete_pool: true
 
-# Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2263023
-# Need to identify method to create Inconsistent object without manipulating the omap entries
-#  - test:
-#      name: Inconsistent object pg check for EC pools
-#      desc: Inconsistent object pg check for EC pools
-#      module: test_osd_inconsistency_pg.py
-#      polarion-id: CEPH-83571453
-#      config:
-#        verify_osd_omap_entries:
-#          configurations:
-#            pool-1:
-#              pool_name: Inconsistent_pool_ec
-#              pool_type: erasure
-#              pg_num: 1
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#          omap_config:
-#            obj_start: 0
-#            obj_end: 5
-#            num_keys_obj: 10
-#        delete_pool: true
-
   - test:
       name: Inconsistent object secondary pg check using pool snapshot
       desc: Inconsistent object pg check using pool snapshot for RE pools for secondary OSD in PG

--- a/suites/reef/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/reef/rados/tier-2_rados_trim_tests.yaml
@@ -159,29 +159,6 @@ tests:
             num_keys_obj: 10
         delete_pool: true
 
-# Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2263023
-# Need to identify method to create Inconsistent object without manipulating the omap entries
-#  - test:
-#      name: Inconsistent object pg check for EC pools
-#      desc: Inconsistent object pg check for EC pools
-#      module: test_osd_inconsistency_pg.py
-#      polarion-id: CEPH-83571453
-#      config:
-#        verify_osd_omap_entries:
-#          configurations:
-#            pool-1:
-#              pool_name: Inconsistent_pool_ec
-#              pool_type: erasure
-#              pg_num: 1
-#              k: 2
-#              m: 2
-#              crush-failure-domain: host
-#          omap_config:
-#            obj_start: 0
-#            obj_end: 5
-#            num_keys_obj: 10
-#        delete_pool: true
-
   - test:
       name: Inconsistent object secondary pg check using pool snapshot
       desc: Inconsistent object pg check using pool snapshot for RE pools for secondary OSD in PG

--- a/tests/rados/test_inconsistency_osd_epoch.py
+++ b/tests/rados/test_inconsistency_osd_epoch.py
@@ -65,7 +65,12 @@ def run(ceph_cluster, **kw):
         log.info(f"Initial epoch before generating inconsistency is {init_epoch}")
 
         # Create inconsistency objects
-        pg_id = rados_obj.create_inconsistent_object(pool_name, oname)
+        try:
+            pg_id = rados_obj.create_inconsistent_object(pool_name, oname)
+        except Exception as err:
+            log.error(f"Failed to generate inconsistent object. Error : {err}")
+            raise Exception("Inconsistent object not generated error")
+
         log.debug(f"PG ID {pg_id} has inconsistent object generated on it.")
 
         # Checking for inconsistency in the PG list


### PR DESCRIPTION
1. Modified the test_osd_inconsistency.py file, where the method to check the health warnings was updated.
2. Test case : CEPH-83571453 marked inactive and Tests from CephCI removed. instead the Inconsistent Object test for EC pools will be run in test : CEPH-83586175

Pass logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-K01ZN8