### PR TITLE
fixing s3select TFA issue of too many open files and integrating parquet tests

### DIFF
--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -225,6 +225,20 @@ tests:
         timeout: 500
 
   # test s3-select with query generation of incorrect syntax
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: client
+        sudo: True
+        commands:
+          - "echo '\n\n# increase limit on number of open files\n*               soft    nofile          16384\n*               hard    nofile          16384' >> /etc/security/limits.conf"
+          - "echo 'ulimit -n 16384' >> /etc/profile"
+      desc: increase ulimit number of open files to 16384
+      module: exec.py
+      name: increase ulimit number of open files to 16384
+      polarion-id: CEPH-10362
+
   - test:
       name: test s3select with depth1 queries on csv objects
       desc: test s3select with depth1 queries of incorrect syntax for checking rgw crashes on csv objects
@@ -243,4 +257,24 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth2.yaml
+        timeout: 3600
+
+  - test:
+      name: test s3select with depth1 queries on parquet objects
+      desc: test s3select with depth1 queries of incorrect syntax for checking rgw crashes on parquet objects
+      polarion-id: CEPH-83575176
+      module: sanity_rgw.py
+      config:
+        script-name: test_s3select.py
+        config-file-name: test_s3select_query_gen_parquet_depth1.yaml
+        timeout: 3600
+
+  - test:
+      name: test s3select with depth2 queries on parquet objects
+      desc: test s3select with depth2 queries of incorrect syntax for checking rgw crashes on parquet objects
+      polarion-id: CEPH-83575176
+      module: sanity_rgw.py
+      config:
+        script-name: test_s3select.py
+        config-file-name: test_s3select_query_gen_parquet_depth2.yaml
         timeout: 3600


### PR DESCRIPTION
this PR is to fix s3select TFA issue of too many open files and integrating parquet tests into cephci
polarion: CEPH-83575176
tfa ticket: https://issues.redhat.com/browse/RHCEPHQE-14498

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/s3select_parquet_and_tfa/cephci-run-8J01OC/
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
