### PR TITLE
TFA fix for cg_snap_interop_workflow_2

### DIFF
--- a/tests/cephfs/snapshot_clone/cg_snap_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_test.py
@@ -2249,6 +2249,7 @@ def cg_snap_interop_2(cg_test_params):
         for qs_member in qs_set:
             if "/" in qs_member:
                 group_name, subvol_name = re.split("/", qs_member)
+                cmd = f"ceph fs subvolume getpath {fs_name} {subvol_name} {group_name}"
                 subvol_dict.update(
                     {subvol_name: {"group_name": group_name, "mount_point": ""}}
                 )


### PR DESCRIPTION
# Description

JIRA: https://issues.redhat.com/browse/RHCEPHQE-15221
Fix description: getpath cmd for non-default subvolgroup was missing during mount section of script code.
so getpath cmd of default group was being all used all times, hence the script failure. This is been addressed with fix.

Passed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OIJGSH

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
