### PR TITLE
integrating apple session policy batch deletes hotfix tests into cephci

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -108,7 +108,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_list_not_truncated.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform assume role on principle user and perform IOs
@@ -119,7 +118,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role call with permissive session policies
       desc: Perform assume role call with permissive session policies
@@ -128,7 +126,6 @@ tests:
       config:
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_permissive_session_policy.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role call with restrictive session policies
       desc: Perform assume role call with restrictive session policies
@@ -137,7 +134,22 @@ tests:
       config:
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
-        timeout: 500
+  - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
   - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
@@ -146,7 +158,6 @@ tests:
       config:
         script-name: test_sts_using_boto_server_side_copy.py
         config-file-name: test_sts_using_boto_server_side_copy.yaml
-        timeout: 500
   - test:
       name: STS Tests for handling non-existent object condition
       desc: STS test using boto for handling non-existent object condition
@@ -155,7 +166,6 @@ tests:
       config:
         script-name: test_sts_using_boto_unexisting_object.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: STS test with invalid arn in the role's policy
       desc: STS test with invalid arn in the role's policy
@@ -164,7 +174,6 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
-        timeout: 500
   - test:
       name: STS test with invalid principal in the role's policy
       desc: STS test with invalid principal in the role's policy
@@ -173,7 +182,7 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_invalid_principal.yaml
-        timeout: 500
+
   - test:
       name: reshard cancel command
       desc: reshard cancel command
@@ -182,7 +191,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled
@@ -192,7 +200,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard and max_dynamic_shard
@@ -202,7 +209,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard max_dynamic_shard and reshard_thread_interval
@@ -212,7 +218,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
-        timeout: 500
 
   - test:
       name: Bucket setlifeycle with invalid date in LC conf
@@ -222,7 +227,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_invalid_date.yaml
-        timeout: 300
 
   - test:
       name: LC enabled on bucket removes pre and post uploaded objects
@@ -232,7 +236,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_enable_object_exp.yaml
-        timeout: 300
 
   - test:
       name: Control functionality for RGW lifecycle
@@ -242,7 +245,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_rgw_enable_lc_threads.yaml
-        timeout: 300
 
   - test:
       name: Test ACL Operations
@@ -253,7 +255,6 @@ tests:
         test-version: v2
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using LC
@@ -263,7 +264,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Test no crash during deleting bucket with aborted multipart upload
@@ -273,7 +273,6 @@ tests:
       config:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
-        timeout: 500
 
   - test:
       name: Test functionality of bucket check fix
@@ -283,7 +282,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
-        timeout: 500
 
   # - test:
   #     name: Test functionality of user stat reset
@@ -294,7 +292,6 @@ tests:
   #     config:
   #       script-name: test_Mbuckets_with_Nobjects.py
   #       config-file-name: test_user_stats_reset.yaml
-  #       timeout: 500
 
   - test:
       name: Test NFS cluster and export create
@@ -305,7 +302,6 @@ tests:
         run-on-rgw: true
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
-        timeout: 300
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -141,7 +141,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_zlib_type
@@ -151,7 +150,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_zstd_type
@@ -161,7 +159,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -171,7 +168,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with sharing enabled
@@ -181,7 +177,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-        timeout: 300
 
   # REST API test
   - test:
@@ -192,7 +187,6 @@ tests:
       config:
         script-name: user_op_using_rest.py
         config-file-name: test_user_with_REST.yaml
-        timeout: 300
 
   # Swift basic operation
 
@@ -204,7 +198,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_modify_tenanted_subuser.yaml
-        timeout: 300
 
   - test:
        name: Swift bulk delete operation
@@ -214,7 +207,6 @@ tests:
        config:
            script-name: test_swift_bulk_delete.py
            config-file-name: test_swift_bulk_delete.yaml
-           timeout: 300
 
   - test:
       name: swift upload large object tests
@@ -224,7 +216,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_upload.yaml
-        timeout: 300
 
   - test:
       name: swift download large object tests
@@ -234,7 +225,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_download.yaml
-        timeout: 300
 
   - test:
       name: Get object with different tenant swift user with same name
@@ -244,7 +234,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
-        timeout: 300
 
   - test:
       name: delete container with different tenant swift user with same name
