### PR TITLE
Added pool cleanup for RBD and RBD mirror related tests

### DIFF
--- a/tests/rbd_mirror/test_11489.py
+++ b/tests/rbd_mirror/test_11489.py
@@ -93,9 +93,11 @@ def run(**kw):
                     return 1
                 time.sleep(10)
 
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_9470.py
+++ b/tests/rbd_mirror/test_9470.py
@@ -38,12 +38,14 @@ def test_9470(rbd_mirror, pool_type, **kw):
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror1.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
 
 def run(**kw):

--- a/tests/rbd_mirror/test_9471.py
+++ b/tests/rbd_mirror/test_9471.py
@@ -40,12 +40,14 @@ def test_9471(rbd_mirror, pool_type, **kw):
         mirror1.promote(imagespec=imagespec)
         mirror1.benchwrite(imagespec=imagespec, io=config[pool_type].get("io_total"))
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
-    return 1
+        return 1
+
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
 
 def run(**kw):

--- a/tests/rbd_mirror/test_9474.py
+++ b/tests/rbd_mirror/test_9474.py
@@ -27,12 +27,14 @@ def test_9474(rbd_mirror, pool_type, **kw):
             p.spawn(hard_reboot, osd_cred, name="ceph-rbd2")
         time.sleep(60)
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
 
 def run(**kw):

--- a/tests/rbd_mirror/test_9475.py
+++ b/tests/rbd_mirror/test_9475.py
@@ -32,12 +32,14 @@ def test_9475(rbd_mirror, pool_type, **kw):
             )
         time.sleep(30)
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[pool])
         return 0
 
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
 
 def run(**kw):

--- a/tests/rbd_mirror/test_expand_or_shrink_img_at_secondary.py
+++ b/tests/rbd_mirror/test_expand_or_shrink_img_at_secondary.py
@@ -61,15 +61,16 @@ def test_expand_or_shrink_img_at_secondary(rbd_mirror, pool_type, **kw):
             )
             p.spawn(mirror2.resize_image, imagespec=imagespec, size=size)
 
+        if flag:
+            log.error("Expanding secondary image did not fail as expected")
     except IOonSecondaryError:
         log.info("Expanding secondary image has failed as expected")
         flag = 0
 
-    if flag:
-        log.error("Expanding secondary image did not fail as expected")
+    finally:
+        mirror1.delete_image(imagespec)
+        mirror1.clean_up(peercluster=mirror2, pools=[pool])
 
-    mirror1.delete_image(imagespec)
-    mirror1.clean_up(peercluster=mirror2, pools=[pool])
     return flag
 
 

--- a/tests/rbd_mirror/test_rbd_clone_mirror.py
+++ b/tests/rbd_mirror/test_rbd_clone_mirror.py
@@ -69,6 +69,7 @@ def run(**kw):
             image_name=clone1,
             clone_version="v2",
         )
+
         # enable journal based mirroring for pool mode
         mirror1, mirror2 = [
             rbdmirror.RbdMirror(cluster, config)
@@ -103,7 +104,6 @@ def run(**kw):
         mirror1.delete_image(imagespec1)
         mirror1.delete_image(imagespec2)
         mirror1.delete_image(imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
         return 0
 
     except ValueError as ve:
@@ -114,3 +114,5 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_rbd_mirror.py
+++ b/tests/rbd_mirror/test_rbd_mirror.py
@@ -54,7 +54,6 @@ def run(**kw):
         mirror1.wait_for_status(imagespec=imagespec, state_pattern="up+stopped")
         mirror2.wait_for_status(imagespec=imagespec, state_pattern="up+replaying")
         mirror1.check_data(peercluster=mirror2, imagespec=imagespec)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
         return 0
 
     except ValueError as ve:
@@ -65,3 +64,5 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+    finally:
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_rbd_mirror_image.py
+++ b/tests/rbd_mirror/test_rbd_mirror_image.py
@@ -86,9 +86,6 @@ def run(**kw):
         mirror1.mirror_snapshot_schedule_remove(
             poolname=poolname, imagename=imagename_1
         )
-        # Cleans up the configuration
-        mirror1.delete_image(imagespec_1)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
         return 0
 
     except ValueError as ve:
@@ -99,3 +96,8 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        # Cleans up the configuration
+        mirror1.delete_image(imagespec_1)
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_rbd_mirror_rename_image.py
+++ b/tests/rbd_mirror/test_rbd_mirror_rename_image.py
@@ -53,10 +53,6 @@ def run(**kw):
         time.sleep(30)
         out2 = mirror2.exec_cmd(cmd=f"rbd info {poolname}/rename_image")
         log.info(out2)
-
-        # Cleans up the configuration
-        mirror1.delete_image(f"{poolname}/rename_image")
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
         return 0
 
     except ValueError as ve:
@@ -67,3 +63,8 @@ def run(**kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        # Cleans up the configuration
+        mirror1.delete_image(f"{poolname}/rename_image")
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])

--- a/tests/rbd_mirror/test_rbd_mirror_snapshot.py
+++ b/tests/rbd_mirror/test_rbd_mirror_snapshot.py
@@ -109,10 +109,6 @@ def test_snapshot_schedule(rbd_mirror, pool_type, **kw):
                 poolname=poolname, imagename=imagename_2
             )
 
-        # Cleans up the configuration
-        mirror1.delete_image(imagespec)
-        mirror1.delete_image(imagespec_2)
-        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
         return 0
 
     except ValueError as ve:
@@ -124,6 +120,12 @@ def test_snapshot_schedule(rbd_mirror, pool_type, **kw):
     except Exception as e:
         log.exception(e)
         return 1
+
+    finally:
+        # Cleans up the configuration
+        mirror1.delete_image(imagespec)
+        mirror1.delete_image(imagespec_2)
+        mirror1.clean_up(peercluster=mirror2, pools=[poolname])
 
 
 def run(**kw):


### PR DESCRIPTION
# Description
Some of the RBD and RBD mirror test suites execution keep the pool as it is without proper cleanup of test pools
hence added pool cleanup methods in `finally` clause of test which doesn't exist.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
