### PR TITLE
systemctl and daemon methods for failover/failback

### DIFF
--- a/suites/reef/nvmeof/tier-1_nvmeof_ha_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_ha_sanity.yaml
@@ -115,8 +115,60 @@ tests:
         fault-injection-methods:                # Failure induction
           - tool: systemctl
             nodes: node6
-      desc: E2E-Test NVMEoF 2GW test with mutliple subsystems
+      desc: NVMEoF failover-failback test via systemctl rpm tool
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
-      name: E2E Ceph NVMeoF 2-GW HA sanity test
+      name: NVMeoF 2-GW HA failover-failback via systemctl
       polarion-id: CEPH-83588636
+
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 2G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+            - count: 2
+              size: 2G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes: node6
+      desc: NVMEoF failover-failback test via cephadm daemon orchestration
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 2-GW HA failover-failback via orchestrator
+      polarion-id: CEPH-83588699

--- a/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -126,6 +126,63 @@ tests:
       name: NVMeoF 4-GW HA test Single failure
       polarion-id: CEPH-83589010
 
+# 4GW HA Single-sub multinode Failover and failback parallely via ceph orchestrator daemon
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            - count: 2
+              size: 5G
+              lb_group: node7
+            - count: 2
+              size: 5G
+              lb_group: node8
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes:
+              - node7
+              - node9
+      desc: Single-sub multinode Failover-failback via ceph daemon orchestrator
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW Test HA multinode fail parallel via orchestrator
+      polarion-id: CEPH-83589010
+
 # 4GW HA Single-sub multinode Failover and failback parallely
   - test:
       abort-on-fail: true

--- a/tests/nvmeof/workflows/nvme_gateway.py
+++ b/tests/nvmeof/workflows/nvme_gateway.py
@@ -12,6 +12,7 @@ class NVMeGateway(NVMeGWCLI):
         super(NVMeGateway, self).__init__(node)
         self._ana_group = self.fetch_gateway()
         self._ana_group_id = self.ana_group["load_balancing_group"]
+        self._daemon_name = self.ana_group["name"].split(".", 1)[1]
         self.systemctl = SystemCtl(node)
 
     @property
@@ -29,6 +30,14 @@ class NVMeGateway(NVMeGWCLI):
     @ana_group.setter
     def ana_group(self, value):
         self._ana_group = value
+
+    @property
+    def daemon_name(self):
+        return self._daemon_name
+
+    @daemon_name.setter
+    def daemon_name(self, value):
+        self._daemon_name = value
 
     @property
     def system_unit_id(self):


### PR DESCRIPTION
# Description

- Support failover and failback with mutliple tools
   - systemctl 
   - daemon

**Test results:**

```
2024-04-30 19:50:04,591 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.run.py:947 -
All test logs located here: /Users/sunilkumarn/logs/HA_Sanity-failtool-08

All test logs located here: /Users/sunilkumarn/logs/HA_Sanity-failtool-08

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
NVMeoF 2-GW HA failover-failba   NVMEoF failover-failback test via systemctl rpm tool           0:06:34.753854                   Pass
NVMeoF 2-GW HA failover-failba   NVMEoF failover-failback test via cephadm demon orchestratio   0:06:46.564375                   Pass

```