### PR TITLE
[TFA] Fixing add network delay testcase for existing delay baremetal

### DIFF
--- a/tests/misc_env/configure-tc.py
+++ b/tests/misc_env/configure-tc.py
@@ -92,6 +92,18 @@ def run(ceph_cluster: Ceph, config: Dict, **kwargs) -> int:
         try:
             exec_command(
                 node=node,
+                command=f"sudo tc qdisc show dev {dev} | grep netem",
+            )
+            LOG.info("delay already exist, change the existing delay")
+            verb = "change"
+
+        except Exception:  # no-qa
+            LOG.info("Introduce network delay")
+            verb = "add"
+
+        try:
+            exec_command(
+                node=node,
                 check_ec=True,
                 sudo=True,
                 command=f"tc qdisc {verb} dev {dev} {rule}",


### PR DESCRIPTION
# Description

[root@mero006 ~]# sudo tc qdisc delete dev enp5s0f0 root netem delay 20ms
[root@mero006 ~]# sudo tc qdisc show dev enp5s0f0 | grep netem || sudo tc qdisc add dev enp5s0f0 root netem delay 20ms
[root@mero006 ~]# sudo tc qdisc show dev enp5s0f0
qdisc netem 8006: root refcnt 65 limit 1000 delay 20ms
[root@mero006 ~]# sudo tc qdisc show dev enp5s0f0 | grep netem || sudo tc qdisc add dev enp5s0f0 root netem delay 20ms
qdisc netem 8006: root refcnt 65 limit 1000 delay 20ms
[root@mero006 ~]#

if delay already exist will not add delay, if not will add delay
delay already exist: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-22GGTL/apply-net-qos_0.log
delay does not exist: http://magna002.ceph.redhat.com/ceph-qe-logs/anuchaithra/cephci-run-1LUTJF/apply-net-qos_0.log
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
