### PR TITLE
Fixing the versioned bucket test on colocated archive zone

### DIFF
--- a/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -262,6 +262,20 @@ tests:
       name: create non-tenanted user
       polarion-id: CEPH-83575199
 
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node4
+            rgw_endpoints:
+              - node4:80
+
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
 
   - test:
       clusters:
@@ -269,6 +283,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
+            run-on-haproxy: true
             timeout: 300
       desc: Perform IOs and test bucket versioned at the colocated archive zone
       module: sanity_rgw_multisite.py


### PR DESCRIPTION
# Description

This test was run on rgw node of the archive zone hence the bucket creation was failing. 
Adding haproxy config with back rgw as the primary zone's, would fix the issue.

TFA jira ticket :(https://issues.redhat.com/browse/RHCEPHQE-14534)
ceph-qe-scripts pr : https://github.com/red-hat-storage/ceph-qe-scripts/pull/597
logs http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HB5QEY
