### PR TITLE
Adding Support for Erasure Coded Filesystems

### DIFF
--- a/tests/cephfs/cephfs_mirroring/test_cephfs_mirroring_snap_status_using_asok.py
+++ b/tests/cephfs/cephfs_mirroring/test_cephfs_mirroring_snap_status_using_asok.py
@@ -325,7 +325,12 @@ def run(ceph_cluster, **kw):
                 )
 
             log.info("Remove Subvolume Group")
-            fs_util_ceph1.remove_subvolumegroup(source_clients[0], subvol_group_name)
+            fs_util_ceph1.remove_subvolumegroup(
+                source_clients[0],
+                vol_name=source_fs,
+                group_name=subvol_group_name,
+                validate=False,
+            )
 
             log.info("Delete the mounted paths")
             source_clients[0].exec_command(

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -54,7 +54,7 @@ def function_execution_time(func):
 
 
 class FsUtils(object):
-    def __init__(self, ceph_cluster):
+    def __init__(self, ceph_cluster, **kwargs):
         """
         FS Utility object
         Args:
@@ -67,6 +67,8 @@ class FsUtils(object):
         self.mgrs = ceph_cluster.get_ceph_objects("mgr")
         self.osds = ceph_cluster.get_ceph_objects("osd")
         self.mdss = ceph_cluster.get_ceph_objects("mds")
+        self.clients = ceph_cluster.get_ceph_objects("client")
+        self.test_data = kwargs.get("test_data")
 
     def prepare_clients(self, clients, build):
         """
@@ -1252,6 +1254,96 @@ class FsUtils(object):
                     )
         return cmd_out, cmd_rc
 
+    def create_osd_pool(
+        self,
+        client,
+        pool_name,
+        pg_num=None,
+        pgp_num=None,
+        erasure=False,
+        validate=True,
+        **kwargs,
+    ):
+        """
+        Creates an OSD pool with given arguments.
+        It supports the following optional arguments:
+        Args:
+            client:
+            pool_name:
+            pg_num: int
+            pgp_num: int
+            erasure: bool
+            validate: bool
+            **kwargs:
+                erasure_code_profile: str
+                crush_rule_name: str
+                expected_num_objects: int
+                autoscale_mode: str (on, off, warn)
+                check_ec: bool (default: True)
+        Returns:
+            Returns the cmd_out and cmd_rc for the create command.
+        """
+        if erasure:
+            pool_cmd = f"ceph osd pool create {pool_name} {pg_num or ''} {pgp_num or ''} erasure"
+            if kwargs.get("erasure_code_profile"):
+                pool_cmd += f" {kwargs.get('erasure_code_profile')}"
+        else:
+            pool_cmd = f"ceph osd pool create {pool_name} {pg_num or ''} {pgp_num or ''} replicated"
+
+        if kwargs.get("crush_rule_name"):
+            pool_cmd += f" {kwargs.get('crush_rule_name')}"
+        if kwargs.get("expected_num_objects"):
+            pool_cmd += f" {kwargs.get('expected_num_objects')}"
+        if erasure and kwargs.get("autoscale_mode"):
+            pool_cmd += f" --autoscale-mode={kwargs.get('autoscale_mode')}"
+
+        cmd_out, cmd_rc = client.exec_command(
+            sudo=True, cmd=pool_cmd, check_ec=kwargs.get("check_ec", True)
+        )
+
+        if validate:
+            out, rc = client.exec_command(
+                sudo=True, cmd="ceph osd pool ls --format json"
+            )
+            pool_ls = json.loads(out)
+            if pool_name not in pool_ls:
+                raise CommandFailed(f"Creation of OSD pool: {pool_name} failed")
+
+        return cmd_out, cmd_rc
+
+    @staticmethod
+    def str_to_bool(value):
+        """
+        Convert a string representation of a boolean to an actual boolean.
+
+        Args:
+            value (str): The string representation of the boolean value.
+
+        Returns:
+            bool: The corresponding boolean value.
+
+        Raises:
+            ValueError: If the string does not represent a boolean value.
+        """
+        if isinstance(value, str):
+            value = value.strip().lower()
+            if value in {"true", "1", "t", "yes", "y"}:
+                return True
+            elif value in {"false", "0", "f", "no", "n"}:
+                return False
+        raise ValueError(f"Cannot convert {value} to bool")
+
+    @staticmethod
+    def get_custom_config_value(test_data, key_name):
+        if "custom-config" in test_data and isinstance(
+            test_data["custom-config"], list
+        ):
+            for config in test_data["custom-config"]:
+                key, value = config.split("=")
+                if key == key_name:
+                    return FsUtils.str_to_bool(value.lower())
+        return False
+
     def create_fs(self, client, vol_name, validate=True, **kwargs):
         """
         This Function creates the cephfs volume with vol_name given
@@ -1266,17 +1358,57 @@ class FsUtils(object):
         Returns:
 
         """
