### PR TITLE
Move to the latest version of black formatter

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1,4 +1,5 @@
 """This module implements the required foundation data structures for testing."""
+
 import datetime
 import json
 import pickle
@@ -299,9 +300,11 @@ class Ceph(object):
                     if "pool" in node.hostname:
                         logger.info(node.hostname)
                         devices = node.create_lvm(
-                            devices[0:1]
-                            if not device_to_add
-                            else device_to_add.split(),
+                            (
+                                devices[0:1]
+                                if not device_to_add
+                                else device_to_add.split()
+                            ),
                             num=random.randint(1, 10) if device_to_add else None,
                             check_lvm=False if device_to_add else True,
                         )

--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -7,6 +7,7 @@ operations part of the cluster lifecycle.
 Over here, we create a glue between the CLI and CephCI to allow the QE to write test
 scenarios for verifying and validating cephadm.
 """
+
 from typing import Dict
 
 from cli.utilities.configure import setup_ibm_licence

--- a/ceph/ceph_admin/alert_manager.py
+++ b/ceph/ceph_admin/alert_manager.py
@@ -1,4 +1,5 @@
 """Deploy the alert manager service in the cluster via cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/apply.py
+++ b/ceph/ceph_admin/apply.py
@@ -6,6 +6,7 @@ Module to deploy ceph role service(s) using orchestration command
 
 This is a mixin object and can be applied to the supported service classes.
 """
+
 import re
 from typing import Dict
 

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -1,4 +1,5 @@
 """Module that allows QE to interface with cephadm bootstrap CLI."""
+
 import json
 import tempfile
 from distutils.version import LooseVersion
@@ -215,9 +216,9 @@ class BootstrapMixin:
             # an upgrade occurs. This enables us to execute the test in the right
             # context.
             self.config["base_url"] = _details[0]
-            self.config[
-                "container_image"
-            ] = f"{_details[1]}/{_details[2]}:{_details[3]}"
+            self.config["container_image"] = (
+                f"{_details[1]}/{_details[2]}:{_details[3]}"
+            )
             self.cluster.rhcs_version = _rhcs_version
             rhbuild = f"{_rhcs_version}-{_platform}"
             base_url = _details[0]

--- a/ceph/ceph_admin/ceph.py
+++ b/ceph/ceph_admin/ceph.py
@@ -1,4 +1,5 @@
 """Interface to the base command ceph."""
+
 from ceph.ceph_admin import CephAdmin
 
 

--- a/ceph/ceph_admin/cephadm_ansible.py
+++ b/ceph/ceph_admin/cephadm_ansible.py
@@ -5,6 +5,7 @@ playbooks supported,
 - cephadm-purge-cluster.yaml
 - cephadm-clients.yaml
 """
+
 import re
 
 from ceph.ceph_admin.common import config_dict_to_string

--- a/ceph/ceph_admin/cephfs_mirror.py
+++ b/ceph/ceph_admin/cephfs_mirror.py
@@ -1,4 +1,5 @@
 """Manage the CephFS Mirror service via the cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/common.py
+++ b/ceph/ceph_admin/common.py
@@ -1,4 +1,5 @@
 """Contains common functions that can used across the module."""
+
 from typing import Dict
 
 

--- a/ceph/ceph_admin/crash.py
+++ b/ceph/ceph_admin/crash.py
@@ -1,4 +1,5 @@
 """Manage the Crash service via cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/daemon.py
+++ b/ceph/ceph_admin/daemon.py
@@ -1,4 +1,5 @@
 """CephADM orchestration Daemon operations."""
+
 from utility.log import Log
 
 from .add import AddMixin

--- a/ceph/ceph_admin/dashboard.py
+++ b/ceph/ceph_admin/dashboard.py
@@ -1,4 +1,5 @@
 """Manage the Ceph Dashboard service via ceph CLI."""
+
 import json
 import tempfile
 from json import loads

--- a/ceph/ceph_admin/device.py
+++ b/ceph/ceph_admin/device.py
@@ -1,4 +1,5 @@
 """CephADM orchestration Device operations."""
+
 from time import sleep
 from typing import Dict, Optional, Tuple
 

--- a/ceph/ceph_admin/grafana.py
+++ b/ceph/ceph_admin/grafana.py
@@ -1,4 +1,5 @@
 """Manage the Ceph Grafana service via cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -1,6 +1,7 @@
 """
 Contains helper functions that can used across the module.
 """
+
 import json
 import os
 import tempfile

--- a/ceph/ceph_admin/host.py
+++ b/ceph/ceph_admin/host.py
@@ -1,4 +1,5 @@
 """Cephadm orchestration host operations."""
+
 import json
 from copy import deepcopy
 

--- a/ceph/ceph_admin/iscsi.py
+++ b/ceph/ceph_admin/iscsi.py
@@ -1,4 +1,5 @@
 """Module to deploy and manage Ceph's iSCSI service."""
+
 from typing import Dict
 
 from ceph.utils import get_nodes_by_ids

--- a/ceph/ceph_admin/ls.py
+++ b/ceph/ceph_admin/ls.py
@@ -1,4 +1,5 @@
 """Module that interfaces with ceph orch ls CLI."""
+
 from typing import Dict, Optional, Tuple
 
 from .common import config_dict_to_string

--- a/ceph/ceph_admin/maintenance.py
+++ b/ceph/ceph_admin/maintenance.py
@@ -12,6 +12,7 @@ Example:
 This module is inherited where hosts are placed or exited from maintenance using orchestrator.
 
 """
+
 from json import loads
 from time import sleep
 from typing import Dict

--- a/ceph/ceph_admin/manager.py
+++ b/ceph/ceph_admin/manager.py
@@ -1,4 +1,5 @@
 """Perform the manager operations via Ceph's cephadm CLI."""
+
 from json import loads
 
 from .ceph import CephCLI

--- a/ceph/ceph_admin/mds.py
+++ b/ceph/ceph_admin/mds.py
@@ -1,4 +1,5 @@
 """Manage MDS service via Ceph's cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/mgr.py
+++ b/ceph/ceph_admin/mgr.py
@@ -1,4 +1,5 @@
 """Manage the Manager service via Ceph's cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/mon.py
+++ b/ceph/ceph_admin/mon.py
@@ -1,4 +1,5 @@
 """Manage the Monitor service via cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/nfs.py
+++ b/ceph/ceph_admin/nfs.py
@@ -1,4 +1,5 @@
 """Manage the NFS service via the cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/node_exporter.py
+++ b/ceph/ceph_admin/node_exporter.py
@@ -1,4 +1,5 @@
 """Module to deploy Node-Exporter service and individual daemon(s)."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/nvmeof.py
+++ b/ceph/ceph_admin/nvmeof.py
@@ -1,4 +1,5 @@
 """Manage the NVMeoF service via ceph-adm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/orch.py
