### PR TITLE
[TFA]: Fix issue seen with mulipart upload failure with sse-s3

### DIFF
--- a/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -219,6 +219,55 @@ tests:
       polarion-id: CEPH-83575199
 
   - test:
+      clusters:
+        ceph-pri:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-sec:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.sec}"
+            timeout: 120
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.pri}"
+            timeout: 120
+      desc: Setting vault configs for sse-s3 on multisite
+      module: exec.py
+      name: set sse-s3 vault configs on multisite
+
+  - test:
       name: notify copy events with kafka_broker_persistent
       desc: notify copy events with kafka_broker_persistent
       polarion-id: CEPH-83574066
@@ -242,6 +291,7 @@ tests:
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
       polarion-id: CEPH-83586489
+      comment: Known issue Bug-2298084 targeted tp 6.1z7
 
   - test:
       name: notify put,delete events with kafka_broker_persistent


### PR DESCRIPTION
# Description

Failure was due to missing pre-req which is needed for sse-s3 testcase execution
log before fix: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-226/rgw/32/tier-2_rgw_ms_test-bucket-notifications/
1. Setup and configure vault agent
2. Setting vault configs for sse-s3 on multisite

Log after fix:
[test_sse_s3_per_bucket_with_notifications_dynamic_reshard_0.log](https://github.com/user-attachments/files/16281406/test_sse_s3_per_bucket_with_notifications_dynamic_reshard_0.log)
here failure is a known product issue in quincy:

https://bugzilla.redhat.com/show_bug.cgi?id=2298084


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