@@ -254,7 +243,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
-        timeout: 300
 
   - test:
       name: upload large object with same name using tenant swift user
@@ -264,7 +252,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_upload_large_obj_with_same_obj_name.yaml
-        timeout: 300
 
   # Versioning Tests
 
@@ -276,7 +263,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_enable.yaml
-        timeout: 300
 
   - test:
       name: Test versioning of objects copy
@@ -286,7 +272,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_copy.yaml
-        timeout: 300
 
   - test:
       name: Test suspension of object versioning
@@ -296,7 +281,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test deletion of object versions
@@ -306,7 +290,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_delete.yaml
-        timeout: 300
 
   - test:
       name: Test suspension of versioning
@@ -316,7 +299,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test overwrite by another user of versioned objects
@@ -326,7 +308,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: GET object acl info operations on different object versions
@@ -336,7 +317,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_acls.yaml
-        timeout: 300
 
   - test:
       name: Deletes on an object in versioning enabled or suspended container by a new user
@@ -346,7 +326,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_delete_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Versioning with copy objects
@@ -356,7 +335,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_versioning_copy_objects.yaml
-        timeout: 300
 
   # BucketPolicy Tests
   - test:
@@ -367,7 +345,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_replace.yaml
-        timeout: 300
 
   - test:
       name: Delete bucket policy
@@ -377,7 +354,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_delete.yaml
-        timeout: 300
 
   - test:
       name: Modify existing bucket policy to add a new policy in addition existing policy
@@ -387,7 +363,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_modify.yaml
-        timeout: 300
 
   - test:
       name: ListBucketVersions with bucket policy for users in same tenant
@@ -397,7 +372,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
-        timeout: 300
 
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
@@ -407,7 +381,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
-        timeout: 300
 
   - test:
       name: test bucket policy with multiple statements
@@ -417,7 +390,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with conflicting statements
@@ -427,7 +399,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with condition blocks
@@ -437,7 +408,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy condition block with explicit deny
@@ -447,7 +417,15 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
-        timeout: 500
+
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
 
   # Bucket Lifecycle Tests
 
@@ -459,7 +437,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: object expiration with expiration set to Date
@@ -469,7 +446,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_date.yaml
-        timeout: 300
 
   - test:
       name: object expiration for delete marker set
@@ -479,7 +455,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Read lifecycle configuration on a given bucket
@@ -489,7 +464,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_read.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing multiple object versions
@@ -499,7 +473,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_versioning.yaml
-        timeout: 300
 
   - test:
       name: Disable lifecycle configuration on a given bucket
@@ -509,7 +482,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_disable.yaml
-        timeout: 300
 
   - test:
       name: Modify lifecycle configuration on a given bucket
@@ -519,7 +491,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_modify.yaml
-        timeout: 300
 
   # Multi Tenant Tests
 
@@ -531,7 +502,6 @@ tests:
       config:
         script-name: test_multitenant_user_access.py
         config-file-name: test_multitenant_access.yaml
-        timeout: 300
 
   - test:
       name: Generate secret for tenant user
@@ -541,7 +511,6 @@ tests:
       config:
         script-name: test_tenant_user_secret_key.py
         config-file-name: test_tenantuser_secretkey_gen.yaml
-        timeout: 300
 
   # Bucket Listing Tests
   - test:
@@ -552,7 +521,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
 
   - test:
       name: ordered listing of versionsed bucket with top level objects
@@ -562,7 +530,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-        timeout: 300
 
   - test:
       name: unordered listing of bucket with top level objects
@@ -572,7 +539,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
 
   - test:
       name: ordered listing of bucket with pseudo directories and objects
@@ -582,7 +548,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_pseudo_ordered.yaml
-        timeout: 300
 
   - test:
       name: ordered listing of bucket with pseudo directories only
@@ -592,7 +557,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-        timeout: 300
 
   - test:
       name: Bucket radoslist
@@ -602,7 +566,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
 
   # Bucket Request Payer tests
 
@@ -614,7 +577,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer.yaml
-        timeout: 300
 
   - test:
       name: bucket request payer with object download
@@ -624,7 +586,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer_download.yaml
-        timeout: 300
 
   #resharding tests
   - test:
