### PR TITLE
[RADOS] TFA fix for utf-8 decode error & wait_for_device method

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -94,7 +94,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration in ec pool
       polarion-id: CEPH-9212
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -116,7 +115,6 @@ tests:
       module: test_osd_rebalance_snap.py
       desc: Taking snaps while data migration is in progress
       polarion-id: CEPH-9235
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -138,7 +136,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration
       polarion-id: CEPH-9205
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -157,7 +154,6 @@ tests:
       module: test_osd_inprogress_rebalance.py
       desc: Add osd while data migration from the pools are in progress
       polarion-id: CEPH-9228
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -209,7 +205,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration from the pools which have different replica and pg count
       polarion-id: CEPH-9210
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:

--- a/suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -94,7 +94,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration in ec pool
       polarion-id: CEPH-9212
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -116,7 +115,6 @@ tests:
       module: test_osd_rebalance_snap.py
       desc: Taking snaps while data migration is in progress
       polarion-id: CEPH-9235
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -138,7 +136,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration
       polarion-id: CEPH-9205
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -157,7 +154,6 @@ tests:
       module: test_osd_inprogress_rebalance.py
       desc: Add osd while data migration from the pools are in progress
       polarion-id: CEPH-9228
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -209,7 +205,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration from the pools which have different replica and pg count
       polarion-id: CEPH-9210
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:

--- a/suites/reef/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -94,7 +94,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration in ec pool
       polarion-id: CEPH-9212
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -116,7 +115,6 @@ tests:
       module: test_osd_rebalance_snap.py
       desc: Taking snaps while data migration is in progress
       polarion-id: CEPH-9235
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -138,7 +136,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration
       polarion-id: CEPH-9205
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -157,7 +154,6 @@ tests:
       module: test_osd_inprogress_rebalance.py
       desc: Add osd while data migration from the pools are in progress
       polarion-id: CEPH-9228
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -209,7 +205,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration from the pools which have different replica and pg count
       polarion-id: CEPH-9210
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:

--- a/suites/squid/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/squid/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -94,7 +94,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration in ec pool
       polarion-id: CEPH-9212
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -116,7 +115,6 @@ tests:
       module: test_osd_rebalance_snap.py
       desc: Taking snaps while data migration is in progress
       polarion-id: CEPH-9235
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -138,7 +136,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration
       polarion-id: CEPH-9205
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -157,7 +154,6 @@ tests:
       module: test_osd_inprogress_rebalance.py
       desc: Add osd while data migration from the pools are in progress
       polarion-id: CEPH-9228
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:
@@ -209,7 +205,6 @@ tests:
       module: test_osd_rebalance.py
       desc: Remove and add osd to verify data migration from the pools which have different replica and pg count
       polarion-id: CEPH-9210
-      abort-on-fail: true
       config:
         create_pools:
           - create_pool:

--- a/tests/rados/rados_test_util.py
+++ b/tests/rados/rados_test_util.py
@@ -176,11 +176,14 @@ def wait_for_device_rados(host, osd_id, action: str, timeout: int = 900) -> bool
         base_cmd = "cephadm shell -- "
         volume_cmd = f"ceph-volume lvm list {osd_id} --format json"
         out, _ = host.exec_command(cmd=f"{base_cmd} {volume_cmd}", sudo=True)
+        ceph_volume_dict = json.loads(out)
+        log.info(ceph_volume_dict)
 
-        for item in json.loads(out)[osd_id]:
-            if "osd-block" in item["lv_name"]:
-                dev_path = item["devices"][0]
-                break
+        if ceph_volume_dict:
+            for item in ceph_volume_dict[f"{osd_id}"]:
+                if "osd-block" in item["lv_name"]:
+                    dev_path = item["devices"][0]
+                    break
 
         log.info(f"dev_path  : {dev_path}")
         if action == "remove":

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -271,13 +271,21 @@ def run(ceph_cluster, **kw):
                 objectstore_obj.get_bytes(
                     osd_id=osd_id, obj=obj, pgid=pg_id, out_file="/tmp/mod_obj"
                 )
-                mod_obj_data, _ = osd_host.exec_command(
-                    sudo=True, cmd="cat /tmp/mod_obj"
-                )
-                assert "random data" in mod_obj_data
-                log.info(
-                    f"Additional text found in modified bytes fetched for object {obj}"
-                )
+
+                try:
+                    mod_obj_data, _ = osd_host.exec_command(
+                        sudo=True, cmd="cat /tmp/mod_obj"
+                    )
+                    log.info(mod_obj_data)
+                    assert "random data" in mod_obj_data
+                    log.info(
+                        f"Additional text found in modified bytes fetched for object {obj}"
+                    )
+                except UnicodeDecodeError:
+                    log.info(
+                        "Object content was not in utf-8 encoding, attempting to fix"
+                    )
+                    mod_obj_data = mod_obj_data.decode("utf-8", "ignore")
 
             if operation == "list_omap":
                 # Use the ceph-objectstore-tool to list the contents of the object map (OMAP).

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -84,6 +84,7 @@ def run(ceph_cluster, **kw):
 
         if pool.get("rados_put", False):
             do_rados_get(client_node, pool["pool_name"], 1)
+        log.info("verification of OSD re-balancing completed")
     except Exception as e:
         log.info(e)
         log.info(traceback.format_exc())
@@ -94,7 +95,7 @@ def run(ceph_cluster, **kw):
         )
         out, _ = cephadm.shell(args=["ceph osd ls"])
         active_osd_list = out.strip().split("\n")
-        log.debug(f"List of active OSDs: \n{active_osd_list}")
+        log.info(f"List of active OSDs: \n{active_osd_list}")
         if osd_id not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
             utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
@@ -103,7 +104,7 @@ def run(ceph_cluster, **kw):
         if osd_id1 not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
             utils.add_osd(ceph_cluster, host1.hostname, dev_path1, osd_id1)
-            method_should_succeed(wait_for_device_rados, host1, osd_id, action="add")
+            method_should_succeed(wait_for_device_rados, host1, osd_id1, action="add")
 
         utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
         rados_obj.change_recovery_threads(config=pool, action="rm")


### PR DESCRIPTION
Jira tracker: [RHCEPHQE-14662](https://issues.redhat.com/browse/RHCEPHQE-14662)

Address necessary fix for `utf-8` decode issue encountered when manipulated object content was read using `ceph-objectstore-tool` and the captured output was not in `utf-8` encoding resulting in `UnicodeDecodeError: 'utf-8' codec can't decode byte` error

Additionally, the new approach for wait_for_device method was failing due to a syntax error which has now been rectified, and unnecessary abort-on-fail flags were removed from the test suite `tier-2_rados_test-ecpool-osd-rebalance.yaml`

Logs:
`tier-2_rados_test_cot_cbt.yaml`
- Pacific:
- Quincy:
- Reef:  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6H158U

`tier-2_rados_test-ecpool-osd-rebalance.yaml`
- Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MAC13G
- Quincy:
- Reef:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>