### PR TITLE
Adding CBT support

### DIFF
--- a/cli/io/cbt/cbt.py
+++ b/cli/io/cbt/cbt.py
@@ -1,0 +1,129 @@
+import copy
+
+import yaml
+
+from cli import Cli
+from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster
+
+log = Log(__name__)
+
+
+class CbtError(Exception):
+    pass
+
+
+class CBT(Cli):
+    """
+    CBT class inherits from Cli and initializes connection parameters for a specific server and table.
+
+    Attributes:
+        primary_client (object): The primary client instance.
+        archive_path (str): path for storing the results.
+                            Please provide the path where user has permissions to create directories
+    """
+
+    def __init__(self, primary_client, archive_path="~/cephCI/cbt/"):
+        """
+        Initialize the CBT class.
+
+        """
+        super(CBT, self).__init__(primary_client)
+        self.primary_client = primary_client
+        self.archive_path = archive_path
+        self.setup_CBT()
+
+    def setup_CBT(self):
+        """
+        Set up the CBT environment on the primary client.
+
+        This includes enabling EPEL repository, uploading setup script,
+        executing the setup script, and retrieving the Ceph version.
+        """
+        self.enable_epel()
+        self.primary_client.upload_file(
+            src="cli/io/cbt/setup_cbt.sh", dst="setup_cbt.sh"
+        )
+        self.execute(cmd="bash setup_cbt.sh")
+        self.ceph_version = get_ceph_version_from_cluster(self.primary_client)
+
+    def collect_cluster_conf(self, mon_node, mon_ip, osd_nodes):
+        """
+        Collect and store the cluster configuration details.
+
+        Args:
+            mon_node (str): The monitor node hostname.
+            mon_ip (str): The monitor node IP address.
+            osd_nodes (list): List of OSD nodes.
+        """
+        self.placeholders = {
+            "head_placeholder": f"{self.primary_client.node.hostname}",
+            "client_placeholder": f"{self.primary_client.node.hostname}",
+            "osd_nodes": f"{osd_nodes}",
+            "mon_placeholder": f"{mon_node}",
+            "ip_placeholder": f"{mon_ip}",
+            "port_placeholder": "6789",
+        }
+        log.info(self.placeholders)
+        # Temporary assignment of mons
+        self.placeholders["mon_list"] = "{mon_list}"
+
+    def prepare_cbt_conf(self):
+        """
+        Prepare the CBT configuration file.
+
+        Reads the template configuration file, formats it with placeholders,
+        and updates it with the monitor node list.
+        """
+        with open("cli/io/cbt/conf.yaml", "r") as cbt_conf:
+            self.cbt_conf = cbt_conf.read()
+        cbt_conf_content = self.cbt_conf.format(**self.placeholders)
+        self.conf_yaml = yaml.safe_load(cbt_conf_content)
+        mon_list = {
+            f"{self.placeholders['mon_placeholder']}": {
+                "a": f"{self.placeholders['ip_placeholder']}:{self.placeholders['port_placeholder']}"
+            }
+        }
+        self.conf_yaml["cluster"]["mons"] = mon_list
+
+    def execute_cbt(self, benchmarks, benchmark_name):
+        """
+        Execute the CBT benchmark.
+
+        Args:
+            benchmarks (dict): Benchmark configurations.
+            benchmark_name (str): Name of the benchmark to execute.
+        """
+        conf_yaml_copy = copy.deepcopy(self.conf_yaml)
+        conf_yaml_copy.update(benchmarks)
+        self.benchmark_name = benchmark_name
+        log.info(f"{conf_yaml_copy}")
+        with open(f"{benchmark_name}.yaml", "w") as yaml_file:
+            yaml.dump(conf_yaml_copy, yaml_file, default_flow_style=False)
+        self.primary_client.upload_file(
+            src=f"{benchmark_name}.yaml", dst=f"{benchmark_name}.yaml"
+        )
+        self.execute(
+            cmd=f".venv/bin/python cbt/cbt.py --archive={self.archive_path}{self.benchmark_name} "
+            f"--conf=/etc/ceph/ceph.conf {benchmark_name}.yaml",
+            long_running=True,
+        )
+
+    def enable_epel(self):
+        """
+        Enable the Extra Packages for Enterprise Linux (EPEL) repository.
+
+        Determines the appropriate EPEL repository URL based on the primary client's OS version
+        and installs the EPEL repository.
+        """
+        EPEL_REPOS = {
+            "8": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
+            "9": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+        }
+
+        # Epel Repo
+        self.execute(
+            sudo=True,
+            cmd=f"dnf install {EPEL_REPOS[self.primary_client.distro_info['VERSION_ID'][0]]} -y",
+            check_ec=False,
+        )