+++ b/ceph/ceph_admin/orch.py
@@ -3,6 +3,7 @@ Module that interacts with the orchestrator CLI.
 
 Provide the interfaces to ceph orch and in turn manage the orchestration engine.
 """
+
 from datetime import datetime, timedelta
 from json import loads
 from time import sleep

--- a/ceph/ceph_admin/osd.py
+++ b/ceph/ceph_admin/osd.py
@@ -1,4 +1,5 @@
 """Manage OSD service via cephadm CLI."""
+
 import json
 from time import sleep
 from typing import Dict

--- a/ceph/ceph_admin/pause.py
+++ b/ceph/ceph_admin/pause.py
@@ -10,6 +10,7 @@ Example:
 
 This module is inherited where orchestrator operations are paused using pause command.
 """
+
 from typing import Dict
 
 from utility.log import Log

--- a/ceph/ceph_admin/prometheus.py
+++ b/ceph/ceph_admin/prometheus.py
@@ -1,4 +1,5 @@
 """Module to deploy Prometheus service and individual daemon(s)."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/ps.py
+++ b/ceph/ceph_admin/ps.py
@@ -1,4 +1,5 @@
 """Module that interfaces with ceph orch ps CLI."""
+
 from typing import Dict, Optional, Tuple
 
 from .common import config_dict_to_string

--- a/ceph/ceph_admin/rbd_mirror.py
+++ b/ceph/ceph_admin/rbd_mirror.py
@@ -1,4 +1,5 @@
 """Manage the RBD Mirror service via the cephadm CLI."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/registry_login.py
+++ b/ceph/ceph_admin/registry_login.py
@@ -1,4 +1,5 @@
 """Cephadm registry login CLI Command."""
+
 from copy import deepcopy
 from typing import Dict
 

--- a/ceph/ceph_admin/remove.py
+++ b/ceph/ceph_admin/remove.py
@@ -4,6 +4,7 @@ Module to remove ceph role service(s) using orchestration command
 "ceph orch remove service.name "
 This module inherited where service deleted using "remove" operation.
 """
+
 from typing import Dict
 
 from .common import config_dict_to_string

--- a/ceph/ceph_admin/resume.py
+++ b/ceph/ceph_admin/resume.py
@@ -10,6 +10,7 @@ Example:
 
 This module is inherited where orchestrator operations are resumed using resume command.
 """
+
 from typing import Dict
 
 from utility.log import Log

--- a/ceph/ceph_admin/rgw.py
+++ b/ceph/ceph_admin/rgw.py
@@ -1,4 +1,5 @@
 """Module to deploy RGW service and individual daemon(s)."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/shell.py
+++ b/ceph/ceph_admin/shell.py
@@ -1,4 +1,5 @@
 """Interface to cephadm shell CLI."""
+
 from copy import deepcopy
 from typing import Dict, List
 

--- a/ceph/ceph_admin/snmp_gateway.py
+++ b/ceph/ceph_admin/snmp_gateway.py
@@ -1,4 +1,5 @@
 """Module to deploy SNMP-Gateway service and individual daemon(s)."""
+
 from typing import Dict
 
 from .apply import ApplyMixin

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -1,4 +1,5 @@
 """Custom typing objects to avoid circular imports."""
+
 from datetime import datetime
 from typing import Dict, List
 
@@ -17,17 +18,13 @@ class CephAdmProtocol(Protocol):
     config: Dict
     installer: CephInstaller
 
-    def read_cephadm_gen_pub_key(self, ssh_key_path=None):
-        ...
+    def read_cephadm_gen_pub_key(self, ssh_key_path=None): ...
 
-    def distribute_cephadm_gen_pub_key(self, ssh_key_path=None, nodes=None):
-        ...
+    def distribute_cephadm_gen_pub_key(self, ssh_key_path=None, nodes=None): ...
 
-    def set_tool_repo(self, repo=None):
-        ...
+    def set_tool_repo(self, repo=None): ...
 
-    def install(self, **kwargs: Dict) -> None:
-        ...
+    def install(self, **kwargs: Dict) -> None: ...
 
     def shell(
         self,
@@ -36,8 +33,7 @@ class CephAdmProtocol(Protocol):
         check_status: bool = True,
         timeout: int = 600,
         long_running: bool = False,
-    ):
-        ...
+    ): ...
 
 
 class OrchProtocol(CephAdmProtocol, Protocol):
@@ -52,14 +48,11 @@ class OrchProtocol(CephAdmProtocol, Protocol):
         check_status: bool = True,
         timeout: int = 600,
         long_running: bool = False,
-    ):
-        ...
+    ): ...
 
-    def get_role_service(self, service_name: str) -> str:
-        ...
+    def get_role_service(self, service_name: str) -> str: ...
 
-    def get_hosts_by_label(self, label: str) -> List:
-        ...
+    def get_hosts_by_label(self, label: str) -> List: ...
 
     def check_service(
         self,
@@ -67,21 +60,17 @@ class OrchProtocol(CephAdmProtocol, Protocol):
         timeout: int = 300,
         interval: int = 5,
         exist: bool = True,
-    ) -> bool:
-        ...
+    ) -> bool: ...
 
-    def op(self, op: str, config: Dict):
-        ...
+    def op(self, op: str, config: Dict): ...
 
-    def verify_status(self, op: str) -> None:
-        ...
+    def verify_status(self, op: str) -> None: ...
 
     def check_service_restart(
         self,
         service_name: str,
         restart_init_time: datetime,
-    ) -> bool:
-        ...
+    ) -> bool: ...
 
 
 class DaemonProtocol(OrchProtocol, Protocol):

--- a/ceph/ceph_admin/typing_.py
+++ b/ceph/ceph_admin/typing_.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """Custom typing objects to avoid circular imports."""
 
 from datetime import datetime

--- a/ceph/ceph_admin/upgrade.py
+++ b/ceph/ceph_admin/upgrade.py
@@ -1,4 +1,5 @@
 """Module that interfaces with ceph orch upgrade CLI."""
+
 from datetime import datetime, timedelta
 from json import loads
 from time import sleep

--- a/ceph/nvmegw_cli/common.py
+++ b/ceph/nvmegw_cli/common.py
@@ -3,6 +3,7 @@
 - Configure spdk and start spdk.
 - Configure nvme-of targets using control.cli.
 """
+
 from json import loads
 
 from ceph.ceph_admin.common import config_dict_to_string

--- a/ceph/nvmeof/gateway.py
+++ b/ceph/nvmeof/gateway.py
@@ -3,6 +3,7 @@
 - Configure spdk and start spdk.
 - Configure nvme-of targets using control.cli.
 """
+
 import re
 
 from ceph.ceph import CephNode

--- a/ceph/nvmeof/initiator.py
+++ b/ceph/nvmeof/initiator.py
@@ -1,4 +1,5 @@
 """NVME Initiator."""
+
 from .nvme_cli import NVMeCLI
 
 

--- a/ceph/rados/crushtool_workflows.py
+++ b/ceph/rados/crushtool_workflows.py
@@ -10,6 +10,7 @@ Module to Generate, Modify and Apply Crush maps on ceph cluster. Methods include
 8. bin file tests. ( stats, bad mappings etc.)
 9. dump and verify bin file contents
 """
