### PR TITLE
Update new cmd syntax in testlib, add retry cnt for read in io_tool

### DIFF
--- a/tests/cephfs/snapshot_clone/cephfs_cg_io.py
+++ b/tests/cephfs/snapshot_clone/cephfs_cg_io.py
@@ -467,23 +467,22 @@ class CG_snap_IO(object):
         for io_mod in io_modules:
             if io_type == "read":
                 if io_modules[io_mod] == 1:
-                    if io_mod == "cg_smallfile_io_read" or io_mod == "cg_fio_io_read":
-                        qs_id = self.cg_snap_util.get_qs_id(client, qs_members)
-                        log.info(f"qs_id:{qs_id}")
-                        if qs_id != 1:
-                            qs_query = self.cg_snap_util.get_qs_query(
-                                client, qs_id=qs_id
-                            )
-                            log.info(f"qs_query:{qs_query}")
-                            state = qs_query["sets"][qs_id]["state"]["name"]
-                            log.error(
-                                f"FAIL:read io on {qs_member} failed when {qs_id} was in {state}"
-                            )
-                        else:
-                            log.error(
-                                f"FAIL:read io on {qs_member} failed when no QS exists"
-                            )
-                        cg_status = 1
+                    qs_id = self.cg_snap_util.get_qs_id(client, qs_members)
+                    log.info(f"qs_id:{qs_id}")
+                    if qs_id != 1:
+                        qs_query = self.cg_snap_util.get_qs_query(client, qs_id=qs_id)
+                        log.info(f"qs_query:{qs_query}")
+                        state = qs_query["sets"][qs_id]["state"]["name"]
+                        log.info(f"io_modules:{io_modules}")
+                        log.error(
+                            f"FAIL:{io_mod} io on {qs_member} failed when {qs_id} was in {state}"
+                        )
+                    else:
+                        log.info(f"io_modules:{io_modules}")
+                        log.error(
+                            f"FAIL:{io_mod} io on {qs_member} failed when no QS exists"
+                        )
+                    cg_status = 1
                 elif io_type == "write":
                     if io_modules[io_mod] == 1:
                         qs_id = self.cg_snap_util.get_qs_id(client, qs_members)
@@ -798,11 +797,11 @@ class CG_snap_IO(object):
             if fio_cnt == 0:
                 raise Exception(f"No fio files created in {dir_path} even after 60secs")
             fio_file = random.choice(fio_files)
-            fio_file_path = f"{dir_path}/{fio_file}"
+
             out, _ = client.exec_command(
                 sudo=True,
-                cmd=f"fio --name={fio_file_path} --ioengine=libaio --size 2M --rw=read --bs=1M --direct=1 "
-                f"--numjobs=1 --iodepth=5 --runtime=10",
+                cmd=f"fio --name={fio_file} --ioengine=libaio --size 2M --rw=read --bs=1M --direct=1 "
+                f"--numjobs=1 --iodepth=5 --runtime=10 --debug=io",
                 timeout=10,
             )
             log.info(f"fio_io {io_type} cmd op : {out}")


### PR DESCRIPTION
# Description
Change description:
Testlib cg_snap_utils.py is updated for cmd syntax change from 'ceph fs subvolume quiesce' to 'ceph fs quiesce'
cg_io tool is updated to include two retries to handle read error and fio read mnt_path error is corrected.

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-012F6M/cg_snap_test_0.log
<Note: Please ignore workflow_6 test failure in above log, its code is being validated>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
