### PR TITLE
[TFA] Fix the playbook failure due to undefined variable

### DIFF
--- a/tests/cephadm/ansible_wrapper/ceph_config/set-ceph-config.yaml
+++ b/tests/cephadm/ansible_wrapper/ceph_config/set-ceph-config.yaml
@@ -3,6 +3,8 @@
   gather_facts: false
   become: true
   any_errors_fatal: true
+  vars:
+    value: "{{ value }}"
   tasks:
     - name: Set ceph config
       ceph_config:
@@ -17,4 +19,4 @@
         who: "{{ who }}"
         option: "{{ option }}"
       register: result
-      failed_when: value !=  result.stdout
+      failed_when: (value | string | lower) != (result.stdout | lower)


### PR DESCRIPTION
Problem:
Playbook fails with validation of the config because of the condition statement 

Reason for Failure:
Earlier, the playbook was failing with error -

_2024-05-13 10:46:39,446 (cephci.cli.utilities.operations) [DEBUG] - cephci.RH.7.1.rhel-9.Regression.18.2.1-173.dmfg.123.cephci.ceph.ceph.py:1533 - b" failed_when_result: 'The conditional check ''{{ value }} != {{ result.stdout }}'' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated.'"_

because the condition was -
`failed_when: "{{ value }} != {{ result.stdout }}" `

Now, to fix above error, the code was changed to 
`failed_when: value !=  result.stdout `
[https://github.com/red-hat-storage/cephci/commit/2f58105c72cee923806a6463cdef30f11751f43a]

due to which the playbook is failing with new error -

  _failed_when_result: 'The conditional check ''value != result.stdout'' failed. The error was: error while evaluating conditional (value != result.stdout): ''value'' is undefined. ''value'' is undefined'_

Solution:
Declare the variable "value" under "vars" to resolve the 'value'' is undefined error. And add the string formatting to resolve the "Conditional is marked as unsafe error" which was fixed earlier. 