### PR TITLE
cephci integration: CEPH-83573543: Verify lifecycle removes all the n…

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -220,3 +220,13 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_1k_bucket.yaml
         timeout: 300
+
+  - test:
+      name: Test non-current deletion via s3cmd
+      desc: Test non-current deletion via s3cmd
+      polarion-id: CEPH-83573543
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_lifecycle_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
+        timeout: 300

--- a/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
@@ -110,6 +110,16 @@ tests:
       name: configure client
 
   - test:
+      name: Test non-current deletion via s3cmd
+      desc: Test non-current deletion via s3cmd
+      polarion-id: CEPH-83573543
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_lifecycle_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
+        timeout: 300
+
+  - test:
       name: Bucket Lifecycle expiration of incomplete multipart
       desc: Bucket Lifecycle expiration of incomplete multipart
       polarion-id: CEPH-11195

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -85,6 +85,16 @@ tests:
         timeout: 300
 
   - test:
+      name: Test non-current deletion via s3cmd
+      desc: Test non-current deletion via s3cmd
+      polarion-id: CEPH-83573543
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_lifecycle_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
+        timeout: 300
+
+  - test:
       name: Bucket Lifecycle expiration of incomplete multipart
       desc: Bucket Lifecycle expiration of incomplete multipart
       polarion-id: CEPH-11195

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -85,6 +85,16 @@ tests:
         timeout: 300
 
   - test:
+      name: Test non-current deletion via s3cmd
+      desc: Test non-current deletion via s3cmd
+      polarion-id: CEPH-83573543
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_lifecycle_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
+        timeout: 300
+
+  - test:
       name: Bucket Lifecycle expiration of incomplete multipart
       desc: Bucket Lifecycle expiration of incomplete multipart
       polarion-id: CEPH-11195


### PR DESCRIPTION
…on-current objects, while the current object is removed via s3cmd

cephci integration: CEPH-83573543: Verify lifecycle removes all the non-current objects, while the current object is removed via s3cmd

log: 
[Uploading Test_non-current_deletion_via_s3cmd_0.log…]()


dependent on ceph-qe-script PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/602

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
