### PR TITLE
Automate CEPH-83581754

### DIFF
--- a/ceph/nvmegw_cli/namespace.py
+++ b/ceph/nvmegw_cli/namespace.py
@@ -1,5 +1,3 @@
-import re
-
 from ceph.nvmegw_cli.execute import ExecuteCommandMixin
 
 
@@ -10,14 +8,6 @@ class Namespace(ExecuteCommandMixin):
 
     def set_qos(self, **kwargs):
         """Set QoS for namespace."""
-        subsystem = kwargs.get("args", {}).get("subsystem")
-        _, namespaces = self.list(args={"subsystem": subsystem})
-
-        pattern = r"\│\s*(\d+)\s*│"
-        nsid = [int(match) for match in re.findall(pattern, namespaces)]
-
-        kwargs.setdefault("args", {}).update({"nsid": nsid[0]})
-
         return self.run_nvme_cli("set_qos", **kwargs)
 
     def add(self, **kwargs):

--- a/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -132,6 +132,47 @@ tests:
       name: Basic E2E-Test Ceph NVMEoF GW sanity test collocated with OSD node
       polarion-id: CEPH-83575442
 
+# Perform QoS while IO is running between Targets
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+          - disconnect_all
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5002
+            allow_host: "*"
+        initiators:                            # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode2
+            listener_port: 5002
+            node: node10
+        namespaces:
+          - command: set_qos
+            args:
+              nsid: 1
+              rw-ios-per-second: 10
+              subsystem: nqn.2016-06.io.spdk:cnode2
+      desc: Perform QoS while IO is running between Targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Perform QoS while IO is running between Targets
+      polarion-id: CEPH-83581754
+
 #  GW deployment collocation with Mon_MGR nodes
   - test:
       abort-on-fail: true

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -3,6 +3,7 @@ Test suite that verifies the deployment of Ceph NVMeoF Gateway
  with supported entities like subsystems , etc.,
 
 """
+
 import json
 from copy import deepcopy
 
@@ -298,7 +299,10 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             with parallel() as p:
                 for initiator in config["initiators"]:
                     p.spawn(initiators, ceph_cluster, nvmegwcli, initiator)
-
+                    if config.get("namespaces"):
+                        for qos_args in config["namespaces"]:
+                            if qos_args["command"] == "set_qos":
+                                p.spawn(nvmegwcli.namespace.set_qos, **qos_args)
         return 0
     except Exception as err:
         LOG.error(err)


### PR DESCRIPTION
# Description

https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581754

Configure NVMe initiators and NVMe targets with namespaces mapped with bdevs.
Run IO between Initiators and targets.
While IO is in progress, check if we can set QoS for a created namespace in subsystem having all mandatory args.

loglink: http://magna002.ceph.redhat.com/cephci-jenkins/harika/cephci-run-8FYM3Z/


<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
