### PR TITLE
adding configs for sse_s3 also in install_vault and integrating notif_transition, curl multipart upload test cases

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
@@ -183,6 +183,16 @@ tests:
         timeout: 500
 
   - test:
+      name: Test rgw multipart upload through curl
+      desc: Test rgw multipart upload through curl
+      polarion-id: CEPH-9801
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
+        timeout: 500
+
+  - test:
       name: Test rgw put bucket website with users of same and different tenant
       desc: Test rgw put bucket website with users of same and different tenant
       polarion-id: CEPH-11148

--- a/suites/reef/rgw/sanity_rgw.yaml
+++ b/suites/reef/rgw/sanity_rgw.yaml
@@ -131,6 +131,17 @@ tests:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
         timeout: 500
+
+  - test:
+      name: Test rgw multipart upload through curl
+      desc: Test rgw multipart upload through curl
+      polarion-id: CEPH-9801
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
+        timeout: 500
+
   - test:
       name: Test rename of large object using sts user through AWS
       desc: Test rename of large object using sts user through AWS

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -330,6 +330,31 @@ tests:
         timeout: 300
 
   - test:
+      name: notify on lifecycle transition events
+      desc: notify on lifecycle transition events
+      polarion-id: CEPH-83591037
+      module: sanity_rgw.py
+      comments: Known issue BZ-2282699, fails below 7.1
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_transition_notifications.yaml
+
+        timeout: 300
+
+  - test:
+      name: notify on lifecycle transition events with multipart objects
+      desc: notify on lifecycle transition events with multipart objects
+      polarion-id: CEPH-83591037
+      module: sanity_rgw.py
+      comments: Known issue BZ-2282699, fails below 7.1
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_multipart_transition_notifications.yaml
+        timeout: 300
+
+  - test:
       name: check-ceph-health
       module: exec.py
       config:

--- a/suites/squid/rgw/sanity_rgw.yaml
+++ b/suites/squid/rgw/sanity_rgw.yaml
@@ -132,6 +132,15 @@ tests:
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
         timeout: 500
   - test:
+      name: Test rgw multipart upload through curl
+      desc: Test rgw multipart upload through curl
+      polarion-id: CEPH-9801
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
+        timeout: 500
+  - test:
       name: Test rename of large object using sts user through AWS
       desc: Test rename of large object using sts user through AWS
       polarion-id: CEPH-83575419

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -330,6 +330,31 @@ tests:
         timeout: 300
 
   - test:
+      name: notify on lifecycle transition events
+      desc: notify on lifecycle transition events
+      polarion-id: CEPH-83591037
+      module: sanity_rgw.py
+      comments: Known issue BZ-2282699
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_transition_notifications.yaml
+
+        timeout: 300
+
+  - test:
+      name: notify on lifecycle transition events with multipart objects
+      desc: notify on lifecycle transition events with multipart objects
+      polarion-id: CEPH-83591037
+      module: sanity_rgw.py
+      comments: Known issue BZ-2282699
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_rule_multipart_transition_notifications.yaml
+        timeout: 300
+
+  - test:
       name: check-ceph-health
       module: exec.py
       config:

--- a/tests/misc_env/install_vault.py
+++ b/tests/misc_env/install_vault.py
@@ -294,17 +294,24 @@ def _configure_rgw_daemons(node: CephNode, config: Dict) -> None:
         ("rgw_crypt_s3_kms_backend", "vault"),
         ("rgw_crypt_vault_secret_engine", config["agent"]["engine"]),
         ("rgw_crypt_vault_auth", config["agent"]["auth"]),
+        ("rgw_crypt_sse_s3_backend", "vault"),
+        ("rgw_crypt_sse_s3_vault_secret_engine", config["agent"]["engine"]),
+        ("rgw_crypt_sse_s3_vault_auth", config["agent"]["auth"]),
     ]
 
     if config["agent"]["auth"] == "token":
         configs += [
             ("rgw_crypt_vault_token_file", config["agent"]["token_file"]),
             ("rgw_crypt_vault_addr", config["url"]),
+            ("rgw_crypt_sse_s3_vault_token_file", config["agent"]["token_file"]),
+            ("rgw_crypt_sse_s3_vault_addr", config["url"]),
         ]
     else:
         configs += [
             ("rgw_crypt_vault_prefix", config["agent"]["prefix"]),
             ("rgw_crypt_vault_addr", "http://127.0.0.1:8100"),
+            ("rgw_crypt_sse_s3_vault_prefix", config["agent"]["prefix"]),
+            ("rgw_crypt_sse_s3_vault_addr", "http://127.0.0.1:8100"),
         ]
 
     for daemon in rgw_daemons:


### PR DESCRIPTION
adding configs for sse_s3 also in install_vault and integrating notif_transition, curl multipart upload test cases
sse_s3 tests in s3 tests failed because of not setting vault configs explicitly for sse_s3
fail log: http://magna002.ceph.redhat.com/cephci-jenkins/test-runs/18.2.1-126/Weekly/rgw/34/tier-2_ssl_rgw_ecpool_test/execute_s3tests_0.log

ceph-qe-scripts PR's:
https://github.com/red-hat-storage/ceph-qe-scripts/pull/589
https://github.com/red-hat-storage/ceph-qe-scripts/pull/596

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
