### PR TITLE
TFA fixes for Stretch mode BM pipeline failures

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3086,6 +3086,24 @@ class RadosOrchestrator:
         log.error("Noautoscale flag not set on the cluster. Returning Fail..")
         return False
 
+    def get_pg_autoscale_status(self, pool_name=None):
+        """
+        Executes autoscale-status command and returns o/p
+
+        Args:
+            pool_name: Name of the pool
+
+        Returns:
+            json object of the pool values.
+        """
+        cmd = "ceph osd pool autoscale-status"
+        out = self.run_ceph_command(cmd=cmd)
+        if pool_name:
+            for pool in out:
+                if pool["pool_name"] == pool_name:
+                    return pool
+        return out
+
     def create_rbd_image(self, pool_name, img_name, **kwargs):
         """
         Creates rbd image on the given pool

--- a/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -566,10 +566,17 @@ tests:
       abort-on-fail: true
 
   - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts
+
+  - test:
       name: BlueStore Checksum algorithms
       module: test_bluestore_configs.py
       polarion-id: CEPH-83571646
       config:
+        pool_type : replicated
         checksums:
           - none
           - crc32c
@@ -580,15 +587,21 @@ tests:
       desc: Verify the different applicable BlueStore Checksum algorithms
 
   - test:
-      name: BlueStore cache size tuning
-      module: test_bluestore_configs.py
-      polarion-id: CEPH-83571675
+      name: Pg autoscaler bulk flag
+      module: pool_tests.py
+      polarion-id: CEPH-83573412
+      desc: Ceph PG autoscaler bulk flag tests
       config:
-        bluestore_cache: true
-      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+        test_autoscaler_bulk_feature: true
+        pool_name: test_bulk_features
+        delete_pool: true
 
-  - test:
-      name: Mute ceph health alerts
-      polarion-id: CEPH-83573854
-      module: mute_alerts.py
-      desc: Mute health alerts
+# Bug : https://bugzilla.redhat.com/show_bug.cgi?id=2279839
+#  - test:
+#      name: BlueStore cache size tuning
+#      module: test_bluestore_configs.py
+#      polarion-id: CEPH-83571675
+#      config:
+#        pool_type : replicated
+#        bluestore_cache: true
+#      desc: Verify tuning of BlueStore cache size for HDDs and SSDs

--- a/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -353,16 +353,6 @@ tests:
         delete_pool: true
 
   - test:
-      name: Pg autoscaler bulk flag
-      module: pool_tests.py
-      polarion-id: CEPH-83573412
-      desc: Ceph PG autoscaler bulk flag tests
-      config:
-        test_autoscaler_bulk_feature: true
-        pool_name: test_bulk_features
-        delete_pool: true
-
-  - test:
       name: PG number maximum limit check
       module: pool_tests.py
       desc: Check the pg_num maximut limit is <=128
@@ -566,10 +556,27 @@ tests:
       abort-on-fail: true
 
   - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts
+
+  - test:
+      name: Pg autoscaler bulk flag
+      module: pool_tests.py
+      polarion-id: CEPH-83573412
+      desc: Ceph PG autoscaler bulk flag tests
+      config:
+        test_autoscaler_bulk_feature: true
+        pool_name: test_bulk_features
+        delete_pool: true
+
+  - test:
       name: BlueStore Checksum algorithms
       module: test_bluestore_configs.py
       polarion-id: CEPH-83571646
       config:
+        pool_type : replicated
         checksums:
           - none
           - crc32c
@@ -579,16 +586,12 @@ tests:
           - xxhash64
       desc: Verify the different applicable BlueStore Checksum algorithms
 
-  - test:
-      name: BlueStore cache size tuning
-      module: test_bluestore_configs.py
-      polarion-id: CEPH-83571675
-      config:
-        bluestore_cache: true
-      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
-
-  - test:
-      name: Mute ceph health alerts
-      polarion-id: CEPH-83573854
-      module: mute_alerts.py
-      desc: Mute health alerts
+# Bug : https://bugzilla.redhat.com/show_bug.cgi?id=2279839
+#  - test:
+#      name: BlueStore cache size tuning
+#      module: test_bluestore_configs.py
+#      polarion-id: CEPH-83571675
+#      config:
+#        pool_type : replicated
+#        bluestore_cache: true
+#      desc: Verify tuning of BlueStore cache size for HDDs and SSDs

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -247,6 +247,7 @@ class MonConfigMethods:
         """
 
         base_cmd = "ceph config rm"