-        fs_cmd = f"ceph fs volume create {vol_name}"
-        if kwargs.get("placement"):
-            fs_cmd += f" --placement='{kwargs.get('placement')}'"
+
+        erasure = (
+            FsUtils.get_custom_config_value(self.test_data, "erasure")
+            if self.test_data
+            else False
+        )
+        if erasure:
+            self.create_osd_pool(
+                client, f"cephfs.{vol_name}.data-ec", pg_num=64, erasure=True
+            )
+            self.create_osd_pool(
+                client, f"cephfs.{vol_name}.meta", pg_num=64, erasure=False
+            )
+            client.exec_command(
+                sudo=True,
+                cmd=f"ceph osd pool set cephfs.{vol_name}.data-ec allow_ec_overwrites true",
+            )
+            fs_cmd = f"ceph fs new {vol_name} cephfs.{vol_name}.meta cephfs.{vol_name}.data-ec --force"
+        else:
+            fs_cmd = f"ceph fs volume create {vol_name}"
+            if kwargs.get("placement"):
+                fs_cmd += f" --placement='{kwargs.get('placement')}'"
+
         cmd_out, cmd_rc = client.exec_command(
             sudo=True, cmd=fs_cmd, check_ec=kwargs.get("check_ec", True)
         )
-        if validate:
+        if kwargs.get("check_ec", True) and validate:
             out, rc = client.exec_command(sudo=True, cmd="ceph fs ls --format json")
             volname_ls = json.loads(out)
             if vol_name not in [i["name"] for i in volname_ls]:
                 raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
