### PR TITLE
Remove snap-sched multi-fs test as BZ is not fixed for 5.3

### DIFF
--- a/suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
+++ b/suites/pacific/cephfs/tier-2_cephfs_test-snapshot-clone.yaml
@@ -238,11 +238,4 @@ tests:
       abort-on-fail: false
       config:
         test_name : functional
-  - test:
-      name: snap_sched_multi_fs
-      module: snapshot_clone.snap_schedule_retention_vol_subvol.py
-      polarion-id: CEPH-83581235
-      desc: snap schedule and retention functional test on multi-fs setup
-      abort-on-fail: false
-      config:
-        test_name : systemic
+

--- a/tests/cephfs/cephfs_bugs/test_client_blocklist_large_session_metadata.py
+++ b/tests/cephfs/cephfs_bugs/test_client_blocklist_large_session_metadata.py
@@ -46,14 +46,14 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd="ceph config set client log_to_file true",
         )
-        log.info("Set client config client inject fixed oldest tid to true")
+        log.info("Set client config client_inject_fixed_oldest_tid to true")
         out, rc = client1.exec_command(
             sudo=True,
-            cmd='ceph config set client "client inject fixed oldest tid" true',
+            cmd='ceph config set client "client_inject_fixed_oldest_tid" true',
         )
         out, rc = client1.exec_command(
             sudo=True,
-            cmd='ceph config get client "client inject fixed oldest tid"',
+            cmd='ceph config get client "client_inject_fixed_oldest_tid"',
         )
         log.info(out)
         if "true" not in out.strip():
@@ -217,7 +217,7 @@ def run(ceph_cluster, **kw):
         )
         client1.exec_command(
             sudo=True,
-            cmd='ceph config set client "client inject fixed oldest tid" false',
+            cmd='ceph config set client "client_inject_fixed_oldest_tid" false',
         )
         mds_session_metadata_threshold_default = out.strip()
         client1.exec_command(sudo=True, cmd=f"umount {fuse_mount_dir}", check_ec=False)


### PR DESCRIPTION
# Description

1) TFA fix 1 - snap schedule multi-fs test case remove from pacific suite

JIRA: https://issues.redhat.com/browse/RHCEPHQE-14822
multi-fs snap-schedule test executed in 5.3 codeline fails as below,
2024-06-11 02:05:44,337 (cephci.snapshot_clone.snap_schedule_retention_vol_subvol) [ERROR] - cephci.RH.5.3.rhel-8.Regression.16.2.10-263.cephfs.26.cephci.ceph.ceph.py:1605 - Error ENOENT: schedule multiplier "m" not recognized

This step is from snap-sched multi fs support test case, but relevant BZ is not fixed yet in 5.3 codeline,

Logs:
[root@ceph-sumar-regression-lizwb0-node7 ~]# ceph fs ls
name: cephfs, metadata pool: cephfs.cephfs.meta, data pools: [cephfs.cephfs.data ]
name: cephfs_1, metadata pool: cephfs.cephfs_1.meta, data pools: [cephfs.cephfs_1.data ]
[root@ceph-sumar-regression-lizwb0-node7 ~]# ceph fs snap-schedule add / 1h
Schedule set for path /
[root@ceph-sumar-regression-lizwb0-node7 ~]# ceph fs snap-schedule status
{"fs": "cephfs", "subvol": null, "path": "/", "rel_path": "/", "schedule": "1h", "retention": {}, "start": "2024-06-11T00:00:00", "created": "2024-06-11T12:42:37", "first": null, "last": null, "last_pruned": null, "created_count": 0, "pruned_count": 0, "active": true}

2) TFA fix for test-clients 'Verify_Client_is_blocklisted_if_session_metadata_is_bloated'
Script failed as it could not recognize option "client inject fixed oldest tid", but this works in 7.1 codeline.
In 5.3 option is recognized when given as "client_inject_fixed_oldest_tid"

[root@ceph-sumar-regression-lizwb0-node7 ~]# ceph config get client client_inject_fixed_oldest_tid
false
[root@ceph-sumar-regression-lizwb0-node7 ~]# ceph version
ceph version 16.2.10-263.el8cp (f4193b8aa7363c02dcb0c8f35e06f6299957c826) pacific (stable)

Also this works for 7.1 too,
[root@magna030 ~]# ceph config get client client_inject_fixed_oldest_tid
false
So changing in script to client_inject_fixed_oldest_tid

5.3 Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AXAJ8U

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
