### PR TITLE
Re-enable d3n testcases in baremetal

### DIFF
--- a/suites/reef/rgw/sanity_rgw.yaml
+++ b/suites/reef/rgw/sanity_rgw.yaml
@@ -322,16 +322,16 @@ tests:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
         timeout: 500
-#  - test:
-#      name: D3n-cache enable
-#      desc: D3n-cache enable
-#      module: sanity_rgw.py
-#      polarion-id: CEPH-83575567
-#      config:
-#        script-name: test_d3n_cache.py
-#        config-file-name: test_d3n_cache_enable.yaml
-#        timeout: 500
-#        run-on-rgw: true
+  - test:
+      name: D3n-cache enable
+      desc: D3n-cache enable
+      module: sanity_rgw.py
+      polarion-id: CEPH-83575567
+      config:
+        script-name: test_d3n_cache.py
+        config-file-name: test_d3n_cache_enable.yaml
+        timeout: 500
+        run-on-rgw: true
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
       desc: Test GetBucketLocation bucket policy for users in same tenant

--- a/suites/squid/rgw/sanity_rgw.yaml
+++ b/suites/squid/rgw/sanity_rgw.yaml
@@ -322,16 +322,16 @@ tests:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
         timeout: 500
-#  - test:
-#      name: D3n-cache enable
-#      desc: D3n-cache enable
-#      module: sanity_rgw.py
-#      polarion-id: CEPH-83575567
-#      config:
-#        script-name: test_d3n_cache.py
-#        config-file-name: test_d3n_cache_enable.yaml
-#        timeout: 500
-#        run-on-rgw: true
+  - test:
+      name: D3n-cache enable
+      desc: D3n-cache enable
+      module: sanity_rgw.py
+      polarion-id: CEPH-83575567
+      config:
+        script-name: test_d3n_cache.py
+        config-file-name: test_d3n_cache_enable.yaml
+        timeout: 500
+        run-on-rgw: true
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
       desc: Test GetBucketLocation bucket policy for users in same tenant


### PR DESCRIPTION
# Description

Re enable d3n testcases in bare-metal execution, with fixes provided in
PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/600

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
