### PR TITLE
Fix Build issue at Readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,7 @@ python:
    - requirements: docs/requirements.txt
 
 build:
+  os: ubuntu-22.04
   apt_packages:
     - libcurl4-openssl-dev
     - libssl-dev

--- a/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway_sub_scale.py
@@ -179,7 +179,7 @@ def execute_and_log_results(node):
         "cat /proc/meminfo | grep -iE 'hugepage|^mem|swap'",
         "cat /proc/cpuinfo | grep -iE 'cpu'",
         "ps -eo pid,ppid,cmd,comm,%mem,%cpu --sort=-%mem | head -20",
-        "top -n 1 | grep -iE '^tasks|^mib|reactor|^%cpu|python'",
+        "top -b | head -n 20",
     ]
     for cmd in commands:
         output, _ = node.installer.exec_command(cmd, sudo=True)


### PR DESCRIPTION
# Description
- **`Config validation error in build.os. Value os not found`**
- Minor issue fixed in scale module.
<img width="1296" alt="image" src="https://github.com/red-hat-storage/cephci/assets/31158377/6b1fc819-8357-4aa2-8f8a-cc56615fcbd2">

