### PR TITLE
[tfa][dmfg] Fix ansible-wrapper bootstrap registry login for IBM suites

### DIFF
--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-custom-ssh.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-custom-ssh.yaml
@@ -11,3 +11,6 @@
         monitoring: "{{ monitoring | default(False) }}"
         firewalld: "{{ firewalld | default(False) }}"
         ssh_user: "{{ ssh_user }}"
+        registry_url: "{{ registry_url | default() }}"
+        registry_username: "{{ registry_username | default() }}"
+        registry_password: "{{ registry_password | default() }}"

--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-exisitng-keys.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/bootstrap-with-exisitng-keys.yaml
@@ -8,3 +8,7 @@
       cephadm_bootstrap:
         mon_ip: "{{ mon_ip }}"
         allow_overwrite: "{{ allow_overwrite | default(False) }}"
+        image: "{{ image | default(False) }}"
+        registry_url: "{{ registry_url | default() }}"
+        registry_username: "{{ registry_username | default() }}"
+        registry_password: "{{ registry_password | default() }}"

--- a/tests/cephadm/ansible_wrapper/cephadm_bootstrap/cephadm-bootstrap.yaml
+++ b/tests/cephadm/ansible_wrapper/cephadm_bootstrap/cephadm-bootstrap.yaml
@@ -11,3 +11,6 @@
         mon_ip: "{{ mon_ip }}"
         monitoring: "{{ monitoring | default(False) }}"
         firewalld: "{{ firewalld | default(False) }}"
+        registry_url: "{{ registry_url | default() }}"
+        registry_username: "{{ registry_username | default() }}"
+        registry_password: "{{ registry_password | default() }}"


### PR DESCRIPTION
# Description

Problem:
Ansible-wrapper related tests fail while running the bootstrap playbook for IBM deployments.

Reason for Failure:
The IBM deployment requires registry details in order to pull the images. The playbook yaml files do not provide a way to populate the registry details provided in the ansible-playbook command.

Solution:
Add registry details to the bootstrap playbook yaml files so that the details can be populated when provided in the ansible-playbook boostrap command.

Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2AYR04