### PR TITLE
Incorrect timeout evaluation in long_running

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1524,8 +1524,6 @@ class CephNode(object):
             channel.set_combine_stderr(True)
             channel.exec_command(cmd)
 
-            # Channel timeout is per operation. Waiting for a specified duration or
-            # command execution completion.
             if timeout:
                 _end_time = datetime.datetime.now() + datetime.timedelta(
                     seconds=timeout
@@ -1543,7 +1541,8 @@ class CephNode(object):
 
                         data = channel.recv(1024)
 
-                if not timeout and _end_time > datetime.datetime.now():
+                # time check - raise exception when exceeded.
+                if timeout is not None and _end_time > datetime.datetime.now():
                     channel.close()
                     raise SocketTimeoutException(
                         f"{cmd} failed to complete within {timeout}s"


### PR DESCRIPTION
# Description

Unit testing indicated that `if not timeout ...` was not getting evaluated correctly. This patch switches to checking `if timeout is not None ...`


- [x] Unit testing completed

_Log snippets_
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/psathyan/src/cephci/run.py", line 830, in run
    rc = test_mod.run(
  File "/home/psathyan/src/cephci/tests/misc_env/install_prereq.py", line 78, in run
    ceph_nodes[0].exec_command(cmd="sleep 120", long_running=True, timeout=10)
  File "/home/psathyan/src/cephci/ceph/ceph.py", line 1584, in exec_command
    return self.long_running(**kw)
  File "/home/psathyan/src/cephci/ceph/ceph.py", line 1565, in long_running
    raise CommandFailed(be)
ceph.ceph.CommandFailed: sleep 120 failed to complete within 10s
```
Run summary
```
2024-07-17 08:22:22,555 (cephci.install_prereq) [INFO] - cephci.run.py:956 -
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KIZHA6

All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-KIZHA6

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:00:02.122958                   Failed
2024-07-17 08:22:22,736 (cephci.install_prereq) [INFO] - cephci.run.py:1012 -
```
