### PR TITLE
TFA: deleted bucket stats and bucket pol retain at archive zone

### DIFF
--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -291,7 +291,6 @@ def run(**kw):
             retain_bucket_pol_at_archive(
                 primary_client_node, secondary_client_node, archive_client_node
             )
-
         stat_all_archive_site_buckets = config.get("stat-all-buckets-at-archive")
         if stat_all_archive_site_buckets:
             log.info("Bucket stats should not fail for any bucket at the archive site")
@@ -300,11 +299,12 @@ def run(**kw):
             )
             try:
                 for bucket in bucket_list_archive:
-                    log.info(f"Perform bucket stats on {bucket} at archive site")
-                    output, _ = archive_client_node.exec_command(
-                        cmd=f"sudo radosgw-admin bucket stats --bucket {bucket}"
-                    )
-                    log.info(f"Output : {output}")
+                    if bucket.find("deleted"):
+                        log.info(f"Perform bucket stats on {bucket} at archive site")
+                        output, _ = archive_client_node.exec_command(
+                            cmd=f"sudo radosgw-admin bucket stats --bucket {bucket}"
+                        )
+                        log.info(f"Output : {output}")
             except BaseException as err:
                 log.error("Error: %s" % err)
                 raise Exception(

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -430,9 +430,12 @@ def retain_bucket_pol_at_archive(
             0
         ]
     )
+    bucket_name_list = json.loads(
+        primary_client_node.exec_command(cmd="sudo radosgw-admin bucket list")[0]
+    )
     for bucket in range(0, total_buckets - 2):
         bucket_id = bucket_stat_pri_doc[bucket]["id"]
-        bucket_name = bucket_stat_pri_doc[bucket]["bucket"]
+        bucket_name = bucket_name_list[bucket]
         log.info(f"Test attrs are same for bucket {bucket_name} on all sites")
         json_doc_arc = json.loads(
             archive_client_node.exec_command(
@@ -1432,9 +1435,11 @@ def generate_self_signed_certificate(subject: Dict) -> Tuple:
             encryption_algorithm=serialization.NoEncryption(),
         ).decode("utf-8"),
         cert.public_bytes(serialization.Encoding.PEM).decode("utf-8"),
-        ca_cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
-        if ca_cert
-        else None,
+        (
+            ca_cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+            if ca_cert
+            else None
+        ),
     )
 
 


### PR DESCRIPTION
# Description

deleted bucket stats and bucket pol retained at archive zone.

This would address the issue seen with bucket stats for deleted bucket and bucket policy retained at the archive site for tenanted buckets.

Testing the below configs
            test-bucket-pol-retained-archive: true
            stat-all-buckets-at-archive: true

TFA fail log:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-164/rgw/41/tier-2_rgw_ms_archive_with_haproxy/
https://issues.redhat.com/browse/RHCEPHQE-14447


logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IU8XZE