### PR TITLE
removing mon_host check in cephfs peer connection

### DIFF
--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -277,26 +277,15 @@ class CephfsMirroringUtils(object):
             site_name = data[id]["site_name"]
             client_name = data[id]["client_name"]
             fs_name = data[id]["fs_name"]
-            mon_hosts = data[id]["mon_host"]
-            mon_host_list = list(
-                set(host.split(":")[1] for host in mon_hosts.split(","))
-            )
-            log.info(f"Mon Hosts from the Output : {mon_host_list}")
-            target_mon_node_ip_list = self.fs_util_ceph2.get_mon_node_ips()
-            log.info(f"Target Mon Hosts : {target_mon_node_ip_list}")
 
             target_site_name = target_site_name
             target_user = f"client.{target_user}"
             target_fs_name = target_fs_name
-            # target_mon_hosts = target_mon_node_ip_list
 
             if (
                 site_name == target_site_name
                 and client_name == target_user
                 and fs_name == target_fs_name
-                # and set(mon_host_list) == set(target_mon_hosts)
-                # BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2248176 -
-                # Will remove the check once the issue is fixed
             ):
                 log.info(
                     "Peer Connection validated and mirroring is successfully established."


### PR DESCRIPTION
# Description

cephfs-mirror - tfa issue : mirror test cases are failing in latest builds 

Logs : 
7.0z2 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TZ4Z78/
7.1 - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SV92FQ/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
