### PR TITLE
[LibFix] Add cluster info and ceph logs to results page

### DIFF
--- a/run.py
+++ b/run.py
@@ -647,6 +647,7 @@ def run(args):
                 "total_time": total_time,
                 "info": info,
                 "send_to_cephci": send_to_cephci,
+                "prefix": instances_name,
             }
             email_results(test_result=test_res)
             return 1
@@ -701,6 +702,7 @@ def run(args):
         "run_id": run_id,
     }
     download_path = run_dir if not log_directory else log_directory
+    cluster_info = []
 
     for test in tests:
         test = test.get("test")
@@ -725,6 +727,10 @@ def run(args):
         start = datetime.datetime.now()
 
         for cluster_name in test.get("clusters", ceph_cluster_dict):
+            # Add cluster names
+            if cluster_name not in cluster_info:
+                cluster_info.append(cluster_name)
+
             # If Performance and CPU usage monitoring is enabled, perform pre-reqs
             if enable_perf_mon:
                 if not upload_mem_and_cpu_logger_script(
@@ -996,6 +1002,8 @@ def run(args):
         "total_time": total_time,
         "info": info,
         "send_to_cephci": send_to_cephci,
+        "cluster_info": cluster_info,
+        "prefix": instances_name,
     }
 
     email_results(test_result=test_res)

--- a/templates/result-email-template.html
+++ b/templates/result-email-template.html
@@ -69,6 +69,20 @@
             <th style="color: blue">Compose</th>
             <td>{{ test_results[0]['compose-id'] }}</td>
         </tr>
+        {% if cluster_info %}
+            <tr>
+                <th style="color: blue">Cluster Configuration</th>
+                <td>
+                    {% for info in cluster_info %}
+                        <a style="color: blue;" href="./cluster_info_{{ info }}.yaml">{{ info }}</a>,
+                    {% endfor %}
+                </td>
+            </tr>
+        {% endif %}
+        <tr>
+            <th style="color: blue">Cluster Logs</th>
+            <td><a style="color: blue;" href="./ceph_logs">{{ prefix }}</a></td>
+        </tr>
         <tr>
             <th style="color: blue">Results</th>
             <td>{{ log_link }}</td>

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1074,7 +1074,6 @@ def email_results(test_result):
 
     Returns: None
     """
-
     try:
         run_id = test_result["run_id"]
         results_list = test_result["result"]
@@ -1169,9 +1168,13 @@ def create_html_file(test_result) -> str:
         suite_run_time = test_result["total_time"]
         info = test_result["info"]
         test_results = test_result["result"]
+        prefix = test_result["prefix"]
     except KeyError as kerr:
         log.error(f"Key not found : {kerr}")
         exit(1)
+
+    # Check for cluster info
+    cluster_info = test_result.get("cluster_info", None)
 
     # we are checking for /ceph/cephci-jenkins to see if the magna is already mounted
     # on system we are executing
@@ -1198,6 +1201,8 @@ def create_html_file(test_result) -> str:
         trigger_user=trigger_user,
         info=info,
         use_abs_log_link=True,
+        prefix=prefix,
+        cluster_info=cluster_info,
     )
 
     # Result.html file is stored in the folder containing the log files.
@@ -1211,6 +1216,8 @@ def create_html_file(test_result) -> str:
         trigger_user=trigger_user,
         info=info,
         use_abs_log_link=False,
+        cluster_info=cluster_info,
+        prefix=prefix,
     )
 
     abs_path = os.path.join(run_dir, "index.html")


### PR DESCRIPTION
Add below changes to update `index.html` -

1. Cluster Configuration - Path to cluster configuration file
2. Cluster Logs - Path to ceph cluster node logs

Example -
![image](https://github.com/red-hat-storage/cephci/assets/41667569/5bf0d1fc-b5e3-4cdb-ad2e-1ac915d0c615)