### PR TITLE
CEPH-83591092: OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
@@ -8,6 +8,10 @@
 #     1.https://bugzilla.redhat.com/show_bug.cgi?id=1900127
 #     2. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
 #     3. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
+#     4. https://bugzilla.redhat.com/show_bug.cgi?id=2264053
+#     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
+#     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
+#     7. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #===============================================================================================
 tests:
   - test:
@@ -115,6 +119,14 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+# moved prior to Inconsistent object test due to chances of an OSD being down
+  - test:
+      name: OSD restart when bluefs_shared_alloc_size is lower than bluestore_min_alloc_size
+      module: test_bug_fixes.py
+      config:
+        lower_bluefs_shared_alloc_size: true
+      polarion-id: CEPH-83591092
+      desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
 
   - test:
       name: Inconsistent objects in  EC pool functionality check

--- a/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
@@ -9,6 +9,10 @@
 #     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
 #     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
 #     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
+#     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264053
+#     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
+#     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
+#     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #===============================================================================================
 tests:
   - test:
@@ -121,6 +125,15 @@ tests:
       module: test_rados_ballooning_client.py
       polarion-id: CEPH-83584004
       desc: Verify MON ballooning client
+
+# moved prior to Inconsistent object test due to chances of an OSD being down
+  - test:
+      name: OSD restart when bluefs_shared_alloc_size is lower than bluestore_min_alloc_size
+      module: test_bug_fixes.py
+      config:
+        lower_bluefs_shared_alloc_size: true
+      polarion-id: CEPH-83591092
+      desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
 
   - test:
       name: Inconsistent objects in  EC pool functionality check

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -9,6 +9,10 @@
 #     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
 #     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
 #     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
+#     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264053
+#     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
+#     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
+#     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #===============================================================================================
 tests:
   - test:
@@ -121,6 +125,15 @@ tests:
       module: test_rados_ballooning_client.py
       polarion-id: CEPH-83584004
       desc: Verify MON ballooning client
+
+# moved prior to Inconsistent object test due to chances of an OSD being down
+  - test:
+      name: OSD restart when bluefs_shared_alloc_size is lower than bluestore_min_alloc_size
+      module: test_bug_fixes.py
+      config:
+        lower_bluefs_shared_alloc_size: true
+      polarion-id: CEPH-83591092
+      desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
 
   - test:
       name: Inconsistent objects in  EC pool functionality check

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -9,6 +9,10 @@
 #     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
 #     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
 #     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
+#     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264053
+#     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
+#     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
+#     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #===============================================================================================
 tests:
   - test:
@@ -121,6 +125,15 @@ tests:
       module: test_rados_ballooning_client.py
       polarion-id: CEPH-83584004
       desc: Verify MON ballooning client
+
+# moved prior to Inconsistent object test due to chances of an OSD being down
+  - test:
+      name: OSD restart when bluefs_shared_alloc_size is lower than bluestore_min_alloc_size
+      module: test_bug_fixes.py
+      config:
+        lower_bluefs_shared_alloc_size: true
+      polarion-id: CEPH-83591092
+      desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
 
   - test:
       name: Inconsistent objects in  EC pool functionality check

--- a/tests/rados/rados_test_util.py
+++ b/tests/rados/rados_test_util.py
@@ -177,7 +177,7 @@ def wait_for_device_rados(host, osd_id, action: str, timeout: int = 900) -> bool
         volume_cmd = f"ceph-volume lvm list {osd_id} --format json"
         out, _ = host.exec_command(cmd=f"{base_cmd} {volume_cmd}", sudo=True)
 
-        for item in json.loads(out)["osd_id"]:
+        for item in json.loads(out)[osd_id]:
             if "osd-block" in item["lv_name"]:
                 dev_path = item["devices"][0]
                 break

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -8,6 +8,7 @@ import time
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
+from ceph.rados.rados_bench import RadosBench
 from cli.utilities.utils import reboot_node
 from tests.rados.monitor_configurations import MonConfigMethods
 from utility.log import Log
