### PR TITLE
Updating mero1 config file to change client node magna010 to magna011

### DIFF
--- a/conf/baremetal/mero1_1admin_4node_4client.yaml
+++ b/conf/baremetal/mero1_1admin_4node_4client.yaml
@@ -109,9 +109,9 @@ globals:
           role:
             - client
           root_password: passwd
-        - hostname: magna010
+        - hostname: magna011
           id: node6
-          ip: 10.8.128.10
+          ip: 10.8.128.11
           role:
             - client
           root_password: passwd


### PR DESCRIPTION
# Description

Updating mero1 config file to change client node magna010 to magna011
[root@magna011 etc]# ceph -s
  cluster:
    id:     d9dee3c6-b92f-11ee-b6ad-ac1f6b40d3fc
    health: HEALTH_OK
 
  services:
    mon: 3 daemons, quorum mero006,mero010,mero008 (age 5d)
    mgr: mero008.hmlfdh(active, since 5d), standbys: mero006.ulnavu, mero010.hunihl
    mds: 3/3 daemons up, 1 standby
    osd: 48 osds: 48 up (since 5d), 48 in (since 6w)
    rgw: 2 daemons active (2 hosts, 1 zones)
 
  data:
    volumes: 2/2 healthy
    pools:   21 pools, 2657 pgs
    objects: 33.48k objects, 24 GiB
    usage:   132 GiB used, 349 TiB / 349 TiB avail
    pgs:     2657 active+clean
 
  io:
    client:   638 KiB/s rd, 5.1 KiB/s wr, 461 op/s rd, 71 op/s wr
 
[root@magna011 etc]# 
