### PR TITLE
[Test][Cephadm] Verify wrong image name while upgrade

### DIFF
--- a/suites/reef/upgrades/tier1-upgrade-rhcs-6x-to-7x.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-rhcs-6x-to-7x.yaml
@@ -116,13 +116,14 @@ tests:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      polarion-id: CEPH-83573791,CEPH-83573790,CEPH-83588994
       config:
         command: start
         service: upgrade
         base_cmd_args:
           verbose: true
         verify_cluster_health: true
+        verify_image: true
       destroy-cluster: false
       abort-on-fail: true
   - test:


### PR DESCRIPTION
Verifies whether `ceph orch upgrade` adds the prefix "docker.io" to image

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
