### PR TITLE
Adding retry command for nfs touch

### DIFF
--- a/suites/reef/cephfs/tier-2_cephfs_test-nfs.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test-nfs.yaml
@@ -288,7 +288,6 @@ tests:
       module: cephfs_nfs.nfs_update_cluster_node_changes.py
       name: "nfs cluster host changes and verification"
       polarion-id: "CEPH-83574013"
-      comments: "Product Bug BZ-2238301"
   - test:
       abort-on-fail: false
       desc: "test cephfs nfs with io and network failures"

--- a/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
@@ -8,6 +8,7 @@ from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from utility.log import Log
+from utility.retry import retry
 
 log = Log(__name__)
 
@@ -151,7 +152,10 @@ def run(ceph_cluster, **kw):
         rc = fs_util.cephfs_nfs_mount(
             client1, nfs_server, nfs_export_name, nfs_mounting_dir
         )
-        client1.exec_command(sudo=True, cmd=f"touch {nfs_mounting_dir}/file")
+        retry_exec_command = retry(CommandFailed, tries=3, delay=30)(
+            client1.exec_command
+        )
+        retry_exec_command(sudo=True, cmd=f"touch {nfs_mounting_dir}/file")
 
         return 0
     except Exception as e:


### PR DESCRIPTION
# Description.
Adding retry command for nfs touch

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