+        apply_cmd = f"ceph orch apply mds {vol_name}"
+        if erasure and validate:
+            if kwargs.get("placement"):
+                apply_cmd += f" --placement='{kwargs.get('placement')}'"
+            client.exec_command(
+                sudo=True,
+                cmd=f"{apply_cmd}",
+            )
+            time.sleep(20)
+            retry_mds_status = retry(CommandFailed, tries=3, delay=30)(
+                self.get_mds_status
+            )
+            retry_mds_status(
+                client,
+                1,
+                vol_name=vol_name,
+                expected_status="active",
+            )
+            # self.wait_for_mds_process(client,process_name=vol_name)
+
         return cmd_out, cmd_rc
 
     def create_subvolumegroup(
@@ -1720,63 +1852,6 @@ class FsUtils(object):
             volname_ls = json.loads(out)
             if vol_name in [i["name"] for i in volname_ls]:
                 raise CommandFailed(f"Creation of filesystem: {vol_name} failed")
-        return cmd_out, cmd_rc
-
-    def create_osd_pool(
-        self,
-        client,
-        pool_name,
-        pg_num=None,
-        pgp_num=None,
-        erasure=False,
-        validate=True,
-        **kwargs,
-    ):
-        """
-        Creates an OSD pool with given arguments.
-        It supports the following optional arguments:
-        Args:
-            client:
-            pool_name:
-            pg_num: int
-            pgp_num: int
-            erasure: bool
-            validate: bool
-            **kwargs:
-                erasure_code_profile: str
-                crush_rule_name: str
-                expected_num_objects: int
-                autoscale_mode: str (on, off, warn)
-                check_ec: bool (default: True)
-        Returns:
-            Returns the cmd_out and cmd_rc for the create command.
-        """
-        if erasure:
-            pool_cmd = f"ceph osd pool create {pool_name} {pg_num or ''} {pgp_num or ''} erasure"
-            if kwargs.get("erasure_code_profile"):
-                pool_cmd += f" {kwargs.get('erasure_code_profile')}"
-        else:
-            pool_cmd = f"ceph osd pool create {pool_name} {pg_num or ''} {pgp_num or ''} replicated"
-
-        if kwargs.get("crush_rule_name"):
-            pool_cmd += f" {kwargs.get('crush_rule_name')}"
-        if kwargs.get("expected_num_objects"):
-            pool_cmd += f" {kwargs.get('expected_num_objects')}"
-        if erasure and kwargs.get("autoscale_mode"):
-            pool_cmd += f" --autoscale-mode={kwargs.get('autoscale_mode')}"
-
-        cmd_out, cmd_rc = client.exec_command(
-            sudo=True, cmd=pool_cmd, check_ec=kwargs.get("check_ec", True)
-        )
-
-        if validate:
-            out, rc = client.exec_command(
-                sudo=True, cmd="ceph osd pool ls --format json"
-            )
-            pool_ls = json.loads(out)
-            if pool_name not in pool_ls:
-                raise CommandFailed(f"Creation of OSD pool: {pool_name} failed")
-
         return cmd_out, cmd_rc
 
     def fs_client_authorize(

--- a/tests/cephfs/multifs/multifs_flag.py
+++ b/tests/cephfs/multifs/multifs_flag.py
@@ -21,7 +21,8 @@ def run(ceph_cluster, **kw):
     4. Enable enable_multiple and try creating filesystem
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -39,9 +40,10 @@ def run(ceph_cluster, **kw):
             client1.exec_command(
                 sudo=True, cmd="ceph fs flag set enable_multiple false"
             )
-        out, rc = client1.exec_command(
-            sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
+        out, rc = fs_util.create_fs(
+            client1, vol_name="cephfs_new", check_ec=False, validate=False
         )
+
         if rc == 0:
             raise CommandFailed(
                 "We are able to create multipe filesystems even after setting enable_multiple to false"
@@ -50,7 +52,8 @@ def run(ceph_cluster, **kw):
             "We are not able to create multipe filesystems after setting enable_multiple to false as expected"
         )
         client1.exec_command(sudo=True, cmd="ceph fs flag set enable_multiple true")
-        client1.exec_command(sudo=True, cmd="ceph fs volume create cephfs_new")
+        fs_util.create_fs(client1, vol_name="cephfs_new")
+
         log.info(
             "We are able to create multipe filesystems after setting enable_multiple to True as expected"
         )

--- a/tests/cephfs/multifs/multifs_fusemounts.py
+++ b/tests/cephfs/multifs/multifs_fusemounts.py
@@ -25,7 +25,8 @@ def run(ceph_cluster, **kw):
     4. validate if the mount points are still present
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -38,9 +39,8 @@ def run(ceph_cluster, **kw):
             )
             return 1
         client1 = clients[0]
-        client1.exec_command(
-            sudo=True, cmd="ceph fs volume create cephfs_new", check_ec=False
-        )
+        fs_util.create_fs(client1, vol_name="cephfs_new", check_ec=False)
+
         if not fs_util.wait_for_mds_process(client1, "cephfs_new"):
             raise CommandFailed("Failed to start MDS deamons")
         total_fs = fs_util.get_fs_details(client1)

--- a/tests/cephfs/multifs/multifs_kernelmounts.py
+++ b/tests/cephfs/multifs/multifs_kernelmounts.py
@@ -24,7 +24,8 @@ def run(ceph_cluster, **kw):
     4. validate if the mount points are still present
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -43,10 +44,8 @@ def run(ceph_cluster, **kw):
         ]
         hosts = " ".join(host_list)
         fs_name = "cephfs_new"
-        client1.exec_command(
-            sudo=True,
-            cmd=f"ceph fs volume create {fs_name} --placement='2 {hosts}'",
-            check_ec=False,
+        fs_util.create_fs(
+            client1, vol_name=fs_name, placement=f"2 {hosts}", check_ec=False
         )
 
         for host in host_list:

--- a/tests/cephfs/multifs/multifs_multiplefs.py
+++ b/tests/cephfs/multifs/multifs_multiplefs.py
@@ -24,7 +24,8 @@ def run(ceph_cluster, **kw):
     4. Run IOs on the FSs
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -48,11 +49,8 @@ def run(ceph_cluster, **kw):
             )
             daemon_ls_before = json.loads(out)
             daemon_count_before = len(daemon_ls_before)
-            client1.exec_command(
-                sudo=True,
-                cmd=f"ceph fs volume create cephfs_{i}",
-                check_ec=False,
-            )
+            fs_util.create_fs(client1, vol_name=f"cephfs_{i}", check_ec=False)
+
             fs_util.wait_for_mds_process(client1, f"cephfs_{i}")
             out_after, rc = client1.exec_command(
                 sudo=True, cmd="ceph orch ps --daemon_type mds -f json"

--- a/tests/cephfs/multifs/multifs_same_pool.py
+++ b/tests/cephfs/multifs/multifs_same_pool.py
@@ -20,7 +20,8 @@ def run(ceph_cluster, **kw):
     3. try creating cephfs1 with data pool and meta datapool of cephfs
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))

