### PR TITLE
Fixed TC mismatch b/w reef and quincy suites

### DIFF
--- a/suites/quincy/cephfs/tier-3_cephfs_bugs.yaml
+++ b/suites/quincy/cephfs/tier-3_cephfs_bugs.yaml
@@ -4,20 +4,23 @@
 # Conf file : conf/pacific/cephfs/tier-3_cephfs_4clients_4osd.yaml
 # Description - This test suite contains tests which were automated during bug verification
 # Test-Case Covered:
-#   CEPH-11260 - Change replication size of Cephfs pools increase and decrease, with client IO
-#   CEPH-83574833 - Performace test for file write_sync() on cephfs kernel mount
-#   CEPH-83574632 - Allow recreating file system with specific fscid
-#   CEPH-83572726 - Active-Active MDS with multiclients to verify the race condition
-#   CEPH-83575622 - create a file(fileA) , create a hard link (fileB),
-#            remove the fileA first and then fileB and run this in a loop for some time and check for deadlock
-#   CEPH-83575623 - Run fsstress.sh repeatedly on fuse and kernel clients for a while and validate no crash is seen.
-#   CEPH-83575781: Remove contents of lost+found directory.
-#   CEPH-83575762: Run create and unlink operations concurrently.
-#   CEPH-83575630: Check for large omaps with files and snapshots.
-#   CEPH-83575624: Check for Standby-reply nodes changes if there is a network glitch for more than 60 seconds.
-#   CEPH-83583762: Check to prevent usage of Pools which has Pool level snaps for Filesystem creation.
-#   CEPH-83584084: Validate if no repeated mclientscaps(revoke) entries found in MDS.
-#   CEPH-83586730: validate standby replay node not removed after setting mds_inject_health_dummy
+  # CEPH-11260 - Change replication size of Cephfs pools increase and decrease, with client IO
+  # CEPH-83574833 - Performace test for file write_sync() on cephfs kernel mount
+  # CEPH-83574632 - Allow recreating file system with specific fscid
+  # CEPH-83572726 - Active-Active MDS with multiclients to verify the race condition
+  # CEPH-83575622 - create a file(fileA) , create a hard link (fileB),
+  #          remove the fileA first and then fileB and run this in a loop for some time and check for deadlock
+  # CEPH-83575623 - Run fsstress.sh repeatedly on fuse and kernel clients for a while and validate no crash is seen.
+  # CEPH-83575781: Remove contents of lost+found directory.
+  # CEPH-83575762: Run create and unlink operations concurrently.
+  # CEPH-83575630: Check for large omaps with files and snapshots.
+  # CEPH-83575624: Check for Standby-reply nodes changes if there is a network glitch for more than 60 seconds.
+  # CEPH-83583762: Check to prevent usage of Pools which has Pool level snaps for Filesystem creation.
+  # CEPH-83584084: Validate if no repeated mclientscaps(revoke) entries found in MDS.
+  # CEPH-83586730: validate standby replay node not removed after setting mds_inject_health_dummy
+  # CEPH-83583721 - Validate the details of all MDS servers are displayed with command `ceph mds metadata`.
+  # CEPH-83583723 - Ensure deletion of clones are allowed when the clones are stuck and in pending state
+  # CEPH-83589266 - Validate Ceph commands when ceph file system is in failed state
 #=======================================================================================================================
 ---
 tests:
@@ -220,14 +223,33 @@ tests:
       desc: Creation of pool-level snaps for pools actively associated with a filesystem is disallowed
       abort-on-fail: false
   - test:
-      name: Validate if no repeated mclientscaps(revoke) entries found in MDS.
-      module: cephfs_bugs.test_validate_mclientcaps_revoke_ack.py
-      polarion-id: CEPH-83584084
-      desc: Validate if no repeated mclientscaps(revoke) entries found in MDS.
-      abort-on-fail: false
-  - test:
       name: validate standby replay node not removed after setting mds_inject_health_dummy
       module: cephfs_bugs.test_mds_inject_health_dummy.py
       polarion-id: CEPH-83586730
       desc: validate standby reply node not removed after setting mds_inject_health_dummy
       abort-on-fail: false
+  - test:
+      name:  Validate the details of all MDS servers are displayed with command ceph mds metadata
+      module: cephfs_bugs.validate_mds_metadata.py
+      polarion-id: CEPH-83583721
+      desc: Validate the details of all MDS servers are displayed with command ceph mds metadata
+      abort-on-fail: false
+  - test:
+      name: Ensure deletion of clones are allowed when the clones are stuck and in pending state
+      module: cephfs_bugs.test_clone_delete_with_FS_fail.py
+      polarion-id: CEPH-83583723
+      desc: Ensure deletion of clones are allowed when the clones are stuck and in pending state
+      abort-on-fail: false
+  - test:
+      name: Validate Ceph commands when ceph file system is in failed state
+      module: cephfs_bugs.validate_ceph_ops_wtih_fs_fail.py
+      polarion-id: CEPH-83589266
+      desc: Validate Ceph commands when ceph file system is in failed state
+      abort-on-fail: false
+  - test:
+      name: Verify Ceph Health Warning for Slow MDS Requests After Cluster Installation
+      module: cephfs_bugs.validate_mds_health_with_client_evict.py
+      polarion-id: CEPH-83591136
+      desc: Verify Ceph Health Warning for Slow MDS Requests After Cluster Installation
+      abort-on-fail: false
+

--- a/suites/quincy/cephfs/tier-3_cephfs_bugs_baremetal.yaml
+++ b/suites/quincy/cephfs/tier-3_cephfs_bugs_baremetal.yaml
@@ -144,3 +144,10 @@ tests:
       polarion-id: CEPH-83586294
       desc: Validate if MDS Cache Oversized Warning seen when standby-allow is added
       abort-on-fail: false
+  - test:
+      name: Validate if no repeated mclientscaps(revoke) entries found in MDS.
+      module: cephfs_bugs.test_validate_mclientcaps_revoke_ack.py
+      polarion-id: CEPH-83584084
+      desc: Validate if no repeated mclientscaps(revoke) entries found in MDS.
+      abort-on-fail: false
+

--- a/suites/reef/cephfs/tier-3_cephfs_bugs.yaml
+++ b/suites/reef/cephfs/tier-3_cephfs_bugs.yaml
@@ -223,7 +223,7 @@ tests:
       desc: Creation of pool-level snaps for pools actively associated with a filesystem is disallowed
       abort-on-fail: false
   - test:
-      name: validate standby reply node not removed after setting mds_inject_health_dummy
+      name: validate standby replay node not removed after setting mds_inject_health_dummy
       module: cephfs_bugs.test_mds_inject_health_dummy.py
       polarion-id: CEPH-83586730
       desc: validate standby reply node not removed after setting mds_inject_health_dummy
@@ -252,3 +252,4 @@ tests:
       polarion-id: CEPH-83591136
       desc: Verify Ceph Health Warning for Slow MDS Requests After Cluster Installation
       abort-on-fail: false
+


### PR DESCRIPTION
# Description

There were a few TC mismatches between Quincy and Reef Suites. Fixed them and a complete suite was executed on both suites.

Logs : 
Quincy : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5XX587/

Reef : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4CD1WQ/

=============================================================

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
