### PR TITLE
TFA: Remove verify-io, as MS test cases are checked via a sync-status

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -362,7 +362,6 @@ tests:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
-            verify-io-on-site: ["ceph-sec"]
 
   - test:
       name: bucket granular sync policy on bucket with flow directional and storage class

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -371,7 +371,6 @@ tests:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
-            verify-io-on-site: ["ceph-sec"]
   - test:
       clusters:
         ceph-pri:

--- a/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -357,7 +357,6 @@ tests:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
-            verify-io-on-site: ["ceph-sec"]
 
   - test:
       name: bucket granular sync policy on bucket with flow directional and storage class

--- a/suites/squid/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/squid/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -271,7 +271,6 @@ tests:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
             timeout: 300
-            verify-io-on-site: ["ceph-pri"]
   - test:
       name: Test DBR reshard list and cancel command on secondary
       desc: Test DBR reshard list and cancel command on secondary


### PR DESCRIPTION
TFA: Removing verify-io, since MS test cases are checked via a sync-status in ceph-qe-script
https://issues.redhat.com/browse/RHCEPHQE-14824