### PR TITLE
fix wipefs issue

### DIFF
--- a/pipeline/scripts/ci/server_setup_utils.sh
+++ b/pipeline/scripts/ci/server_setup_utils.sh
@@ -77,18 +77,22 @@ function wipe_drives {
         exit 2
     fi
 
-    read -a devices -d ' ' <<< $disks
-    for disk in "${devices[@]}" ; do
-      echo "Device - ${disk}"
-      IFS=',' read -r name type <<< "$dev"
+    arr=()
+    while IFS='[[:space:]]+' read -r value; do
+      arr+=("$value")
+    done <<< "$(echo $disks)"
+
+    for disk in "${arr}" ; do
+      IFS=',' read -r name type <<< "$disk"
+      echo "name: $name, type: $type"
 
       # shellcheck disable=SC2076
-      # Skip wipefs for root, cd-rom.,etc
+      # Skip wipefs for root, cd-rom.,etc disks
       if [[ "${root_disk}" =~ "${name}" || "${type}" != "disk" ]]; then
         echo "Skipping this disk :  disk - ${name} , type - ${type}"
         continue
       else
-        sshpass -p ${password} ssh ${username}@${node} "wipefs -a --force /dev/${disk}"
+        sshpass -p ${password} ssh ${username}@${node} "wipefs -a --force /dev/${name}"
       fi
     done
 }


### PR DESCRIPTION
# Description