--- a/tests/cephfs/snapshot_clone/clone_attributes.py
+++ b/tests/cephfs/snapshot_clone/clone_attributes.py
@@ -39,7 +39,13 @@ def run(ceph_cluster, **kw):
     2. Delete subvolumegroup
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -51,15 +57,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_clone_attr_vol_1"},
         ]
@@ -84,6 +90,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,
@@ -121,7 +128,7 @@ def run(ceph_cluster, **kw):
         fs_util.fuse_mount(
             [client1],
             fuse_mounting_dir_2,
-            extra_params=f" -r {clonevol_path.strip()}",
+            extra_params=f" -r {clonevol_path.strip()} --client_fs {default_fs}",
         )
         quota_attrs_clone = fs_util.get_quota_attrs(clients[0], fuse_mounting_dir_2)
         client1.exec_command(

--- a/tests/cephfs/snapshot_clone/clone_cancel_in_progress.py
+++ b/tests/cephfs/snapshot_clone/clone_cancel_in_progress.py
@@ -28,7 +28,13 @@ def run(ceph_cluster, **kw):
     try:
         bz = "1980920"
         tc = "CEPH-83574681"
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
 
         log.info(f"Running CephFS tests for BZ-{bz}")
         log.info(f"Running CephFS tests for BZ-{tc}")
@@ -37,21 +43,23 @@ def run(ceph_cluster, **kw):
         build = config.get("build", config.get("rhbuild"))
         fs_util.prepare_clients(clients, build)
         client1 = clients[0]
-        create_cephfs = "ceph fs volume create cephfs"
-        client1.exec_command(sudo=True, cmd=create_cephfs)
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, default_fs)
+        if not fs_details:
+            fs_util.create_fs(client1, default_fs)
         subvolume_name_generate = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(5))
         )
         subvolume = {
-            "vol_name": "cephfs",
+            "vol_name": default_fs,
             "subvol_name": f"subvol_{subvolume_name_generate}",
         }
         subvolume_name = subvolume["subvol_name"]
         fs_util.create_subvolume(client1, **subvolume)
         log.info("Get the path of sub volume")
         subvol_path, rcc = client1.exec_command(
-            sudo=True, cmd=f"ceph fs subvolume getpath cephfs {subvolume_name}"
+            sudo=True, cmd=f"ceph fs subvolume getpath {default_fs} {subvolume_name}"
         )
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
@@ -65,6 +73,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,
@@ -75,19 +84,19 @@ def run(ceph_cluster, **kw):
         )
         log.info("Checking Pre-requisites")
         fs_util.create_snapshot(
-            client1, "cephfs", subvolume_name, f"subvol_1_snap{subvolume_name}"
+            client1, default_fs, subvolume_name, f"subvol_1_snap{subvolume_name}"
         )
         new_subvolume_name = f"subvol_1_snap_clone{subvolume_name}_1"
         fs_util.create_clone(
             client1,
-            "cephfs",
+            default_fs,
             subvolume_name,
             f"subvol_1_snap{subvolume_name}",
             new_subvolume_name,
         )
         stdout, stderr = client1.exec_command(
             sudo=True,
-            cmd=f"ceph fs subvolume rm cephfs {new_subvolume_name}",
+            cmd=f"ceph fs subvolume rm {default_fs} {new_subvolume_name}",
             check_ec=False,
         )
         log.info(stdout, stderr)
