### PR TITLE
NVMeoF b2b upgrade test suite

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -13,12 +13,13 @@ from cli.utilities.configure import setup_ibm_licence
 from utility.log import Log
 
 from .bootstrap import BootstrapMixin
+from .registry_login import RegistryLoginMixin
 from .shell import ShellMixin
 
 logger = Log(__name__)
 
 
-class CephAdmin(BootstrapMixin, ShellMixin):
+class CephAdmin(BootstrapMixin, ShellMixin, RegistryLoginMixin):
     """
     Ceph administrator base class which enables ceph pre-requisites
     and Inherits HostMixin and BootstrapMixin classes to support

--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -138,32 +138,50 @@ class CephAdmin(BootstrapMixin, ShellMixin):
             for node in self.cluster.get_nodes():
                 node.exec_command(sudo=True, cmd=cmd)
 
-    def set_cdn_tool_repo(self):
+    def set_cdn_tool_repo(self, release=None):
         """
         Enable the cdn Tools repo on all ceph node.
-        """
-        rh_build = self.config.get("rhbuild", "6.0-rhel-9")
-        os_major_version = rh_build.split("-")[-1]
 
-        if rh_build.startswith("7"):
-            cdn_repo = {
-                "9": "rhceph-7-tools-for-rhel-9-x86_64-rpms",
-            }
-        elif rh_build.startswith("6"):
-            cdn_repo = {
-                "9": "rhceph-6-tools-for-rhel-9-x86_64-rpms",
-            }
-        elif rh_build.startswith("5"):
-            cdn_repo = {
+        Args:
+            release (Str): Ceph Release Version (default: None)
+        """
+        rh_cdn_repos = {
+            "7": {"9": "rhceph-7-tools-for-rhel-9-x86_64-rpms"},
+            "6": {"9": "rhceph-6-tools-for-rhel-9-x86_64-rpms"},
+            "5": {
                 "8": "rhceph-5-tools-for-rhel-8-x86_64-rpms",
                 "9": "rhceph-5-tools-for-rhel-9-x86_64-rpms",
-            }
-        else:
-            raise Exception(f"Unsupported version {rh_build}")
+            },
+        }
+        ibm_cdn_repos = {
+            "7": {
+                "9": "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-7-rhel-9.repo"
+            },
+            "6": {
+                "9": "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-6-rhel-9.repo"
+            },
+            "5": {
+                "9": "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-5-rhel-9.repo",
+                "8": "https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/ibm-storage-ceph-5-rhel-8.repo",
+            },
+        }
 
-        cmd = f"subscription-manager repos --enable={cdn_repo[os_major_version]}"
+        rh_build = self.config.get("rhbuild", "7.1-rhel-9")
+        _release = rh_build[0]
+        if release:
+            _release = release[0]
+        os_major_version = rh_build.split("-")[-1]
+        ibm_build = self.config.get("ibm_build")
+
+        if ibm_build:
+            repo = ibm_cdn_repos[_release][os_major_version]
+        else:
+            repo = rh_cdn_repos[_release][os_major_version]
 
         for node in self.cluster.get_nodes(ignore="client"):
+            cmd = f"subscription-manager repos --enable={repo}"
+            if ibm_build:
+                cmd = f"yum-config-manager --add-repo {repo}"
             node.exec_command(sudo=True, cmd=cmd)
 
     def setup_upstream_repository(self, repo_url=None):

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -230,10 +230,10 @@ class BootstrapMixin:
             #       used in the CI test modules.
             #       The `set_cdn_tool_repo` should be taken out, once
             #       we have upstream build with all necessary pkg sources.
-            self.set_cdn_tool_repo()
+            self.set_cdn_tool_repo(_rhcs_version)
         elif build_type == "released" or custom_repo.lower() == "cdn":
             custom_image = False
-            self.set_cdn_tool_repo()
+            self.set_cdn_tool_repo(_rhcs_version)
             self.cluster.use_cdn = True
         elif custom_repo:
             self.set_tool_repo(repo=custom_repo)

