### PR TITLE
Re-enable curl testcases for ssl suite

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
@@ -181,15 +181,14 @@ tests:
         commands:
           - "ceph versions"
 
-  # - test:
-  #     name: Test rgw through CURL
-  #     desc: Test rgw through CURL
-  #     polarion-id: CEPH-83575572
-  #     module: sanity_rgw.py
-  #     config:
-  #       script-name: ../curl/test_rgw_using_curl.py
-  #       config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-  #       timeout: 500
+  - test:
+      name: Test rgw through CURL
+      desc: Test rgw through CURL
+      polarion-id: CEPH-83575572
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
 
   - test:
       name: S3CMD small and multipart object download post upgrade

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
@@ -181,15 +181,14 @@ tests:
         commands:
           - "ceph versions"
 
-  # - test:
-  #     name: Test rgw through CURL
-  #     desc: Test rgw through CURL
-  #     polarion-id: CEPH-83575572
-  #     module: sanity_rgw.py
-  #     config:
-  #       script-name: ../curl/test_rgw_using_curl.py
-  #       config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-  #       timeout: 500
+  - test:
+      name: Test rgw through CURL
+      desc: Test rgw through CURL
+      polarion-id: CEPH-83575572
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
 
   - test:
       name: S3CMD small and multipart object download post upgrade


### PR DESCRIPTION
# Description

Re-enable curl testcases for ssl suite with the support provided in ceph-qe-scripts:
https://github.com/red-hat-storage/ceph-qe-scripts/pull/617

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
