### PR TITLE
Stretch_mode.py: Added -ve scenarios in stretch mode testing

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -795,7 +795,10 @@ class RadosOrchestrator:
         """
 
         mgr_modules = self.run_ceph_command(cmd="ceph mgr module ls")
-        if "pg_autoscaler" not in mgr_modules["enabled_modules"]:
+        if (
+            "pg_autoscaler" not in mgr_modules["enabled_modules"]
+            and "pg_autoscaler" not in mgr_modules["always_on_modules"]
+        ):
             cmd = "ceph mgr module enable pg_autoscaler"
             self.node.shell([cmd])
 

--- a/ceph/rados/monitor_workflows.py
+++ b/ceph/rados/monitor_workflows.py
@@ -186,6 +186,8 @@ class MonitorWorkflows:
         Args:
             kwargs: the accepted KW args for the method are:
                 host: Cluster object of the host from where mon needs to be Added
+                add_label: Arg specifying if the mon label should be added to host or not.
+                        Default is True.
                 location_type: Name of the crush bucket type if needed (optional - Stretch mode)
                 location_name: Name of the crush location type if needed (optional - Stretch mode)
 
@@ -194,6 +196,7 @@ class MonitorWorkflows:
         """
         # Checking if mon service exists before removing
         host = kwargs.get("host")
+        add_label = kwargs.get("add_label", True)
         hostname = host.hostname
         host_ip = host.ip_address
         if self.check_mon_exists_on_host(host=hostname):
@@ -222,12 +225,13 @@ class MonitorWorkflows:
             return False
         log.info(f"Mon service running on host {hostname} post addition")
 
-        # Adding mon label on host if not present
-        labels = self.get_host_labels(host=hostname)
-        if "mon" not in labels:
-            cmd = f"ceph orch host label add {hostname} mon"
-            self.client.exec_command(sudo=True, cmd=cmd)
-            log.debug(f"Added mon label from host : {hostname}")
+        if add_label:
+            # Adding mon label on host if not present
+            labels = self.get_host_labels(host=hostname)
+            if "mon" not in labels:
+                cmd = f"ceph orch host label add {hostname} mon"
+                self.client.exec_command(sudo=True, cmd=cmd)
+                log.debug(f"Added mon label from host : {hostname}")
 
         log.debug(f"Mon successfully added on host : {hostname}")
         return True

--- a/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -111,6 +111,22 @@ tests:
           delete_pool: true
       destroy-cluster: false
 
+  # Blocked due to BZ 2172795. Bugzilla fixed.
+  # Another bugzilla posing issues : 2252788
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
   - test:
       name: Verify scrub logs
       module: test_scrub_log.py
@@ -318,21 +334,6 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
-
-# Blocked due to BZ 2172795. Bugzilla fixed
-  - test:
-      name: Verify cluster behaviour during PG autoscaler warn
-      module: pool_tests.py
-      polarion-id:  CEPH-83573413
-      config:
-        verify_pool_warnings:
-          pool_configs:
-            - type: replicated
-              conf: sample-pool-1
-            - type: erasure
-              conf: sample-pool-2
-          pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
-      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
   - test:
       name: Verify degraded pool behaviour at min_size

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -291,6 +291,7 @@ tests:
         pool_name: test_stretch_pool5
         replacement_site: DC1
         tiebreaker_mon_site_name: arbiter
+        add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 

--- a/suites/quincy/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -198,7 +198,7 @@ tests:
               conf: sample-pool-1
             - type: replicated
               conf: sample-pool-2
-        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+        pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
         verify_inflation: false
       desc: Verify that the duplicates in the PG log entries are trimmed regularly
       abort-on-fail: true

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -96,6 +96,22 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+  # Blocked due to BZ 2172795. Bugzilla fixed.
+  # Another bugzilla posing issues : 2252788
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
   - test:
       name: Verify scrub logs
       module: test_scrub_log.py
@@ -106,7 +122,7 @@ tests:
               conf: sample-pool-2
             - type: erasure
               conf: sample-pool-2
-        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+        pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
   - test:
@@ -318,21 +334,6 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
-
-# Blocked due to BZ 2172795. Bugzilla fixed.
-  - test:
-      name: Verify cluster behaviour during PG autoscaler warn
-      module: pool_tests.py
-      polarion-id:  CEPH-83573413
-      config:
-        verify_pool_warnings:
-          pool_configs:
-            - type: replicated
-              conf: sample-pool-1
-            - type: erasure
-              conf: sample-pool-2
-          pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
-      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
   - test:
       name: Verify degraded pool behaviour at min_size

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -291,6 +291,7 @@ tests:
         pool_name: test_stretch_pool5
         replacement_site: DC1
         tiebreaker_mon_site_name: arbiter
+        add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 

--- a/suites/reef/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -198,7 +198,7 @@ tests:
               conf: sample-pool-1
             - type: replicated
               conf: sample-pool-2
-        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
         verify_inflation: false
       desc: Verify that the duplicates in the PG log entries are trimmed regularly
       abort-on-fail: true

--- a/suites/reef/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -96,6 +96,22 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+  # Blocked due to BZ 2172795. Bugzilla fixed.
+  # Another bugzilla posing issues : 2252788
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
   - test:
       name: Verify scrub logs
       module: test_scrub_log.py
@@ -106,7 +122,7 @@ tests:
               conf: sample-pool-2
             - type: erasure
               conf: sample-pool-2
-        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
   - test:
@@ -318,21 +334,6 @@ tests:
             compression_min_blob_size: 1B
             byte_size: 10KB
       desc: Verification of the effect of compression on replicated pools
-
-# Blocked due to BZ 2172795. Bugzilla fixed.
-  - test:
-      name: Verify cluster behaviour during PG autoscaler warn
-      module: pool_tests.py
-      polarion-id:  CEPH-83573413
-      config:
-        verify_pool_warnings:
-          pool_configs:
-            - type: replicated
-              conf: sample-pool-1
-            - type: erasure
-              conf: sample-pool-2
-          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
-      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
   - test:
       name: Verify degraded pool behaviour at min_size

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -294,6 +294,7 @@ tests:
         pool_name: test_stretch_pool5
         replacement_site: DC1
         tiebreaker_mon_site_name: arbiter
+        add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 


### PR DESCRIPTION
1. Added a -ve scenario with mon replacement, where mon daemon is added without CRUSH location.
Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BIQWKO

2. Added few checks in Autoscaler functionality tests

The test failed as the PG autoscaler mode on all the pools was off. I have added additional checks to make sure that the pg_autoscaler mode on the test pool is warn, before moving to further tests. Also, to avoid any false failures, I have moved the test to top of the suite file.

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W420VN/Verify_cluster_behaviour_during_PG_autoscaler_warn_0.log 

Fail log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-183/rados/41/tier-2_rados_test-pool-functionalities/Verify_cluster_behaviour_during_PG_autoscaler_warn_0.log 