### PR TITLE
[TFA] Since in primary default realm is india, but in secondary its RealmOne, verify Io failed

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_multirealm_61GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_multirealm_61GA_to_7x_latest.yaml
@@ -132,6 +132,7 @@ tests:
       name: deploy cluster
       polarion-id: CEPH-83575222
   - test:
+      abort-on-fail: true
       clusters:
         ceph-pri:
           config:
@@ -352,7 +353,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -366,7 +366,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -379,7 +378,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -428,11 +426,8 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects post upgrade
@@ -444,7 +439,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -457,7 +451,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -470,7 +463,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
@@ -352,7 +352,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -366,7 +365,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -415,11 +413,8 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects post upgrade
@@ -431,7 +426,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -444,7 +438,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade


### PR DESCRIPTION

# Description

in primary default realm is india, but in secondary its RealmOne
That is why we are seeing verification getting failed as realms are different
***********************************************************************************************************************
[root@ceph-pri-anrao-up-1087oa-node5 ~]# radosgw-admin sync status
          realm 386e9ea4-f12e-49ff-ac50-2d96157a2338 (india)
      zonegroup f13b422f-8921-4c55-b47f-652952b8ba60 (shared)
           zone 0cc52a4e-d0c5-4e53-a91e-0b04d957049b (primary)
   current time 2024-07-19T07:49:24Z
zonegroup features enabled: resharding
                   disabled: compress-encrypted
  metadata sync no sync (zone is master)
      data sync source: 6abf84a8-63fa-4343-9f3b-c702ac08ef62
                        syncing
                        full sync: 0/128 shards
                        incremental sync: 128/128 shards
                        data is caught up with source
[root@ceph-pri-anrao-up-1087oa-node5 ~]# radosgw-admin bucket list
[
    "helenf.852-bucky-299-0",
    "brownfield-manual-bkt",
    "helenf.852-bucky-299-1"
]
[root@ceph-pri-anrao-up-1087oa-node5 ~]#
*****************************************************************************************************
[root@ceph-sec-anrao-up-1087oa-node5 ~]# radosgw-admin bucket list
[]
[root@ceph-sec-anrao-up-1087oa-node5 ~]# radosgw-admin sync status
          realm eef665b9-297c-422a-98e4-7a6bfe99ff0f (RealmOne)
      zonegroup b61fc5cd-3878-47de-86ef-1932fad75e1b (RealmOneZonegroup)
           zone 73b7b3d8-e157-40d6-b077-4599ffea8721 (RealmOneZoneA)
   current time 2024-07-19T07:49:17Z
zonegroup features enabled: resharding
                   disabled: compress-encrypted
  metadata sync no sync (zone is master)
      data sync source: 1449c2b4-67a1-4288-a046-87863848b798
                        syncing
                        full sync: 0/128 shards
                        incremental sync: 128/128 shards
                        data is caught up with source

[root@ceph-sec-anrao-up-1087oa-node5 ~]# radosgw-admin sync status --rgw-realm india
          realm 386e9ea4-f12e-49ff-ac50-2d96157a2338 (india)
      zonegroup f13b422f-8921-4c55-b47f-652952b8ba60 (shared)
           zone 6abf84a8-63fa-4343-9f3b-c702ac08ef62 (secondary)
   current time 2024-07-19T07:49:57Z
zonegroup features enabled: resharding
                   disabled: compress-encrypted
  metadata sync syncing
                full sync: 0/64 shards
                incremental sync: 64/64 shards
                metadata is caught up with master
      data sync source: 0cc52a4e-d0c5-4e53-a91e-0b04d957049b
                        syncing
                        full sync: 0/128 shards
                        incremental sync: 128/128 shards
                        data is caught up with source
[root@ceph-sec-anrao-up-1087oa-node5 ~]# radosgw-admin bucket list --rgw-realm india
[
    "helenf.852-bucky-299-0",
    "brownfield-manual-bkt",
    "helenf.852-bucky-299-1"
]
[root@ceph-sec-anrao-up-1087oa-node5 ~]#

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
