### PR TITLE
Fixing recreating of user in upgrade suite

### DIFF
--- a/suites/reef/cephfs/tier-0_cephfs_upgrade_70_to_71.yaml
+++ b/suites/reef/cephfs/tier-0_cephfs_upgrade_70_to_71.yaml
@@ -151,6 +151,7 @@ tests:
             abort-on-fail: false
             config:
               timeout: 30
+              recreate_user: False
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
             name: "creation of Prerequisites for Upgrade"

--- a/tests/cephfs/cephfs_upgrade/cephfs_io.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_io.py
@@ -27,7 +27,8 @@ def run(ceph_cluster, **kw):
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
         fs_util.prepare_clients(clients, build)
-        fs_util.auth_list(clients)
+        recreate_user = config.get("recreate_user", False)
+        fs_util.auth_list(clients, recreate=recreate_user)
         timeout = config.get("timeout", 1800)
         log.info("checking Pre-requisites")
         if not clients:

--- a/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_mds_failover.py
@@ -28,7 +28,6 @@ def run(ceph_cluster, **kw):
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
         fs_util.prepare_clients(clients, build)
-        fs_util.auth_list(clients)
         log.info("checking Pre-requisites")
         if not clients:
             log.info(

--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -865,6 +865,7 @@ def cg_quiesce_test(cg_quiesce_params):
     p.start()
     time.sleep(10)
     snap_qs_dict = {}
+    qs_id_val = "Not Started"
     for qs_member in qs_set:
         snap_qs_dict.update({qs_member: []})
     if p.is_alive():
@@ -964,7 +965,7 @@ def cg_quiesce_test(cg_quiesce_params):
     cg_snap_util.cleanup_cg_io(cg_io_client, mnt_pt_list)
     mnt_pt_list.clear()
 
-    snap_name = f"cg_snap_{rand_str}"
+    # snap_name = f"cg_snap_{rand_str}"
     log.info("Remove CG snapshots")
     for qs_member in qs_member_dict:
         snap_list = snap_qs_dict[qs_member]

--- a/tests/cephfs/cephfs_upgrade/metadata_version_validation.py
+++ b/tests/cephfs/cephfs_upgrade/metadata_version_validation.py
@@ -1,7 +1,6 @@
 import json
 import traceback
 
-from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
 
 log = Log(__name__)
@@ -23,9 +22,7 @@ This Script needs 2 times of run:
 def run(ceph_cluster, **kw):
     ceph_version_path = "/tmp/ceph_versions.json"
     log.info("Upgrade checking initiated")
-    fs_util = FsUtils(ceph_cluster)
     client = ceph_cluster.get_ceph_objects("client")[0]
-    fs_util.auth_list([client])
     check_list = ["mon", "mgr", "osd", "mds", "overall"]
     cluster_stat_commands = [
         "ceph fs ls",
@@ -153,7 +150,12 @@ def run(ceph_cluster, **kw):
             for line in after_upgrade_file.readlines():
                 log.info(line)
             clients = ceph_cluster.get_ceph_objects("client")
-            cmd = "dnf clean all;dnf -y install ceph-common --nogpgcheck;dnf -y update ceph-common --nogpgcheck"
+            cmd = (
+                "dnf clean all;dnf -y install ceph-common --nogpgcheck;"
+                "dnf -y update ceph-common --nogpgcheck; "
+                "dnf -y install ceph-fuse --nogpgcheck;"
+                "dnf -y update ceph-fuse --nogpgcheck;"
+            )
             for client in clients:
                 client.exec_command(sudo=True, cmd=cmd)
         else:

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -632,19 +632,20 @@ class FsUtils(object):
         Args:
             clients:
             **kwargs:
-
+            recreate : if passed as false then will not create user if already exists or
+                any kwargs like mds, osd are passed then it will create irrespective of this filed
         Returns:
 
         """
         fs_info = self.get_fs_info(clients[0])
         for client in clients:
             log.info("Giving required permissions for clients:")
-            client.exec_command(
+            out, rc = client.exec_command(
                 sudo=True,
                 cmd=f"ceph auth get client.{client.node.hostname}",
                 check_ec=False,
             )
-            if client.node.exit_status == 0:
+            if not rc and kwargs.get("recreate", True):
                 client.exec_command(
                     sudo=True, cmd=f"ceph auth del client.{client.node.hostname}"
                 )
@@ -714,17 +715,18 @@ class FsUtils(object):
                     cmd=f"chmod 644 /etc/ceph/ceph.client.{client.node.hostname}_{kwargs.get('path')}.keyring",
                 )
             else:
-                client.exec_command(
-                    sudo=True,
-                    cmd=f"ceph auth get-or-create client.{client.node.hostname}"
-                    f" mon 'allow *' mds "
-                    f"'allow *, allow * path=/' osd 'allow *'"
-                    f" -o /etc/ceph/ceph.client.{client.node.hostname}.keyring",
-                )
-                client.exec_command(
-                    sudo=True,
-                    cmd=f"chmod 644 /etc/ceph/ceph.client.{client.node.hostname}.keyring",
-                )
+                if kwargs.get("recreate", True):
+                    client.exec_command(
+                        sudo=True,
+                        cmd=f"ceph auth get-or-create client.{client.node.hostname}"
+                        f" mon 'allow *' mds "
+                        f"'allow *, allow * path=/' osd 'allow *'"
+                        f" -o /etc/ceph/ceph.client.{client.node.hostname}.keyring",
+                    )
+                    client.exec_command(
+                        sudo=True,
+                        cmd=f"chmod 644 /etc/ceph/ceph.client.{client.node.hostname}.keyring",
+                    )
         return 0
 
     @retry(CommandFailed, tries=3, delay=60)


### PR DESCRIPTION
# Description
We have made the following updates in the upgrade suite:
Removed instances of user re-creation that were affecting fuse and kernel mounts.
Despite these fixes, we are still experiencing issues with the quiesce test failure in the final step:

Test7: Post-upgrade CG Quiesce Feature Validation

Please review these changes and merge
@sumabai, could you please work on top of these fixes?

Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-60QNB3/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