@@ -96,19 +105,21 @@ def run(ceph_cluster, **kw):
         if "is not ready for operation rm" in error_result:
             log.info("Clone is in-progress as expected")
         client1.exec_command(
-            sudo=True, cmd=f"ceph fs clone cancel cephfs {new_subvolume_name}"
+            sudo=True, cmd=f"ceph fs clone cancel {default_fs} {new_subvolume_name}"
         )
         result2, error2 = client1.exec_command(
-            sudo=True, cmd=f"ceph fs clone status cephfs {new_subvolume_name}"
+            sudo=True, cmd=f"ceph fs clone status {default_fs} {new_subvolume_name}"
         )
         out1 = json.loads(result2)
         out2 = out1["status"]["state"]
         if out2 == "canceled":
-            fs_util.remove_subvolume(client1, "cephfs", new_subvolume_name, force=True)
+            fs_util.remove_subvolume(
+                client1, default_fs, new_subvolume_name, force=True
+            )
         fs_util.remove_snapshot(
-            client1, "cephfs", subvolume_name, f"subvol_1_snap{subvolume_name}"
+            client1, default_fs, subvolume_name, f"subvol_1_snap{subvolume_name}"
         )
-        fs_util.remove_subvolume(client1, "cephfs", subvolume_name)
+        fs_util.remove_subvolume(client1, default_fs, subvolume_name)
         return 0
     except Exception as e:
         log.error(e)

--- a/tests/cephfs/snapshot_clone/clone_cancel_status.py
+++ b/tests/cephfs/snapshot_clone/clone_cancel_status.py
@@ -38,7 +38,13 @@ def run(ceph_cluster, **kw):
     3. ceph fs subvolumegroup rm <vol_name> <group_name>
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -50,15 +56,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_clone_cancel_1"}
         ]
@@ -83,6 +89,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,

--- a/tests/cephfs/snapshot_clone/clone_remove_subvol.py
+++ b/tests/cephfs/snapshot_clone/clone_remove_subvol.py
@@ -39,7 +39,13 @@ def run(ceph_cluster, **kw):
     2. Delete subvolumegroup
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -51,15 +57,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_remove_vol_1"},
         ]
@@ -84,6 +90,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,
@@ -121,7 +128,7 @@ def run(ceph_cluster, **kw):
         fs_util.fuse_mount(
             [client1],
             fuse_mounting_dir_2,
-            extra_params=f" -r {clonevol_path.strip()}",
+            extra_params=f" -r {clonevol_path.strip()} --client_fs {default_fs}",
         )
         fs_util.remove_snapshot(client1, **snapshot)
         fs_util.remove_subvolume(client1, **subvolume)
