### PR TITLE
Adding retry for getting standby_reply mds

### DIFF
--- a/conf/baremetal/mero1_1admin_4node_4client.yaml
+++ b/conf/baremetal/mero1_1admin_4node_4client.yaml
@@ -16,6 +16,7 @@ globals:
             - mgr
             - rgw
             - osd
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda
@@ -40,6 +41,7 @@ globals:
             - mon
             - osd
             - _admin
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda
@@ -63,6 +65,7 @@ globals:
             - mon
             - mgr
             - osd-bak
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda
@@ -88,6 +91,7 @@ globals:
             - alertmanager
             - grafana
             - prometheus
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda

--- a/conf/baremetal/mero2_1admin_4node_4client.yaml
+++ b/conf/baremetal/mero2_1admin_4node_4client.yaml
@@ -16,6 +16,7 @@ globals:
             - mon
             - mgr
             - rgw
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda
@@ -41,6 +42,7 @@ globals:
             - osd
             - mds
             - _admin
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda
@@ -64,6 +66,7 @@ globals:
             - mon
             - mgr
             - osd-bak
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda
@@ -89,6 +92,7 @@ globals:
             - alertmanager
             - grafana
             - prometheus
+            - nfs
           root_password: passwd
           volumes:
             - /dev/sda


### PR DESCRIPTION
# Description
Adding retry for getting standby_reply mds

MDS is taking time to move to standby_replay mode.
so added retry mechanism around it.

Failed logs : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-194/cephfs/49/tier-3_cephfs_bugs/validate_standby_reply_node_not_removed_after_setting_mds_inject_health_dummy_0.log

Passed logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UJX5PG/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
