### PR TITLE
[RADOS] TFA fix for ceph df stats and ceph osd df stats

### DIFF
--- a/conf/reef/rados/depressa-cluster.yaml
+++ b/conf/reef/rados/depressa-cluster.yaml
@@ -1,0 +1,128 @@
+# 7 node cluster with 1 client
+# baremetal config for depressa Octo lab machines
+---
+globals:
+  - ceph-cluster:
+      name: ceph-depressa
+      networks:
+        public:
+          - 10.1.172.0/23
+        cluster:
+          - 172.20.0.0/16
+      nodes:
+        - hostname: depressa002
+          id: node1
+          ip: 10.1.172.202
+          root_password: passwd
+          role:
+            - _admin
+            - installer
+            - mon
+            - mgr
+            - rgw
+            - osd
+            - node-exporter
+            - alertmanager
+            - grafana
+            - prometheus
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa003
+          id: node2
+          ip: 10.1.172.203
+          root_password: passwd
+          role:
+            - _admin
+            - mon
+            - mgr
+            - rgw
+            - osd
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+
+        - hostname: depressa004
+          id: node3
+          ip: 10.1.172.204
+          root_password: passwd
+          role:
+            - _admin
+            - mon
+            - mgr
+            - osd
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa005
+          id: node4
+          ip: 10.1.172.205
+          root_password: passwd
+          role:
+            - _admin
+            - mds
+            - rgw
+            - osd
+            - crash
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa006
+          id: node5
+          ip: 10.1.172.206
+          root_password: passwd
+          role:
+            - nfs
+            - rgw
+            - osd
+            - node-exporter
+          volumes:
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa011
+          id: node6
+          ip: 10.1.172.211
+          root_password: passwd
+          role:
+            - mds
+            - osd
+            - nfs
+            - crash
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1
+        - hostname: depressa012
+          id: node7
+          ip: 10.1.172.212
+          root_password: passwd
+          role:
+            - osd
+            - rgw
+            - client
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/nvme0n1
+            - /dev/nvme1n1

--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -106,18 +106,6 @@ tests:
         host_level: true
 
   - test:
-      name: ceph osd df stats
-      module: test_osd_df.py
-      desc: Mark osd out and inspect stats change in ceph osd df
-      polarion-id: CEPH-10787
-      config:
-        run_iteration: 3
-        create_pool: true
-        pool_name: test-osd-df
-        write_iteration: 4
-        delete_pool: true
-
-  - test:
       name: ObjectStore block stats verification
       module: test_objectstore_block.py
       desc: Reduce data from an object and verify the decrease in blocks
@@ -142,6 +130,18 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  - test:
+      name: ceph osd df stats
+      module: test_osd_df.py
+      desc: Mark osd out and inspect stats change in ceph osd df
+      polarion-id: CEPH-10787
+      config:
+        run_iteration: 3
+        create_pool: true
+        pool_name: test-osd-df
+        write_iteration: 4
+        delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864
   # will be un-commented once fix is available

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -107,18 +107,6 @@ tests:
         host_level: true
 
   - test:
-      name: ceph osd df stats
-      module: test_osd_df.py
-      desc: Mark osd out and inspect stats change in ceph osd df
-      polarion-id: CEPH-10787
-      config:
-        run_iteration: 3
-        create_pool: true
-        pool_name: test-osd-df
-        write_iteration: 4
-        delete_pool: true
-
-  - test:
       name: ObjectStore block stats verification
       module: test_objectstore_block.py
       desc: Reduce data from an object and verify the decrease in blocks
@@ -143,6 +131,18 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  - test:
+      name: ceph osd df stats
+      module: test_osd_df.py
+      desc: Mark osd out and inspect stats change in ceph osd df
+      polarion-id: CEPH-10787
+      config:
+        run_iteration: 3
+        create_pool: true
+        pool_name: test-osd-df
+        write_iteration: 4
+        delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864
   # will be un-commented once fix is available

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -107,18 +107,6 @@ tests:
         host_level: true
 
   - test:
-      name: ceph osd df stats
-      module: test_osd_df.py
-      desc: Mark osd out and inspect stats change in ceph osd df
-      polarion-id: CEPH-10787
-      config:
-        run_iteration: 3
-        create_pool: true
-        pool_name: test-osd-df
-        write_iteration: 4
-        delete_pool: true
-
-  - test:
       name: ObjectStore block stats verification
       module: test_objectstore_block.py
       desc: Reduce data from an object and verify the decrease in blocks
@@ -145,6 +133,18 @@ tests:
               pg_num: 1
               disable_pg_autoscale: true
             # EC pool will be added later
+
+  - test:
+      name: ceph osd df stats
+      module: test_osd_df.py
+      desc: Mark osd out and inspect stats change in ceph osd df
+      polarion-id: CEPH-10787
+      config:
+        run_iteration: 3
+        create_pool: true
+        pool_name: test-osd-df
+        write_iteration: 4
+        delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864
   # will be un-commented once fix is available

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -71,7 +71,7 @@ def run(ceph_cluster, **kw):
 
                 # Verify Ceph df output post object creation
                 try:
-                    while counter < 3:
+                    while counter < 5:
                         pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
                         ceph_df_obj = pool_stat["stats"]["objects"]
                         if ceph_df_obj == obj_num:
@@ -95,7 +95,9 @@ def run(ceph_cluster, **kw):
                         )
                         return 1
                 except KeyError:
-                    log.error("No stats about the pools requested found on the cluster")
+                    log.error(
+                        f"No stats found on the cluster for the requested pool {pool_name}"
+                    )
                     return 1
 
                 # delete all objects from the pool
@@ -105,7 +107,7 @@ def run(ceph_cluster, **kw):
                 # Verify Ceph df output post objects deletion
                 try:
                     counter = 1
-                    while counter < 3:
+                    while counter < 5:
                         pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
                         ceph_df_obj = pool_stat.get("stats")["objects"]
                         if ceph_df_obj == 0:
@@ -122,12 +124,14 @@ def run(ceph_cluster, **kw):
                             time.sleep(30)
                     else:
                         log.error(
-                            f"ceph df stats display incorrect objects {ceph_df_obj} for {pool_name} even after"
-                            f"60 secs"
+                            f"ceph df stats display incorrect objects {ceph_df_obj} for {pool_name} even after "
+                            f"120 secs"
                         )
                         return 1
                 except KeyError:
-                    log.error("No stats about the pools requested found on the cluster")
+                    log.error(
+                        f"No stats found on the cluster for the requested pool {pool_name}"
+                    )
                     return 1
 
                 log.info(f"ceph df stats verification completed for {obj_num} objects")


### PR DESCRIPTION
PR addresses necessary code changes to fix Ceph-ci pipeline failures for two test cases,
- test_osd_df.py: Failed continuously due to inconsistent stats
After multiple rounds of investigation it was found that the test passes consistently if run with an aged OSD setup because all the necessary unrelated header files and metadata are already created and do not mess with the current statistics

- test_cephdf.py: Failed intermittently due to timing issue.
The verification iterations were increased from 2 to 4 as ceph df is sometimes slow to account the changes in number of objects in the pool

Pass logs:
Reef: 
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G79TIR
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-V5W3P9
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SIKQZZ
Quincy:
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OAX7IB
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-700RK0
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G8BKEI
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-96XCM9
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-H1ZLZH
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Q7HOER
Pacific:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>