### PR TITLE
[SuiteFix] Move out NFS scale down tests from tier-2-cluster-elasticity

### DIFF
--- a/suites/quincy/cephadm/tier-2-cluster-elasticity.yaml
+++ b/suites/quincy/cephadm/tier-2-cluster-elasticity.yaml
@@ -705,28 +705,6 @@ tests:
       abort-on-fail: true
 
   - test:
-      name: Scale down NFS Service
-      desc: Scale down NFS-Ganesha service to 1 node
-      module: test_nfs.py
-      polarion-id: CEPH-83573586
-      config:
-        command: apply
-        service: nfs
-        base_cmd_args:
-          verbose: true
-        pos_args:
-          - mynfs                         # nfs service ID
-          - nfs-ganesha-pool              # name of the pool
-        args:
-          placement:
-            nodes:
-              - node10
-            limit: 2
-            sep: ";"
-      destroy-cluster: false
-      abort-on-fail: true
-
-  - test:
       name: check-ceph-health
       module: exec.py
       config:

--- a/suites/reef/cephadm/tier2-cluster-elasticity.yaml
+++ b/suites/reef/cephadm/tier2-cluster-elasticity.yaml
@@ -691,27 +691,6 @@ tests:
       destroy-cluster: false
 
   - test:
-      name: Scale down NFS Service
-      desc: Scale down NFS-Ganesha service to 1 node
-      module: test_nfs.py
-      polarion-id: CEPH-83573586
-      config:
-        command: apply
-        service: nfs
-        base_cmd_args:
-          verbose: true
-        pos_args:
-          - mynfs                         # nfs service ID
-          - nfs-ganesha-pool              # name of the pool
-        args:
-          placement:
-            nodes:
-              - node10
-            limit: 1
-            sep: ";"
-      destroy-cluster: false
-
-  - test:
       name: check-ceph-health
       module: exec.py
       config:


### PR DESCRIPTION
The NFS now has separate suite and is having all these operations handled there along with other nfs ops. Hence moving this redundant test out

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