+
 import json
 import re
 

--- a/ceph/rados/monitor_workflows.py
+++ b/ceph/rados/monitor_workflows.py
@@ -1,6 +1,7 @@
 """
 Module to perform Serviceability scenarios on mon daemons
 """
+
 import datetime
 import time
 

--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -3,6 +3,7 @@ Module to change pool attributes
 1. Autoscaler tunables
 2. Snapshots
 """
+
 import datetime
 import random
 import time

--- a/ceph/rados/rados_bench.py
+++ b/ceph/rados/rados_bench.py
@@ -5,6 +5,7 @@ It contains a benchmarking facility that exercises the cluster by way of librado
 the low level native object storage API provided by Ceph.
 
 """
+
 from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
 from time import time
 

--- a/ceph/rados/rados_scrub.py
+++ b/ceph/rados/rados_scrub.py
@@ -19,6 +19,7 @@
    5. verify_scrub  method used for the verification of scheduled scrub
       happened or not.
 """
+
 import datetime
 from collections import defaultdict
 

--- a/ceph/rados/serviceability_workflows.py
+++ b/ceph/rados/serviceability_workflows.py
@@ -1,6 +1,7 @@
 """
 Module to perform Serviceability scenarios on Cluster Hosts / Nodes
 """
+
 import datetime
 import json
 import time

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -5,6 +5,7 @@
     3. Set osd out
     3. Zap device path
 """
+
 from json import loads
 
 from ceph.ceph_admin.daemon import Daemon

--- a/cli/cloudproviders/openstack.py
+++ b/cli/cloudproviders/openstack.py
@@ -124,9 +124,11 @@ class Openstack:
             log.error(e)
             raise CloudProviderError(e)
 
-        self.wait_for_node_state(
-            name, STATE_RUNNING, timeout, interval
-        ) if node else None
+        (
+            self.wait_for_node_state(name, STATE_RUNNING, timeout, interval)
+            if node
+            else None
+        )
 
         return True
 
@@ -299,9 +301,11 @@ class Openstack:
             log.error(e)
             raise CloudProviderError(e)
 
-        self.wait_for_volume_state(
-            name, STATE_AVAILABLE, timeout, interval
-        ) if volume else None
+        (
+            self.wait_for_volume_state(name, STATE_AVAILABLE, timeout, interval)
+            if volume
+            else None
+        )
 
         return True
 

--- a/cli/performance/utilities/memory_and_cpu_logger.py
+++ b/cli/performance/utilities/memory_and_cpu_logger.py
@@ -1,6 +1,7 @@
 """
 A tool to monitor and log memory consumption processes.
 """
+
 from __future__ import print_function
 
 import argparse

--- a/compute/baremetal.py
+++ b/compute/baremetal.py
@@ -1,4 +1,5 @@
 """Collects the Baremetal information and creates the cephNode object."""
+
 from copy import deepcopy
 from os.path import expanduser
 from typing import List, Optional

--- a/compute/ibm_vpc.py
+++ b/compute/ibm_vpc.py
@@ -1,4 +1,5 @@
 """IBM-Cloud VPC provider implementation for CephVMNode."""
+
 import re
 import socket
 from copy import deepcopy
@@ -391,9 +392,9 @@ class CephVMNodeIBM:
             instance_prototype_model["volume_attachments"] = volume_attachment_list
             instance_prototype_model["vpc"] = vpc_identity_model
             instance_prototype_model["image"] = image_identity_model
-            instance_prototype_model[
-                "primary_network_interface"
-            ] = network_interface_prototype_model
+            instance_prototype_model["primary_network_interface"] = (
+                network_interface_prototype_model
+            )
             instance_prototype_model["zone"] = zone_identity_model
 
             # Set up parameter values

--- a/compute/ibmcloud.py
+++ b/compute/ibmcloud.py
@@ -1,4 +1,5 @@
 """Support VM lifecycle operation in an OpenStack Cloud."""
+
 import socket
 from typing import Optional
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 isort:skip_file
 
 """
+
 import os
 import sys
 

--- a/init_suite.py
+++ b/init_suite.py
@@ -1,4 +1,5 @@
 """Retrieve and process CephCI suites."""
+
 import os
 from copy import deepcopy
 from glob import glob

--- a/mita/openstack.py
+++ b/mita/openstack.py
@@ -1,4 +1,5 @@
 """Module to interface with the OpenStack API."""
+
 import datetime
 import socket
 from time import sleep

--- a/mita/v2.py
+++ b/mita/v2.py
@@ -1,4 +1,5 @@
 """Support VM lifecycle operation in an OpenStack Cloud."""
+
 import socket
 from datetime import datetime, timedelta
 from time import sleep

--- a/pipeline/scripts/ci/upload_compose.py
+++ b/pipeline/scripts/ci/upload_compose.py
@@ -9,6 +9,7 @@ Note:
     we would create .repo files in /etc/yum.conf.d/ for sync operations. Also, the
     script works only on CentOS-7 due to options provided for reposync.
 """
+
 import logging
 import subprocess
 import sys

--- a/pipeline/scripts/ci/upstream_cli.py
+++ b/pipeline/scripts/ci/upstream_cli.py
@@ -3,6 +3,7 @@ This script provides the upstream latest rpm repo path and container image.
 Please note that this script should be run under root privileges
 inorder to pull the image and podman should be installed on that host.
 """
+
 import logging
 import os
 import re

--- a/rest/common/config/config.py
+++ b/rest/common/config/config.py
@@ -1,6 +1,5 @@
 """Config file reader"""
 
-
 import json
 import os
 

--- a/storage/ibm_cos.py
+++ b/storage/ibm_cos.py
@@ -30,6 +30,7 @@ cos:
 Reference:
   https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-python
 """
+
 import logging
 
 import ibm_boto3