@@ -635,7 +596,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500
 
   # AWS4 Auth tests
   - test:
@@ -646,7 +606,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-        timeout: 300
 
   # v1 tests
   # ACLs tests
@@ -661,7 +620,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: test acls on all users
@@ -673,7 +631,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_all_usrs.py
         config-file-name: test_acls_all_usrs.yaml
-        timeout: 300
 
   - test:
       name: test acls with copy objects on different users
@@ -685,7 +642,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_copy_obj.py
         config-file-name: test_acls_copy_obj.yaml
-        timeout: 300
 
   - test:
       name: acls reset
@@ -697,7 +653,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_reset.py
         config-file-name: test_acls_reset.yaml
-        timeout: 300
 
   # multipart test
 
@@ -711,7 +666,6 @@ tests:
         run-on-rgw: true
         script-name: test_multipart_upload_cancel.py
         config-file-name: test_multipart_upload_cancel.yaml
-        timeout: 300
 
   # User, Bucket rename, Bucket link and unlink
 
@@ -723,7 +677,6 @@ tests:
       config:
         script-name: test_user_bucket_rename.py
         config-file-name: test_user_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket rename
@@ -734,7 +687,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket link and unlink
@@ -745,7 +697,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_link_unlink.yaml
-        timeout: 500
 
   # Multifactor Authentication tests
   - test:
@@ -760,7 +711,6 @@ tests:
         extra-pkgs:
           8:
             - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.2-3.el8.x86_64.rpm
-        timeout: 500
 
   - test:
       name: multipart versioned object deletion with mfa token
@@ -774,7 +724,6 @@ tests:
         extra-pkgs:
           8:
             - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.2-3.el8.x86_64.rpm
-        timeout: 500
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed
@@ -788,7 +737,6 @@ tests:
         extra-pkgs:
           8:
             - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.2-3.el8.x86_64.rpm
-        timeout: 500
 
   - test:
       abort-on-fail: true
@@ -826,7 +774,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-        timeout: 300
 
   # Index-less buckets
 
@@ -839,7 +786,6 @@ tests:
         test-version: v2
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
-        timeout: 500
 
   - test:
       name: Versioning with copy objects and delete with differnt user
@@ -849,7 +795,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_delete_version_object_using_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test deleting the current version of the object
@@ -859,7 +804,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_delete_current_version_object.yaml
-        timeout: 300
 
   - test:
       name: Test copy versioned objects to another versioned bucket
@@ -869,7 +813,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_copy_version_object_to_version_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Write modify and read objects in the versioned bucket
@@ -879,7 +822,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_access_versioned_objects.yaml
-        timeout: 300
 
   - test:
       name: object lock verification
@@ -889,7 +831,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_governance.yaml
-        timeout: 500
 
   - test:
       name: object level retention test Compliance
@@ -899,7 +840,6 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_compliance.yaml
-        timeout: 500
 
   - test:
       name: object level retention test Governance mode
@@ -909,7 +849,6 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_governance.yaml
-        timeout: 500
 
   - test:
       name: NFS export delete
@@ -919,7 +858,6 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-        timeout: 500
 
   - test:
       name: Test user modify with placement id
@@ -930,7 +868,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
-        timeout: 500
 
   - test:
       name: Bucket Lifecycle expiration of incomplete multipart
@@ -940,7 +877,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_incomplete_multipart.yaml
-        timeout: 300
 
   - test:
       name: Swift user with read access
@@ -950,7 +886,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_read.yaml
-        timeout: 300
 
   - test:
       name: Swift user with write access
@@ -960,7 +895,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_write.yaml
-        timeout: 300
 
   - test:
       name: Swift user with readwrite access
@@ -970,7 +904,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_readwrite.yaml
-        timeout: 300
 
   - test:
       name: Test LC with custom worktime
@@ -980,7 +913,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_custom_worktime.yaml
-        timeout: 300
 
   - test:
       name: Test Etag not empty for complete multipart upload in aws
@@ -990,7 +922,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
-        timeout: 500
 
   # - test:
   #     name: Test LC transition with rule by lc process
