### PR TITLE
Fix for Upgrade from 5.3 to 7.x

### DIFF
--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -361,10 +361,13 @@ class BootstrapMixin:
                 "prometheus",
                 "node_exporter",
                 "alertmanager",
-                "promtail",
                 "snmp_gateway",
-                "loki",
             ]
+            if self.cluster.rhcs_version >= LooseVersion("6.0"):
+                supported_overrides += [
+                    "promtail",
+                    "loki",
+                ]
             if self.cluster.rhcs_version >= LooseVersion("7.0"):
                 supported_overrides += [
                     "nvmeof",


### PR DESCRIPTION
# Description

Fix for Upgrade from 5.3 to 7.x
[Uploading cephci-run-9V8SCK.zip…]()

[deploy_cluster_0.log](https://github.com/user-attachments/files/16247577/deploy_cluster_0.log)