+        verify_removal = kwargs.get("verify_rm", True)
         cmd = f"{base_cmd} {kwargs['section']}"
         if kwargs.get("location_type"):
             cmd = f"{cmd}/{kwargs['location_type']}:{kwargs['location_value']}"
@@ -255,10 +256,11 @@ class MonConfigMethods:
 
         # Sleeping for 10 second for config to be applied
         time.sleep(10)
-        log.debug("verifying the value set")
-        if self.verify_set_config(**kwargs):
-            log.error(f"Value for config: {kwargs['name']} is still set")
-            return False
+        log.debug("verifying the value removed")
+        if verify_removal:
+            if self.verify_set_config(**kwargs):
+                log.error(f"Value for config: {kwargs['name']} is still set")
+                return False
 
         log.info(f"Value for config: {kwargs['name']} was removed")
         return True

--- a/tests/rados/test_osd_memory_target.py
+++ b/tests/rados/test_osd_memory_target.py
@@ -129,8 +129,13 @@ def run(ceph_cluster, **kw):
             return 1
         finally:
             log.info("\n ****** Executing finally block ******* \n")
-            mon_obj.remove_config(section="osd", name="osd_memory_target")
-            mon_obj.remove_config(section=f"osd.{osd_id}", name="osd_memory_target")
+            mon_obj.remove_config(
+                section="osd", name="osd_memory_target", verify_rm=False
+            )
+            if "osd_id" in locals() or "osd_id" in globals():
+                mon_obj.remove_config(
+                    section=f"osd.{osd_id}", name="osd_memory_target", verify_rm=False
+                )
             # log cluster health
             rados_obj.log_cluster_health()
         return 0
@@ -286,8 +291,14 @@ def run(ceph_cluster, **kw):
             return 1
         finally:
             log.info("\n ****** Executing finally block ******* \n")
-            mon_obj.remove_config(section=f"osd.{osd_ran}", name="osd_memory_target")
-            mon_obj.remove_config(section=f"osd.{osd_ran2}", name="osd_memory_target")
+            if "osd_ran" in locals() or "osd_ran" in globals():
+                mon_obj.remove_config(
+                    section=f"osd.{osd_ran}", name="osd_memory_target", verify_rm=False
+                )
+            if "osd_ran2" in locals() or "osd_ran2" in globals():
+                mon_obj.remove_config(
+                    section=f"osd.{osd_ran2}", name="osd_memory_target", verify_rm=False
+                )
             mon_obj.remove_config(
                 section="osd",
                 location_type="host",


### PR DESCRIPTION
Test : Ceph PG autoscaler bulk flag tests 
fail log : http://magna002.ceph.redhat.com/cephci-jenkins/results/baremetal/RH/7.1/rhel-9/18.2.1-168/rados/46/tier-3_rados_test-stretch-mode-baremetal/Pg_autoscaler_bulk_flag_0.log
Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SQZ5EX 

test: [BlueStore Checksum algorithms]
fail log : http://magna002.ceph.redhat.com/cephci-jenkins/results/baremetal/RH/7.1/rhel-9/18.2.1-168/rados/46/tier-3_rados_test-stretch-mode-baremetal/BlueStore_Checksum_algorithms_0.log 
Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KD474I 

BlueStore cache size tuning -> this test has been commented out until bz fix, or we change the OSD deployment via spec with custom osd service name, instead of deploying them via cli individually. 