### PR TITLE
Adding tc 83589266

### DIFF
--- a/suites/reef/cephfs/tier-3_cephfs_bugs.yaml
+++ b/suites/reef/cephfs/tier-3_cephfs_bugs.yaml
@@ -20,6 +20,7 @@
   # CEPH-83586730: validate standby replay node not removed after setting mds_inject_health_dummy
   # CEPH-83583721 - Validate the details of all MDS servers are displayed with command `ceph mds metadata`.
   # CEPH-83583723 - Ensure deletion of clones are allowed when the clones are stuck and in pending state
+  # CEPH-83589266 - Validate Ceph commands when ceph file system is in failed state
 #=======================================================================================================================
 ---
 tests:
@@ -244,4 +245,10 @@ tests:
       module: cephfs_bugs.test_clone_delete_with_FS_fail.py
       polarion-id: CEPH-83583723
       desc: Ensure deletion of clones are allowed when the clones are stuck and in pending state
+      abort-on-fail: false
+  - test:
+      name: Validate Ceph commands when ceph file system is in failed state
+      module: cephfs_bugs.validate_ceph_ops_wtih_fs_fail.py
+      polarion-id: CEPH-83589266
+      desc: Validate Ceph commands when ceph file system is in failed state
       abort-on-fail: false

--- a/tests/cephfs/cephfs_bugs/validate_ceph_ops_wtih_fs_fail.py
+++ b/tests/cephfs/cephfs_bugs/validate_ceph_ops_wtih_fs_fail.py
@@ -1,0 +1,59 @@
+import traceback
+
+from ceph.ceph import CommandFailed
+from ceph.parallel import parallel
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    try:
+        """
+        CEPH-83589266 - Validate Ceph commands when ceph file system is in failed state
+
+
+        """
+        tc = "CEPH-83583721"
+        log.info("Running cephfs %s test case" % (tc))
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        clients = ceph_cluster.get_ceph_objects("client")
+        build = config.get("build", config.get("rhbuild"))
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        client1 = clients[0]
+        fs_name = "cephfs_fail"
+        fs_util.create_fs(client1, fs_name)
+        fs_util.wait_for_mds_process(clients[0], fs_name)
+        client1.exec_command(sudo=True, cmd=f"ceph fs fail {fs_name}")
+
+        with parallel() as p:
+            p.spawn(
+                client1.exec_command,
+                sudo=True,
+                cmd=f"ceph fs subvolume create {fs_name} subvol_1;",
+                check_ec=False,
+                timeout=720,
+            )
+            p.spawn(client1.exec_command, sudo=True, cmd="ceph fs status")
+            p.spawn(client1.exec_command, sudo=True, cmd="ceph mgr stat")
+            p.spawn(client1.exec_command, sudo=True, cmd="ceph pg stat")
+            for result in p:
+                log.info(result)
+        return 0
+
+    except CommandFailed as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    except Exception as e:
+        log.error(e)
+        log.error(traceback.format_exc())
+        return 1
+    finally:
+        client1.exec_command(
+            sudo=True, cmd="ceph config set mon mon_allow_pool_delete true"
+        )
+        fs_util.remove_fs(client1, fs_name)

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -102,7 +102,10 @@ class FsUtils(object):
                 client.node.exec_command(
                     cmd="git clone https://github.com/bengland2/smallfile.git"
                 )
-        if clients[0].node.vm_node.node_type == "baremetal":
+        if (
+            hasattr(clients[0].node, "vm_node")
+            and clients[0].node.vm_node.node_type == "baremetal"
+        ):
             cmd = "dnf clean all;dnf -y install ceph-common --nogpgcheck;dnf -y update ceph-common --nogpgcheck"
             for client in clients:
                 client.exec_command(sudo=True, cmd=cmd)


### PR DESCRIPTION
# Description
CEPH-83589266 - Validate Ceph commands when ceph file system is in failed state
1. Created ceph fs volume
2. Triggered ceph fs fail
3. Tried created volumes after the Fs is down.Volume creation was stuck.
4. on the other window triggered ceph isostat. Ceph iostat command went with out any stuck. in older builds ceph iostat command was getting stuck when volume creation was stuck.

[root@ceph-amk-bz-xvxd2m-node7 ~]# ceph fs status

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3A2Z7H/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