--- a/storage/ibm_cos_awscli.py
+++ b/storage/ibm_cos_awscli.py
@@ -7,6 +7,7 @@ Pre-requisites:
     create ~/.aws/credentials
 References : https://github.com/aws/aws-cli
 """
+
 import logging
 
 import awscli.clidriver

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,5 +4,5 @@ mock
 flake8
 tox
 isort
-black==23.12.0
+black
 yamllint

--- a/tests/ceph_ansible/add_rbd_mirror_daemon.py
+++ b/tests/ceph_ansible/add_rbd_mirror_daemon.py
@@ -29,9 +29,9 @@ def run(ceph_cluster, **kw):
         [obj.node.ip_address for obj in other_cluster.get_ceph_objects(role="mon")]
     )
 
-    config["ansi_config"][
-        "ceph_rbd_mirror_remote_cluster"
-    ] = other_cluster.get_cluster_fsid(rhbuild=config["build"])
+    config["ansi_config"]["ceph_rbd_mirror_remote_cluster"] = (
+        other_cluster.get_cluster_fsid(rhbuild=config["build"])
+    )
 
     write_configs_to_rbdmirrors_yaml(ceph_installer, config)
 

--- a/tests/ceph_ansible/docker_to_podman.py
+++ b/tests/ceph_ansible/docker_to_podman.py
@@ -1,4 +1,5 @@
 """Migrates from docker to podman"""
+
 from utility.log import Log
 
 log = Log(__name__)

--- a/tests/ceph_ansible/filestore_to_bluestore.py
+++ b/tests/ceph_ansible/filestore_to_bluestore.py
@@ -1,4 +1,5 @@
 """Filestore to bluestore migrations"""
+
 from utility.log import Log
 
 log = Log(__name__)

--- a/tests/ceph_ansible/purge_dashboard.py
+++ b/tests/ceph_ansible/purge_dashboard.py
@@ -1,4 +1,5 @@
 """ Module to purge ceph dashboard."""
+
 import json
 
 from utility.log import Log

--- a/tests/ceph_ansible/shrink_mon.py
+++ b/tests/ceph_ansible/shrink_mon.py
@@ -1,4 +1,5 @@
 """Shrinks the Ceph monitors from the cluster"""
+
 import re
 
 from utility.log import Log

--- a/tests/ceph_ansible/switch_rpm_to_container.py
+++ b/tests/ceph_ansible/switch_rpm_to_container.py
@@ -1,4 +1,5 @@
 """switches non-containerized ceph daemon to containerized ceph daemon"""
+
 import yaml
 
 from utility.log import Log

--- a/tests/ceph_ansible/test_ansible_roll_over.py
+++ b/tests/ceph_ansible/test_ansible_roll_over.py
@@ -1,4 +1,5 @@
 """adds ceph daemons on existing cluster"""
+
 import datetime
 import re
 

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -4,6 +4,7 @@ Test suite that verifies the deployment of Red Hat Ceph Storage via the cephadm 
 The intent of the suite is to simulate a standard operating procedure expected by a
 customer.
 """
+
 from copy import deepcopy
 
 from ceph.ceph import Ceph

--- a/tests/cephadm/test_cephadm_ansible.py
+++ b/tests/cephadm/test_cephadm_ansible.py
@@ -5,6 +5,7 @@ Playbook supported
 - cephadm-purge-cluster.yaml
 - cephadm-clients.yaml
 """
+
 from ceph.ceph_admin.cephadm_ansible import CephadmAnsible
 from utility.log import Log
 

--- a/tests/cephadm/test_client.py
+++ b/tests/cephadm/test_client.py
@@ -1,4 +1,5 @@
 """Manage the client via cephadm CLI."""
+
 import time
 from typing import Dict
 

--- a/tests/cephadm/test_dashboard.py
+++ b/tests/cephadm/test_dashboard.py
@@ -1,4 +1,5 @@
 """Manage the ceph dashboard service via cephadm CLI."""
+
 from ceph.ceph_admin import CephAdmin, dashboard
 from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.helper import get_cluster_state

--- a/tests/cephfs/dir_pinning.py
+++ b/tests/cephfs/dir_pinning.py
@@ -3,6 +3,7 @@ This is cephfs testcase that perform MDSfailover on active-active mdss,
 performing client IOs with no pinning, then IO operation with pinning
 Which require 4 clients, 2 for fuse mount and rest2 for kernel mount
 """
+
 import timeit
 import traceback
 

--- a/tests/cephfs/snapshot_clone/cephfs_cg_io.py
+++ b/tests/cephfs/snapshot_clone/cephfs_cg_io.py
@@ -3,6 +3,7 @@ This is cephfs consistency group snapshot feature IO module
 It contains methods to start read and write IO on quiesce-set/consistency group.
 Also, validates IO failure by checking current quiesce state on quiesce set.
 """
+
 import datetime
 import random
 import string

--- a/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
+++ b/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
@@ -3,6 +3,7 @@ This is cephfs snapshot schedule utility module
 It contains all the re-useable functions related to cephfs snapshot schedule and retention feature
 
 """
+
 import datetime
 import json
 import random

--- a/tests/dashboard/alerts.py
+++ b/tests/dashboard/alerts.py
@@ -1,4 +1,5 @@
 """Module to test ceph health alerts"""
+
 import traceback
 from json import loads
 from time import sleep

--- a/tests/misc_env/configure-tc.py
+++ b/tests/misc_env/configure-tc.py
@@ -1,4 +1,5 @@
 """This module helps configure network delays using linux tc."""
+
 from typing import Dict, Optional, Tuple
 
 from ceph.ceph import Ceph, CephNode

--- a/tests/misc_env/configure_warp.py
+++ b/tests/misc_env/configure_warp.py
@@ -21,6 +21,7 @@ Sample test script
         module: configure_warp.py
         name: Configure WARP
 """
+
 from json import loads
 from typing import Dict, List
 

--- a/tests/misc_env/cosbench.py
+++ b/tests/misc_env/cosbench.py
@@ -21,6 +21,7 @@ Sample test script
         module: cosbench.py
         name: deploy cosbench
 """
+
 from json import loads
 from typing import Dict, List
 

--- a/tests/misc_env/gather_cluster_info.py
+++ b/tests/misc_env/gather_cluster_info.py
@@ -1,4 +1,5 @@
 """Module that executes workflows required for ODF CI tests."""
+
 import binascii
 import os
 from json import loads

--- a/tests/misc_env/haproxy.py
+++ b/tests/misc_env/haproxy.py
@@ -16,6 +16,7 @@ Sample test script
         module: haproxy.py
         name: Configure HAproxy
 """
+
 from typing import List
 
 from jinja2 import Template

--- a/tests/misc_env/homogenous_osd_cluster.py
+++ b/tests/misc_env/homogenous_osd_cluster.py
@@ -7,6 +7,7 @@ Sample test script
       module: homogenous_osd_cluster.py
       name: OSD homogenous deploy on specific devices
 """
+
 import json
 import traceback
 from typing import List

--- a/tests/misc_env/osd_specific_device.py
+++ b/tests/misc_env/osd_specific_device.py
@@ -9,6 +9,7 @@ Sample test script
       module: osd_specific_device.py
       name: OSD on specific device
 """
+
 import json
 from typing import List
 

--- a/tests/misc_env/push_cosbench_workload.py
+++ b/tests/misc_env/push_cosbench_workload.py
@@ -21,6 +21,7 @@ Sample test script
         module: push_cosbench_workload.py
         name: push cosbench fill workload
 """
+
 import json
 import math
 import time

--- a/tests/misc_env/push_warp_workload.py
+++ b/tests/misc_env/push_warp_workload.py
@@ -25,6 +25,7 @@ Sample test script
         module: push_warp_workload.py
         name: Configure WARP
 """
+
 from datetime import date
 from typing import List
 

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -3,6 +3,7 @@ Test suite that verifies the deployment of Ceph NVMeoF Gateway HA
  with supported entities like subsystems , etc.,
 
 """
+
 from copy import deepcopy
 
 from ceph.ceph import Ceph

