### PR TITLE
Further Improvements to long_running method

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1145,6 +1145,18 @@ class CommandFailed(Exception):
     pass
 
 
+class TimeoutException(Exception):
+    """Operation timeout exception."""
+
+    pass
+
+
+def check_timeout(end_time, timeout):
+    """Raises an exception when current time is greater"""
+    if timeout and datetime.datetime.now() >= end_time:
+        raise TimeoutException("Command exceed the allocated execution time.")
+
+
 class RolesContainer(object):
     """
     Container for single or multiple node roles.
@@ -1521,7 +1533,7 @@ class CephNode(object):
             channel.settimeout(timeout)
 
             # A mismatch between stdout and stderr streams have been observed hence
-            # combining the streams and logging is set to debug level only.
+            # combining the streams and logging is set to debug level.
             channel.set_combine_stderr(True)
             channel.exec_command(cmd)
 
@@ -1532,22 +1544,17 @@ class CephNode(object):
 
             while not channel.exit_status_ready():
                 # Prevent high resource consumption
-                sleep(2)
-
+                sleep(1)
                 if channel.recv_ready():
                     data = channel.recv(1024)
                     while data:
                         for line in data.splitlines():
                             logger.debug(line)
 
+                        check_timeout(_end_time, timeout)
                         data = channel.recv(1024)
 
-                # time check - raise exception when exceeded.
-                if timeout and datetime.datetime.now() > _end_time:
-                    channel.close()
-                    raise SocketTimeoutException(
-                        f"{cmd} failed to complete within {timeout}s"
-                    )
+                check_timeout(_end_time, timeout)
 
             logger.info(f"Command completed on {datetime.datetime.now()}")
             return channel.recv_exit_status()
@@ -1555,6 +1562,10 @@ class CephNode(object):
         except socket.timeout as terr:
             logger.error(f"Command failed to execute within {timeout} seconds.")
             raise SocketTimeoutException(terr)
+        except TimeoutException as tex:
+            channel.close()
+            logger.error(f"{cmd} failed to execute within {timeout}s.")
+            raise CommandFailed(tex)
         except BaseException as be:  # noqa
             logger.exception(be)
             raise CommandFailed(be)


### PR DESCRIPTION
# Description

During unit testing, it has been observed that the method does not honor the timeout when there is a continuous stream of reads.

For example, if the below command is executed
```
node.exec(cmd="while [ -f /ceph-qe-ready ]; do echo 'Writing...' ; done",
    long_running=True,
    timeout=10
)
```
then the timeout of 10 seconds is never honoured due to never ending reads.

In this patch, the loop around data reading is removed and a singular controlled loop is implemented.

*Unit Testing*
- [x] Positive Run
- [x] Negative Run
- [x] e2e run 

*Results*
_e2e run_
`All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-H4G5JF`

_Negative run_
```
Failure induced by using above code fragment
raceback (most recent call last):
  File "/home/psathyan/src/cephci/run.py", line 830, in run
    rc = test_mod.run(
  File "/home/psathyan/src/cephci/tests/misc_env/install_prereq.py", line 76, in run
    ceph_nodes[0].exec_command(cmd='while [ -f /ceph-qa-ready ]; do echo "I am in" ; sleep 1 ; done', long_running=True, timeout=10)
  File "/home/psathyan/src/cephci/ceph/ceph.py", line 1577, in exec_command
    return self.long_running(**kw)
  File "/home/psathyan/src/cephci/ceph/ceph.py", line 1558, in long_running
    raise CommandFailed(be)
ceph.ceph.CommandFailed: while [ -f /ceph-qa-ready ]; do echo "I am in" ; sleep 1 ; done failed to complete within 10s
2024-07-18 02:58:01,520 (cephci.install_prereq) [INFO] - cephci.ceph.ceph.py:1582 - Running command podman --version | awk {'print $3'} on 10.0.65.48 timeout 600
2024-07-18 02:58:01,541 (cephci.install_prereq) [INFO] - cephci.ceph.ceph.py:1582 - Running command docker --version | awk {'print $3'} on 10.0.65.48 timeout 600
2024-07-18 02:58:01,602 (cephci.install_prereq) [INFO] - cephci.ceph.ceph.py:1582 - Running command ceph --version | awk '{print $3}' on 10.0.65.142 timeout 600
2024-07-18 02:58:01,623 (cephci.install_prereq) [INFO] - cephci.run.py:1069 - ceph Version
2024-07-18 02:58:01,624 (cephci.install_prereq) [INFO] - cephci.run.py:919 - Test <module 'install_prereq' from '/home/psathyan/src/cephci/tests/misc_env/install_prereq.py'> failed
Test <module 'install_prereq' from '/home/psathyan/src/cephci/tests/misc_env/install_prereq.py'> failed
2024-07-18 02:58:01,625 (cephci.install_prereq) [INFO] - cephci.run.py:927 - Aborting on test failure
2024-07-18 02:58:01,626 (cephci.install_prereq) [INFO] - cephci.run.py:956 -
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GWCZXT

All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GWCZXT

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:00:10.145809                   Failed
2024-07-18 02:58:01,766 (cephci.install_prereq) [INFO] - cephci.run.py:1012 -
```

_Postive run_
```
Test <module 'sanity_rgw' from '/home/psathyan/src/cephci/tests/rgw/sanity_rgw.py'> passed
2024-07-18 06:04:20,276 (cephci.sanity_rgw) [INFO] - cephci.run.py:956 -
All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZBISWR

All test logs located here: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZBISWR

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup pre-requisites             Install software pre-requisites for cluster deployment.        0:06:23.785803                   Pass
RHCS deploy cluster using ceph   bootstrap with registry-url option and deployment services.    0:06:59.281161                   Pass
configure client                 Configure the RGW client system                                0:03:02.665613                   Pass
Parallel run                     RGW tier-1 parallelly.                                         0:03:23.725782                   Pass
``` 