### PR TITLE
Fix issue at enable-fips mode in custom configs.

### DIFF
--- a/run.py
+++ b/run.py
@@ -778,7 +778,7 @@ def run(args):
                     if "ibm-build=" in _config:
                         config["ibm_build"] = bool(_config.split("=")[1])
 
-                    elif "enable-fips-mode=" in _config:
+                    if "enable-fips-mode=" in _config:
                         config["enable_fips_mode"] = bool(_config.split("=")[1])
 
             config["ceph_docker_registry"] = docker_registry


### PR DESCRIPTION
# Description

custom config `enable-fips` argument value was not considered before, if ibm-build present in another custom config argument value.