--- a/cli/io/cbt/conf.yaml
+++ b/cli/io/cbt/conf.yaml
@@ -1,0 +1,24 @@
+cluster:
+  user: 'cephuser'
+  is_teuthology: True
+  head: "{head_placeholder}"
+  clients: ["{client_placeholder}"]
+  osds: {osd_nodes}
+  mons: {mon_list}
+  osds_per_node: 1
+  fs: 'xfs'
+  mkfs_opts: '-f -i size=2048'
+  mount_opts: '-o inode64,noatime,logbsize=256k'
+  conf_file: '/etc/ceph/ceph.conf'
+  rbd_cmd: 'sudo /usr/bin/rbd'
+  ceph_cmd: 'sudo /usr/bin/ceph'
+  iterations: 1
+  use_existing: True
+  clusterid: "ceph"
+  tmp_dir: "/tmp/cbt"
+  pool_profiles:
+    rbd:
+      pg_size: 256
+      pgp_size: 256
+      replication: 3
+

--- a/cli/io/cbt/setup_cbt.sh
+++ b/cli/io/cbt/setup_cbt.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone https://github.com/ceph/cbt.git
+sudo yum install blktrace perf valgrind fio pdsh pdsh-rcmd-ssh ceph-common -y
+python3 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r cbt/requirements.txt

--- a/tests/cephfs/cephfs_cbt.py
+++ b/tests/cephfs/cephfs_cbt.py
@@ -1,0 +1,41 @@
+import random
+import string
+import traceback
+
+from cli.io.cbt.cbt import CBT
+from tests.cephfs.cephfs_utilsV1 import FsUtils
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    try:
+        log.info(f"MetaData Information {log.metadata} in {__name__}")
+        fs_util = FsUtils(ceph_cluster)
+        config = kw.get("config")
+        build = config.get("build", config.get("rhbuild"))
+        clients = ceph_cluster.get_ceph_objects("client")
+        installer = ceph_cluster.get_ceph_objects("installer")
+        fs_util.prepare_clients(clients, build)
+        fs_util.auth_list(clients)
+        mon = ceph_cluster.get_ceph_objects("mon")
+        osds = ceph_cluster.get_nodes("osd")
+        osd_list = [osd.hostname for osd in osds]
+        benchmarks = config.get("cbt_benchmarks")
+        a = CBT(installer[0])
+        a.collect_cluster_conf(mon[0].node.hostname, mon[0].node.ip_address, osd_list)
+        a.prepare_cbt_conf()
+        characters = string.ascii_letters + string.digits
+        # Generate a random string
+        random_string = "".join(random.choice(characters) for _ in range(8))
+        a.execute_cbt(benchmarks, config.get("benchmark_name", random_string))
+
+        return 0
+
+    except Exception as e:
+        log.info(e)
+        log.info(traceback.format_exc())
+        return 1
+    finally:
+        pass


### PR DESCRIPTION
# Description
Adding CBT support.

This PR introduces support for executing the CBT(ceph Benchmarking Tool) on downstream clusters using cephci

Doc : https://docs.google.com/document/d/1NDw2D1lvBLB2g9aJV_l9AOEgSOzFcPWwEml5gd884Lo/edit#heading=h.b6ta3nrbuqy
Latest Logs(11-JUL) : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DEJSIG/


Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8MVEB3/

Latest Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BJP8PO/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
