### PR TITLE
os and tools required attributes under build sections.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,6 +21,8 @@ python:
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.12"
   apt_packages:
     - libcurl4-openssl-dev
     - libssl-dev


### PR DESCRIPTION
# Description

- Two required build attributes (os, tools).
- https://docs.readthedocs.io/en/stable/config-file/v2.html#build
<img width="1675" alt="image" src="https://github.com/user-attachments/assets/6b0a1ea2-b163-4bc7-8ed7-e3393c57e376">
