### PR TITLE
[Tier-3] Intergration of polarion testcase CEPH-83575143 to cephci

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -282,6 +282,19 @@ tests:
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
       polarion-id: CEPH-83575199
+
+  - test:
+      name: bucket granular sync policy on bucket with flow symmetrical and storage class
+      desc: Test bucket granular sync policy on bucket with flow symmetrical and storage class
+      polarion-id: CEPH-83575143
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_bucket_granular_sync_policy.py
+            config-file-name: test_bucket_granularsync_storage_class_symm.yaml
+            timeout: 300
+
   - test:
       clusters:
         ceph-pri:
@@ -333,6 +346,18 @@ tests:
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
             verify-io-on-site: ["ceph-sec"]
+
+  - test:
+      name: bucket granular sync policy on bucket with flow directional and storage class
+      desc: Test bucket granular sync policy on bucket with flow directional and storage class
+      polarion-id: CEPH-83575143
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_bucket_granular_sync_policy.py
+            config-file-name: test_bucket_granularsync_storage_class_direc.yaml
+            timeout: 300
 
   - test:
       name: bucket creation on primary for crash check

--- a/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -282,6 +282,19 @@ tests:
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
       polarion-id: CEPH-83575199
+
+  - test:
+      name: bucket granular sync policy on bucket with flow symmetrical and storage class
+      desc: Test bucket granular sync policy on bucket with flow symmetrical and storage class
+      polarion-id: CEPH-83575143
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_bucket_granular_sync_policy.py
+            config-file-name: test_bucket_granularsync_storage_class_symm.yaml
+            timeout: 300
+
   - test:
       clusters:
         ceph-pri:
@@ -333,6 +346,18 @@ tests:
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
             verify-io-on-site: ["ceph-sec"]
+
+  - test:
+      name: bucket granular sync policy on bucket with flow directional and storage class
+      desc: Test bucket granular sync policy on bucket with flow directional and storage class
+      polarion-id: CEPH-83575143
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_bucket_granular_sync_policy.py
+            config-file-name: test_bucket_granularsync_storage_class_direc.yaml
+            timeout: 300
 
   - test:
       name: bucket creation on primary for crash check


### PR DESCRIPTION
# Description
Intergration of polarion testcase CEPH-83575143 to cephci

depends on : https://github.com/red-hat-storage/ceph-qe-scripts/pull/598

logs attached in : https://issues.redhat.com/browse/RHCEPHQE-14075, as magna is down


[bucket_sync_command_crash_check_on_secondary_0.log](https://github.com/user-attachments/files/15585014/bucket_sync_command_crash_check_on_secondary_0.log)
[startup.log](https://github.com/user-attachments/files/15584997/startup.log)
[get_shared_realm_info_on_primary_0.log](https://github.com/user-
[bucket_granular_sync_policy_on_bucket_with_flow_symmetrical_and_storage_class_0.log](https://github.com/user-attachments/files/15585015/bucket_granular_sync_policy_on_bucket_with_flow_symmetrical_and_storage_class_0.log)
[bucket_granular_sync_policy_on_bucket_with_flow_directional_and_storage_class_0.log](https://github.com/user-attachments/files/15585016/bucket_granular_sync_policy_on_bucket_with_flow_directional_and_storage_class_0.log)
[bucket_creation_on_primary_for_crash_check_0.log](https://github.com/user-attachments/files/15585017/bucket_creation_on_primary_for_crash_check_0.log)
[run_summary.json](https://github.com/user-attachments/files/15585018/run_summary.json)
attachments/files/15584998/get_shared_realm_info_on_primary_0.log)
[setup_pre-requisites_0.log](https://github.com/user-attachments/files/15584999/setup_pre-requisites_0.log)
[setup_multisite_0.log](https://github.com/user-attachments/files/15585000/setup_multisite_0.log)
[get_shared_realm_info_on_secondary_0.log](https://github.com/user-attachments/files/15585001/get_shared_realm_info_on_secondary_0.log)
[Monitoring_Services_deployment_0.log](https://github.com/user-
[create_non-tenanted_user_0.log](https://github.com/user-attachments/files/15585012/create_non-tenanted_user_0.log)
[configure_client_0.log](https://github.com/user-attachments/files/15585013/configure_client_0.log)
attachments/files/15585002/Monitoring_Services_deployment_0.log)
[deploy_cluster_0.log](https://github.com/user-attachments/files/15585004/deploy_cluster_0.log)
[datalog_trim_command_with_delete_marker_enabled_on_Primary_0.log](https://github.com/user-attachments/files/15585007/datalog_trim_command_with_delete_marker_enabled_on_Primary_0.log)
[datalog_omap_offload_with_multipart_objects_on_primary_0.log](https://github.com/user-attachments/files/15585009/datalog_omap_offload_with_multipart_objects_on_primary_0.log)
[datalog_omap_offload_on_primary_0.log](https://github.com/user-attachments/files/15585010/datalog_omap_offload_on_primary_0.log)
[datalog_omap_offload_on_versioned_bucket_on_primary_0.log](https://github.com/user-attachments/files/15585011/datalog_omap_offload_on_versioned_bucket_on_primary_0.log)



<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