--- a/ceph/ceph_admin/registry_login.py
+++ b/ceph/ceph_admin/registry_login.py
@@ -1,0 +1,61 @@
+"""Cephadm registry login CLI Command."""
+from copy import deepcopy
+from typing import Dict
+
+from utility.log import Log
+
+from .common import config_dict_to_string
+from .typing_ import CephAdmProtocol
+
+LOG = Log(__name__)
+BASE_CMD = ["cephadm"]
+
+
+class RegistryLoginMixin:
+    """Cephadm registry-login CLI."""
+
+    def registry_login(
+        self: CephAdmProtocol,
+        node,
+        args: Dict = None,
+        base_cmd_args: Dict = None,
+        check_status: bool = True,
+        timeout: int = 600,
+        long_running: bool = False,
+    ):
+        """
+        Cephadm registry login command.
+
+         To store registry credentials under /etc/ceph/podman-auth.json
+
+        Args:
+            args (Dict): registry-login command options
+            base_cmd_args (Dict)): cephadm base command options
+            check_status (Bool): check command status
+            timeout (Int): Maximum time allowed for execution.
+            long_running (Bool): Long running command (default: False)
+
+        Returns:
+            out (Str), err (Str) stdout and stderr response
+            rc (Int) exit status code if long_running command
+
+        """
+        cmd = deepcopy(BASE_CMD)
+
+        if base_cmd_args:
+            cmd.append(config_dict_to_string(base_cmd_args))
+
+        cmd.append("registry-login")
+        cmd.append(config_dict_to_string(args))
+
+        out = node.exec_command(
+            sudo=True,
+            cmd=" ".join(cmd),
+            timeout=timeout,
+            check_ec=check_status,
+            long_running=long_running,
+        )
+
+        if isinstance(out, tuple):
+            LOG.debug(out[0])
+        return out

--- a/ceph/nvmegw_cli/__init__.py
+++ b/ceph/nvmegw_cli/__init__.py
@@ -9,7 +9,7 @@ from ceph.nvmegw_cli.log_level import LogLevel
 from ceph.nvmegw_cli.namespace import Namespace
 from ceph.nvmegw_cli.subsystem import Subsystem
 from ceph.nvmegw_cli.version import Version
-from cli.utilities.configs import get_registry_details
+from cephci.utils.configs import get_configs, get_registry_credentials
 from cli.utilities.containers import Registry
 
 
@@ -39,10 +39,13 @@ class NVMeGWCLI(ExecuteCommandMixin):
             clas.NVMEOF_CLI_IMAGE = self.NVMEOF_CLI_IMAGE
 
         if "icr.io" in self.NVMEOF_CLI_IMAGE:
-            registry_details = get_registry_details(ibm_build=True)
-            url = registry_details.get("registry-url")
-            username = registry_details.get("registry-username")
-            password = registry_details.get("registry-password")
+            get_configs()
+            registry = get_registry_credentials("cdn", "ibm")
+            if "stg" in self.NVMEOF_CLI_IMAGE:
+                registry = get_registry_credentials("stage", "ibm")
+            url = registry["registry"]
+            username = registry["username"]
+            password = registry["password"]
             Registry(self.node).login(url, username, password)
 
     def fetch_gateway(self):

--- a/ceph/nvmegw_cli/execute.py
+++ b/ceph/nvmegw_cli/execute.py
@@ -6,7 +6,7 @@ LOG = Log(__name__)
 
 class ExecuteCommandMixin:
     BASE_CMD = "podman run --quiet --rm"
-    NVMEOF_CLI_IMAGE = "quay.io/ceph/nvmeof-cli:1.1.0"
+    NVMEOF_CLI_IMAGE = "quay.io/ceph/nvmeof-cli:latest"
 
     def __init__(self, node, port=5500) -> None:
         self.port = port

