### PR TITLE
Alternative way to find root disk

### DIFF
--- a/pipeline/scripts/ci/server_setup_utils.sh
+++ b/pipeline/scripts/ci/server_setup_utils.sh
@@ -65,8 +65,7 @@ function wipe_drives {
     disks=$(sshpass -p ${password} ssh -q ${username}@${node} "lsblk -ndo name,type | awk '{print \$1\",\"\$2}'")
 
     # Find root disk device
-    root_disk=$(sshpass -p ${password} ssh ${username}@${node} 'eval $(lsblk -o PKNAME,MOUNTPOINT -P | grep "MOUNTPOINT=\"/\""); echo $PKNAME')
-
+    root_disk=$(sshpass -p ${password} ssh -q ${username}@${node} "sudo findmnt -v -n -T /boot -o SOURCE"
     if [ -z "${root_disk}" ]; then
         echo "ERR: Unable to find root disk on ${node}"
         exit 2
@@ -85,7 +84,7 @@ function wipe_drives {
 
       # shellcheck disable=SC2076
       # Skip wipefs for root, cd-rom.,etc disks
-      if [[ "${root_disk}" =~ "${name}" || "${type}" != "disk" ]]; then
+      if [[ "${root_disk}" =~ "/dev/${name}" || "${type}" != "disk" ]]; then
         echo "Skipping this disk :  disk - ${name} , type - ${type}"
         continue
       else


### PR DESCRIPTION
# Description

Alternative way to find root disk

```
[jenkins@magna006 cephci]$ bash pipeline/scripts/ci/reimage-octo-node.sh --platform 9.4 --nodes cali002
+ source pipeline/scripts/ci/server_setup_utils.sh
+ OS_VER=
+ NODES=
+ REIMAGE_CMD=/home/jenkins/.tthlg/bin/teuthology-reimage
++ getopt -o hn:p: --long platform:,nodes:,help -- --platform 9.4 --nodes cali002
+ CLI_OPTS=' --platform '\''9.4'\'' --nodes '\''cali002'\'' --'
+ '[' 0 '!=' 0 ']'
+ '[' 4 '!=' 4 ']'
+ eval set -- ' --platform '\''9.4'\'' --nodes '\''cali002'\'' --'
++ set -- --platform 9.4 --nodes cali002 --
+ true
+ case ${1} in
+ OS_VER=9.4
+ shift 2
+ true
+ case ${1} in
+ NODES=cali002
+ shift 2
+ true
+ case ${1} in
+ shift
+ break
+ echo 'Initiating reimage of nodes'
Initiating reimage of nodes
+ nodes_with_mismatch=()
+ for node in ${NODES}
+ echo 'Checking OS on cali002'
Checking OS on cali002
++ ssh ubuntu@cali002.ceph.redhat.com 'cat /etc/os-release | grep VERSION_ID'
++ awk -F '"' '{print $2}'
Warning: Permanently added 'cali002.ceph.redhat.com,10.8.130.2' (ECDSA) to the list of known hosts.
+ actual_os=9.4
+ '[' 9.4 '!=' 9.4 ']'
+ echo 'OS version matches on cali002: 9.4'
OS version matches on cali002: 9.4
+ echo -----------------------------------
-----------------------------------
+ '[' 0 -gt 0 ']'
+ failed_nodes=()
+ for node in ${NODES}
+ initial_setup cali002
+ local node=cali002
+ local password=passwd
+ ssh ubuntu@cali002 'echo "passwd" | sudo passwd --stdin root; \
  grep -qxF "PermitRootLogin yes" /etc/ssh/sshd_config || \
  echo "PermitRootLogin yes" | sudo tee -a /etc/ssh/sshd_config'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
Changing password for user root.
passwd: all authentication tokens updated successfully.
+ ssh ubuntu@cali002 'sudo systemctl restart sshd &'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ sleep 2
+ set_hostnames_repos cali002
+ local node=cali002
+ local username=root
+ local password=passwd
+ echo 'Setting the systems to use shortnames'
Setting the systems to use shortnames
+ sshpass -p passwd ssh root@cali002 'sudo hostnamectl set-hostname $(hostname -s)'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ sshpass -p passwd ssh root@cali002 'sudo sed -i "s/$(hostname)/$(hostname -s)/g" /etc/hosts'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ echo 'Cleaning default repo files to avoid conflicts'
Cleaning default repo files to avoid conflicts
+ sshpass -p passwd ssh root@cali002 'sudo rm -f /etc/yum.repos.d/*; sudo yum clean all'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use "rhc" or "subscription-manager" to register.

0 files removed
+ wipe_drives cali002
+ local node=cali002
+ local username=root
+ local password=passwd
+ echo 'Wipe all data disks clean.'
Wipe all data disks clean.
++ sshpass -p passwd ssh -q root@cali002 'lsblk -ndo name,type | awk '\''{print $1","$2}'\'''
+ disks='sda,disk
sdb,disk
sdc,disk
sdd,disk
sde,disk
sdf,disk
sdg,disk
nvme0n1,disk'
++ sshpass -p passwd ssh -q root@cali002 'findmnt -v -n -T / -o SOURCE '
+ root_disk=/dev/sdb3
+ '[' -z /dev/sdb3 ']'
++ echo /dev/sdb3
++ wc -l
+ '[' 1 '!=' 1 ']'
+ mapfile -t arr
++ printf '%s\n' 'sda,disk
sdb,disk
sdc,disk
sdd,disk
sde,disk
sdf,disk
sdg,disk
nvme0n1,disk'
+ for disk in ${arr[@]}
+ echo 'Device - sda,disk'
Device - sda,disk
+ IFS=,
+ read -r name type
+ echo 'name: sda, type: disk'
name: sda, type: disk
+ [[ /dev/sdb3 =~ /dev/sda ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/sda'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ for disk in ${arr[@]}
+ echo 'Device - sdb,disk'
Device - sdb,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdb, type: disk'
name: sdb, type: disk
+ [[ /dev/sdb3 =~ /dev/sdb ]]
+ echo 'Skipping this disk :  disk - sdb , type - disk'
Skipping this disk :  disk - sdb , type - disk
+ continue
+ for disk in ${arr[@]}
+ echo 'Device - sdc,disk'
Device - sdc,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdc, type: disk'
name: sdc, type: disk
+ [[ /dev/sdb3 =~ /dev/sdc ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/sdc'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ for disk in ${arr[@]}
+ echo 'Device - sdd,disk'
Device - sdd,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdd, type: disk'
name: sdd, type: disk
+ [[ /dev/sdb3 =~ /dev/sdd ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/sdd'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ for disk in ${arr[@]}
+ echo 'Device - sde,disk'
Device - sde,disk
+ IFS=,
+ read -r name type
+ echo 'name: sde, type: disk'
name: sde, type: disk
+ [[ /dev/sdb3 =~ /dev/sde ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/sde'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ for disk in ${arr[@]}
+ echo 'Device - sdf,disk'
Device - sdf,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdf, type: disk'
name: sdf, type: disk
+ [[ /dev/sdb3 =~ /dev/sdf ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/sdf'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ for disk in ${arr[@]}
+ echo 'Device - sdg,disk'
Device - sdg,disk
+ IFS=,
+ read -r name type
+ echo 'name: sdg, type: disk'
name: sdg, type: disk
+ [[ /dev/sdb3 =~ /dev/sdg ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/sdg'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ for disk in ${arr[@]}
+ echo 'Device - nvme0n1,disk'
Device - nvme0n1,disk
+ IFS=,
+ read -r name type
+ echo 'name: nvme0n1, type: disk'
name: nvme0n1, type: disk
+ [[ /dev/sdb3 =~ /dev/nvme0n1 ]]
+ [[ disk != \d\i\s\k ]]
+ sshpass -p passwd ssh root@cali002 'wipefs -a --force /dev/nvme0n1'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
+ reboot_node cali002
+ local node=cali002
+ local username=root
+ local password=passwd
+ echo 'Cleaning default repo files to avoid conflicts'
Cleaning default repo files to avoid conflicts
+ for node in ${NODES}
+ wait_for_node cali002
+ local node=cali002
+ local username=root
+ local password=passwd
+ local max_attempts=10
+ local wait_time=60
+ echo 'Waiting for node cali002 to come back online...'
Waiting for node cali002 to come back online...
+ (( attempt=1 ))
+ (( attempt<=max_attempts ))
+ ping -c 1 cali002
+ echo 'Node cali002 is online'
Node cali002 is online
+ return 0
++ verify_disk cali002
++ local node=cali002
++ local username=root
++ local password=passwd
++ echo 'Verifying wipefs on cali002'
+++ sshpass -p passwd ssh root@cali002 'sudo lsblk -o name,fstype'
Warning: Permanently added 'cali002,10.8.130.2' (ECDSA) to the list of known hosts.
++ output='NAME    FSTYPE
sda
sdb
├─sdb1  ext4
├─sdb2  swap
└─sdb3  ext4
sdc
sdd
sde
sdf
sdg
nvme0n1 '
++ echo 'ouput of lsblk NAME    FSTYPE
sda
sdb
├─sdb1  ext4
├─sdb2  swap
└─sdb3  ext4
sdc
sdd
sde
sdf
sdg
nvme0n1 '
++ read -r line
+++ echo 'NAME    FSTYPE'
+++ awk '{print $2}'
++ [[ ! -z FSTYPE ]]
++ echo true
++ return
+ output='Verifying wipefs on cali002
ouput of lsblk NAME    FSTYPE
sda
sdb
├─sdb1  ext4
├─sdb2  swap
└─sdb3  ext4
sdc
sdd
sde
sdf
sdg
nvme0n1
true'
+ [[ Verifying wipefs on cali002
ouput of lsblk NAME    FSTYPE
sda
sdb
├─sdb1  ext4
├─sdb2  swap
└─sdb3  ext4
sdc
sdd
sde
sdf
sdg
nvme0n1
true == true ]]
+ retry_count=0
+ '[' 0 -gt 0 ']'
+ [[ 0 -gt 0 ]]

```