### PR TITLE
[RADOS] TFA fix for osd_memory_target, enhancements to CBT-COT workflow

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3680,3 +3680,35 @@ class RadosOrchestrator:
                 if entry["daemon_type"] == daemon_type:
                     mgr_node_list.append(host_name)
         return mgr_node_list
+
+    def get_active_osd_list(self) -> list:
+        """
+        Method to fetch list of OSDs which are UP and IN
+        Returns:
+            List of active OSDs
+        """
+        down_osd_list = out_osd_list = []
+        total_list = self.run_ceph_command(cmd="ceph osd ls")
+        log.info(f"ceph osd ls output: {total_list}")
+
+        # prepare list of OSDs which are down
+        down_osd_tree = self.run_ceph_command(cmd="ceph osd tree down")
+        if down_osd_tree["nodes"]:
+            for entry in down_osd_tree["nodes"]:
+                if entry["type"] == "osd":
+                    down_osd_list.append(entry["id"])
+        log.info(f"List of down OSDs: {down_osd_list}")
+
+        # prepare list of OSDs which are out
+        out_osd_tree = self.run_ceph_command(cmd="ceph osd tree out")
+        if out_osd_tree["nodes"]:
+            for entry in out_osd_tree["nodes"]:
+                if entry["type"] == "osd":
+                    out_osd_list.append(entry["id"])
+        log.info(f"List of out OSDs: {out_osd_list}")
+
+        exclude_list = list(set(down_osd_list + out_osd_list))
+        if exclude_list:
+            [total_list.remove(i) for i in exclude_list]
+
+        return total_list

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -48,10 +48,10 @@ def run(ceph_cluster, **kw):
     bluestore_obj = BluestoreToolWorkflows(node=cephadm)
     client = ceph_cluster.get_nodes(role="client")[0]
 
-    out, _ = cephadm.shell(args=["ceph osd ls"])
-    osd_list = out.strip().split("\n")
-
     try:
+        osd_list = rados_obj.get_active_osd_list()
+        log.info(f"List of OSDs: \n{osd_list}")
+
         if config.get("non-collocated"):
             log.info(
                 "\n\n Execution begins for CBT non-collocated scenarios ************ \n\n"

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -43,10 +43,6 @@ def run(ceph_cluster, **kw):
     pool_obj = PoolFunctions(node=cephadm)
     objectstore_obj = objectstoreToolWorkflows(node=cephadm)
 
-    out, _ = cephadm.shell(args=["ceph osd ls"])
-    osd_list = out.strip().split("\n")
-    log.debug(f"List of OSDs: \n{osd_list}")
-
     def get_bench_obj(_osd_id):
         out = objectstore_obj.list_objects(osd_id=_osd_id)
         obj_list = [json.loads(x) for x in out.split()]
@@ -94,6 +90,9 @@ def run(ceph_cluster, **kw):
     ]
     operations = config.get("operations", all_ops)
     try:
+        osd_list = rados_obj.get_active_osd_list()
+        log.info(f"List of OSDs: \n{osd_list}")
+
         log.info("Create a data pool with default config")
         assert rados_obj.create_pool(pool_name="cot-pool")
 


### PR DESCRIPTION
Jira trackers:
- [RHCEPHQE-14829](https://issues.redhat.com/browse/RHCEPHQE-14829): `osd_memory_target` tests started failing as we moved to larger sized deployment where `osd_memory_target` was already determined by the cluster at host level, this interfered with the existing workflow as the precedence of `osd_memory_target` defined at host level sit between OSD and daemon level
To fix this we are no expecting the value of `osd_memory_target` set at OSD level to take over the one defined at host level

Determined order of precedence:
osd_memory_target at OSD level ->>  osd_memory_target at host level ->> osd_memory_target at individual daemon level(osd.0)

- [RHCEPHQE-14833](https://issues.redhat.com/browse/RHCEPHQE-14833): COT tests where failing because of a product bug which caused failure in preceding test that resulted in one OSD getting corrupted. If the same OSD was being used to run any of the COT command in the next test, if would error our consequently.
To fix this we are now fetching the list of only up and active OSDs instead of fetching all the OSDs part of the crush map, this would eliminate possibility of false failures

Logs:
`suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml`
- Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MM6ODK/
- Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-O96GDS/
- Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VY12EI

`tier-2_rados_test_cot_cbt.yaml`
- Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-67XNQE
- Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F325JI
- Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-XPKCKN

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