@@ -1001,7 +932,6 @@ tests:
   #     config:
   #       script-name: test_bucket_lifecycle_object_expiration_transition.py
   #       config-file-name: test_lc_transition_with_lc_process.yaml
-  #       timeout: 500
 
   - test:
       name: Test LC transition without rule by lc process
@@ -1011,4 +941,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
-        timeout: 500

--- a/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
@@ -186,6 +186,24 @@ tests:
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
 
   - test:
+      name: STS aswi Tests to veify role policy allow actions
+      desc: STS aswi Tests to veify role policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_allow_actions.yaml
+
+  - test:
+      name: STS aswi Tests to veify role policy deny actions
+      desc: STS aswi Tests to veify role policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
+
+  - test:
       abort-on-fail: true
       config:
         roles:

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -129,6 +129,22 @@ tests:
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
   - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
+  - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
       polarion-id: CEPH-83574522

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -345,6 +345,15 @@ tests:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
 
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -315,6 +315,15 @@ tests:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
 
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.

--- a/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
@@ -186,6 +186,24 @@ tests:
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
 
   - test:
+      name: STS aswi Tests to veify role policy allow actions
+      desc: STS aswi Tests to veify role policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_allow_actions.yaml
+
+  - test:
+      name: STS aswi Tests to veify role policy deny actions
+      desc: STS aswi Tests to veify role policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
+
+  - test:
       abort-on-fail: true
       config:
         roles:

--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -133,6 +133,44 @@ tests:
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
 
   - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
+
+#  - test:
+#      name: STS test to verify session policy allow put object and deny abort_multipart_upload
+#      desc: STS test to verify session policy allow put object and deny abort_multipart_upload
+#      polarion-id: CEPH-83593390
+#      comments: Known issue BZ-2302541 targeted to 8.1
+#      module: sanity_rgw.py
+#      config:
+#        script-name: test_sts_using_boto_session_policy.py
+#        config-file-name: test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
+#
+#  - test:
+#      name: STS test to verify session policy deny sns topic actions
+#      desc: STS test to verify session policy deny sns topic actions
+#      polarion-id: CEPH-83593390
+#      comments: Known issue BZ-2293233 targeted to 8.1
+#      module: sanity_rgw.py
+#      config:
+#        script-name: test_sts_using_boto_session_policy.py
+#        config-file-name: test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+
+  - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
       polarion-id: CEPH-83574522

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -306,6 +306,15 @@ tests:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
 
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.

--- a/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
@@ -186,6 +186,24 @@ tests:
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
 
   - test:
+      name: STS aswi Tests to veify role policy allow actions
+      desc: STS aswi Tests to veify role policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_allow_actions.yaml
+
+  - test:
+      name: STS aswi Tests to veify role policy deny actions
+      desc: STS aswi Tests to veify role policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
+
+  - test:
       abort-on-fail: true
       config:
         roles:

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -133,6 +133,44 @@ tests:
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
 
   - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
+
+  - test:
+      name: STS test to verify session policy allow put object and deny abort_multipart_upload
+      desc: STS test to verify session policy allow put object and deny abort_multipart_upload
+      polarion-id: CEPH-83593390
+      comments: Known issue BZ-2302541 targeted to 8.1
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
+
+  - test:
+      name: STS test to verify session policy deny sns topic actions
+      desc: STS test to verify session policy deny sns topic actions
+      polarion-id: CEPH-83593390
+      comments: Known issue BZ-2293233 targeted to 8.1
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+
+  - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
       polarion-id: CEPH-83574522


### PR DESCRIPTION
this PR adds support for testing policy actions for features like notification, encryption, tagging, lifecycle, bucket website other than batch deletes.
added support for testing bucket policy, sts assume-role with session policy, aswi role policy (both allow and deny effect).

depends on: https://github.com/red-hat-storage/ceph-qe-scripts/pull/615

hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2284153

polarion id: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83593390

found below bz through automation:
https://bugzilla.redhat.com/show_bug.cgi?id=2302541



automated below bz verification as well, as they are targetted to 8.1 commented the test in lower versions
https://bugzilla.redhat.com/show_bug.cgi?id=2302541
https://bugzilla.redhat.com/show_bug.cgi?id=2293233

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_apple_sts_batch_deletes/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