--- a/suites/reef/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
@@ -1,0 +1,196 @@
+##############################################################################################
+# Tier-Level: 2
+# Test-Suite: tier1-nvmeof_b2b_upgrade.yaml
+# Scenario: Build to build Upgrade,
+#       - Any GAed to next development build
+#       - Currently, 7(GA) cluster to  7(Latest dev) Build
+#
+# Cluster Configuration: conf/reef/nvmeof/ceph_nvmeof_ha_cluster_4nodes.yaml
+#
+# Test Steps:
+# - Deploy RHCS/IBM 7(GA) cluster in RHEL 9.
+# - Configure NVMeoF gateways and Run IOs in background.
+# - Upgrade cluster from 7(GA) to 7(Latest dev) with NVMe IO in background.
+# - Validate cluster status
+# - Add more namespaces and run IO again.
+# - Perform HA failover and failback.
+################################################################################################
+tests:
+  - test:
+      name: setup install pre-requisistes
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: Bootstrap RHCS 7.x(GA) cluster and deploy services with label placements.
+      desc: Bootstrap RHCS 7.x(GA) cluster and deploy services with label placements.
+      polarion-id: CEPH-83573777
+      module: test_cephadm.py
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                custom_repo: "cdn"
+                custom_image: False
+                rhcs-version: "7.1"
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client1 and client2
+      desc: Configure the RBD client systems
+      module: test_client.py
+      polarion-id: CEPH-83573777
+      config:
+        command: add
+        id: client.1
+        nodes:
+        - node10
+        - node11
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Upgrade Cluster to latest 7.x ceph version
+      desc: Upgrade cluster to latest version with NVMeoF
+      module: test_ceph_nvmeof_upgrade.py
+      polarion-id: CEPH-83576090
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            - count: 2
+              size: 5G
+              lb_group: node7
+            - count: 2
+              size: 5G
+              lb_group: node8
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        upgrade:
+          cdn: false
+          release: null
+      destroy-cluster: false
+      abort-on-fail: true
+
+  # 4 GW Single node failure
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            - count: 2
+              size: 5G
+              lb_group: node7
+            - count: 2
+              size: 5G
+              lb_group: node8
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node7
+          - tool: systemctl
+            nodes: node9
+      desc: 4GW HA test post upgrade
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW HA test Single failure
+      polarion-id: CEPH-83589016

