### PR TITLE
TFA fix to wait for more time for ceph status to be healthy before snap schedule test

### DIFF
--- a/suites/reef/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
@@ -237,3 +237,11 @@ tests:
       abort-on-fail: false
       config:
         test_name : functional
+  - test:
+      name: snap_sched_multi_fs
+      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
+      polarion-id: CEPH-83581235
+      desc: snap schedule and retention functional test on multi-fs setup
+      abort-on-fail: false
+      config:
+        test_name : systemic

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -199,7 +199,7 @@ def run(ceph_cluster, **kw):
                 f"Verify Ceph Status is healthy before starting test {test_case_name}"
             )
             ceph_healthy = 0
-            end_time = datetime.datetime.now() + datetime.timedelta(seconds=60)
+            end_time = datetime.datetime.now() + datetime.timedelta(seconds=300)
             while (datetime.datetime.now() < end_time) and (ceph_healthy == 0):
                 try:
                     fs_util_v1.get_ceph_health_status(client1)
@@ -209,7 +209,7 @@ def run(ceph_cluster, **kw):
                     log.info("Wait for few secs and recheck ceph status")
                     time.sleep(5)
             if ceph_healthy == 0:
-                assert False, "Ceph remains unhealthy even after wait for 60secs"
+                assert False, "Ceph remains unhealthy even after wait for 300secs"
             cleanup_params = run_snap_test(snap_test_params)
             log.info(f"post_test_params:{cleanup_params}")
             snap_test_params["export_created"] = cleanup_params["export_created"]

--- a/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
@@ -57,7 +57,7 @@ def run(ceph_cluster, **kw):
     validate this)
 
     Type - Negative
-    Workflow6 - snap_retention_service_restart: Verify Snapshot retention works even after service restarts.
+    Workflow6 - snap_retention_service_restart: Verify Snapshot retention works even after service restart.
     Verify for mgr, mon and mds.
     Workflow7 - snap_sched_non_existing_path: Verify Snapshot schedule can be created for non-existing path.
     After the start-time is hit for the


### PR DESCRIPTION
# Description

Script: tests/cephfs/snapshot_clone/snap_schedule_retention_vol_subvol.py
Failure: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-194/cephfs/49/tier-4_cephfs_recovery/snap_sched_retention_negative_test_0.log
Fix: Add 5mins wait before exiting test ceph being unhealthy.

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
