### PR TITLE
Automation of the Bug#2249003 verification that  the crashes on a non omap pool

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -162,6 +162,9 @@ tests:
       module: test_omap_entries.py
       polarion-id: CEPH-83571702
       config:
+        crash_config:
+          # Pool created to  verify the Bug#2249003
+          pool_name: re_pool_crash
         # EC pool config is commented out because omaps can be written only on RE pools
         omap_config:
           small_omap:

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -162,6 +162,9 @@ tests:
       module: test_omap_entries.py
       polarion-id: CEPH-83571702
       config:
+        crash_config:
+          # Pool created to  verify the Bug#2249003
+          pool_name: re_pool_crash
         # EC pool config is commented out because omaps can be written only on RE pools
         omap_config:
           small_omap:

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -178,6 +178,9 @@ tests:
       module: test_omap_entries.py
       polarion-id: CEPH-83571702
       config:
+        # Pool created to  verify the Bug#2249003
+        crash_config:
+          pool_name: re_pool_crash
         # EC pool config is commented out because omaps can be written only on RE pools
         omap_config:
           small_omap:


### PR DESCRIPTION
# Description

Automation of the verification steps of the BUG#2249003

Issue : Observing client.admin crash in thread_name 'rados' on executing 'rados clearomap' for a rados pool different than the one where the object is present.

Verification step:
   perform the 'rados clearomap' over a non omap pool and check the crashes.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
