### PR TITLE
Adding ceph log collection for failed test suites

### DIFF
--- a/cephci/cluster_info.py
+++ b/cephci/cluster_info.py
@@ -29,14 +29,15 @@ Utility to gather cluster information
     Usage:
        cephci/cluster_info.py (--reuse <FILE>)
            (--output <YAML>)
-           (--ceph-logs <true/false>)
+           (--ceph-logs <BOOL>)
 
        cephci/cluster_info.py --help
 
     Options:
-       -h --help        Help
-       --reuse <FILE>   Use the stored vm state for rerun
-       --output <YAML>  Create file with cluster info collected
+       -h --help            Help
+       --reuse <FILE>       Use the stored vm state for rerun
+       --output <YAML>      Create file with cluster info collected
+       --ceph-logs <BOOL>     Collect ceph logs? True or False.
 """
 
 
@@ -169,6 +170,8 @@ def get_ceph_var_logs(cluster, log_dir):
         download_dir = os.path.join(log_dir, "ceph_logs", node.hostname)
         os.makedirs(download_dir, exist_ok=True)
         file_attributes = node.get_listdir_attr(dir_path=CEPH_VAR_LOG_DIR, sudo=True)
+        if not file_attributes:
+            continue
         for attribute in file_attributes:
             if S_ISDIR(attribute.st_mode):
                 os.makedirs(
@@ -218,11 +221,11 @@ if __name__ == "__main__":
     # Collect cluster information
     _dict, _info = _load_cluster_config(config), {}
     for name in _dict:
+        if ceph_logs in ["true", True]:
+            get_ceph_var_logs(_dict.get(name), output)
+
         _info = gather_info(_dict.get(name))
 
         # Write data to stream
         _output = os.path.join(output, f"cluster_info_{name}.yaml")
         write_output(_info, _output)
-
-        if ceph_logs:
-            get_ceph_var_logs(_dict.get(name), output)

--- a/run.py
+++ b/run.py
@@ -32,6 +32,7 @@ from ceph.utils import (
     create_ceph_nodes,
     create_ibmc_ceph_nodes,
 )
+from cephci.cluster_info import get_ceph_var_logs
 from cli.performance.memory_and_cpu_utils import (
     start_logging_processes,
     stop_logging_process,
@@ -1006,6 +1007,7 @@ def run(args):
         for cluster in ceph_cluster_dict.keys():
             installer = ceph_cluster_dict[cluster].get_nodes(role="installer")[0]
             sosreport.run(installer.ip_address, "cephuser", "cephuser", run_dir)
+            get_ceph_var_logs(ceph_cluster_dict[cluster], run_dir)
         log.info(f"Generated sosreports location : {url_base}/sosreports\n")
 
     return jenkins_rc


### PR DESCRIPTION
# Description

Adding ceph log collection for failed test suites.
Also fixed https://issues.redhat.com/browse/RHCEPHQE-14963

http://10.70.46.85:8080/job/qe-reef-sanity-openstack/44/console
http://10.70.46.85:8080/job/qe-reef-sanity-openstack/45/console
http://10.70.46.85:8080/job/qe-reef-sanity-openstack/47/console
http://10.70.46.85:8080/job/qe-reef-sanity-openstack/49/console