@@ -34,6 +35,9 @@ def run(ceph_cluster, **kw):
     pool_obj = PoolFunctions(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
     client_node = ceph_cluster.get_nodes(role="client")[0]
+    bench_obj = RadosBench(mon_node=cephadm, clients=client_node)
+    osd_nodes = ceph_cluster.get_nodes(role="osd")
+    bench_obj_size_kb = 16384
 
     if config.get("test-config-show-get"):
         doc = (
@@ -296,5 +300,161 @@ def run(ceph_cluster, **kw):
             rados_obj.log_cluster_health()
         log.info(
             "Verification of automatic removal of Slow OSD heartbeat warning has been completed "
+        )
+        return 0
+
+    if config.get("lower_bluefs_shared_alloc_size"):
+        doc = (
+            "\n# CEPH-83591092"
+            "\n Bugzilla trackers:"
+            "\n\t- Pacific: 2264054"
+            "\n\t- Quincy: 2264053"
+            "\n\t- Reef: 2264052 & 2260306"
+            "\n Verify OSDs do not crash terminally when custom 'bluefs_shared_alloc_size' "
+            "is in use and it's below 'bluestore_min_alloc_size' persistent for BlueStore on deployment"
+            "\n\t 1. Deploy a cluster with no default values of 'bluestore_min_alloc_size' and "
+            "'bluefs_shared_alloc_size'"
+            "\n\t 2. Fetch the current active value of 'bluestore_min_alloc_size'"
+            "\n\t 3. Choose one OSD from each OSD node at random"
+            "\n\t 4. Set the value of 'bluefs_shared_alloc_size' to half of 'bluestore_min_alloc_size' "
+            "for each chosen OSD"
+            "\n\t 5. Restart Orch OSD service"
+            "\n\t 6. Create a replicated pool and fill it till 70%"
+            "\n\t 7. Ensure restart of Orch OSD service is successful"
+        )
+
+        log.info(doc)
+        log.info(
+            "Running test to verify OSD resiliency when 'bluefs_shared_alloc_size'"
+            " is below 'bluestore_min_alloc_size'"
+        )
+
+        try:
+            _pool_name = "test-bluefs-shared"
+
+            # get the list of OSDs on the cluster
+            osd_list = rados_obj.run_ceph_command(cmd="ceph osd ls")
+            log.debug(f"List of active OSDs: \n{osd_list}")
+
+            # check the current value of 'bluestore_min_alloc_size'
+            min_alloc_size = int(
+                mon_obj.show_config(
+                    daemon="osd", id=osd_list[0], param="bluestore_min_alloc_size_hdd"
+                )
+            )
+            log.info(
+                f"Current persistent value of 'bluestore_min_alloc_size_hdd' is {min_alloc_size}"
+            )
+            min_alloc_size_ssd = int(
+                mon_obj.show_config(
+                    daemon="osd", id=osd_list[0], param="bluestore_min_alloc_size_ssd"
+                )
+            )
+            log.info(
+                f"Current persistent value of 'bluestore_min_alloc_size_ssd' is {min_alloc_size}"
+            )
+
+            # cherry-pick one OSD ID from each osd node
+            test_osd_list = [
+                rados_obj.collect_osd_daemon_ids(osd_node=node)[0] for node in osd_nodes
+            ]
+
+            log.info(
+                f"OSDs for which bluefs_shared_alloc_size will be modified: {test_osd_list}"
+            )
+            shared_alloc_size = int(min_alloc_size / 2)
+            log.info(
+                f"bluefs_shared_alloc_size parameter will be set to - {shared_alloc_size}"
+            )
+
+            for osd_id in test_osd_list:
+                mon_obj.set_config(
+                    section=f"osd.{osd_id}",
+                    name="bluefs_shared_alloc_size",
+                    value=shared_alloc_size,
+                )
+
+            time.sleep(5)
+
+            # restart OSD orch service
+            assert rados_obj.restart_daemon_services(daemon="osd")
+
+            # determine how much % cluster is already filled
+            current_fill_ratio = rados_obj.get_cephdf_stats()["stats"][
+                "total_used_raw_ratio"
+            ]
+
+            # determine the number of objects to be written to the pool
+            # to achieve 70% utilization
+            osd_df_stats = rados_obj.get_osd_df_stats(
+                tree=False, filter_by="name", filter="osd.0"
+            )
+            osd_size = osd_df_stats["nodes"][0]["kb"]
+            num_objs = int(
+                (osd_size * (0.7 - current_fill_ratio) / bench_obj_size_kb) + 1
+            )
+
+            # create a sample pool to write data
+            assert rados_obj.create_pool(pool_name=_pool_name)
+
+            # fill the cluster till 70% capacity
+            bench_config = {
+                "seconds": 300,
+                "b": f"{bench_obj_size_kb}KB",
+                "no-cleanup": True,
+                "max-objects": num_objs,
+            }
+            bench_obj.write(client=client_node, pool_name=_pool_name, **bench_config)
+
+            time.sleep(10)
+
+            # log the cluster and pool fill %
+            cluster_fill = (
+                int(rados_obj.get_cephdf_stats()["stats"]["total_used_raw_ratio"]) * 100
+            )
+            pool_fill = (
+                int(
+                    rados_obj.get_cephdf_stats(pool_name=_pool_name)["stats"][
+                        "percent_used"
+                    ]
+                )
+                * 100
+            )
+
+            log.info(f"Cluster fill %: {cluster_fill}")
+            log.info(f"Pool {_pool_name} fill %: {pool_fill}")
+
+            # restart OSD orch service
+            assert rados_obj.restart_daemon_services(daemon="osd")
+
+            # check for any crashes reported during the test
+            crash_list = rados_obj.run_ceph_command("ceph crash ls-new")
+            if len(crash_list) != 0:
+                log.error(f"Crash reported on the cluster: {crash_list}")
+                raise Exception(f"Crash reported on the cluster: {crash_list}")
+
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            return 1
+        finally:
+            log.info(
+                "\n \n ************** Execution of finally block begins here *************** \n \n"
+            )
+            # delete pool
+            rados_obj.delete_pool(pool=_pool_name)
+
+            # remove bluefs_shared_alloc_size
+            if "test_osd_list" in locals() or "test_osd_list" in globals():
+                for osd_id in test_osd_list:
+                    mon_obj.remove_config(
+                        section=f"osd.{osd_id}", name="bluefs_shared_alloc_size"
+                    )
+
+            # log cluster health
+            rados_obj.log_cluster_health()
+        log.info(
+            "Verification of OSD resiliency when 'bluefs_shared_alloc_size' "
+            "is below 'bluestore_min_alloc_size' has been completed "
         )
         return 0


### PR DESCRIPTION
[CEPH-83591092](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83591092): Tier-2 test to verify OSDs do not crash terminally when custom 'bluefs_shared_alloc_size' is in use and it's below 'bluestore_min_alloc_size' persistent for BlueStore during cluster deployment

Jira tracker: [RHCEPHQE-14428](https://issues.redhat.com/browse/RHCEPHQE-14428)

Bugzilla trackers:
- Pacific: https://bugzilla.redhat.com/show_bug.cgi?id=2264053 
- Quincy: https://bugzilla.redhat.com/show_bug.cgi?id=2264054 
- Reef: https://bugzilla.redhat.com/show_bug.cgi?id=2264052  & https://bugzilla.redhat.com/show_bug.cgi?id=2260306

Test modules modified:
- tests/rados/test_bug_fixes.py

Test suites modified:
- suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
- suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
- suites/reef/rados/tier-2_rados_test-bugfixes.yaml
- suites/quincy/rados/tier-2_rados_test-bugfixes.yaml

Steps:
1. Deploy a cluster with no default values of 'bluestore_min_alloc_size' and 'bluefs_shared_alloc_size''
2. Fetch the current active value of 'bluestore_min_alloc_size'
3. Choose one OSD from each OSD node at random
4. Set the value of 'bluefs_shared_alloc_size' to half of 'bluestore_min_alloc_size' for each chosen OSD
5. Restart Orch OSD service
6. Fill the cluster till 70%
7. Ensure restart of Orch OSD service is successful

Logs:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8VCHYT
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AT67PD
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KMVVN0/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>