--- a/tests/nvmeof/test_ceph_nvmeof_upgrade.py
+++ b/tests/nvmeof/test_ceph_nvmeof_upgrade.py
@@ -1,0 +1,283 @@
+"""
+Test suite that verifies the deployment of Ceph NVMeoF Gateway HA
+ with supported entities like subsystems , etc.,
+
+"""
+from concurrent.futures import ThreadPoolExecutor
+from distutils.version import LooseVersion
+from json import loads
+
+from ceph.ceph import Ceph
+from ceph.ceph_admin.orch import Orch
+from ceph.nvmegw_cli import NVMeGWCLI
+from ceph.parallel import parallel
+from ceph.utils import get_nodes_by_ids
+from cephci.utils.configs import get_configs, get_registry_credentials
+from cli.utilities.containers import Registry
+from tests.cephadm import test_nvmeof
+from tests.nvmeof.test_ceph_nvmeof_high_availability import (
+    configure_subsystems,
+    teardown,
+)
+from tests.nvmeof.workflows.ha import HighAvailability
+from tests.rbd.rbd_utils import initial_rbd_config
+from utility.log import Log
+
+LOG = Log(__name__)
+
+
+class UpgradeFailure(Exception):
+    pass
+
+
+def upgrade_prerequisites(cluster, orch, **upg_cfg):
+    """Run all Pre-requisites.
+
+     - Identify the registry from build and login into registry.
+     - Todo: Support CDN Build upgrade.
+
+    Args:
+        cluster: Ceph cluster
+        orch: Ceph Orch object
+        args: Pre-requisites args
+
+    ::Example
+        cfg:
+          cdn: True | False     # Boolean
+          ibm_build: True | False # Boolean
+          overrides: List of container images
+          release: Ceph Version
+
+    """
+    cdn = upg_cfg.get("cdn", False)
+    ibm_build = upg_cfg.get("ibm_build", False)
+    overrides = upg_cfg.get("overrides")
+    release = upg_cfg.get("release")
+    registry = None
+
+    if ibm_build:
+        get_configs()
+        if not cdn:
+            registry = get_registry_credentials("stage", "ibm")
+        else:
+            registry = get_registry_credentials("cdn", "ibm")
+    if registry:
+        for node in cluster.get_nodes(ignore="client"):
+            Registry(node).login(
+                registry["registry"], registry["username"], registry["password"]
+            )
+            args = {
+                "registry-url": registry["registry"],
+                "registry-username": registry["username"],
+                "registry-password": registry["password"],
+            }
+            orch.registry_login(node=node, args=args)
+
+    # Set Repo based on release
+    if not cdn:
+        orch.set_tool_repo()
+
+        if overrides and not cdn:
+            override_dict = dict(item.split("=") for item in overrides)
+            supported_overrides = [
+                "grafana",
+                "keepalived",
+                "haproxy",
+                "prometheus",
+                "node_exporter",
+                "alertmanager",
+                "promtail",
+                "snmp_gateway",
+                "loki",
+            ]
+            if release >= LooseVersion("7.0"):
+                supported_overrides += [
+                    "nvmeof",
+                ]
+
+            for image in supported_overrides:
+                image_key = f"{image}_image"
+                if override_dict.get(image_key):
+                    cmd = f"ceph config set mgr mgr/cephadm/container_image_{image}"
+                    cmd += f" {override_dict[image_key]}"
+                    orch.shell(args=[cmd])
+    else:
+        # Todo: Support CDN repo builds in future
+        orch.set_cdn_tool_repo(release)
+
+
+def fetch_nvme_versions(gateways):
+    """Fetch Gateway Versions"""
+    info = dict()
+    for gateway in gateways:
+        _, gw = gateway.gateway.info(**{"base_cmd_args": {"format": "json"}})
+        gw = loads(gw)
+        node_info = {
+            "version": gw["version"],
+            "spdk-version": gw["spdk_version"],
+        }
+        info[gateway.hostname] = node_info
+
+    return info
+
+
+def compare_nvme_versions(pre_upgrade, post_upgrade):
+    """Compare the NVMe and SPDK versions before and after the upgrade.
+
+    Args:
+        pre_upgrade: Pre Upgrade Versions
+        post_upgrade: Post Upgrade Versions
+    """
+
+    def lv(metric):
+        return LooseVersion(metric)
+
+    for node, versions in post_upgrade.items():
+        if lv(versions["version"]) < lv(pre_upgrade[node]["version"]):
+            raise UpgradeFailure("NVMe Gateway Version is Lower or Same.")
+        if lv(versions["spdk-version"]) < lv(pre_upgrade[node]["spdk-version"]):
+            raise UpgradeFailure("SPDK Version is Lower")
+        LOG.info(
+            f"[ {node} ] Upgraded NVMe Version - {post_upgrade[node]},  Previous Version - {pre_upgrade[node]}"
+        )
+
+
+def run(ceph_cluster: Ceph, **kwargs) -> int:
+    """Return the status of the Ceph NVMEof HA test execution.
+
+    - Configure Gateways
+    - Configures Initiators and Run FIO on NVMe targets.
+    - Perform failover and failback.
+    - Validate the IO continuation prior and after to failover and failback
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        kwargs: Key/value pairs of configuration information to be used in the test.
+
+    Returns:
+        int - 0 when the execution is successful else 1 (for failure).
+
+    Example:
+
+        # Execute the nvmeof GW test
+            - test:
+                name: Ceph NVMeoF deployment
+                desc: Configure NVMEoF gateways and initiators
+                config:
+                    gw_nodes:
+                     - node6
+                    rbd_pool: rbd
+                    do_not_create_image: true
+                    rep-pool-only: true
+                    cleanup-only: true                          # only for cleanup
+                    rep_pool_config:
+                      pool: rbd
+                    install: true                               # Run SPDK with all pre-requisites
+                    subsystems:                                 # Configure subsystems with all sub-entities
+                      - nqn: nqn.2016-06.io.spdk:cnode3
+                        serial: 3
+                        bdevs:
+                          count: 1
+                          size: 100G
+                        listener_port: 5002
+                        allow_host: "*"
+                    initiators:                             # Configure Initiators with all pre-req
+                      - nqn: connect-all
+                        listener_port: 4420
+                        node: node10
+                    upgrade:
+                      cdn: True or False
+                      release: 7.1                  # if cdn, provide release
+    """
+    LOG.info("Upgrade Ceph cluster with NVMEoF Gateways")
+    config = kwargs["config"]
+    rbd_pool = config["rbd_pool"]
+    rbd_obj = initial_rbd_config(**kwargs)["rbd_reppool"]
+    ibm_build = config.get("ibm_build", False)
+    orch = Orch(cluster=ceph_cluster, **config)
+    container_image = config.get("container_image")
+    upgrade = config["upgrade"]
+    overrides = kwargs.get("test_data", {}).get("custom-config")
+    gw_nodes = get_nodes_by_ids(ceph_cluster, config["gw_nodes"])
+
+    # Todo: Fix the CDN NVMe CLI image issue with framework support.
+    for key, value in dict(item.split("=") for item in overrides).items():
+        if key == "nvmeof_cli_image":
+            NVMeGWCLI.NVMEOF_CLI_IMAGE = value
+            break
+    io_tasks = []
+    executor = ThreadPoolExecutor()
+
+    try:
+        if config.get("install"):
+            cfg = {
+                "no_cluster_state": False,
+                "config": {
+                    "command": "apply",
+                    "service": "nvmeof",
+                    "args": {"placement": {"nodes": [i.hostname for i in gw_nodes]}},
+                    "pos_args": [rbd_pool],
+                },
+            }
+            test_nvmeof.run(ceph_cluster, **cfg)
+
+        ha = HighAvailability(ceph_cluster, config["gw_nodes"], **config)
+        nvmegwcli = ha.gateways[0]
+
+        # Configure Subsystem
+        if config.get("subsystems"):
+            with parallel() as p:
+                for subsys_args in config["subsystems"]:
+                    subsys_args["ceph_cluster"] = ceph_cluster
+                    p.spawn(
+                        configure_subsystems, rbd_obj, rbd_pool, nvmegwcli, subsys_args
+                    )
+
+        pre_upg_versions = fetch_nvme_versions(ha.gateways)
+
+        # Prepare and Run FIO on NVMe devices
+        namespaces = ha.fetch_namespaces(nvmegwcli)
+        initiators = config["initiators"]
+        ha.prepare_io_execution(initiators)
+        ha.compare_client_namespace([i["uuid"] for i in namespaces])
+        for initiator in ha.clients:
+            io_tasks.append(executor.submit(initiator.start_fio))
+
+        # Setup regisgtry
+        upg_cfg = {
+            "release": upgrade.get("release") or config.get("rhbuild"),
+            "cdn": upgrade["cdn"],
+            "overrides": overrides,
+            "ibm_build": ibm_build,
+        }
+
+        upgrade_prerequisites(ceph_cluster, orch, **upg_cfg)
+
+        # Install cephadm
+        orch.install()
+
+        # Check service versions vs available and target containers
+        orch.upgrade_check(image=container_image)
+
+        # Start Upgrade
+        config.update({"args": {"image": "latest"}})
+        orch.start_upgrade(config)
+
+        # Monitor upgrade status, till completion
+        orch.monitor_upgrade_status()
+
+        # Validate upgraded versions of NVMe Gateways
+        post_upg_versions = fetch_nvme_versions(ha.gateways)
+        compare_nvme_versions(pre_upg_versions, post_upg_versions)
+
+        return 0
+    except Exception as err:
+        LOG.error(err)
+    finally:
+        if io_tasks:
+            LOG.info("Waiting for completion of IOs.")
+            executor.shutdown(wait=True, cancel_futures=True)
+        if config.get("cleanup"):
+            teardown(ceph_cluster, rbd_obj, config)
+
+    return 1


### PR DESCRIPTION
# Description

- NVMeoF Gateway Build-to-build upgrade.

**_`CEPH-83576090 | NVMe Build to Build Direct Upgrade`_**




```
All test logs located here: /Users/sunilkumarn/logs/b2b-upgrade-02

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup install pre-requisistes    Setup phase to deploy the required pre-requisites for runnin   0:06:13.781017                   Pass
Bootstrap RHCS 7.x(GA) cluster   Bootstrap RHCS 7.x(GA) cluster and deploy services with labe   0:15:29.433281                   Pass
Configure client1 and client2    Configure the RBD client systems                               0:01:52.713422                   Pass
Upgrade Cluster to latest 7.x    Upgrade cluster to latest version with NVMeoF                  0:21:31.769711                   Pass
NVMeoF 4-GW HA test Single fai   4GW HA test post upgrade                                       0:15:56.282388                   Pass
```

