### PR TITLE
Adding test to failover and failback using power off and power on nodes

### DIFF
--- a/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -1,5 +1,5 @@
 # Basic Ceph-NvmeoF sanity Test suite
-# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_ha_cluster_4nodes.yaml
 # inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
@@ -590,3 +590,92 @@ tests:
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 4-GW HA 4-sub n-1 node fail parallel
       polarion-id: CEPH-83589021
+
+# 4GW HA 4-subsystems node Failover and failback using power off|on
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node8
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: power_on_off
+            nodes:
+              - node8
+          - tool: power_on_off
+            nodes:
+              - node7
+      desc: 4GW HA 4-subsystems Failover and failback using node power on off
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub fail using node power on off
+      polarion-id: CEPH-83589012

--- a/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -1,5 +1,5 @@
 # Basic Ceph-NvmeoF sanity Test suite
-# cluster configuration file: conf/squid/nvmeof/ceph_nvmeof_sanity.yaml
+# cluster configuration file: conf/reef/nvmeof/ceph_nvmeof_ha_cluster_4nodes.yaml
 # inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
 
 tests:
@@ -95,16 +95,16 @@ tests:
             serial: 1
             bdevs:
             - count: 2
-              size: 2G
+              size: 5G
               lb_group: node6
             - count: 2
-              size: 2G
+              size: 5G
               lb_group: node7
             - count: 2
-              size: 2G
+              size: 5G
               lb_group: node8
             - count: 2
-              size: 2G
+              size: 5G
               lb_group: node9
             listener_port: 4420
             listeners:
@@ -120,6 +120,8 @@ tests:
         fault-injection-methods:                # Failure induction
           - tool: systemctl
             nodes: node7
+          - tool: systemctl
+            nodes: node9
       desc: 4GW HA test Single subsystem systemctl Failure
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
@@ -204,11 +206,13 @@ tests:
         fault-injection-methods:                # Failure induction
           - tool: daemon
             nodes: node7
+          - tool: daemon
+            nodes: node8
       desc: 4GW HA test 4 subsystes Single daemon Failure
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: NVMeoF 4-GW HA test Single failure with daemon failure
-      polarion-id: CEPH-83589016
+      polarion-id: CEPH-83589010
 
 # 4GW HA Single-sub multinode Failover and failback parallely via ceph orchestrator daemon
   - test:
@@ -261,68 +265,15 @@ tests:
             nodes:
               - node7
               - node9
+          - tool: daemon
+            nodes:
+              - node6
+              - node8
       desc: Single-sub multinode Failover-failback via ceph daemon orchestrator
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: NVMeoF 4-GW Test HA multinode fail parallel via orchestrator
       polarion-id: CEPH-83589019
-
-# 4GW HA Single-sub multinode Failover and failback parallely
-  - test:
-      abort-on-fail: true
-      config:
-        rbd_pool: rbd
-        do_not_create_image: true
-        rep-pool-only: true
-        rep_pool_config:
-          pool: rbd
-        install: true                           # Run SPDK with all pre-requisites
-        cleanup:
-          - pool
-          - gateway
-          - initiators
-        gw_nodes:
-          - node6
-          - node7
-          - node8
-          - node9
-        subsystems:                             # Configure subsystems with all sub-entities
-          - nqn: nqn.2016-06.io.spdk:cnode1
-            serial: 1
-            bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
-            listener_port: 4420
-            listeners:
-              - node6
-              - node7
-              - node8
-              - node9
-            allow_host: "*"
-        initiators:                             # Configure Initiators with all pre-req
-          - nqn: connect-all
-            listener_port: 4420
-            node: node10
-        fault-injection-methods:                # Failure induction
-          - tool: systemctl
-            nodes:
-              - node7
-              - node9
-      desc: 4GW HA Single-sub multinode Failover and failback parallely
-      destroy-cluster: false
-      module: test_ceph_nvmeof_high_availability.py
-      name: Test NVMeoF 4-GW HA multinode fail parallel
-      polarion-id:
 
   # 4GW Multi node sequential failover-failback
   - test:
@@ -383,7 +334,7 @@ tests:
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 4-GW HA multi node sequential failure
-      polarion-id:
+      polarion-id: CEPH-83591997
 
 # 4GW HA 2-subsystems multinode Failover and failback parallely
   - test:
@@ -446,11 +397,15 @@ tests:
             nodes:
               - node6
               - node9
+          - tool: systemctl
+            nodes:
+              - node7
+              - node8
       desc: 4GW HA 2-subsystems multinode Failover and failback parallely
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 4-GW HA 2-sub multinode fail parallel
-      polarion-id:
+      polarion-id: CEPH-83591996
 
 # 4GW HA 4-subsystems multinode Failover and failback parallely
   - test:
@@ -533,8 +488,194 @@ tests:
             nodes:
               - node8
               - node7
+          - tool: systemctl
+            nodes:
+              - node9
+              - node6
       desc: 4GW HA 4-subsystems multinode Failover and failback parallely
       destroy-cluster: false
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 4-GW HA 4-sub multinode fail parallel
-      polarion-id:
+      polarion-id: CEPH-83591995
+
+# 4GW HA 4-subsystems multinode Failover and failback parallely
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node8
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes:
+              - node6
+              - node8
+              - node7
+          - tool: daemon
+            nodes:
+              - node6
+              - node8
+              - node9
+      desc: 4GW HA 4-subsystems multinode Failover and failback parallely
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub n-1 node fail parallel
+      polarion-id: CEPH-83589021
+
+# 4GW HA 4-subsystems node Failover and failback using power off|on
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node8
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: power_on_off
+            nodes:
+              - node8
+          - tool: power_on_off
+            nodes:
+              - node7
+      desc: 4GW HA 4-subsystems Failover and failback using node power on off
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub fail using node power on off
+      polarion-id: CEPH-83589012


### PR DESCRIPTION
Adding automation for NVMe HA failover and failback using power off and power on nodes for test case - https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83589012

Success Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U5NV9Y/
