### PR TITLE
[TFA-issue-fix] Deployment failure issue with migrate default ss to ms

### DIFF
--- a/conf/reef/rgw/migrate_default_single_to_multisite.yaml
+++ b/conf/reef/rgw/migrate_default_single_to_multisite.yaml
@@ -22,6 +22,7 @@ globals:
         role:
           - mon
           - osd
+          - rgw
 
       node4:
         disk-size: 20
@@ -41,7 +42,6 @@ globals:
       node6:
         role:
           - client
-          - rgw
 
   - ceph-cluster:
       name: ceph-sec
@@ -66,6 +66,7 @@ globals:
         role:
           - mon
           - osd
+          - rgw
 
       node4:
         disk-size: 20
@@ -85,4 +86,3 @@ globals:
       node6:
         role:
           - client
-          - rgw

--- a/conf/squid/rgw/migrate_default_single_to_multisite.yaml
+++ b/conf/squid/rgw/migrate_default_single_to_multisite.yaml
@@ -22,6 +22,7 @@ globals:
         role:
           - mon
           - osd
+          - rgw
 
       node4:
         disk-size: 20
@@ -41,7 +42,6 @@ globals:
       node6:
         role:
           - client
-          - rgw
 
   - ceph-cluster:
       name: ceph-sec
@@ -66,6 +66,7 @@ globals:
         role:
           - mon
           - osd
+          - rgw
 
       node4:
         disk-size: 20
@@ -85,4 +86,3 @@ globals:
       node6:
         role:
           - client
-          - rgw

--- a/suites/reef/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/reef/rgw/migrate_default_single_to_multisite.yaml
@@ -57,7 +57,7 @@ tests:
                       nodes:
                         - node5
                         - node4
-                        - node6
+                        - node3
         ceph-sec:
           config:
             verify_cluster_health: true
@@ -104,7 +104,7 @@ tests:
                       nodes:
                         - node5
                         - node4
-                        - node6
+                        - node3
       desc: RHCS cluster deployment using cephadm.
       polarion-id: CEPH-83575222
       destroy-cluster: false
@@ -147,7 +147,7 @@ tests:
             rgw_endpoints:
               - node4:80
               - node5:80
-              - node6:80
+              - node3:80
         ceph-pri:
           config:
             haproxy_clients:
@@ -155,7 +155,7 @@ tests:
             rgw_endpoints:
               - node4:80
               - node5:80
-              - node6:80
+              - node3:80
 
       desc: "Configure HAproxy"
       module: haproxy.py

--- a/suites/squid/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/squid/rgw/migrate_default_single_to_multisite.yaml
@@ -57,7 +57,7 @@ tests:
                       nodes:
                         - node5
                         - node4
-                        - node6
+                        - node3
         ceph-sec:
           config:
             verify_cluster_health: true
@@ -104,7 +104,7 @@ tests:
                       nodes:
                         - node5
                         - node4
-                        - node6
+                        - node3
       desc: RHCS cluster deployment using cephadm.
       polarion-id: CEPH-83575222
       destroy-cluster: false
@@ -148,7 +148,7 @@ tests:
             rgw_endpoints:
               - node4:80
               - node5:80
-              - node6:80
+              - node3:80
         ceph-pri:
           config:
             haproxy_clients:
@@ -156,7 +156,7 @@ tests:
             rgw_endpoints:
               - node4:80
               - node5:80
-              - node6:80
+              - node3:80
 
       desc: "Configure HAproxy"
       module: haproxy.py


### PR DESCRIPTION
# Description
pass log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-13TSNV/

issue: https://issues.redhat.com/browse/RHCEPHQE-15239
Weekly ceph version: 18.2.1-219
https://reportportal-ocs3.apps.ocp-c1.prod.psi.redhat.com/ui/#rhcs/launches/all/3011
[RH][7.1][rhel-9][openstack][rgw] Weekly Test Run #15
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-219/rgw/48/

 migrate_default_single_to_multisite --> Error EINVAL: Cannot place <RGWSpec for service_name=rgw.rgw.default> on ceph-pri-weekly-joi41j-rj401m-node6: Unknown hosts

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