@@ -130,8 +137,8 @@ def run(ceph_cluster, **kw):
         )
         return 0
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
     finally:
         log.info("Clean Up in progess")

--- a/tests/cephfs/snapshot_clone/clone_subvolume_full_vol.py
+++ b/tests/cephfs/snapshot_clone/clone_subvolume_full_vol.py
@@ -39,7 +39,13 @@ def run(ceph_cluster, **kw):
     2. Delete subvolumegroup
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -51,15 +57,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_full_vol_1"},
         ]
@@ -84,6 +90,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,
@@ -99,7 +106,7 @@ def run(ceph_cluster, **kw):
         )
         c_out2, c_err2 = client1.exec_command(
             sudo=True,
-            cmd="ceph fs subvolume info cephfs subvol_full_vol --group_name subvolgroup_full_vol_1 -f json",
+            cmd=f"ceph fs subvolume info {default_fs} subvol_full_vol --group_name subvolgroup_full_vol_1 -f json",
         )
         c_out2_result = json.loads(c_out2)
         log.info(c_out2_result)
@@ -134,7 +141,7 @@ def run(ceph_cluster, **kw):
         fs_util.fuse_mount(
             [client1],
             fuse_mounting_dir_2,
-            extra_params=f" -r {clonevol_path.strip()}",
+            extra_params=f" -r {clonevol_path.strip()} --client_fs {default_fs}",
         )
         client1.exec_command(
             sudo=True, cmd=f"diff -qr {kernel_mounting_dir_1} {fuse_mounting_dir_2}"

--- a/tests/cephfs/snapshot_clone/clone_threads.py
+++ b/tests/cephfs/snapshot_clone/clone_threads.py
@@ -74,7 +74,13 @@ def run(ceph_cluster, **kw):
     3. ceph fs subvolumegroup rm <vol_name> <group_name>
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -91,18 +97,18 @@ def run(ceph_cluster, **kw):
             sudo=True,
             cmd="ceph config set mgr mgr/volumes/snapshot_clone_no_wait false",
         )
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         rmclone_list = [
             {"vol_name": default_fs, "subvol_name": f"clone_{x}"} for x in range(1, 6)
         ]
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup = {"vol_name": default_fs, "group_name": "subvolgroup_1"}
         fs_util.create_subvolumegroup(client1, **subvolumegroup)
         subvolume = {
@@ -121,7 +127,7 @@ def run(ceph_cluster, **kw):
         fs_util.fuse_mount(
             [client1],
             fuse_mounting_dir_1,
-            extra_params=f" -r {subvol_path.strip()}",
+            extra_params=f" -r {subvol_path.strip()} --client_fs {default_fs}",
         )
         client1.exec_command(
             sudo=True,

--- a/tests/cephfs/snapshot_clone/max_snapshot_limit.py
+++ b/tests/cephfs/snapshot_clone/max_snapshot_limit.py
@@ -34,7 +34,13 @@ def run(ceph_cluster, **kw):
     2. Deletes snapshot and subvolume created.
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -46,15 +52,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolume = {
             "vol_name": default_fs,
             "subvol_name": "subvol_max_snap",
@@ -73,6 +79,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,

--- a/tests/cephfs/snapshot_clone/snap_schedule.py
+++ b/tests/cephfs/snapshot_clone/snap_schedule.py
@@ -47,7 +47,13 @@ def run(ceph_cluster, **kw):
     5. Remove FS
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -82,7 +88,7 @@ def run(ceph_cluster, **kw):
         fs_util.auth_list(clients)
         log.info("checking Pre-requisites")
 
-        default_fs = "cephfs_snap_1"
+        default_fs = "cephfs_snap_1" if not erasure else "cephfs_snap_1_ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))

--- a/tests/cephfs/snapshot_clone/snapshot_flag.py
+++ b/tests/cephfs/snapshot_clone/snapshot_flag.py
@@ -37,7 +37,13 @@ def run(ceph_cluster, **kw):
     3. Del SubvolumeGroups
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -49,15 +55,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_flag_snapshot_1"},
         ]
@@ -82,6 +88,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,

--- a/tests/cephfs/snapshot_clone/snapshot_nfs_mount.py
+++ b/tests/cephfs/snapshot_clone/snapshot_nfs_mount.py
@@ -38,7 +38,14 @@ def run(ceph_cluster, **kw):
     3. Del SubvolumeGroups
     """
     try:
-        fs_util_v1 = FsUtilsv1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsv1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsv1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
+        # fs_util_v1 = FsUtilsv1(ceph_cluster)
         snap_util = SnapUtils(ceph_cluster)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
@@ -53,7 +60,7 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"

--- a/tests/cephfs/snapshot_clone/snapshot_reboot.py
+++ b/tests/cephfs/snapshot_clone/snapshot_reboot.py
@@ -38,7 +38,13 @@ def run(ceph_cluster, **kw):
     7. Validate the checksums
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -50,15 +56,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_reboot_snapshot_1"},
         ]
@@ -83,6 +89,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         fs_util.create_file_data(
             client1, kernel_mounting_dir_1, 3, "snap1", "snap_1_data "
@@ -108,6 +115,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_2,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         retry_revert = retry(CommandFailed, tries=3, delay=60)(client1.exec_command)
         retry_revert(

--- a/tests/cephfs/snapshot_clone/snapshot_write.py
+++ b/tests/cephfs/snapshot_clone/snapshot_write.py
@@ -31,7 +31,13 @@ def run(ceph_cluster, **kw):
 
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -43,15 +49,15 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_details = fs_util.get_fs_info(client1, default_fs)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_write_snapshot_1"},
         ]
@@ -76,6 +82,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         fs_util.create_file_data(
             client1, kernel_mounting_dir_1, 3, "snap1", "snap_1_data "
@@ -103,8 +110,8 @@ def run(ceph_cluster, **kw):
             raise CommandFailed("touch is working in .snap directory")
         return 0
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
 
     finally:

--- a/tests/cephfs/snapshot_clone/subvolume_info_retain.py
+++ b/tests/cephfs/snapshot_clone/subvolume_info_retain.py
@@ -42,7 +42,13 @@ def run(ceph_cluster, **kw):
     3. Del SubvolumeGroups
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -54,7 +60,7 @@ def run(ceph_cluster, **kw):
                 f"This test requires minimum 1 client nodes.This has only {len(clients)} clients"
             )
             return 1
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
@@ -62,7 +68,7 @@ def run(ceph_cluster, **kw):
         client1 = clients[0]
         fs_details = fs_util.get_fs_info(client1)
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, default_fs)
         subvolumegroup_list = [
             {"vol_name": default_fs, "group_name": "subvolgroup_info_retain"},
         ]
@@ -87,6 +93,7 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={default_fs}",
         )
         client1.exec_command(
             sudo=True,
@@ -153,8 +160,8 @@ def run(ceph_cluster, **kw):
         )
         return 0
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
     finally:
         log.info("Clean Up in progess")


### PR DESCRIPTION
# Description

In this PR, we are introducing support for the creation of erasure coded (EC) filesystems and modifying all tests to run in both EC and replicated modes.

We are obtaining the filesystem configuration from the --custom-config erasure=True option. When this option is specified in run.py, all tests will run on EC pools. Without this option, the tests will execute in the default replicated mode.

Additionally, we will update the test suites in the CephFS metadata file to include configurations with the custom-config option. This will enable the tests to run on both EC and replicated filesystems, ensuring comprehensive coverage and validation.

Snapshots with ec : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZPDW4S/
without ec : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VXMP2Q/

Multifs with ec : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-7TEUOX
without ec: 	http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QN90V8

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