--- a/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
+++ b/tests/nvmeof/test_ceph_nvmeof_sub_limit.py
@@ -2,6 +2,7 @@
 Test suite that verifies the deployment of Ceph NVMeoF Gateway with incremental subsystem scaling
 to find subsystem limitations
 """
+
 import json
 from copy import deepcopy
 

--- a/tests/nvmeof/test_ceph_nvmeof_upgrade.py
+++ b/tests/nvmeof/test_ceph_nvmeof_upgrade.py
@@ -3,6 +3,7 @@ Test suite that verifies the deployment of Ceph NVMeoF Gateway HA
  with supported entities like subsystems , etc.,
 
 """
+
 from concurrent.futures import ThreadPoolExecutor
 from distutils.version import LooseVersion
 from json import loads

--- a/tests/nvmeof/test_ceph_nvmeof_vmware_clients.py
+++ b/tests/nvmeof/test_ceph_nvmeof_vmware_clients.py
@@ -4,6 +4,7 @@ Test module that configures esx server for a nvmeof GW subsystem
  This Test module will be re-written or enhanced based NVMeOF 7.1 test requirements for vmware.,
 
 """
+
 import json
 import re
 from copy import deepcopy

--- a/tests/nvmeof/test_io_perf.py
+++ b/tests/nvmeof/test_io_perf.py
@@ -1,4 +1,5 @@
 """Test module to execute IO on different protocols and generate reports."""
+
 import json
 import os
 import re

--- a/tests/nvmeof/test_nvme_cli.py
+++ b/tests/nvmeof/test_nvme_cli.py
@@ -4,6 +4,7 @@ Test suite that verifies the deployment of Red Hat Ceph Storage via the cephadm 
 The intent of the suite is to simulate a standard operating procedure expected by a
 customer.
 """
+
 from copy import deepcopy
 
 from ceph.ceph import Ceph

--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -21,6 +21,7 @@ Requirement parameters
 Entry Point:
     def run(**kwargs):
 """
+
 import importlib
 import os
 from time import sleep

--- a/tests/rados/customer_scenarios.py
+++ b/tests/rados/customer_scenarios.py
@@ -15,6 +15,7 @@ Currently automated scenarios:
           new mappings for around next hour or so.. The suite `Sanity_rados` is part of the workflow for this test.
           The workflow makes sure that there have been enough operations on monitor for this test to provide results.
 """
+
 import datetime
 import json
 import re

--- a/tests/rados/scheduled_scrub_scenarios.py
+++ b/tests/rados/scheduled_scrub_scenarios.py
@@ -3,7 +3,6 @@
    Based on the test cases setting the scrub parameters and verifying the functionality.
 """
 
-
 import os
 import sys
 import time

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -8,6 +8,7 @@ New we have methods 2 Methods for deployment :
 
 Once all the code movement for stretch mode happens, Test cases will be updated to use one of the two methods mentioned.
 """
+
 import datetime
 import re
 import time

--- a/tests/rados/test_bluestore_configs.py
+++ b/tests/rados/test_bluestore_configs.py
@@ -1,4 +1,5 @@
 """ Module to verify scenarios related to BlueStore config changes"""
+
 import time
 
 from ceph.ceph_admin import CephAdmin
@@ -114,10 +115,10 @@ def run(ceph_cluster, **kw):
 
             for checksum in checksum_list:
                 # create pools with given config when OSD csum_type is default crc32c
