### PR TITLE
[TFA]: Fix typo on restart post zone modify

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -646,7 +646,7 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone secondary --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-              - "ceph arch restart rgw.shared.sec"
+              - "ceph orch restart rgw.shared.sec"
             timeout: 120
         ceph-arc:
           config:
@@ -656,7 +656,7 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone archive --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-              - "ceph arch restart rgw.shared.arc"
+              - "ceph orch restart rgw.shared.arc"
             timeout: 120
       desc: enabled default encryption and zlib compression
       module: exec.py


### PR DESCRIPTION
Signed-off-by: MadhaviKasturi <mkasturi@redhat.com>

# Description
Fix typo in restart post zone modify

TFA failure seen in Quincy - http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/openstack/RH/6.1/rhel-9/Weekly/17.2.6-216/rgw/31/tier-2_rgw_multisite_archive_with_haproxy/enabled_default_encryption_and_zlib_compression_0.log

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
