### PR TITLE
Integrating the tests in PR 594

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -421,14 +421,14 @@ tests:
         ceph-pri:
           config:
             set-env: true
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_haproxy.yaml
+            script-name: test_data_sync_init_remote.py
+            config-file-name: test_data_sync_init_remote_zone.yaml
             run-on-haproxy: true
             timeout: 300
-      desc: test M buckets on haproxy node
+      desc: Test data sync init feature for multiple buckets resharded to 1999 shards
       module: sanity_rgw_multisite.py
-      name: test M buckets on haproxy node
-      polarion-id: CEPH-9789
+      name: Test data sync init feature for multiple buckets resharded to 1999 shards
+      polarion-id: CEPH-83575300 #CEPH-83575303
 
   - test:
       clusters:
@@ -444,33 +444,6 @@ tests:
       name: test LC from primary to secondary
       polarion-id: CEPH-11194
       comments: bug-1991808, test LC rules from primary to secondary
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-sec:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.sec rgw_sync_lease_period 10"
-              - "ceph orch restart rgw.shared.sec"
-            timeout: 120
-        ceph-pri:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.pri rgw_sync_lease_period 10"
-              - "ceph orch restart rgw.shared.pri"
-            timeout: 120
-        ceph-arc:
-          config:
-            cephadm: true
-            commands:
-              - "ceph config set client.rgw.shared.arc rgw_sync_lease_period 10"
-              - "ceph orch restart rgw.shared.arc"
-            timeout: 120
-      desc: Setting rgw_sync_lease_period to 100 on multisite archive
-      module: exec.py
-      name: Setting rgw_sync_lease_period to 100 on multisite archive
 
   - test:
       clusters:


### PR DESCRIPTION
# Description
ceph-qe-scripts PR https://github.com/red-hat-storage/ceph-qe-scripts/pull/594
Test data sync init feature for multiple buckets resharded to 1999 shards

[tier-3][automation][CEPH-83575300]: Automate the data sync init feature
[tier-3][automation][CEPH-83575303]: Test when multiple buckets are resharded to 1999 shards
Logs

http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/594/pr_594_test_data_sync_init_remote_zone_1 this has failed with slow sync since we are full syncing 4 buckets all resharded to 1999 shards and having 2K objects each (this fails with the current sync _status logic of 1500 seconds, so is expected to fail with slow sync.)
(workaround is to increase the sync status retries)

Passed log after making above changes mentioned in log 1
http://magna002.ceph.redhat.com/ceph-qe-logs/vidushi/pr_594_test_data_sync_init_remote_zone_1


Additionally this PR is removing the test CEPH-9789 which is present in other sanity suites as well, and also removing the sync lease period setting since we are using the sync_status mechanism for replication tests

