### PR TITLE
[dmfg] Add test to validate cephadm command timeout

### DIFF
--- a/cli/utilities/cephadm-hold-lock-utility.py
+++ b/cli/utilities/cephadm-hold-lock-utility.py
@@ -1,0 +1,148 @@
+import argparse
+import fcntl
+import os
+import sys
+import time
+from typing import Any, Optional
+
+LOCK_DIR = "/run/cephadm"
+
+
+class _Acquire_ReturnProxy(object):
+    def __init__(self, lock: "FileLock") -> None:
+        self.lock = lock
+        return None
+
+    def __enter__(self) -> "FileLock":
+        return self.lock
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.lock.release()
+        return None
+
+
+class FileLock(object):
+    def __init__(self, name: str, timeout: int = -1) -> None:
+        if not os.path.exists(LOCK_DIR):
+            os.mkdir(LOCK_DIR, 0o700)
+        self._lock_file = os.path.join(LOCK_DIR, name + ".lock")
+
+        self._lock_file_fd: Optional[int] = None
+        self.timeout = timeout
+        self._lock_counter = 0
+        return None
+
+    @property
+    def is_locked(self) -> bool:
+        return self._lock_file_fd is not None
+
+    def acquire(
+        self, timeout: Optional[int] = None, poll_intervall: float = 0.05
+    ) -> _Acquire_ReturnProxy:
+        # Use the default timeout, if no timeout is provided.
+        if timeout is None:
+            timeout = self.timeout
+
+        # Increment the number right at the beginning.
+        # We can still undo it, if something fails.
+        self._lock_counter += 1
+
+        lock_id = id(self)  # noqa
+        lock_filename = self._lock_file  # noqa
+        start_time = time.time()
+        try:
+            while True:
+                if not self.is_locked:
+                    self._acquire()
+
+                if self.is_locked:
+                    break
+                elif timeout >= 0 and time.time() - start_time > timeout:
+                    raise Timeout(self._lock_file)  # noqa
+                else:
+                    time.sleep(poll_intervall)
+        except Exception:
+            # Something did go wrong, so decrement the counter.
+            self._lock_counter = max(0, self._lock_counter - 1)
+
+            raise
+        return _Acquire_ReturnProxy(lock=self)
+
+    def release(self, force: bool = False) -> None:
+        if self.is_locked:
+            self._lock_counter -= 1
+
+            if self._lock_counter == 0 or force:
+                self._release()
+                self._lock_counter = 0
+
+        return None
+
+    def __enter__(self) -> "FileLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.release()
+        return None
+
+    def __del__(self) -> None:
+        self.release(force=True)
+        return None
+
+    def _acquire(self) -> None:
+        open_mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+        fd = os.open(self._lock_file, open_mode)
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (IOError, OSError):
+            os.close(fd)
+        else:
+            self._lock_file_fd = fd
+        return None
+
+    def _release(self) -> None:
+        fd = self._lock_file_fd
+        self._lock_file_fd = None
+        fcntl.flock(fd, fcntl.LOCK_UN)  # type: ignore
+        os.close(fd)  # type: ignore
+        return None
+
+
+def command_hold_lock(args):
+    lock = FileLock(args.fsid, args.timeout)
+    lock.acquire()
+    while True:
+        time.sleep(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Hold cephadm lock",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(help="sub-command")
+    parser_connect = subparsers.add_parser("hold-lock", help="hold onto cephadm lock")
+    parser_connect.set_defaults(func=command_hold_lock)
+    parser_connect.add_argument(
+        "--fsid", help="cluster fsid for which to hold lock", required=True
+    )
+    parser_connect.add_argument(
+        "--timeout", help="timeout for holding lock", required=False, default=-1
+    )
+
+    args = parser.parse_args()
+    if "func" not in args:
+        print("No command specified")
+        sys.exit()
+    # print(args)
+    r = args.func(args)
+
+    if not r:
+        r = 0
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/utilities/utils.py
+++ b/cli/utilities/utils.py
@@ -998,3 +998,22 @@ def create_trusted_ca_key(installer, nodes, copy_to_other_nodes=False):
 
     except Exception:
         raise OperationFailedError("Failed to create trusted CA key")
+
+
+def get_process_info(node, process="", awk=""):
+    """
+    Executes the ps aux command
+    Args:
+        node (ceph): Node where the cmd has to be executed
+        process (str): Name of the process
+        awk (str): Column number of the output.
+                   Example: If "10" is provided here,
+                   then the 10th column will be printed
+    """
+    cmd = "ps aux"
+    if process:
+        cmd = cmd + f" | grep {process}"
+    if awk:
+        cmd = cmd + " | awk {{'print $" + f"{awk}" + "'}}"
+    out, _ = node.exec_command(cmd=cmd, sudo=True)
+    return out.split("\n")

--- a/suites/quincy/cephadm/tier2-cephadm-mgr-timeout.yaml
+++ b/suites/quincy/cephadm/tier2-cephadm-mgr-timeout.yaml
@@ -1,0 +1,105 @@
+#===============================================================================================
+# Tier-level: 2
+# Test-Case:
+#      Validate that cephadm commands get timed out after setting the
+#      default_cephadm_command_timeout
+#
+# Cluster Configuration:
+#   conf/quincy/cephadm/tier-0.yaml
+#
+# Test steps:
+#   (1) Bootstrap cluster with all services
+#   (2) Set default_cephadm_command_timeout using below command
+#       - # ceph config set mgr mgr/cephadm/default_cephadm_command_timeout 120
+#   (3) Download the 'cephadm-hold-lock.py' script and execute it using below command
+#       - # python3 cephadm-hold-lock.py hold-lock --fsid 4f7cd5d0-263b-11ee-9d53-fa163e26fc8c &
+#   (4) Check that hold-lock process is running under 'ps aux'
+#   (5) Refresh devices using below command
+#       - # ceph orch device ls --refresh
+#   (6) Check that the ceph-volume inventory process is running under 'ps aux'
+#   (7) Wait for the length of time the timeout is set in the step (2) and check if the command
+#       gets timed out using below command
+#       - # ceph health detail
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      desc: bootstrap and deploy services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: Deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node4
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW,RBD client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      name: Test mgr cephadm command timeout
+      desc: Test mgr cephadm command timeout
+      polarion-id: CEPH-83574672
+      module: test_cephadm_mgr_timeout.py

--- a/tests/cephadm/test_cephadm_mgr_timeout.py
+++ b/tests/cephadm/test_cephadm_mgr_timeout.py
@@ -1,0 +1,76 @@
+from ceph.waiter import WaitUntil
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError, UnexpectedStateError
+from cli.utilities.utils import get_process_info
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Verify cephadm command timeout
+    Args:
+        **kw: Key/value pairs of configuration information
+              to be used in the test.
+    """
+    admin = ceph_cluster.get_nodes(role="_admin")[0]
+
+    # Set default_cephadm_command_timeout to 120 seconds
+    CephAdm(admin).ceph.config.set(
+        key="mgr/cephadm/default_cephadm_command_timeout", value="120", daemon="mgr"
+    )
+    log.info("Default cephadm command timeout set to 120 seconds")
+
+    # Upload the 'cephadm-hold-lock-utility.py' script to the admin node
+    admin.upload_file(
+        "cli/utilities/cephadm-hold-lock-utility.py",
+        "/root/cephadm-hold-lock-utility.py",
+        sudo=True,
+    )
+    log.info("File 'cephadm-hold-lock-utility.py' uploaded successfully")
+
+    # Execute the 'cephadm-hold-lock-utility.py' script
+    fsid = CephAdm(admin).ceph.fsid()
+    if not fsid:
+        raise OperationFailedError("Failed to get cluster FSID")
+    cmd = f"python3 /root/cephadm-hold-lock-utility.py hold-lock --fsid {fsid} & > /tmp/tmp.txt"
+    admin.exec_command(sudo=True, long_running=True, cmd=cmd)
+
+    # Check that hold-lock process is running under 'ps aux'
+    out = get_process_info(admin, process="cephadm", awk="13")
+    if "hold-lock" not in out:
+        raise OperationFailedError("failed to list the lock task in 'ps aux'")
+    log.info("hold-lock process is running")
+
+    # Refresh devices
+    conf = {"refresh": True}
+    if not CephAdm(admin).ceph.orch.device.ls(**conf):
+        raise OperationFailedError("Failed to refresh devices")
+
+    # Check that the ceph-volume inventory process is running under 'ps aux'
+    timeout, interval = 60, 10
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        out = get_process_info(admin, process="cephadm", awk="17")
+        if "ceph-volume" in out:
+            log.info("ceph-volume inventory process is running")
+            break
+    if w.expired:
+        raise OperationFailedError(
+            "failed to list the timeout ceph-volume task in 'ps aux'"
+        )
+
+    # Wait for 120 seconds for the timeout to trigger and check if the command timed out
+    timeout, interval = 150, 10
+    for w in WaitUntil(timeout=timeout, interval=interval):
+        out = CephAdm(admin).ceph.health(detail=True)
+        if (
+            'Command "cephadm ceph-volume -- inventory" timed out'
+            and "HEALTH_WARN" in out
+        ):
+            log.info("ceph-volume inventory command timed out successfully")
+            break
+    if w.expired:
+        raise UnexpectedStateError(
+            "ceph-volume inventory command is not being timed out"
+        )
+    return 0


### PR DESCRIPTION
# Description
Validate that after setting a cephadm command timeout value, if a lock is introduced then the cephadm command must get timed out

### Test steps

- Bootstrap cluster with all services
- Set default_cephadm_command_timeout using below command
- `# ceph config set mgr mgr/cephadm/default_cephadm_command_timeout 120`
- Download the 'cephadm-hold-lock.py' script and execute it using below command
- `# python3 cephadm-hold-lock.py hold-lock --fsid 4f7cd5d0-263b-11ee-9d53-fa163e26fc8c &`
- Check that hold-lock process is running under `ps aux`
- Refresh devices using below command
- `# ceph orch device ls --refresh`
- Check that the ceph-volume inventory process is running under `ps aux`
- Wait for the length of time the timeout is set in the step (2) and check if the command gets timed out using below command
- `# ceph health detail`

### Logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VVOROQ