### PR TITLE
Verify ceph status is healthy before starting snap schedule test

### DIFF
--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_5x_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_5x_to_7x.yaml
@@ -190,6 +190,7 @@ tests:
       module: cephfs_upgrade.cephfs_post_upgrade_validation.py
       name: "Validates NFS after upgrade"
       polarion-id: CEPH-83575098
+      comments: product bug bz-2276916
   - test:
       name: cephfs_volume_management
       module: cephfs_volume_management.py

--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_6x_to_7x.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_6x_to_7x.yaml
@@ -193,6 +193,7 @@ tests:
       module: cephfs_upgrade.cephfs_post_upgrade_validation.py
       name: "Validates NFS after upgrade"
       polarion-id: CEPH-83575098
+      comments: product bug bz-2276916
   - test:
       name: cephfs_volume_management
       module: cephfs_volume_management.py

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import random
 import re
@@ -194,6 +195,21 @@ def run(ceph_cluster, **kw):
                             f"after:{daemon_count_after}"
                         )
                         multi_fs = 1
+            log.info(
+                f"Verify Ceph Status is healthy before starting test {test_case_name}"
+            )
+            ceph_healthy = 0
+            end_time = datetime.datetime.now() + datetime.timedelta(seconds=60)
+            while (datetime.datetime.now() < end_time) and (ceph_healthy == 0):
+                try:
+                    fs_util_v1.get_ceph_health_status(client1)
+                    ceph_healthy = 1
+                except Exception as ex:
+                    log.info(ex)
+                    log.info("Wait for few secs and recheck ceph status")
+                    time.sleep(5)
+            if ceph_healthy == 0:
+                assert False, "Ceph remains unhealthy even after wait for 60secs"
             cleanup_params = run_snap_test(snap_test_params)
             log.info(f"post_test_params:{cleanup_params}")
             snap_test_params["export_created"] = cleanup_params["export_created"]


### PR DESCRIPTION
# Description

TFA issues seen with two snap schedule tests are addresed in this PR.
Issue: snap schedule cmd fails with error,
arning: due to ceph-mgr restart, some PG states may not be up to date
Module 'snap_schedule' is not enabled/loaded
Fix: As its false alarm, verify ceph status is healthy in test setup, before running snap schedule cmds.

Jira: https://issues.redhat.com/browse/RHCEPHQE-14464

Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XWC7LU 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
