### PR TITLE
Additional OpenStack networks for deployment.

### DIFF
--- a/compute/openstack.py
+++ b/compute/openstack.py
@@ -1,4 +1,5 @@
 """Support VM lifecycle operation in an OpenStack Cloud."""
+
 import socket
 from datetime import datetime, timedelta
 from time import sleep
@@ -79,14 +80,13 @@ class CephVMNodeV2:
     """Represent the VMNode required for cephci."""
 
     default_rhosd_network_names = [
+        "provider_net_cci_16",
+        "provider_net_cci_15",
+        "provider_net_cci_14",
+        "provider_net_cci_13",
         "provider_net_cci_12",
         "provider_net_cci_11",
         "provider_net_cci_9",
-        "provider_net_cci_8",
-        "provider_net_cci_7",
-        "provider_net_cci_6",
-        "provider_net_cci_5",
-        "provider_net_cci_4",
     ]
 
     default_rhos01_network_names = [


### PR DESCRIPTION
# Description

Removing older defined networks due to frequent issues in gathering network addresses. Along with newly defined networks that are sparsely used.

<details>

<summary>click to expand checklist</summary>

- [x] Review the automation design
- [x] Submit PR for code review and approve
- [x] Unit testing
</details>

_Log snippets_

Said networks are used here
```
2024-07-15 01:30:43,225 (cephci.utility.xunit) [INFO] - cephci.compute.openstack.py:162 - OSP Config network set used are - ['provider_net_cci_16', 'provider_net_cci_15', 'provider_net_cci_14', 'provider_net_cci_13', 'provider_net_cci_12', 'provider_net_cci_11', 'provider_net_cci_9']
```

VM specific
```
2024-07-15 01:34:03,250 (cephci.utility.xunit) [INFO] - cephci.compute.openstack.py:186 - Starting to create VM with name ceph-psathyan-W6GMX9-node6
2024-07-15 01:34:12,018 (cephci.utility.xunit) [INFO] - cephci.compute.openstack.py:192 - ceph-psathyan-W6GMX9-node6 networks: ['provider_net_cci_16']
2024-07-15 01:34:33,408 (cephci.utility.xunit) [INFO] - cephci.compute.openstack.py:449 - ceph-psathyan-W6GMX9-node6 moved to running state in 20 seconds.
2024-07-15 01:35:13,254 (cephci.utility.xunit) [DEBUG] - cephci.ceph.parallel.py:89 - result is None
2024-07-15 01:35:13,255 (cephci.utility.xunit) [DEBUG] - cephci.ceph.parallel.py:89 - result is None
2024-07-15 01:35:13,257 (cephci.utility.xunit) [DEBUG] - cephci.ceph.parallel.py:89 - result is None
2024-07-15 01:35:13,258 (cephci.utility.xunit) [DEBUG] - cephci.ceph.parallel.py:89 - result is None
2024-07-15 01:35:13,259 (cephci.utility.xunit) [DEBUG] - cephci.ceph.parallel.py:89 - result is None
2024-07-15 01:35:13,260 (cephci.utility.xunit) [INFO] - cephci.ceph.utils.py:371 - Done creating nodes
2024-07-15 01:35:14,512 (cephci.utility.xunit) [INFO] - cephci.run.py:270 - Done creating osp instances
2024-07-15 01:35:14,513 (cephci.utility.xunit) [INFO] - cephci.run.py:271 - Waiting for Floating IPs to be available
2024-07-15 01:35:14,514 (cephci.utility.xunit) [INFO] - cephci.run.py:272 - Sleeping 15 Seconds
```

_Test summary_

```
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W6GMX9

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:06:43.661648                   Pass
RHCS deploy cluster using ceph   bootstrap with registry-url option and deployment services.    0:07:07.679409                   Pass
configure client                 Configure the RGW client system                                0:02:42.838016                   Pass
Parallel run                     RGW tier-1 parallelly.                                         0:03:21.879056                   Pass
enable bucket versioning         Basic versioning test, also called as test to enable bucket    0:10:00.533070                   Pass
Bucket Lifecycle Object_expira   Test object expiration for non current version expiration      0:13:44.639667                   Pass
Bucket Lifecycle Object_transi   Test object transition for Prefixand versioned buckets         0:12:39.210002                   Pass
S3CMD small and multipart obje   S3CMD small and multipart object download or GET               0:02:10.761738                   Pass
2024-07-15 02:34:08,191 (cephci.sanity_rgw) [INFO] - cephci.run.py:1080 - final rc of test run 0
````
