### PR TITLE
[RADOS] Alternate approach to 'wait_for_device' method

### DIFF
--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -188,14 +188,17 @@ def set_osd_in(
     return ret_val
 
 
-def osd_remove(ceph_cluster, osd_id):
+def osd_remove(ceph_cluster, osd_id, zap=False):
     """
     osd remove
     Args:
         ceph_cluster: ceph cluster
         osd_id: osd id
+        zap: flag to control zapping of device
     """
     config = {"command": "rm", "service": "osd", "pos_args": [osd_id]}
+    if zap:
+        config["base_cmd_args"] = {"zap": True}
     log.info(f"Executing OSD {config.pop('command')} service")
     osd = OSD(cluster=ceph_cluster, **config)
     osd.rm(config)

--- a/suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
@@ -6,6 +6,8 @@
 # Conf: conf/pacific/rados/7-node-cluster.yaml
 # Bugs:
 #     1.https://bugzilla.redhat.com/show_bug.cgi?id=1900127
+#     2. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
+#     3. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
 #===============================================================================================
 tests:
   - test:
@@ -132,3 +134,19 @@ tests:
         delete_pool:
           - ecpool
       comments: Failure due to BZ#2277111
+
+  - test:
+      name: Verification of ceph config show & get
+      module: test_bug_fixes.py
+      config:
+        test-config-show-get: true
+      polarion-id: CEPH-83590689
+      desc: Verify ceph config show & get outputs
+
+  - test:
+      name: Verification of Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat: true
+      polarion-id: CEPH-83590688
+      desc: Generate Slow OSD heartbeats by inducing network delay

--- a/suites/quincy/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
+++ b/suites/quincy/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
@@ -152,8 +152,16 @@ tests:
       name: "configure client"
   -
     test:
-      name: Using Blustore-tool add DB and WAL to existing OSD
-      desc: Using Blustore-tool add DB and WAL to existing OSD
+      name: Using Bluestore-tool add DB and WAL to existing OSD
+      desc: Using Bluestore-tool add DB and WAL to existing OSD
       module: test_add_db_wal_cbt.py
       polarion-id: CEPH-83584018
       abort-on-fail: true
+
+  - test:
+      name: Verification of recovery from Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat-baremetal: true
+      polarion-id: CEPH-83590688
+      desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
@@ -7,6 +7,8 @@
 # Bugs:
 #     1. https://bugzilla.redhat.com/show_bug.cgi?id=2233800
 #     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
+#     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
+#     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
 #===============================================================================================
 tests:
   - test:
@@ -138,3 +140,19 @@ tests:
         delete_pool:
           - ecpool
       comments: Failure due to BZ#2277111
+
+  - test:
+      name: Verification of ceph config show & get
+      module: test_bug_fixes.py
+      config:
+        test-config-show-get: true
+      polarion-id: CEPH-83590689
+      desc: Verify ceph config show & get outputs
+
+  - test:
+      name: Verification of Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat: true
+      polarion-id: CEPH-83590688
+      desc: Generate Slow OSD heartbeats by inducing network delay

--- a/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -605,3 +605,11 @@ tests:
 #        pool_type : replicated
 #        bluestore_cache: true
 #      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
+      name: Verification of recovery from Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat-baremetal: true
+      polarion-id: CEPH-83590688
+      desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/reef/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
+++ b/suites/reef/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
@@ -163,5 +163,5 @@ tests:
       module: test_bug_fixes.py
       config:
         slow-osd-heartbeat-baremetal: true
-      polarion-id: CEPH-83584004
+      polarion-id: CEPH-83590688
       desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -145,7 +145,7 @@ tests:
       module: test_bug_fixes.py
       config:
         test-config-show-get: true
-      polarion-id: CEPH-83584004
+      polarion-id: CEPH-83590689
       desc: Verify ceph config show & get outputs
 
   - test:
@@ -153,5 +153,5 @@ tests:
       module: test_bug_fixes.py
       config:
         slow-osd-heartbeat: true
-      polarion-id: CEPH-83584004
+      polarion-id: CEPH-83590688
       desc: Generate Slow OSD heartbeats by inducing network delay

--- a/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -601,5 +601,5 @@ tests:
       module: test_bug_fixes.py
       config:
         slow-osd-heartbeat-baremetal: true
-      polarion-id: CEPH-83584004
+      polarion-id: CEPH-83590688
       desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/squid/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
+++ b/suites/squid/rados/tier-2_rados_bm_add_db_wal_cbt.yaml
@@ -152,8 +152,16 @@ tests:
       name: "configure client"
   -
     test:
-      name: Using Blustore-tool add DB and WAL to existing OSD
-      desc: Using Blustore-tool add DB and WAL to existing OSD
+      name: Using Bluestore-tool add DB and WAL to existing OSD
+      desc: Using Bluestore-tool add DB and WAL to existing OSD
       module: test_add_db_wal_cbt.py
       polarion-id: CEPH-83584018
       abort-on-fail: true
+
+  - test:
+      name: Verification of recovery from Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat-baremetal: true
+      polarion-id: CEPH-83590688
+      desc: Verify auto removal of Slow OSD heartbeat

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -7,6 +7,8 @@
 # Bugs:
 #     1. https://bugzilla.redhat.com/show_bug.cgi?id=2233800
 #     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
+#     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
+#     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
 #===============================================================================================
 tests:
   - test:
@@ -137,3 +139,19 @@ tests:
         inconsistent_obj_count: 4
         delete_pool:
           - ecpool
+
+  - test:
+      name: Verification of ceph config show & get
+      module: test_bug_fixes.py
+      config:
+        test-config-show-get: true
+      polarion-id: CEPH-83590689
+      desc: Verify ceph config show & get outputs
+
+  - test:
+      name: Verification of Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat: true
+      polarion-id: CEPH-83590688
+      desc: Generate Slow OSD heartbeats by inducing network delay

--- a/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -593,3 +593,11 @@ tests:
 #        pool_type : replicated
 #        bluestore_cache: true
 #      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
+      name: Verification of recovery from Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat-baremetal: true
+      polarion-id: CEPH-83590688
+      desc: Verify auto removal of Slow OSD heartbeat

--- a/tests/rados/rados_test_util.py
+++ b/tests/rados/rados_test_util.py
@@ -156,3 +156,44 @@ def get_slow_requests_log(node, start_time, end_time, service_name="mon"):
         log.error(f"Exception hit while command execution. {er}")
     should_not_be_empty(j_log, "Failed to retrieve slow requests")
     return j_log
+
+
+def wait_for_device_rados(host, osd_id, action: str, timeout: int = 900) -> bool:
+    """
+    Waiting for the device to be removed/added based on the action
+    Args:
+        host: host object
+        osd_id: osd id
+        action: add/remove device path
+        timeout: wait timeout in seconds
+    Returns:  True -> pass, False -> fail
+    """
+    dev_path = None
+    end_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+    while end_time > datetime.datetime.now():
+        flag = True
+
+        base_cmd = "cephadm shell -- "
+        volume_cmd = f"ceph-volume lvm list {osd_id} --format json"
+        out, _ = host.exec_command(cmd=f"{base_cmd} {volume_cmd}", sudo=True)
+
+        for item in json.loads(out)["osd_id"]:
+            if "osd-block" in item["lv_name"]:
+                dev_path = item["devices"][0]
+                break
+
+        log.info(f"dev_path  : {dev_path}")
+        if action == "remove":
+            if dev_path:
+                flag = False
+        else:
+            if not dev_path:
+                flag = False
+        if flag:
+            log.info(f"The OSD {action} is completed.")
+            return True
+        log.info(
+            f"Waiting for OSD {osd_id} to {action}. checking status again in 2 minutes"
+        )
+        time.sleep(120)
+    return False

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -21,8 +21,9 @@ def run(ceph_cluster, **kw):
     which do not fit in any other existing segregation
 
     Currently, covers the following tests:
-    - CEPH-: Verify ceph config show and get for all daemons
-    - CEPH-: Induce Slow OSD heartbeat warning by controlled network delay
+    - CEPH-83590689 | BZ-2011756: Verify ceph config show and get for all daemons
+    - CEPH-83590688 | BZ-2229651: Induce Slow OSD heartbeat warning by controlled network delay
+    - CEPH-83590688 | BZ-2229651: Verify auto removal of slow osd heartbeat warning after 15 mins of OSD node restart
     """
 
     log.info(run.__doc__)
@@ -36,7 +37,7 @@ def run(ceph_cluster, **kw):
 
     if config.get("test-config-show-get"):
         doc = (
-            "\n# CEPH-"
+            "\n# CEPH-83590689"
             "\n Verify ceph config show and get command for all daemons"
             "\n\t 1. Deploy a cluster with at least 1 mon, mgr, OSD, and RGW each"
             "\n\t 2. Retrieve the ceph config show output for each daemon"
@@ -130,7 +131,7 @@ def run(ceph_cluster, **kw):
 
     if config.get("slow-osd-heartbeat"):
         doc = (
-            "\n# CEPH-"
+            "\n# CEPH-83590688"
             "\n Verify slow osd heartbeat warning being generated when network delay > 1 sec"
             "\n\t 1. Deploy a cluster with at least 2 OSD hosts"
             "\n\t 2. Ensure Cluster health condition should be HEALTH_OK"
@@ -218,7 +219,7 @@ def run(ceph_cluster, **kw):
 
     if config.get("slow-osd-heartbeat-baremetal"):
         doc = (
-            "\n# CEPH-"
+            "\n# CEPH-83590688"
             "\n Verify auto removal of slow osd heartbeat warning after 15 mins of OSD node restart"
             "\n\t 1. Deploy a cluster with at least 2 OSD hosts"
             "\n\t 2. Ensure Cluster health condition should be HEALTH_OK"

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -6,7 +6,7 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from tests.rados.rados_test_util import (
     create_pools,
     get_device_path,
-    wait_for_device,
+    wait_for_device_rados,
     write_to_pools,
 )
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
@@ -59,10 +59,10 @@ def run(ceph_cluster, **kw):
         utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
         method_should_succeed(utils.set_osd_out, ceph_cluster, osd_id)
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, test_pool=pool_name)
-        utils.osd_remove(ceph_cluster, osd_id)
+        utils.osd_remove(ceph_cluster, osd_id, zap=True)
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, test_pool=pool_name)
         method_should_succeed(utils.zap_device, ceph_cluster, host.hostname, dev_path)
-        method_should_succeed(wait_for_device, host, osd_id, action="remove")
+        method_should_succeed(wait_for_device_rados, host, osd_id, action="remove")
         osd_id1 = acting_pg_set[1]
         host1 = rados_obj.fetch_host_node(daemon_type="osd", daemon_id=osd_id1)
         should_not_be_empty(host1, "Failed to fetch host details")
@@ -72,7 +72,7 @@ def run(ceph_cluster, **kw):
         )
         method_should_succeed(utils.set_osd_out, ceph_cluster, osd_id1)
         utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
-        method_should_succeed(wait_for_device, host, osd_id, action="add")
+        method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, test_pool=pool_name)
 
         acting_pg_set1 = rados_obj.get_pg_acting_set(pool_name=pool["pool_name"])
@@ -98,12 +98,12 @@ def run(ceph_cluster, **kw):
         if osd_id not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
             utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
-            method_should_succeed(wait_for_device, host, osd_id, action="add")
+            method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
 
         if osd_id1 not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
             utils.add_osd(ceph_cluster, host1.hostname, dev_path1, osd_id1)
-            method_should_succeed(wait_for_device, host1, osd_id, action="add")
+            method_should_succeed(wait_for_device_rados, host1, osd_id, action="add")
 
         utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
         rados_obj.change_recovery_threads(config=pool, action="rm")


### PR DESCRIPTION
Jira tracker: [RHCEPHQE-13984](https://issues.redhat.com/browse/RHCEPHQE-13984): I would want to make robust: "wait_for_device()" method used in OSD replacements

Scope is to enhance the existing method `wait_for_device` to make it more robust and reduce occurrences of false failure

Test modules changed:
- `osd_remove` in `ceph/rados/utils.py`
- `wait_for_device_rados` in `tests/rados/rados_test_util.py`

Test cases modified:
-`tests/rados/test_bug_fixes.py`
-`tests/rados/test_osd_inprogress_rebalance.py`

Logs:
Quincy:
Reef:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>