### PR TITLE
TFA fix for the Inconsistent objects in EC pool functionality check

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3484,8 +3484,9 @@ class RadosOrchestrator:
             return None
         log.info(f"Performing the scrub on the pg-{pg_id}")
         self.run_scrub(pgid=pg_id)
-        # sleeping for 10 seconds, waiting for scrubbing to be over
-        time.sleep(10)
+        self.start_check_scrub_complete(
+            pg_id=pg_id, user_initiated=True, wait_time=1800
+        )
         inconsistent_details = self.get_inconsistent_object_details(pg_id)
         obj_count = len(inconsistent_details["inconsistents"])
         log.info(f"The inconsistent object count is -{obj_count}")

--- a/tests/rados/test_osd_ecpool_inconsistency_scenario.py
+++ b/tests/rados/test_osd_ecpool_inconsistency_scenario.py
@@ -193,7 +193,7 @@ def get_inconsistent_count(scrub_object, pg_id, rados_obj, operation):
         scrub_begin_weekday,
         scrub_end_hour,
         scrub_end_weekday,
-    ) = scrub_object.add_begin_end_hours(0, 1)
+    ) = scrub_object.add_begin_end_hours(0, 2)
 
     scrub_object.set_osd_configuration("osd_scrub_begin_hour", scrub_begin_hour)
     scrub_object.set_osd_configuration("osd_scrub_begin_week_day", scrub_begin_weekday)
@@ -201,14 +201,14 @@ def get_inconsistent_count(scrub_object, pg_id, rados_obj, operation):
     scrub_object.set_osd_configuration("osd_scrub_end_week_day", scrub_end_weekday)
     scrub_object.set_osd_configuration("osd_scrub_min_interval", osd_scrub_min_interval)
     scrub_object.set_osd_configuration("osd_scrub_max_interval", osd_scrub_max_interval)
-    endTime = datetime.now() + timedelta(minutes=60)
+    endTime = datetime.now() + timedelta(minutes=120)
 
     while datetime.now() <= endTime:
         if operation == "scrub":
             log.debug(f"Running scrub on pg : {pg_id}")
 
             if rados_obj.start_check_scrub_complete(
-                pg_id=pg_id, user_initiated=False, wait_time=5400
+                pg_id=pg_id, user_initiated=False, wait_time=7200
             ):
                 log.info(f"Scrub completed on pg : {pg_id}")
                 operation_chk_flag = True
@@ -216,7 +216,7 @@ def get_inconsistent_count(scrub_object, pg_id, rados_obj, operation):
         else:
             log.debug(f"Running deep-scrub on pg : {pg_id}")
             if rados_obj.start_check_deep_scrub_complete(
-                pg_id=pg_id, user_initiated=False, wait_time=3600
+                pg_id=pg_id, user_initiated=False, wait_time=7200
             ):
                 log.info(f"Deep scrub completed on pg : {pg_id}")
                 operation_chk_flag = True


### PR DESCRIPTION
# Description
Test: Inconsistent objects in EC pool functionality check
  Fail log:http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-170/rados/120/tier-2_rados_test-bugfixes/Inconsistent_objects_in_EC_pool_functionality_check_0.log

Here I am providing the links that are executed continuously seven times. 
 Pass log:
            1. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CT7LX2
            2. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XL90P2
            3. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Z3MB3O
            4. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YJJ7H9
            5. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-26X866
            6. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JJY9WG (Full suite log)
            7. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W6OEHJ (Full suite log)
     

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
