### PR TITLE
TFA: regression issue with long_running method

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1518,6 +1518,7 @@ class CephNode(object):
 
         try:
             channel = ssh().get_transport().open_session()
+            channel.settimeout(timeout)
 
             # A mismatch between stdout and stderr streams have been observed hence
             # combining the streams and logging is set to debug level only.
@@ -1542,7 +1543,7 @@ class CephNode(object):
                         data = channel.recv(1024)
 
                 # time check - raise exception when exceeded.
-                if timeout is not None and _end_time > datetime.datetime.now():
+                if timeout and datetime.datetime.now() > _end_time:
                     channel.close()
                     raise SocketTimeoutException(
                         f"{cmd} failed to complete within {timeout}s"


### PR DESCRIPTION
# Description

Incorrect check was performed when evaluating maximum allocated run duration. This patch fixes the patch statement.

- [x] Unit testing

*Logs*

```
2024-07-18 00:51:25,753 (cephci.install_prereq) [INFO] - cephci.ceph.ceph.py:1515 - long running command on 10.0.66.198 -- subscription-manager register --username qa@redhat.com --password MTQj5t3n5K86p3gH --serverurl subscription.rhsm.redhat.com:443 --baseurl https://cdn.redhat.com --force with 3600 seconds
2024-07-18 00:51:31,792 (cephci.install_prereq) [DEBUG] - cephci.ceph.ceph.py:1541 - b'Registering to: subscription.rhsm.redhat.com:443/subscription'
2024-07-18 00:51:31,794 (cephci.install_prereq) [DEBUG] - cephci.ceph.ceph.py:1541 - b'The system has been registered with ID: bc9bfcc7-2d7b-42d9-8887-d7c3b0c8c51a'
2024-07-18 00:51:31,795 (cephci.install_prereq) [DEBUG] - cephci.ceph.ceph.py:1541 - b'The registered system name is: ceph-psathyan-5gaepi-node1-installer'
2024-07-18 00:51:31,796 (cephci.install_prereq) [INFO] - cephci.ceph.ceph.py:1552 - Command completed on 2024-07-18 00:51:31.795900
```