-                create_pool_write_iops(
-                    param=checksum, pool_type="replicated"
-                ) if pool_type == "replicated" else create_pool_write_iops(
-                    param=checksum, pool_type="ec"
+                (
+                    create_pool_write_iops(param=checksum, pool_type="replicated")
+                    if pool_type == "replicated"
+                    else create_pool_write_iops(param=checksum, pool_type="ec")
                 )
 
             for checksum in checksum_list:
@@ -135,10 +136,10 @@ def run(ceph_cluster, **kw):
                 log.info(f"global checksum set verified - {out}")
 
                 # create pools with given config when OSD csum_type is varied
-                create_pool_write_iops(
-                    param=checksum, pool_type="replicated"
-                ) if pool_type == "replicated" else create_pool_write_iops(
-                    param=checksum, pool_type="ec"
+                (
+                    create_pool_write_iops(param=checksum, pool_type="replicated")
+                    if pool_type == "replicated"
+                    else create_pool_write_iops(param=checksum, pool_type="ec")
                 )
         except Exception as E:
             log.error(f"Verification failed with exception: {E.__doc__}")

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -15,6 +15,7 @@ Test Module to perform specific functionalities of ceph-bluestore-tool.
  - ceph-bluestore-tool bluefs-bdev-new-wal --path osd path --dev-target new-device
  - ceph-bluestore-tool bluefs-bdev-new-db --path osd path --dev-target new-device
 """
+
 import json
 import math
 import random

--- a/tests/rados/test_brownfield.py
+++ b/tests/rados/test_brownfield.py
@@ -5,7 +5,6 @@ Tests included:
 
 """
 
-
 import json
 
 from api import Api

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -1,6 +1,7 @@
 """
 Module to verify scenarios related to RADOS Bug fixes
 """
+
 import datetime
 import random
 import time

--- a/tests/rados/test_clay_ecpool.py
+++ b/tests/rados/test_clay_ecpool.py
@@ -11,6 +11,7 @@ Tests Performed:
 7. Perform Repair on the PGs on Clay pool
 8. Recovery with only K shards of EC Pool
 """
+
 import time
 
 from ceph.ceph_admin import CephAdmin

--- a/tests/rados/test_crash_daemon.py
+++ b/tests/rados/test_crash_daemon.py
@@ -1,6 +1,7 @@
 """
 Module to verify health warning generated after crashing a ceph daemon
 """
+
 import random
 import time
 

--- a/tests/rados/test_crushtool_workflows.py
+++ b/tests/rados/test_crushtool_workflows.py
@@ -6,6 +6,7 @@ test Module to :
 4. Move Bucket items.
 5. Print the output of bin tests
 """
+
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.crushtool_workflows import CrushToolWorkflows

--- a/tests/rados/test_data_migration_bw_pools.py
+++ b/tests/rados/test_data_migration_bw_pools.py
@@ -9,6 +9,7 @@ Methods:
     rados cppool
     rados import/export
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_ec_86.py
+++ b/tests/rados/test_ec_86.py
@@ -2,6 +2,7 @@
 Module to deploy 8+6 EC pool with custom CRUSH rules for testing
 
 """
+
 import time
 
 from ceph.ceph_admin import CephAdmin

--- a/tests/rados/test_inconsistency_osd_epoch.py
+++ b/tests/rados/test_inconsistency_osd_epoch.py
@@ -3,7 +3,6 @@ This file contains the  methods to generate inconsistent objects, collect the OS
  and then change the epoch to check if the inconsistency persists.
 """
 
-
 import random
 import traceback
 

--- a/tests/rados/test_libcephsqlite.py
+++ b/tests/rados/test_libcephsqlite.py
@@ -2,6 +2,7 @@
 Module to verify libcephsqlite's ability to reopen a database connection if
 current connection is down/blocklisted.
 """
+
 import random
 import time
 

--- a/tests/rados/test_mon_addition_removal.py
+++ b/tests/rados/test_mon_addition_removal.py
@@ -2,6 +2,7 @@
 Module to test addition and removal of mon daemons
 
 """
+
 import random
 
 from ceph.ceph_admin import CephAdmin

--- a/tests/rados/test_mon_config_history.py
+++ b/tests/rados/test_mon_config_history.py
@@ -3,6 +3,7 @@ This module tests :
 1. Changes to monitor config database by setting new config
 2. Verifies if the config change is successfully logged into the config history and a new version is created
 """
+
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from tests.rados.monitor_configurations import MonConfigMethods

--- a/tests/rados/test_mon_config_reset.py
+++ b/tests/rados/test_mon_config_reset.py
@@ -3,6 +3,7 @@ This module tests :
 1. Changes to monitor config database by setting new config.
 2. Verifies if the config can be reverted to any version and the config changes made are reverted.
 """
+
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from tests.rados.monitor_configurations import MonConfigMethods

--- a/tests/rados/test_mon_mgr_weight.py
+++ b/tests/rados/test_mon_mgr_weight.py
@@ -1,6 +1,7 @@
 """
 Module to ensure Mgr daemon does not crash when Monitor weights are out of place
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_mon_pg_warn.py
+++ b/tests/rados/test_mon_pg_warn.py
@@ -2,6 +2,7 @@
 Module to verify MANY_OBJECTS_PER_PG health warning and
 manual-increment of 'mon_pg_warn_max_object_skew' MGR parameter
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_mon_system_operations.py
+++ b/tests/rados/test_mon_system_operations.py
@@ -7,6 +7,7 @@ Removing a monitor from a healthy cluster
 Mon daemon failure - restart and kill
 
 """
+
 import random
 
 from ceph.ceph_admin import CephAdmin

--- a/tests/rados/test_object_ops.py
+++ b/tests/rados/test_object_ops.py
@@ -54,10 +54,14 @@ def run(ceph_cluster, **kw):
                         "Object size needs to be multiple of 2 for parallel writes, "
                         f"Input object size has been changed to {o_size}"
                     )
-                rados_obj.run_parallel_io(
-                    pool_name=pool_name, obj_name=object_name, obj_size=o_size
-                ) if "parallel" in pool_name else rados_obj.run_concurrent_io(
-                    pool_name=pool_name, obj_name=object_name, obj_size=o_size
+                (
+                    rados_obj.run_parallel_io(
+                        pool_name=pool_name, obj_name=object_name, obj_size=o_size
+                    )
+                    if "parallel" in pool_name
+                    else rados_obj.run_concurrent_io(
+                        pool_name=pool_name, obj_name=object_name, obj_size=o_size
+                    )
                 )
                 d_stored += o_size
 

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -16,6 +16,7 @@ Possible obj operations:
     remove-clone-metadata
 ceph-objectstore-tool --data-path path to osd [ --op list $obj_ID]
 """
+
 import json
 import random
 

--- a/tests/rados/test_omap_entries.py
+++ b/tests/rados/test_omap_entries.py
@@ -4,6 +4,7 @@ thereby increasing the OMAP entries generated on the pool.
 Verifying the Bug#2249003 - Observing client.admin crash in thread_name 'rados' on executing 'rados clearomap'
 for a rados pool different than the one where the object is present.
 """
+
 import random
 import time
 

--- a/tests/rados/test_online_reads_balancer.py
+++ b/tests/rados/test_online_reads_balancer.py
@@ -2,6 +2,7 @@
 Module to test Reads balancer functionality on RHCS 8.0 and above clusters
 
 """
+
 import re
 import time
 

--- a/tests/rados/test_osd_async_recovery.py
+++ b/tests/rados/test_osd_async_recovery.py
@@ -1,6 +1,7 @@
 """
 This file contains the  methods to verify the async messages in the OSD logs.
 """
+
 import time
 import traceback
 

--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -2,6 +2,7 @@
 Tier-3 test module to perform various operations on large OMAPS
 and execute OSD compaction during IOPS with and without OSD failure
 """
+
 import random
 import time
 

--- a/tests/rados/test_osd_db_wal_configuration.py
+++ b/tests/rados/test_osd_db_wal_configuration.py
@@ -1,6 +1,7 @@
 """
 Module to check the addition of  DB/wal devices to an existing OSD
 """
+
 import math
 import random
 import traceback

--- a/tests/rados/test_osd_df.py
+++ b/tests/rados/test_osd_df.py
@@ -317,9 +317,9 @@ def verify_deviation(
         status: status of host/node or osd | new or old or ignored
     Returns: True -> pass | False - fail
     """
-    acting_total_size = (
-        acting_total_raw_use
-    ) = acting_total_data = acting_total_avail = 0
+    acting_total_size = acting_total_raw_use = acting_total_data = (
+        acting_total_avail
+    ) = 0
     stored_data_kb = config["WI"] * 4 * 1024
     pre_osd_df_stats = config["pre_osd_df_stats"]
     post_osd_df_stats = config["post_osd_df_stats"]

--- a/tests/rados/test_osd_full.py
+++ b/tests/rados/test_osd_full.py
@@ -2,6 +2,7 @@
 Module to verify scenarios related to OSD being nearfull, backfill-full
 and completely full
 """
+
 import datetime
 import json
 import time

--- a/tests/rados/test_osd_memory_target.py
+++ b/tests/rados/test_osd_memory_target.py
@@ -1,6 +1,7 @@
 """
 Tier-2 test to verify the effect of osd_memory_target set at different precedence level
 """
+
 import random
 import time
 

--- a/tests/rados/test_osd_onode_trimming.py
+++ b/tests/rados/test_osd_onode_trimming.py
@@ -3,6 +3,7 @@ Method to verify the onode trimming
 Bugzilla:
   https://bugzilla.redhat.com/show_bug.cgi?id=1947215
 """
+
 import datetime
 import re
 import time

--- a/tests/rados/test_osdmap_trim.py
+++ b/tests/rados/test_osdmap_trim.py
@@ -1,6 +1,7 @@
 """
 Method to create OSDMAPs and verify automatic trimming and logging in mon logs
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_pg_dups_trimming.py
+++ b/tests/rados/test_pg_dups_trimming.py
@@ -1,6 +1,7 @@
 """
 Module to Verify if PG dup entries are trimmed successfully.
 """
+
 import datetime
 import json
 import random

--- a/tests/rados/test_pg_log_limit.py
+++ b/tests/rados/test_pg_log_limit.py
@@ -4,6 +4,7 @@ Bugzilla:
  - https://bugzilla.redhat.com/show_bug.cgi?id=1608060
  - https://bugzilla.redhat.com/show_bug.cgi?id=1644409
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -10,6 +10,7 @@ Module to perform tier-4 tests on pools WRT OSD daemons.
 7. Replacement of a failed OSD host
 
 """
+
 import datetime
 import random
 import time

--- a/tests/rados/test_reads_balancer.py
+++ b/tests/rados/test_reads_balancer.py
@@ -2,6 +2,7 @@
 Module to test Reads balancer functionality on RHCS 7.0 and above clusters
 
 """
+
 import datetime
 import re
 import time

--- a/tests/rados/test_replica1.py
+++ b/tests/rados/test_replica1.py
@@ -1,4 +1,5 @@
 """ Test module to verify replica-1 non-resilient pool functionalities"""
+
 import time
 from copy import deepcopy
 

--- a/tests/rados/test_scrub_chunk_max.py
+++ b/tests/rados/test_scrub_chunk_max.py
@@ -2,6 +2,7 @@
 Module to verify functionality and effect of OSD scrub_chunk_max parameter.
 BZ #1382226 - PG scrub bypasses 'osd_scrub_chunk_max' limit to find hash boundary
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_scrub_cpu_memory_usage.py
+++ b/tests/rados/test_scrub_cpu_memory_usage.py
@@ -1,6 +1,7 @@
 """
 The program verifies the CPU and memory consumption of OSD during the scheduled scrub
 """
+
 import datetime
 import time
 

--- a/tests/rados/test_scrub_log.py
+++ b/tests/rados/test_scrub_log.py
@@ -1,6 +1,7 @@
 """
 Module to Verify if PG scrub & deep-scrub messages are logged into the OSD logs
 """
+
 import re
 import time
 

--- a/tests/rados/test_scrub_omap.py
+++ b/tests/rados/test_scrub_omap.py
@@ -6,7 +6,6 @@ AS part of verification the script  perform the following tasks-
    3. While creating objects check that osds status
 """
 
-
 import datetime
 import time
 from threading import Thread

--- a/tests/rados/test_stretch_negative_scenarios.py
+++ b/tests/rados/test_stretch_negative_scenarios.py
@@ -9,6 +9,7 @@ includes:
 4. Try making the Datacenter weights uneven. Health warning generated
 
 """
+
 import random
 import time
 from collections import namedtuple

--- a/tests/rbd/rbd_resize_image_with_image_feature.py
+++ b/tests/rbd/rbd_resize_image_with_image_feature.py
@@ -19,7 +19,6 @@ Test Case Flow:
 6. Repeat steps 1 to 5 for ecpool
 """
 
-
 from ceph.parallel import parallel
 from tests.rbd.exceptions import RbdBaseException
 from tests.rbd.rbd_utils import (

--- a/tests/rbd/rbd_system.py
+++ b/tests/rbd/rbd_system.py
@@ -7,6 +7,7 @@ following things are done
 - Call the appropriate test script
 - Return the status code of the script.
 """
+
 from utility.log import Log
 
 log = Log(__name__)

--- a/tests/rbd/test_concurrent_write_pwl_cache.py
+++ b/tests/rbd/test_concurrent_write_pwl_cache.py
@@ -21,6 +21,7 @@ Support
 - Configure cluster with PWL Cache.
 - Only replicated pool supported, No EC pools.
 """
+
 from time import sleep
 
 from ceph.parallel import parallel

--- a/tests/rbd/test_performance_immutable_cache.py
+++ b/tests/rbd/test_performance_immutable_cache.py
@@ -22,6 +22,7 @@
     11. Repeat the above operations without immutable cache
     12.check the performance make sure cache gives good performance
 """
+
 from test_rbd_immutable_cache import configure_immutable_cache
 
 from ceph.rbd.initial_config import initial_rbd_config

--- a/tests/rbd/test_performance_pwl_cache.py
+++ b/tests/rbd/test_performance_pwl_cache.py
@@ -18,6 +18,7 @@ Support
 - Configure cluster with PWL Cache.
 - Only replicated pool supported, No EC pools.
 """
+
 import datetime
 import re
 from time import sleep

--- a/tests/rbd/test_rbd.py
+++ b/tests/rbd/test_rbd.py
@@ -10,6 +10,7 @@ This module will not install any pre-requisites of the repo.
 
 This module returns 0 on success else 1.
 """
+
 import json
 import re
 from time import sleep

--- a/tests/rbd/test_rbd_compression.py
+++ b/tests/rbd/test_rbd_compression.py
@@ -15,6 +15,7 @@
     5. verify "rbd_compression_hint" to "incompressible" on global, pool and image level
     6. Repeat the above steps for ecpool
 """
+
 import json
 
 from tests.rbd.rbd_utils import get_ceph_config, initial_rbd_config, set_ceph_config

--- a/tests/rbd/test_rbd_immutable_cache.py
+++ b/tests/rbd/test_rbd_immutable_cache.py
@@ -17,6 +17,7 @@
     7. Perform snapshot,protect and clone of rbd images
     8. Read the cloned images from the cache path
 """
+
 import time
 
 from tests.rbd.rbd_utils import initial_rbd_config

--- a/tests/rbd/test_rbd_immutable_cache_cluster_operations.py
+++ b/tests/rbd/test_rbd_immutable_cache_cluster_operations.py
@@ -19,6 +19,7 @@
     8) check ceph health status
     9) Perform test on both Replicated and EC pool
 """
+
 import time
 
 from test_rbd_immutable_cache import configure_immutable_cache

--- a/tests/rbd/test_rbd_migration_image_s3_object.py
+++ b/tests/rbd/test_rbd_migration_image_s3_object.py
@@ -14,6 +14,7 @@ Test Case Flow :
 3. Mention s3 object as source for live migration preparation.
 4. Execute and commit migration and verify.
 """
+
 import json
 from time import sleep
 

--- a/tests/rbd/test_rbd_persistent_write_back_cache.py
+++ b/tests/rbd/test_rbd_persistent_write_back_cache.py
@@ -10,6 +10,7 @@ Support
 - Only replicated pool supported, No EC pools.
 - Cannot be executed in parallel, if it is same pool or image.
 """
+
 from time import sleep
 
 from ceph.parallel import parallel

--- a/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
+++ b/tests/rbd/test_rbd_persistent_writeback_cache_flush.py
@@ -18,6 +18,7 @@ Support
 - Configure cluster with PWL Cache.
 - Only replicated pool supported, No EC pools.
 """
+
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
 from tests.rbd.rbd_peristent_writeback_cache import (

--- a/tests/rbd/test_rbd_persistent_writeback_cache_invalidate.py
+++ b/tests/rbd/test_rbd_persistent_writeback_cache_invalidate.py
@@ -21,6 +21,7 @@ Support
 - Configure cluster with PWL Cache.
 - Only replicated pool supported, No EC pools.
 """
+
 from time import sleep
 
 from ceph.parallel import parallel

--- a/tests/rbd/test_rbd_pwl_cache_cluster_operation.py
+++ b/tests/rbd/test_rbd_pwl_cache_cluster_operation.py
@@ -28,7 +28,6 @@ Support
 - Configure cluster with PWL Cache.
 - Only replicated pool supported, No EC pools."""
 
-
 import time
 
 from ceph.ceph_admin import CephAdmin

--- a/tests/rbd_mirror/rbd_mirror_reconfigure_primary_cluster.py
+++ b/tests/rbd_mirror/rbd_mirror_reconfigure_primary_cluster.py
@@ -18,6 +18,7 @@
     7) Demote initially promoted secondary as primary
     8) Promote newly created mirrored cluster as primary
 """
+
 # import datetime
 # import time
 

--- a/tests/rbd_mirror/rbd_mirror_reconfigure_secondary_cluster.py
+++ b/tests/rbd_mirror/rbd_mirror_reconfigure_secondary_cluster.py
@@ -16,6 +16,7 @@
     5) verify peer cluster got added successfully after failover
     6) verify all the images from primary mirrored to secondary
 """
