### PR TITLE
Adding log statements for intermittent failure

### DIFF
--- a/tests/cephfs/cephfs_bugs/test_mds_inject_health_dummy.py
+++ b/tests/cephfs/cephfs_bugs/test_mds_inject_health_dummy.py
@@ -63,10 +63,12 @@ def run(ceph_cluster, **kw):
             if "standby-replay" in value["state"]
         }
         standby_replay_mds = fs_util.get_standby_replay_mdss(client1, fs_name=fs_name)
+        log.info(f"standby_replay_mds : {standby_replay_mds}")
         standby_replay_mdss_obj = [
             ceph_cluster.get_node_by_hostname(i.split(".")[1])
             for i in standby_replay_mds
         ]
+        log.info(f"standby_replay_mdss_obj : {standby_replay_mdss_obj}")
         out, rc = client1.exec_command(sudo=True, cmd="ceph orch ps -f json")
         output = json.loads(out)
         deamon_dict = fs_util.filter_daemons(output, "mds", fs_name)


### PR DESCRIPTION
# Description
We are consistently seeing a failure in our pipeline runs. Interestingly, when the same suite is executed outside the pipeline, it passes successfully.

We used the same builds for both local and CI runs, but observed discrepancies between them. To investigate further, we have added a few log statements to gain more clarity

CI run Log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-191/cephfs/48/tier-3_cephfs_bugs/
Local run log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JETR79/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
