### PR TITLE
NVMe Baremetal pipeline fix 

### DIFF
--- a/pipeline/scripts/ci/server_setup_utils.sh
+++ b/pipeline/scripts/ci/server_setup_utils.sh
@@ -116,7 +116,8 @@ function set_hostnames_repos {
   local username="${2:-root}"
   local password="${3:-passwd}"
   echo 'Setting the systems to use shortnames'
-  sshpass -p ${password} ssh ${username}@${node} 'sudo hostnamectl set-hostname $(hostname -s)'
+  sshpass -p ${password} ssh ${username}@${node} "sudo hostnamectl set-hostname ${node}"
+  sshpass -p ${password} ssh ${username}@${node} "sudo echo ${node} > /etc/hostname"
   sshpass -p ${password} ssh ${username}@${node} 'sudo sed -i "s/$(hostname)/$(hostname -s)/g" /etc/hosts'
 
   echo 'Cleaning default repo files to avoid conflicts'

--- a/suites/reef/baremetal/deploy/rh/nvme_cali_1admin_6node_2client.yaml
+++ b/suites/reef/baremetal/deploy/rh/nvme_cali_1admin_6node_2client.yaml
@@ -134,7 +134,7 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 2G
+              size: 20G
               lb_group: node7
             listener_port: 4420
             listeners:
@@ -145,7 +145,7 @@ tests:
             serial: 2
             bdevs:
             - count: 2
-              size: 2G
+              size: 20G
               lb_group: node8
             listener_port: 4420
             listeners:

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -27,7 +27,11 @@ class NVMeInitiator(Initiator):
         )
         out = json.loads(out)["blockdevices"]
         uuids = sorted(
-            [i["wwn"].removeprefix("uuid.") for i in out if i["wwn"] is not None]
+            [
+                i["wwn"].removeprefix("uuid.")
+                for i in out
+                if i.get("wwn", "").startswith("uuid.")
+            ]
         )
         LOG.debug(f"[ {self.node.hostname} ] LSBLK UUIds : {log_json_dump(out)}")
         return uuids


### PR DESCRIPTION
# Description

**Two issues,**
- NVMe Devices validation failure against which are exposed in initiator as NVMeoF disks had a issue of consuming all SSD disks for list the of UUIDs, Now its specifically picks the right NVMe-Over-TCP disks to validate against the Ceph NVMe subsystem namespaces.
```
Issue:
-------
2024-06-17 06:13:36,445 (cephci.test_ceph_nvmeof_high_availability) [INFO] - cephci.RH.7.1.rhel-9.Baremetal.18.2.1-194.nvmeotcp.25.cephci.tests.nvmeof.workflows.ha.py:424 - Expcted NVMe Targets : ['63558a83-25d9-4b37-9fae-691398307dcf', '0751a5e8-6816-4e57-a9f7-7101c1a3c399', '39e7fd08-e1b5-4f99-b811-591882611364', 'e1547f03-1747-4110-aac3-879bfff6af8c'] Vs LSBLK devices: ['0751a5e8-6816-4e57-a9f7-7101c1a3c399', '0x6f4ee08005fa300029709b3d99379c61', '0x6f4ee08005fa300029709b409e3860ba', '0x6f4ee08005fa300029709b45a34f8e3a', '0x6f4ee08005fa300029709b48a87a0b24', '0x6f4ee08005fa300029709b4cadcb674b', '0x6f4ee08005fa300029709b4fb32bed04', '0x6f4ee08005fa300029709b53b8974232', '39e7fd08-e1b5-4f99-b811-591882611364', '63558a83-25d9-4b37-9fae-691398307dcf', 'e1547f03-1747-4110-aac3-879bfff6af8c', 'eui.00000000000000008ce38ee20a24a001']


Solution:
---------
>>> out = subprocess.getoutput("lsblk -I 8,259 -o name,wwn --json")
>>> out = json.loads(out)["blockdevices"]
>>> [i["wwn"].removeprefix("uuid.") for i in out if i.get("wwn", "").startswith("uuid.")]
[]
>>> out.append({"name": "nvme2n1", "wwn": "uuid.12345667890"})
>>> [i["wwn"].removeprefix("uuid.") for i in out if i.get("wwn", "").startswith("uuid.")]
['12345667890']
```
-   Issue in the hostnames, where host had multiple hostnames set in the run.