+
 import ast
 import datetime
 import time

--- a/tests/rbd_mirror/test_rbd_mirror_connection_metrics.py
+++ b/tests/rbd_mirror/test_rbd_mirror_connection_metrics.py
@@ -16,6 +16,7 @@
         6. Verify ceph exporter from prometheus for network connection
            health metrics.
 """
+
 from tests.rbd_mirror import rbd_mirror_utils as rbdmirror
 from utility.log import Log
 

--- a/tests/rbd_mirror/test_rbd_mirror_image_features.py
+++ b/tests/rbd_mirror/test_rbd_mirror_image_features.py
@@ -12,6 +12,7 @@
     6. Verify if change of any image features in primary site gets mirrored in secondary site.
     7. perform test on both replicated and EC pool
 """
+
 import datetime
 import time
 

--- a/tests/rbd_mirror/test_rbd_mirror_replica_count.py
+++ b/tests/rbd_mirror/test_rbd_mirror_replica_count.py
@@ -21,6 +21,7 @@
         9. IO's should not stop and cluster health status should be healthy
         10. check data consistency among mirror clusters.
 """
+
 from ceph.parallel import parallel
 from tests.rbd.rbd_utils import Rbd
 from tests.rbd_mirror import rbd_mirror_utils as rbdmirror

--- a/tests/rbd_mirror/test_rbd_mirror_secondary_full.py
+++ b/tests/rbd_mirror/test_rbd_mirror_secondary_full.py
@@ -16,6 +16,7 @@
         6. keep on running IOs till secondary cluster becomes full
         7. verify after secondary becomes full, mirroring should fail
 """
