### PR TITLE
fix_nsid in namespace add in scale tests 

### DIFF
--- a/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
@@ -134,22 +134,23 @@ def configure_namespaces(
             LOG.info(num)
             LOG.info(namespaces)
             config["args"].clear()
-            config["args"].update(
-                {
+            config = {
+                "base_cmd_args": {"format": "json"},
+                "args": {
                     "rbd-image": f"{name}-image{num}",
-                    "nsid": num,
                     "rbd-pool": pool,
                     "subsystem": f"nqn.2016-06.io.spdk:cnode{sub_num}",
-                }
-            )
+                },
+            }
 
             namespace_func = fetch_method(_cls, command)
-            namespace_func(**config)
+            _, namespaces = namespace_func(**config)
+            nsid = json.loads(namespaces)["nsid"]
 
             _config = {
                 "base_cmd_args": {"format": "json"},
                 "args": {
-                    "nsid": num,
+                    "nsid": nsid,
                     "subsystem": f"nqn.2016-06.io.spdk:cnode{sub_num}",
                 },
             }


### PR DESCRIPTION
Fix namespace add failures as at http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/openstack/IBM/7.1/rhel-9/Regression/18.2.1-149/nvmeotcp/105/tier-3_2-nvmeof-gw_2-sub_ns/Scale_to_2048_namespaces_with_IO_on_2GW_and_2_subsystems_0.log

Tests run log - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DRXTLL
Already cluster had namespaces as below before running test
# nvmeof subsystem list
Subsystems:
╒═══════════╤════════════════════════════╤════════════╤══════════╤══════════════════╤═════════════╤══════════════╕
│ Subtype   │ NQN                        │ HA State   │   Serial │ Controller IDs   │   Namespace │          Max │
│           │                            │            │   Number │                  │       Count │   Namespaces │
╞═══════════╪════════════════════════════╪════════════╪══════════╪══════════════════╪═════════════╪══════════════╡
│ NVMe      │ nqn.2016-06.io.spdk:cnode2 │ enabled    │        2 │ 2041-4080        │           9 │         2048 │
├───────────┼────────────────────────────┼────────────┼──────────┼──────────────────┼─────────────┼──────────────┤
│ NVMe      │ nqn.2016-06.io.spdk:cnode1 │ enabled    │        1 │ 2041-4080        │           11 │         2048 │
╘═══════════╧════════════════════════════╧════════════╧══════════╧══════════════════╧═════════════╧══════════════╛