### PR TITLE
Improved logging and added polarion Id

### DIFF
--- a/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -181,7 +181,7 @@ tests:
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: NVMeoF 4-GW Test HA multinode fail parallel via orchestrator
-      polarion-id: CEPH-83589010
+      polarion-id: CEPH-83589019
 
 # 4GW HA Single-sub multinode Failover and failback parallely
   - test:


### PR DESCRIPTION
# Description

- Improved logging and added polarion Id

```
All test logs located here: /Users/sunilkumarn/logs/4GW-HA-Upgrade-01

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:08:39.253507                   Pass
deploy cluster                   RHCS cluster deployment using cephadm                          0:15:34.272586                   Pass
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:00:55.061867                   Pass
NVMeoF 4-GW HA test Single fai   4GW HA test Single subsystem Single Failure                    0:09:55.229624                   Pass
NVMeoF 4-GW Test HA multinode    Single-sub multinode Failover-failback via ceph daemon orche   0:10:57.775954                   Pass
Test NVMeoF 4-GW HA multinode    4GW HA Single-sub multinode Failover and failback parallely    0:10:56.911706                   Pass
Test NVMeoF 4-GW HA multi node   4GW HA test Single multinode sequential Failure                0:11:25.455098                   Pass
Test NVMeoF 4-GW HA 2-sub mult   4GW HA 2-subsystems multinode Failover and failback parallel   0:10:54.945000                   Pass
Test NVMeoF 4-GW HA 4-sub mult   4GW HA 4-subsystems multinode Failover and failback parallel   0:11:01.196723                   Pass

```