+
 from ceph.parallel import parallel
 from tests.rbd.rbd_utils import Rbd
 from tests.rbd_mirror import rbd_mirror_utils as rbdmirror

--- a/tests/rgw/java_s3tests.py
+++ b/tests/rgw/java_s3tests.py
@@ -13,6 +13,7 @@ Requirement parameters
 Entry Point:
     def run(**args):
 """
+
 import binascii
 import json
 import os

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -45,7 +45,6 @@ Below configs are needed in order to run the tests
 
 """
 
-
 import yaml
 
 from utility import utils

--- a/utility/collect_logs.py
+++ b/utility/collect_logs.py
@@ -8,6 +8,7 @@ Run shell script on installer node, then upload all the collected logs to magna
   python collect_logs.py --ip x.x.x.x --username abc --password abcd
   python collect_logs.py -h
 """
+
 import json
 import os
 import re

--- a/utility/ibm_dns_cleanup.py
+++ b/utility/ibm_dns_cleanup.py
@@ -1,6 +1,7 @@
 """
     Utility to cleanup orphan DNS record from IBM environment
 """
+
 import math
 import sys
 from typing import Dict

--- a/utility/ibm_volume_cleanup.py
+++ b/utility/ibm_volume_cleanup.py
@@ -1,6 +1,7 @@
 """
     Utility to cleanup orphan volumes from IBM environment
 """
+
 import sys
 from time import sleep
 from typing import Dict

--- a/utility/lvm_utils.py
+++ b/utility/lvm_utils.py
@@ -43,10 +43,12 @@ def lvm_uncache(osd, vg_name):
 
 
 def make_partition(osd, device, start=None, end=None, gpt=False):
-    osd.exec_command(
-        cmd="sudo parted --script %s mklabel gpt" % device
-    ) if gpt else osd.exec_command(
-        cmd="sudo parted --script %s mkpart primary %s %s" % (device, start, end)
+    (
+        osd.exec_command(cmd="sudo parted --script %s mklabel gpt" % device)
+        if gpt
+        else osd.exec_command(
+            cmd="sudo parted --script %s mkpart primary %s %s" % (device, start, end)
+        )
     )
 
 

--- a/utility/psi_remove_vms.py
+++ b/utility/psi_remove_vms.py
@@ -10,6 +10,7 @@
         ceph-ci             1 week
         ceph-core           1 weeks
 """
+
 import smtplib
 import sys
 from datetime import datetime, timezone
@@ -159,9 +160,9 @@ def send_email(payload: Dict) -> list:
             recipient = email
 
             msg = MIMEMultipart("alternative")
-            msg[
-                "Subject"
-            ] = "Notification: Your subscriptions are marked/removed in RHOS-D"
+            msg["Subject"] = (
+                "Notification: Your subscriptions are marked/removed in RHOS-D"
+            )
             msg["From"] = sender
             msg["To"] = recipient
             html = """\

--- a/utility/rp_client.py
+++ b/utility/rp_client.py
@@ -76,6 +76,7 @@ Sample Output File:
     ]
 
 """
+
 import datetime
 import json
 import logging

--- a/utility/sosreport.py
+++ b/utility/sosreport.py
@@ -8,6 +8,7 @@ then upload all the collected logs to magna/directory(run_dir) provided
   python sosreport.py --ip x.x.x.x --username abc --password abcd --directory /tmp/cephci-run-ysfyu
   python sosreport.py -h
 """
+
 import os
 import re
 import sys

--- a/utility/xunit.py
+++ b/utility/xunit.py
@@ -1,4 +1,5 @@
 """Create xUnit result files."""
+
 from datetime import timedelta
 
 from junitparser import (


### PR DESCRIPTION
# Description

Dependabot recommends that we move to the latest version of black to fix Regular Expression Denial of Service vulnerability in black. This should not have any impact on the functionality as it being a code formatter.

Fixes: https://github.com/red-hat-storage/cephci/security/dependabot/2

<details>
<summary>click to expand checklist</summary>

- [x] Submit PR for code review and approve
- [x] Unit testing of the changes

</details>

_Log snippet_
```
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W6GMX9

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:06:43.661648                   Pass
RHCS deploy cluster using ceph   bootstrap with registry-url option and deployment services.    0:07:07.679409                   Pass
configure client                 Configure the RGW client system                                0:02:42.838016                   Pass
Parallel run                     RGW tier-1 parallelly.                                         0:03:21.879056                   Pass
enable bucket versioning         Basic versioning test, also called as test to enable bucket    0:10:00.533070                   Pass
Bucket Lifecycle Object_expira   Test object expiration for non current version expiration      0:13:44.639667                   Pass
Bucket Lifecycle Object_transi   Test object transition for Prefixand versioned buckets         0:12:39.210002                   Pass
S3CMD small and multipart obje   S3CMD small and multipart object download or GET               0:02:10.761738                   Pass
2024-07-15 02:34:08,191 (cephci.sanity_rgw) [INFO] - cephci.run.py:1080 - final rc of test run 0
```
