### PR TITLE
Fixing client failures in BM config

### DIFF
--- a/tests/cephfs/cephfs_bugs/test_client_blocklist_large_session_metadata.py
+++ b/tests/cephfs/cephfs_bugs/test_client_blocklist_large_session_metadata.py
@@ -72,17 +72,26 @@ def run(ceph_cluster, **kw):
         if "10000" not in out.strip():
             log.error("mds_max_completed_requests could not be set 10000")
             return 1
-        mds = fs_util.get_active_mdss(clients[0], fs_name)[0]
-        for mds_node in mds_nodes:
-            log.info(mds_node.node.hostname)
-            if mds_node.node.hostname in mds:
-                log.info("Get the mdthresh_evicted ceph mds perf cntr value")
-                mds_daemon = f"mds.{mds}"
-                out, rc = mds_node.exec_command(
-                    sudo=True,
-                    cmd=f"cephadm shell ceph daemon {mds_daemon} perf dump | grep mdthresh_evicted",
-                )
-                mds_perf_out = out.strip().split("\n")
+        mds = fs_util.get_active_mdss(clients[0], fs_name)
+        mds_active_node = ceph_cluster.get_node_by_hostname(mds[0].split(".")[1])
+        log.info("Get the mdthresh_evicted ceph mds perf cntr value")
+        mds_daemon = f"mds.{mds[0]}"
+        out, rc = mds_active_node.exec_command(
+            sudo=True,
+            cmd=f"cephadm shell ceph daemon {mds_daemon} perf dump | grep mdthresh_evicted",
+        )
+        mds_perf_out = out.strip().split("\n")
+
+        # for mds_node in mds_nodes:
+        #     log.info(mds_node.node.hostname)
+        #     if mds_node.node.hostname in mds:
+        #         log.info("Get the mdthresh_evicted ceph mds perf cntr value")
+        #         mds_daemon = f"mds.{mds}"
+        #         out, rc = mds_active_node.exec_command(
+        #             sudo=True,
+        #             cmd=f"cephadm shell ceph daemon {mds_daemon} perf dump | grep mdthresh_evicted",
+        #         )
+        #         mds_perf_out = out.strip().split("\n")
         mdthresh_evicted_before = mds_perf_out[0].split(":")[1]
         log.info(f"mdthresh_evicted_before:{mdthresh_evicted_before}")
         subvolume = {

--- a/tests/cephfs/clients/client_fstab_auto_mount.py
+++ b/tests/cephfs/clients/client_fstab_auto_mount.py
@@ -335,7 +335,7 @@ def run(ceph_cluster, **kw):
             for mds in fs_util_v1.mdss:
                 FsUtilsV1.deamon_op(mds, rf"mds\.{fs_name}\.", "restart")
             for mds in fs_util_v1.mdss:
-                FsUtilsV1.check_deamon_status(mds, "mds", "active")
+                FsUtilsV1.check_deamon_status(mds, rf"mds\.{fs_name}\.", "active")
         else:
             rc = fs_util.client_clean_up(
                 client_info["fuse_clients"], "", client_info["mounting_dir"], "umount"
@@ -351,7 +351,7 @@ def run(ceph_cluster, **kw):
             for mds in fs_util_v1.mdss:
                 FsUtilsV1.deamon_op(mds, rf"mds\.{fs_name}\.", "restart")
             for mds in fs_util_v1.mdss:
-                FsUtilsV1.check_deamon_status(mds, "mds", "active")
+                FsUtilsV1.check_deamon_status(mds, rf"mds\.{fs_name}\.", "active")
 
         log.info("Execution of Test cases CEPH-%s ended:" % (tc))
         print("Script execution time:------")

--- a/tests/cephfs/clients/mds_conf_modifying.py
+++ b/tests/cephfs/clients/mds_conf_modifying.py
@@ -226,7 +226,7 @@ def set_balance_automate_and_validate(client):
         "balance_automate"
     ]
 
-    if default_balance_automate_value.lower() != "false":
+    if str(default_balance_automate_value).lower() != "false":
         log.error(
             f"balance automate values is expected to be disabled by default.\n "
             f"but the value is {default_balance_automate_value}"
@@ -239,7 +239,7 @@ def set_balance_automate_and_validate(client):
     json_data = json.loads(out)
     balance_automate = json_data["mdsmap"]["flags_state"]["balance_automate"]
 
-    if balance_automate != "true":
+    if str(balance_automate).lower() != "true":
         log.error(
             f"balance automate values is unable to set to True.\n "
             f"and the current value is {balance_automate}"
@@ -252,7 +252,7 @@ def set_balance_automate_and_validate(client):
     out, rc = client.exec_command(sudo=True, cmd="ceph fs get cephfs -f json")
     json_data = json.loads(out)
     balance_automate = json_data["mdsmap"]["flags_state"]["balance_automate"]
-    if balance_automate.lower() != "false":
+    if str(balance_automate).lower() != "false":
         log.error(
             f"balance automate values is unable to set to default value.\n "
             f"but the value is {balance_automate}"


### PR DESCRIPTION
# Description
Fixing client failures in BM config

Failed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-H6LYJ9/
Passed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZUHDTH/

We are seeing 3 socket timeouts

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
