### PR TITLE
[TestFix][TFA] Fix node reboot test scenario

### DIFF
--- a/tests/cephadm/test_verify_cluster_health_after_reboot.py
+++ b/tests/cephadm/test_verify_cluster_health_after_reboot.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from ceph.waiter import WaitUntil
 from cli.cephadm.cephadm import CephAdm
 from cli.utilities.utils import get_service_id, reboot_node, set_service_state
@@ -46,6 +48,9 @@ def run(ceph_cluster, **kw):
                 raise ClusterNotHealthy(
                     f"Ceph cluster not healthy after rebooting {node.hostname}"
                 )
+        # Adding an explicit delay, because sudden reboots are causing the cluster Health to
+        # HEALTH WARN state.
+        sleep(30)
 
     elif action == "service-state":
         # Get the SERVICE_ID of the mon service


### PR DESCRIPTION
Problem:
The cluster goes to health warn when the node reboot scenario was tested. The scenario included rebooting all the nodes and see if the cluster is healthy and is not going to the bad or warn state. But after few node restarts, we could see the cluster going to bad state

Reason:
The reason behind this behaviour is due to sudden reboots, as the code reboots a node immediately after the previous node is up and cluster check is done.

Solution:
Add an explicit timeout before every node reboot. This has resolved the issue

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
