### PR TITLE
Integrate the list bucket marker test to cephCI

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -206,6 +206,16 @@ tests:
         timeout: 500
 
   - test:
+      name: Test bucket listing with markers on versioned bucket
+      desc: Test bucket listing with markers on versioned bucket
+      polarion-id: CEPH-83572736
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_aws.py
+        config-file-name: ../../aws/configs/test_versioned_list_marker.yaml
+        timeout: 500
+
+  - test:
       name: Test LDAP auth for RGW
       desc: Test LDAP auth for RGW
       polarion-id: CEPH-9793

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -206,6 +206,16 @@ tests:
         timeout: 500
 
   - test:
+      name: Test bucket listing with markers on versioned bucket
+      desc: Test bucket listing with markers on versioned bucket
+      polarion-id: CEPH-83572736
+      module: sanity_rgw.py
+      config:
+        script-name: ../aws/test_aws.py
+        config-file-name: ../../aws/configs/test_versioned_list_marker.yaml
+        timeout: 500
+
+  - test:
       name: Test LDAP auth for RGW
       desc: Test LDAP auth for RGW
       polarion-id: CEPH-9793


### PR DESCRIPTION
On a versioned bucket with multiple objects, if a marker is passed to list objects , the list should return objects after the marker , and should not include the marker entry.

Tracker : http://tracker.ceph.com/issues/21500