```
[jenkins@magna006 cephci]$ bash pipeline/scripts/ci/reimage-octo-node.sh --platform 9.4 --nodes cali003
+ source pipeline/scripts/ci/server_setup_utils.sh
+ OS_VER=
+ NODES=
+ REIMAGE_CMD=/home/jenkins/.tthlg/bin/teuthology-reimage
++ getopt -o hn:p: --long platform:,nodes:,help -- --platform 9.4 --nodes cali003
+ CLI_OPTS=' --platform '\''9.4'\'' --nodes '\''cali003'\'' --'
+ '[' 0 '!=' 0 ']'
+ '[' 4 '!=' 4 ']'
+ eval set -- ' --platform '\''9.4'\'' --nodes '\''cali003'\'' --'
++ set -- --platform 9.4 --nodes cali003 --
+ true
+ case ${1} in
+ OS_VER=9.4
+ shift 2
+ true
+ case ${1} in
+ NODES=cali003
+ shift 2
+ true
+ case ${1} in
+ shift
+ break
+ echo 'Initiating reimage of nodes'
Initiating reimage of nodes
+ nodes_with_mismatch=()
+ for node in ${NODES}
+ echo 'Checking OS on cali003'
Checking OS on cali003
++ ssh ubuntu@cali003.ceph.redhat.com 'cat /etc/os-release | grep VERSION_ID'
++ awk -F '"' '{print $2}'
Warning: Permanently added 'cali003.ceph.redhat.com,10.8.130.3' (ECDSA) to the list of known hosts.
+ actual_os=9.4
+ '[' 9.4 '!=' 9.4 ']'
+ echo 'OS version matches on cali003: 9.4'
OS version matches on cali003: 9.4
+ echo -----------------------------------
-----------------------------------
+ '[' 0 -gt 0 ']'
+ failed_nodes=()
+ for node in ${NODES}
+ initial_setup cali003
+ local node=cali003
+ local password=passwd
+ ssh ubuntu@cali003 'echo "passwd" | sudo passwd --stdin root; \
  grep -qxF "PermitRootLogin yes" /etc/ssh/sshd_config || \
  echo "PermitRootLogin yes" | sudo tee -a /etc/ssh/sshd_config'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
Changing password for user root.
passwd: all authentication tokens updated successfully.
+ ssh ubuntu@cali003 'sudo systemctl restart sshd &'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ sleep 2
+ set_hostnames_repos cali003
+ local node=cali003
+ local username=root
+ local password=passwd
+ echo 'Setting the systems to use shortnames'
Setting the systems to use shortnames
+ sshpass -p passwd ssh root@cali003 'sudo hostnamectl set-hostname $(hostname -s)'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ sshpass -p passwd ssh root@cali003 'sudo sed -i "s/$(hostname)/$(hostname -s)/g" /etc/hosts'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ echo 'Cleaning default repo files to avoid conflicts'
Cleaning default repo files to avoid conflicts
+ sshpass -p passwd ssh root@cali003 'sudo rm -f /etc/yum.repos.d/*; sudo yum clean all'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use "rhc" or "subscription-manager" to register.

0 files removed
+ wipe_drives cali003
+ local node=cali003
+ local username=root
+ local password=passwd
+ echo 'Wipe all data disks clean.'
Wipe all data disks clean.
++ sshpass -p passwd ssh -q root@cali003 'lsblk -ndo name,type | awk '\''{print $1","$2}'\'''
+ disks='sda,disk
sdb,disk
sdc,disk
sdd,disk
sde,disk
sdf,disk
sdg,disk
sr0,rom
nvme0n1,disk'
++ sshpass -p passwd ssh root@cali003 'eval $(lsblk -o PKNAME,MOUNTPOINT -P | grep "MOUNTPOINT=\"/\""); echo $PKNAME'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ root_disk=sdc
+ '[' -z sdc ']'
++ echo sdc
++ wc -l
+ '[' 1 '!=' 1 ']'
+ arr=()
++ echo sda,disk sdb,disk sdc,disk sdd,disk sde,disk sdf,disk sdg,disk sr0,rom nvme0n1,disk
+ IFS='[[:space:]]+'
+ read -r value
+ arr+=("$value")
+ IFS='[[:space:]]+'
+ read -r value
+ for disk in ${arr}
+ echo 'Device - sda,disk'
Device - sda,disk
+ IFS=,
+ read -r name type
+ echo 'name: sda, type: disk'
name: sda, type: disk
+ [[ sdc =~ sda ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/sda'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for disk in ${arr}
+ echo 'Device - sdb,disk'
Device - sdb,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdb, type: disk'
name: sdb, type: disk
+ [[ sdc =~ sdb ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/sdb'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for disk in ${arr}
+ echo 'Device - sdc,disk'
Device - sdc,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdc, type: disk'
name: sdc, type: disk
+ [[ sdc =~ sdc ]]
+ echo 'Skipping this disk :  disk - sdc , type - disk'
Skipping this disk :  disk - sdc , type - disk
+ continue
+ for disk in ${arr}
+ echo 'Device - sdd,disk'
Device - sdd,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdd, type: disk'
name: sdd, type: disk
+ [[ sdc =~ sdd ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/sdd'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for disk in ${arr}
+ echo 'Device - sde,disk'
Device - sde,disk
+ IFS=,
+ read -r name type
+ echo 'name: sde, type: disk'
name: sde, type: disk
+ [[ sdc =~ sde ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/sde'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for disk in ${arr}
+ echo 'Device - sdf,disk'
Device - sdf,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdf, type: disk'
name: sdf, type: disk
+ [[ sdc =~ sdf ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/sdf'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for disk in ${arr}
+ echo 'Device - sdg,disk'
Device - sdg,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdg, type: disk'
name: sdg, type: disk
+ [[ sdc =~ sdg ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/sdg'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for disk in ${arr}
+ echo 'Device - sr0,rom'
Device - sr0,rom
+ IFS=,
+ read -r name type
+ echo 'name: sr0, type: rom'
name: sr0, type: rom
+ [[ sdc =~ sr0 ]]
+ [[ rom != \d\i\s\k ]]
+ echo 'Skipping this disk :  disk - sr0 , type - rom'
Skipping this disk :  disk - sr0 , type - rom
+ continue
+ for disk in ${arr}
+ echo 'Device - nvme0n1,disk'
Device - nvme0n1,disk
+ IFS=,
+ read -r name type
+ echo 'name: nvme0n1, type: disk'
name: nvme0n1, type: disk
+ [[ sdc =~ nvme0n1 ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali003 'wipefs -a --force /dev/nvme0n1'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ reboot_node cali003
+ local node=cali003
+ local username=root
+ local password=passwd
+ echo 'Cleaning default repo files to avoid conflicts'
Cleaning default repo files to avoid conflicts
+ sshpass -p passwd ssh root@cali003 'sudo reboot'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
+ for node in ${NODES}
+ wait_for_node cali003
+ local node=cali003
+ local username=root
+ local password=passwd
+ local max_attempts=10
+ local wait_time=60
+ echo 'Waiting for node cali003 to come back online...'
Waiting for node cali003 to come back online...
+ (( attempt=1 ))
+ (( attempt<=max_attempts ))
+ ping -c 1 cali003
+ echo 'Node cali003 is online'
Node cali003 is online
+ return 0
++ verify_disk cali003
++ local node=cali003
++ local username=root
++ local password=passwd
++ echo 'Verifying wipefs on cali003'
+++ sshpass -p passwd ssh root@cali003 'sudo lsblk -o name,fstype'
Warning: Permanently added 'cali003,10.8.130.3' (ECDSA) to the list of known hosts.
System is going down. Unprivileged users are not permitted to log in anymore. For technical details, see pam_nologin(8).

++ output='NAME    FSTYPE
sda
sdb
sdc
├─sdc1  ext4
├─sdc2  swap
└─sdc3  ext4
sdd
sde
sdf
sdg
sr0
nvme0n1 '
++ echo 'ouput of lsblk NAME    FSTYPE
sda
sdb
sdc
├─sdc1  ext4
├─sdc2  swap
└─sdc3  ext4
sdd
sde
sdf
sdg
sr0
nvme0n1 '
++ read -r line
+++ echo 'NAME    FSTYPE'
+++ awk '{print $2}'
++ [[ ! -z FSTYPE ]]
++ echo true
++ return
+ output='Verifying wipefs on cali003
ouput of lsblk NAME    FSTYPE
sda
sdb
sdc
├─sdc1  ext4
├─sdc2  swap
└─sdc3  ext4
sdd
sde
sdf
sdg
sr0
nvme0n1
true'
+ [[ Verifying wipefs on cali003
ouput of lsblk NAME    FSTYPE
sda
sdb
sdc
├─sdc1  ext4
├─sdc2  swap
└─sdc3  ext4
sdd
sde
sdf
sdg
sr0
nvme0n1
true == true ]]
+ retry_count=0
+ '[' 0 -gt 0 ']'
+ [[ 0 -gt 0 ]]
[jenkins@magna006 cephci]$
```

