### PR TITLE
cphfs-bugs-tfa- timeout with long_running

### DIFF
--- a/tests/cephfs/cephfs_bugs/test_validate_mclientcaps_revoke_ack.py
+++ b/tests/cephfs/cephfs_bugs/test_validate_mclientcaps_revoke_ack.py
@@ -121,7 +121,7 @@ def run(ceph_cluster, **kw):
         clients[0].exec_command(
             sudo=True,
             cmd=f"python /root/{create_large_file_script} {' '.join(file_paths)}",
-            timeout=7200,
+            long_running=True,
         )
 
         log.info("Check for the Ceph Health.")


### PR DESCRIPTION
# Description

TFA: https://reportportal-ocs3.apps.ocp-c1.prod.psi.redhat.com/ui/#rhcs/launches/all/2406/233883
Issue: Timeout after 7200sec

Replace the timeout with the long_running option.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
