### PR TITLE
Fixing upgrade suites failing

### DIFF
--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -634,6 +634,9 @@ class CephfsMirroringUtils(object):
         """
         log.info("Get peer mirror status")
         for node, asok in asok_file.items():
+            asok[0].exec_command(
+                sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"
+            )
             cmd = (
                 f"cd /var/run/ceph/{fsid}/ ; ceph --admin-daemon {asok[1]} fs mirror peer status "
                 f"{fs_name}@{filesystem_id} {peer_uuid} -f json"

--- a/tests/cephfs/cephfs_upgrade/metadata_version_validation.py
+++ b/tests/cephfs/cephfs_upgrade/metadata_version_validation.py
@@ -153,7 +153,7 @@ def run(ceph_cluster, **kw):
             for line in after_upgrade_file.readlines():
                 log.info(line)
             clients = ceph_cluster.get_ceph_objects("client")
-            cmd = "dnf clean all;dnf -y install ceph-common;dnf -y update ceph-common"
+            cmd = "dnf clean all;dnf -y install ceph-common --nogpgcheck;dnf -y update ceph-common --nogpgcheck"
             for client in clients:
                 client.exec_command(sudo=True, cmd=cmd)
         else:


### PR DESCRIPTION
# Description
Fixing upgrade suites failing

cephfs mirror upgrade log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-984Q6H/
It has fix for upgrading the ceph-common

Still we are seeing few intermittent issue. will fis in follow up PR. 
This PR has fix for cephfs mirror upgrade


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
