### PR TITLE
[TFA] Updating testcase timeout for sanity_rgw and sanity_rgw_ms

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
@@ -277,7 +277,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -294,7 +293,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -306,7 +304,6 @@ tests:
           config:
             script-name:  test_multisite_sync_policy.py
             config-file-name:  test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       name: Test multisite sync policy
@@ -318,7 +315,6 @@ tests:
           config:
             script-name:  test_multisite_sync_policy.py
             config-file-name:  test_multisite_sync_policy.yaml
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy tests
@@ -331,7 +327,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy tests
@@ -344,4 +339,3 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_bucket_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -308,7 +308,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -324,7 +323,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -369,7 +367,6 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -381,7 +378,6 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -393,7 +389,6 @@ tests:
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite archive
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -409,7 +404,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test M buckets compression on haproxy node
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -424,7 +418,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets on haproxy node
@@ -438,7 +431,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC from primary to secondary
       module: sanity_rgw_multisite.py
       name: test LC from primary to secondary
@@ -452,21 +444,18 @@ tests:
             commands:
               - "ceph config set client.rgw.shared.sec rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
             commands:
               - "ceph config set client.rgw.shared.pri rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
             commands:
               - "ceph config set client.rgw.shared.arc rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting rgw_sync_lease_period to 10 on multisite archive
       module: exec.py
       name: Setting rgw_sync_lease_period to 10 on multisite archive
@@ -479,7 +468,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
+            timeout: 5000
       desc: test sync on bucket with 0 shards
       module: sanity_rgw_multisite.py
       name: test sync on bucket with 0 shards
@@ -494,7 +483,6 @@ tests:
             commands:
               - "radosgw-admin zonegroup modify --bucket_index_max_shards 11"
               - "radosgw-admin period update --commit"
-            timeout: 120
       desc: Setting bucket_index_max_shards back to 11 shards
       module: exec.py
       name: Setting bucket_index_max_shards back to 11 shards
@@ -506,7 +494,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_prefix_rule_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC transition on multisite, and bucket stats at archive
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite, and bucket stats at archive
@@ -519,7 +506,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_obj_acl_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC transition on multisite with object acl set
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite with object acl set
@@ -534,7 +520,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: test the workaround to sync only from one active zone
       module: exec.py
       name: test the workaround to sync only from one active zone
@@ -547,7 +532,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -560,7 +544,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -575,7 +558,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from_all true"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: Sync to the archive zone from all active sites
       module: exec.py
       name: Sync to the archive zone from all active sites
@@ -587,7 +569,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
             test-bucket-pol-retained-archive: true
       desc: Test bucket policies are reatined at archive site post object uploads
       polarion-id: CEPH-83575576
@@ -600,7 +581,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend_archive_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test versioning suspend on archive
       module: sanity_rgw_multisite.py
       name: test versioning suspend on archive
@@ -616,7 +596,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-sec:
           config:
             cephadm: true
@@ -626,7 +605,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -636,7 +614,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: enabled default encryption and zlib compression
       module: exec.py
       name: enabled default encryption and zlib compression
@@ -647,7 +624,6 @@ tests:
             script-name: test_encrypted_bucket_chown.py
             run-on-haproxy: true
             config-file-name: test_encrypted_bucket_chown.yaml
-            timeout: 300
       desc: test
       module: sanity_rgw_multisite.py
       name: Change bucket ownership to a different user when encryption is enabled

--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -233,7 +233,6 @@ tests:
             set-env: true
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
-            timeout: 300
 
   #  Dynamic resharding tests
   - test:
@@ -247,14 +246,12 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_greenfield.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -267,7 +264,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
       desc: Resharding test - dynamic resharding on versioned bucket
       name: Dynamic Resharding on versioned buckets
       polarion-id: CEPH-83571740
@@ -283,7 +279,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
-            timeout: 300
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects_compression on primary(single site)
@@ -294,7 +289,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects_aws4 on primary(single site)
@@ -305,7 +299,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects_delete on primary(single site)
@@ -316,7 +309,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-            timeout: 300
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects_download on primary(single site)
@@ -327,7 +319,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects_enc on primary(single site)
@@ -338,7 +329,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: Buckets and Objects test
       desc: test_Mbuckets_with_Nobjects_multipart on primary(single site)
@@ -349,7 +339,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
 
   - test:
       name: Bucket listing test
@@ -361,7 +350,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
 
   - test:
       name: Bucket listing test
@@ -373,7 +361,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
 
   - test:
       name: Buckets Versioning test
@@ -385,7 +372,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
-            timeout: 300
 
   # migrating from singlesite to multisite
 
@@ -475,7 +461,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       name: Verify DBR feature enabled on single to multisite cluster
@@ -488,7 +473,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
-            timeout: 300
 
   - test:
       name: Bucket policy tests
@@ -501,7 +485,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: Bucket policy tests
       desc: test_bucket_policy_delete.yaml on secondary
@@ -513,7 +496,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Bucket policy tests
@@ -526,7 +508,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: put and get bucket notification using tenant user
@@ -542,7 +523,6 @@ tests:
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_with_tenant_user.yaml
-            timeout: 300
 
 # Log trimming tests
   - test:
@@ -555,7 +535,7 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_mdlog_trimming.yaml
-            timeout: 300
+            timeout: 5000
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -568,7 +548,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_datalog_trimming.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
 
 
@@ -582,7 +561,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_bilog_trimming.yaml
-            timeout: 300
 
   - test:
       name: bucket request payer
@@ -594,4 +572,3 @@ tests:
           config:
             script-name: test_bucket_request_payer.py
             config-file-name: test_bucket_request_payer.yaml
-            timeout: 300

--- a/suites/quincy/rgw/test-basic-object-operations.yaml
+++ b/suites/quincy/rgw/test-basic-object-operations.yaml
@@ -88,7 +88,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects
@@ -100,7 +99,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with delete
@@ -112,7 +110,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with download
@@ -124,7 +121,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with multipart upload
@@ -136,7 +132,6 @@ tests:
             config:
               script-name: test_swift_basic_ops.py
               config-file-name: test_swift_basic_ops.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: Test object operations with swift

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -110,7 +110,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role call with permissive session policies
       desc: Perform assume role call with permissive session policies
@@ -120,7 +119,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_permissive_session_policy.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role call with restrictive session policies
       desc: Perform assume role call with restrictive session policies
@@ -130,7 +128,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
@@ -140,7 +137,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_server_side_copy.py
         config-file-name: test_sts_using_boto_server_side_copy.yaml
-        timeout: 500
   - test:
       name: STS Tests for handling non-existent object condition
       desc: STS test using boto for handling non-existent object condition
@@ -150,7 +146,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_unexisting_object.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: STS test with invalid arn in the role's policy
       desc: STS test with invalid arn in the role's policy
@@ -160,7 +155,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
-        timeout: 500
   - test:
       name: STS test with invalid principal in the role's policy
       desc: STS test with invalid principal in the role's policy
@@ -169,7 +163,6 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_invalid_principal.yaml
-        timeout: 500
   - test:
       name: reshard cancel command
       desc: reshard cancel command
@@ -179,7 +172,6 @@ tests:
         run-on-rgw: true
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled
@@ -190,7 +182,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard and max_dynamic_shard
@@ -201,7 +192,6 @@ tests:
         run-on-rgw: true
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard max_dynamic_shard and reshard_thread_interval
@@ -212,7 +202,6 @@ tests:
         run-on-rgw: true
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
-        timeout: 500
 
   - test:
       name: Bucket setlifeycle with invalid date in LC conf
@@ -223,7 +212,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_invalid_date.yaml
-        timeout: 300
 
   - test:
       name: LC enabled on bucket removes pre and post uploaded objects
@@ -234,7 +222,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_enable_object_exp.yaml
-        timeout: 300
 
   - test:
       name: Control functionality for RGW lifecycle
@@ -245,7 +232,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_rgw_enable_lc_threads.yaml
-        timeout: 300
 
   - test:
       name: Test ACL Operations
@@ -257,7 +243,6 @@ tests:
         test-version: v2
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using LC
@@ -268,7 +253,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Test NFS cluster and export create
@@ -279,7 +263,6 @@ tests:
         run-on-rgw: true
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
-        timeout: 300
 
   - test:
       abort-on-fail: true
@@ -302,7 +285,6 @@ tests:
       config:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
-        timeout: 500
 
   - test:
       name: Test functionality of bucket check fix
@@ -312,7 +294,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
-        timeout: 500
 
   # - test:
   #     name: Test functionality of user stat reset
@@ -323,7 +304,6 @@ tests:
   #     config:
   #       script-name: test_Mbuckets_with_Nobjects.py
   #       config-file-name: test_user_stats_reset.yaml
-  #       timeout: 500
 
   - test:
       name: Test bucket listing is not truncated
@@ -333,7 +313,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_list_not_truncated.yaml
-        timeout: 500
 
   - test:
       name: Test bi put with incomplete multipart upload

--- a/suites/quincy/rgw/tier-1_rgw_ms_archive_test-upgrade-5-to-latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_ms_archive_test-upgrade-5-to-latest.yaml
@@ -299,7 +299,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -312,7 +311,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       name: test to create "M" no of buckets on primary
       polarion-id: CEPH-9789
       desc: test metadata sync - create buckets
@@ -325,7 +323,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       name: enabling bucket versioning and uploading objects on secondary
       polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
       desc: test_versioning_objects_enable on secondary
@@ -338,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -351,7 +347,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -393,7 +388,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -401,7 +395,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec" , "ceph-arc"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -415,7 +408,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py

--- a/suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-3_latest_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_ms_upgrade_5-3_latest_to_6x_latest.yaml
@@ -284,7 +284,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -299,7 +298,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects
       module: sanity_rgw_multisite.py
       name: m buckets with n objects pre upgrade
@@ -312,7 +310,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -325,7 +322,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -339,7 +335,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -351,7 +346,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -364,7 +358,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -377,7 +370,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -395,7 +387,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
   # To work around the issue of grafana not GAed, setting custom grafana image
 
@@ -437,7 +428,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
       name: swift versioning copy post upgrade
@@ -450,7 +440,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -464,7 +453,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -476,7 +464,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets post upgrade
@@ -494,7 +481,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
   - test:
       clusters:
@@ -503,7 +489,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -516,7 +501,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade
@@ -529,7 +513,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -543,7 +526,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py

--- a/suites/quincy/rgw/tier-1_rgw_ms_upgrade_6-0GA_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_ms_upgrade_6-0GA_to_6x_latest.yaml
@@ -283,7 +283,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -298,7 +297,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects
       module: sanity_rgw_multisite.py
       name: m buckets with n objects pre upgrade
@@ -311,7 +309,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -324,7 +321,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -338,7 +334,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -350,7 +345,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -363,7 +357,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -376,7 +369,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -412,7 +404,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
       name: swift versioning copy post upgrade
@@ -425,7 +416,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -439,7 +429,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -451,7 +440,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets post upgrade
@@ -469,7 +457,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
   - test:
       clusters:
@@ -478,7 +465,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -491,7 +477,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade
@@ -504,7 +489,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -518,7 +502,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py

--- a/suites/quincy/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_multisite.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -295,7 +294,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_sync_policy_extended.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   # - test:
   #     name: bucket granular sync policy with allowed allowed semantic
@@ -309,7 +307,7 @@ tests:
   #           script-name: test_multisite_bucket_granular_sync_policy.py
   #           config-file-name: test_multisite_granular_bucket_sync_policy.yaml
   #           verify-io-on-site: ["ceph-sec"]
-  #           timeout: 300
+  #           timeout: 5500
 
   - test:
       name: S3CMD object download on primary
@@ -321,7 +319,6 @@ tests:
           config:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-            timeout: 300
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
 
   - test:
@@ -334,7 +331,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_enable_enable.yaml
-            timeout: 300
+            timeout: 4000
 
   - test:
       name: bucket granular sync policy on allowed forbidden semantic with directional flow
@@ -346,7 +343,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_allowed_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden forbidden semantic with directional flow
@@ -358,4 +355,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_forbidden.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml
@@ -80,7 +80,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects pre upgrade
@@ -94,7 +93,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
@@ -104,7 +102,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -114,7 +111,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -124,7 +120,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -134,13 +129,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -150,7 +143,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw.py
       name: unordered listing of buckets pre upgrade
@@ -160,7 +152,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations pre upgrade
@@ -170,7 +161,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
       desc: Test bucket stats and radoslist on all buckets
       module: sanity_rgw.py
       name: test bucket stats and radoslist
@@ -193,7 +183,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket
@@ -207,7 +196,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
-        timeout: 300
 
   - test:
       name: Upgrade cluster to latest 6.x ceph version
@@ -231,7 +219,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
-        timeout: 300
 
   - test:
       desc: Retrieve the versions of the cluster
@@ -249,7 +236,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
-        timeout: 300
       desc: test_sse_kms_per_bucket_multipart_object_download_after_transition
       module: sanity_rgw.py
       name: test_sse_kms_per_bucket_multipart_object_download_after_transition
@@ -258,7 +244,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -272,7 +257,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
@@ -282,7 +266,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests post upgrade
@@ -292,7 +275,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -302,7 +284,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -312,13 +293,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets post upgrade
@@ -328,7 +307,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw.py
       name: unordered listing of buckets post upgrade
@@ -338,7 +316,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations post upgrade
@@ -348,7 +325,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
       desc: Test bucket stats and radoslist on all buckets
       module: sanity_rgw.py
       name: test bucket stats and radoslist
@@ -358,7 +334,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled after upgrade
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket after upgrade

--- a/suites/quincy/rgw/tier-1_rgw_upgrade_6-0GA_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_upgrade_6-0GA_to_6x_latest.yaml
@@ -94,7 +94,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test
@@ -104,7 +103,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket
@@ -113,7 +111,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects pre upgrade
@@ -127,7 +124,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
@@ -137,7 +133,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -147,7 +142,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -157,7 +151,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -167,7 +160,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
@@ -183,7 +175,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw.py
       name: unordered listing of buckets pre upgrade
@@ -193,7 +184,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations pre upgrade
@@ -203,7 +193,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
       desc: Test bucket stats and radoslist on all buckets
       module: sanity_rgw.py
       name: test bucket stats and radoslist
@@ -238,7 +227,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -252,7 +240,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
@@ -262,7 +249,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests post upgrade
@@ -272,7 +258,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -282,7 +267,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -292,13 +276,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets post upgrade
@@ -308,7 +290,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw.py
       name: unordered listing of buckets post upgrade
@@ -318,7 +299,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations post upgrade
@@ -328,7 +308,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
       desc: Test bucket stats and radoslist on all buckets
       module: sanity_rgw.py
       name: test bucket stats and radoslist
@@ -337,7 +316,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test
@@ -347,7 +325,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket

--- a/suites/quincy/rgw/tier-1_ssl_rgw_ms_ibm_upgrade_5-3_latest_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_ssl_rgw_ms_ibm_upgrade_5-3_latest_to_6x_latest.yaml
@@ -292,7 +292,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -307,7 +306,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -320,7 +318,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -332,7 +329,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -345,7 +341,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -358,7 +353,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -376,7 +370,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
 #   # Performing cluster upgrade
 
@@ -406,7 +399,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
       name: swift versioning copy post upgrade
@@ -418,7 +410,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -436,7 +427,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
   - test:
       clusters:
@@ -445,7 +435,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
@@ -72,7 +72,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
@@ -83,7 +82,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
-        timeout: 300
 
   # test event time 0 fix for multipart uploads
 
@@ -96,7 +94,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker
@@ -107,7 +104,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_multipart.yaml
-        timeout: 300
 
   # Test Bucket notifications for lifecycle events
 
@@ -120,7 +116,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_object_exp_multipart_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration delete marker
@@ -131,7 +126,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration events
@@ -142,7 +136,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration with parallel lc processing
@@ -153,7 +146,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_parallel_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration non current objects with prefix rule
@@ -164,7 +156,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days_notifications.yaml
-        timeout: 300
 
   # testing rgw through curl
   - test:
@@ -175,7 +166,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_bucket_quota_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw user quota using CURL
       desc: Test rgw user quota using CURL
@@ -184,7 +174,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_user_quota_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw bucket quota conflict using CURL
       desc: Test rgw bucket quota conflict using CURL
@@ -193,7 +182,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
-        timeout: 500
 
   - test:
       name: check-ceph-health

--- a/suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_cloud_transition.yaml
@@ -161,7 +161,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_true.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition retain headobject
@@ -187,7 +186,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_false.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition no retain headobject
@@ -199,7 +197,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_multipart.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition multipart upload

--- a/suites/quincy/rgw/tier-2_rgw_ms-dbr-disable.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ms-dbr-disable.yaml
@@ -204,7 +204,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user

--- a/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -212,7 +212,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -250,7 +249,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -262,7 +260,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -279,14 +276,12 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
   - test:
       clusters:
         ceph-pri:
           config:
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
@@ -304,7 +299,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-            timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker_persistent
@@ -317,7 +311,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-            timeout: 300
 
   - test:
       name: notify copy events with kafka_none
@@ -330,7 +323,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_none_copy.yaml
-            timeout: 300
 
   - test:
       name: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
@@ -343,7 +335,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
-            timeout: 300
 
   - test:
       name: notify on multipart events with kafka_broker_persistent when kafka is down
@@ -356,7 +347,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
-            timeout: 300
 
   - test:
       name: notify on multisite replication create events with kafka_broker on pri site
@@ -369,7 +359,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
-            timeout: 300
 
   - test:
       name: notify on multisite replication create events with kafka_broker on sec site
@@ -382,4 +371,3 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
-            timeout: 300

--- a/suites/quincy/rgw/tier-2_rgw_multisite.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_multisite.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -294,7 +293,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_enabled_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden allowed semantic with symmetrical and directional flow
@@ -306,7 +305,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_allowed.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden enabled semantic with directional and symmetrical flow
@@ -318,4 +317,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_enabled.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/quincy/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -308,7 +308,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -324,7 +323,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -369,7 +367,6 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -381,7 +378,6 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -393,7 +389,6 @@ tests:
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite archive
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -409,7 +404,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test M buckets compression on haproxy node
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -424,7 +418,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets on haproxy node
@@ -438,7 +431,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC from primary to secondary
       module: sanity_rgw_multisite.py
       name: test LC from primary to secondary
@@ -452,21 +444,18 @@ tests:
             commands:
               - "ceph config set client.rgw.shared.sec rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
             commands:
               - "ceph config set client.rgw.shared.pri rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
             commands:
               - "ceph config set client.rgw.shared.arc rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting rgw_sync_lease_period to 10 on multisite archive
       module: exec.py
       name: Setting rgw_sync_lease_period to 10 on multisite archive
@@ -479,7 +468,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
+            timeout: 5000
       desc: test sync on bucket with 0 shards
       module: sanity_rgw_multisite.py
       name: test sync on bucket with 0 shards
@@ -494,7 +483,6 @@ tests:
             commands:
               - "radosgw-admin zonegroup modify --bucket_index_max_shards 11"
               - "radosgw-admin period update --commit"
-            timeout: 120
       desc: Setting bucket_index_max_shards back to 11 shards
       module: exec.py
       name: Setting bucket_index_max_shards back to 11 shards
@@ -506,7 +494,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_prefix_rule_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC transition on multisite, and bucket stats at archive
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite, and bucket stats at archive
@@ -519,7 +506,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_obj_acl_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC transition on multisite with object acl set
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite with object acl set
@@ -534,7 +520,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: test the workaround to sync only from one active zone
       module: exec.py
       name: test the workaround to sync only from one active zone
@@ -547,7 +532,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -560,7 +544,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -575,7 +558,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from_all true"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: Sync to the archive zone from all active sites
       module: exec.py
       name: Sync to the archive zone from all active sites
@@ -587,7 +569,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
             test-bucket-pol-retained-archive: true
       desc: Test bucket policies are reatined at archive site post object uploads
       polarion-id: CEPH-83575576
@@ -600,7 +581,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend_archive_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test versioning suspend on archive
       module: sanity_rgw_multisite.py
       name: test versioning suspend on archive
@@ -616,7 +596,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-sec:
           config:
             cephadm: true
@@ -626,7 +605,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -636,7 +614,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: enabled default encryption and zlib compression
       module: exec.py
       name: enabled default encryption and zlib compression
@@ -647,7 +624,6 @@ tests:
             script-name: test_s3_copy_encryption.py
             run-on-haproxy: true
             config-file-name: test_server_side_copy_object_via_encryption.yaml
-            timeout: 300
       desc: test server_side_copy_object_via_encryption
       module: sanity_rgw_multisite.py
       name: test server_side_copy_object_via_encryption
@@ -660,7 +636,6 @@ tests:
             script-name: test_encrypted_bucket_chown.py
             run-on-haproxy: true
             config-file-name: test_encrypted_bucket_chown.yaml
-            timeout: 300
       desc: test
       module: sanity_rgw_multisite.py
       name: Change bucket ownership to a different user when encryption is enabled

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -9,7 +9,6 @@
 #  config:
 #    script-name: test_Mbuckets_with_Nobjects.py
 #    config-file-name: test_Mbuckets_with_Nobjects.yaml
-#    timeout: 300
 
 # some of the other config option for this yamls are
 
@@ -141,7 +140,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -151,7 +149,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
 
   # REST API test
   - test:
@@ -162,7 +159,6 @@ tests:
       config:
         script-name: user_op_using_rest.py
         config-file-name: test_user_with_REST.yaml
-        timeout: 300
 
   # Swift basic operation
 
@@ -174,7 +170,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_modify_tenanted_subuser.yaml
-        timeout: 300
 
   - test:
        name: Swift bulk delete operation
@@ -184,7 +179,6 @@ tests:
        config:
            script-name: test_swift_bulk_delete.py
            config-file-name: test_swift_bulk_delete.yaml
-           timeout: 300
 
   - test:
       name: swift upload large object tests
@@ -194,7 +188,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_upload.yaml
-        timeout: 300
 
   - test:
       name: swift download large object tests
@@ -204,7 +197,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_download.yaml
-        timeout: 300
 
   - test:
       name: Get object with different tenant swift user with same name
@@ -214,7 +206,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
-        timeout: 300
 
   - test:
       name: delete container with different tenant swift user with same name
@@ -224,7 +215,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
-        timeout: 300
 
   - test:
       name: upload large object with same name using tenant swift user
@@ -234,7 +224,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_upload_large_obj_with_same_obj_name.yaml
-        timeout: 300
 
   # Versioning Tests
 
@@ -246,7 +235,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test overwrite by another user of versioned objects
@@ -256,7 +244,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Deletes on an object in versioning enabled or suspended container by a new user
@@ -266,7 +253,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_delete_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Versioning with copy objects and delete with different user
@@ -276,7 +262,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_delete_version_object_using_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test deleting the current version of the object
@@ -286,7 +271,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_delete_current_version_object.yaml
-        timeout: 300
 
   - test:
       name: Test copy versioned objects to another versioned bucket
@@ -296,7 +280,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_copy_version_object_to_version_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Write modify and read objects in the versioned bucket
@@ -306,7 +289,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_access_versioned_objects.yaml
-        timeout: 300
 
   # BucketPolicy Tests
   - test:
@@ -317,7 +299,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
-        timeout: 300
 
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
@@ -327,7 +308,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
-        timeout: 300
 
   - test:
       name: test bucket policy with multiple statements
@@ -337,7 +317,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with conflicting statements
@@ -347,7 +326,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with condition blocks
@@ -357,7 +335,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy condition block with explicit deny
@@ -367,7 +344,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
-        timeout: 500
 
   # Bucket Lifecycle Tests
   - test:
@@ -378,7 +354,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: object expiration with expiration set to Date
@@ -388,7 +363,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_date.yaml
-        timeout: 300
 
   - test:
       name: object expiration for delete marker set
@@ -398,7 +372,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Read lifecycle configuration on a given bucket
@@ -408,7 +381,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_read.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing multiple object versions
@@ -418,7 +390,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_versioning.yaml
-        timeout: 300
 
   - test:
       name: Disable lifecycle configuration on a given bucket
@@ -428,7 +399,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_disable.yaml
-        timeout: 300
 
   - test:
       name: Modify lifecycle configuration on a given bucket
@@ -438,7 +408,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_modify.yaml
-        timeout: 300
 
   # Multi Tenant Tests
 
@@ -450,7 +419,6 @@ tests:
       config:
         script-name: test_multitenant_user_access.py
         config-file-name: test_multitenant_access.yaml
-        timeout: 300
 
   - test:
       name: Generate secret for tenant user
@@ -460,7 +428,6 @@ tests:
       config:
         script-name: test_tenant_user_secret_key.py
         config-file-name: test_tenantuser_secretkey_gen.yaml
-        timeout: 300
 
   # Bucket Listing Tests
   - test:
@@ -471,7 +438,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
 
   # Bucket Request Payer tests
   - test:
@@ -482,7 +448,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer.yaml
-        timeout: 300
 
   - test:
       name: bucket request payer with object download
@@ -492,7 +457,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer_download.yaml
-        timeout: 300
 
   #resharding tests
   - test:
@@ -503,7 +467,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500
 
   # v1 tests
   # ACLs tests
@@ -517,7 +480,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: test acls on all users
@@ -529,7 +491,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_all_usrs.py
         config-file-name: test_acls_all_usrs.yaml
-        timeout: 300
 
   - test:
       name: test acls with copy objects on different users
@@ -541,7 +502,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_copy_obj.py
         config-file-name: test_acls_copy_obj.yaml
-        timeout: 300
 
   - test:
       name: acls reset
@@ -553,7 +513,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_reset.py
         config-file-name: test_acls_reset.yaml
-        timeout: 300
 
   # multipart test
   - test:
@@ -566,7 +525,6 @@ tests:
         run-on-rgw: true
         script-name: test_multipart_upload_cancel.py
         config-file-name: test_multipart_upload_cancel.yaml
-        timeout: 300
 
   # User, Bucket rename, Bucket link and unlink
   - test:
@@ -577,7 +535,6 @@ tests:
       config:
         script-name: test_user_bucket_rename.py
         config-file-name: test_user_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket rename
@@ -588,7 +545,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket link and unlink
@@ -599,7 +555,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_link_unlink.yaml
-        timeout: 500
 
   # Multifactor Authentication tests
   - test:
@@ -614,7 +569,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
 
   - test:
       name: multipart versioned object deletion with mfa token
@@ -628,7 +582,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed
@@ -642,7 +595,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
 
   - test:
       abort-on-fail: true
@@ -669,8 +621,6 @@ tests:
         test-version: v2
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
-        timeout: 500
-
   - test:
       name: NFS export delete
       desc: NFS cluster and exports delete
@@ -679,7 +629,6 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-        timeout: 500
 
   # Object level locking
   - test:
@@ -690,7 +639,6 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_compliance.yaml
-        timeout: 500
 
   - test:
       name: object level retention test Governance mode
@@ -700,7 +648,6 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_governance.yaml
-        timeout: 500
 
   - test:
       name: object lock no overwrite
@@ -710,7 +657,6 @@ tests:
       config:
         script-name: test_object_lock_no_overwrite.py
         config-file-name: test_object_lock_no_overwrite.yaml
-        timeout: 500
 
   - test:
       name: Test user modify with placement id
@@ -720,4 +666,3 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
-        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
@@ -117,7 +117,6 @@ tests:
       config:
         script-name: ../s3cmd/test_lifecycle_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle expiration of incomplete multipart
@@ -127,7 +126,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_incomplete_multipart.yaml
-        timeout: 300
   - test:
       name: S3CMD small and multipart object download
       desc: S3CMD small and multipart object download or GET
@@ -136,7 +134,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Swift user with read access
@@ -146,7 +143,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_read.yaml
-        timeout: 300
 
   - test:
       name: Swift user with write access
@@ -156,7 +152,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_write.yaml
-        timeout: 300
 
   - test:
       name: Swift user with readwrite access
@@ -166,7 +161,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_readwrite.yaml
-        timeout: 300
 
   - test:
       name: Test LC with custom worktime
@@ -176,7 +170,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_custom_worktime.yaml
-        timeout: 300
 
   - test:
       name: Test Etag not empty for complete multipart upload in aws
@@ -187,7 +180,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
-        timeout: 500
 
   - test:
       name: Test S3 PUT requests with non ascii characters in body
@@ -197,7 +189,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_aws_non_ascii.yaml
-        timeout: 500
 
   # - test:
   #     name: Test LC transition with rule by lc process
@@ -208,7 +199,6 @@ tests:
   #     config:
   #       script-name: test_bucket_lifecycle_object_expiration_transition.py
   #       config-file-name: test_lc_transition_with_lc_process.yaml
-  #       timeout: 500
 
   - test:
       name: Test LC transition without rule by lc process
@@ -218,7 +208,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
-        timeout: 500
 
   - test:
       abort-on-fail: false

--- a/suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml
@@ -78,4 +78,3 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-        timeout: 300

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
@@ -75,7 +75,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_PLAINTEXT PLAIN
@@ -86,7 +85,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_PLAINTEXT security type and SCRAM-SHA-256 mechanism
   - test:
@@ -98,7 +96,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_PLAINTEXT SCRAM-SHA-256
@@ -109,7 +106,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type and PLAIN mechanism
   - test:
@@ -121,7 +117,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_SSL PLAIN
@@ -132,7 +127,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type and SCRAM-SHA-256 mechanism
   - test:
@@ -144,7 +138,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
@@ -155,7 +148,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
@@ -77,7 +77,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
@@ -88,7 +87,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
@@ -99,7 +97,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
@@ -110,7 +107,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type
   - test:
@@ -122,7 +118,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
@@ -133,7 +128,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker and SASL_SSL SCRAM-SHA-256
@@ -144,7 +138,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
@@ -155,7 +148,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -169,7 +161,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
@@ -180,7 +171,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
@@ -191,7 +181,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
@@ -202,7 +191,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
@@ -213,7 +201,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
@@ -224,7 +211,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
@@ -235,7 +221,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
@@ -246,7 +231,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type
   - test:
@@ -258,7 +242,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
@@ -269,7 +252,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_SSL PLAIN
@@ -280,7 +262,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
@@ -291,7 +272,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none and SASL_SSL SCRAM-SHA-256
@@ -302,7 +282,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
@@ -313,7 +292,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
@@ -324,7 +302,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
@@ -335,7 +312,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
@@ -75,7 +75,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SSL security
@@ -86,7 +85,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker_persistent and SSL security
@@ -97,7 +95,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker_persistent and SSL security
@@ -108,7 +105,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -121,7 +117,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SSL security
@@ -132,7 +127,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SSL security
@@ -143,7 +137,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
@@ -154,7 +147,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -8,7 +8,6 @@
 # config:
 #    script-name: test_s3cmd.py
 #    config-file-name: test_s3cmd.yaml
-#    timeout: 300
 #
 # some of the other config option for this yamls are
 #
@@ -139,7 +138,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: S3CMD large object download with GC
@@ -149,7 +147,6 @@ tests:
       config:
         script-name: ../s3cmd/test_large_object_gc.py
         config-file-name: ../../s3cmd/configs/test_large_object_gc.yaml
-        timeout: 300
 
   - test:
       name: S3CMD bucket stats consistency
@@ -159,7 +156,6 @@ tests:
       config:
         script-name: ../s3cmd/test_bucket_stats.py
         config-file-name: ../../s3cmd/configs/test_bucket_stats.yaml
-        timeout: 300
 
   - test:
       name: S3CMD object header size check
@@ -169,7 +165,6 @@ tests:
       config:
         script-name: ../s3cmd/test_header_size.py
         config-file-name: ../../s3cmd/configs/test_header_size.yaml
-        timeout: 300
 
   - test:
       name: Test rgw opslog io though s3cmd
@@ -180,7 +175,6 @@ tests:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_opslog.yaml
         run-on-rgw: true # as logs generated on rgw nodes
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using s3cmd
@@ -190,7 +184,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
-        timeout: 300
 
   - test:
       name: S3CMD object download
@@ -200,7 +193,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit at global scope
@@ -210,7 +202,6 @@ tests:
       config:
         script-name: ../s3cmd/test_ratelimit_global.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for regular buckets
@@ -220,7 +211,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for versioned buckets
@@ -230,7 +220,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for tenanted users
@@ -240,7 +229,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
-        timeout: 300
 
   # - test:
   #     name: Test ratelimit on bucket owner change
@@ -251,7 +239,6 @@ tests:
   #     config:
   #       script-name: ../s3cmd/test_ratelimit_bucketowner.py
   #       config-file-name: ../../s3cmd/configs/test_ratelimit_bucketowner.yaml
-  #       timeout: 300
 
   - test:
       name: Test deletlifecycle rule via s3cmd
@@ -261,7 +248,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
-        timeout: 300
 
   - test:
       name: Test by adding almost 10K buckets to the resharding queue
@@ -271,7 +257,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_1k_bucket.yaml
-        timeout: 300
+        timeout: 5000
 
   - test:
       name: Test multipart upload with failed upload parts using s3cmd and boto3
@@ -281,4 +267,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
-        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
@@ -71,14 +71,12 @@ tests:
       config:
         script-name: test_d3n_cache.py
         config-file-name: test_d3n_cache_enable.yaml
-        timeout: 500
         run-on-rgw: true
 
   - test:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-        timeout: 300
         install_common: false
         run-on-rgw: true
       desc: test to create "M" no of buckets and "N" no of objects with multipart upload
@@ -90,7 +88,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects.yaml
-        timeout: 300
         install_common: false
         run-on-rgw: true
       desc: test to create "M" no of buckets and "N" no of objects
@@ -107,7 +104,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.
@@ -117,7 +113,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: Basic ACLs Test
@@ -129,7 +124,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: Test Rate limits on a User and Bucket level using s3cmd
@@ -140,7 +134,6 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests
@@ -150,4 +143,3 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -73,7 +73,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_broker_persistent and verify details of event record
@@ -84,7 +83,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
 
   # kafka broker type none with persistent flag enabled
 
@@ -97,7 +95,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_none_persistent
@@ -108,7 +105,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent
@@ -119,7 +115,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -132,7 +127,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_none
@@ -143,7 +137,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and verify timestamp of event record
@@ -154,7 +147,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_multipart.yaml
-        timeout: 300
 
   # kafka broker type broker
 
@@ -167,7 +159,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_broker
@@ -178,7 +169,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
@@ -189,7 +179,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_filter.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
@@ -200,7 +189,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
@@ -211,7 +199,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
-        timeout: 300
 
   - test:
       name: put empty bucket notifications
@@ -222,7 +209,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/reef/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/reef/rgw/migrate_default_single_to_multisite.yaml
@@ -170,7 +170,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets compression on haproxy node
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -183,7 +182,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -210,7 +208,6 @@ tests:
               - "ceph config set client.rgw.rgw.default rgw_zonegroup shared"
               - "ceph config set client.rgw.rgw.default rgw_zone primary"
               - "ceph orch restart rgw.rgw.default"
-
 
         ceph-sec:
           config:
@@ -240,7 +237,6 @@ tests:
             config-file-name: test_rgw_restore_index_versioned_buckets.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test rgw restore index tool on versioned bucket
       polarion-id: CEPH-83575473
       module: sanity_rgw_multisite.py
@@ -252,7 +248,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py

--- a/suites/reef/rgw/sanity_rgw.yaml
+++ b/suites/reef/rgw/sanity_rgw.yaml
@@ -84,7 +84,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
         run-on-rgw: true
   - test:
       name: overwrite objects after suspending versioning
@@ -94,7 +93,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_re-upload.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for Prefix and tag based filter and for more than one days
       desc: Test object expiration for Prefix and tag based filter and for more than one days
@@ -103,7 +101,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_and_tag.yaml
-        timeout: 300
   - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
@@ -112,7 +109,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding.yaml
-        timeout: 500
   - test:
       name: object lock verification
       desc: object lock test
@@ -121,7 +117,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_compliance.yaml
-        timeout: 500
   - test:
       name: Test rgw through CURL
       desc: Test rgw through CURL
@@ -130,7 +125,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-        timeout: 500
 
   - test:
       name: Test rgw multipart upload through curl
@@ -140,7 +134,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: Test rename of large object using sts user through AWS
@@ -150,7 +143,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role on principle user and perform IOs
       desc: Perform assume role on principle user and perform IOs
@@ -161,7 +153,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: test bucket notifcation with empty configuration
       desc: verify empty bucket notification deletes the existing configuration
@@ -175,7 +166,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-        timeout: 300
   - test:
       name: Multipart upload with Bucket policy enabled
       desc: Perform multipart upload with Bucket policy enabled
@@ -185,7 +175,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
   - test:
       name: Test ACL Operations
       desc: Test ACL Operations
@@ -196,7 +185,6 @@ tests:
         test-version: v2
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
-        timeout: 300
   - test:
       name: S3CMD basic  operations
       desc: S3CMD basic  operations
@@ -205,7 +193,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
-        timeout: 300
   - test:
       name: Test Ratelimit for tenanted users
       desc: Test Ratelimit for tenanted users
@@ -214,7 +201,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
-        timeout: 300
   - test:
       name: test swift enable version on conatainer of different user
       desc: test swift enable version on conatainer of different user
@@ -223,7 +209,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_enable_version_with_different_user.yaml
-        timeout: 500
   - test:
       name: Add a lifecycle configuration to a bucket with tenant user
       desc: Apply lc configuration to bucket with tenant user and perform get lc with other users of tenant
@@ -232,7 +217,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucket_put_get_lifecycle_configuration_with_tenant_users.yaml
-        timeout: 300
   - test:
       name: Test the byte ranges with get object
       desc: Test the byte ranges with get_object
@@ -242,12 +226,10 @@ tests:
         test-version: v2
         script-name: test_byte_range.py
         config-file-name: test_byte_range.yaml
-        timeout: 500
   - test:
       config:
         script-name: test_quota_management.py
         config-file-name: test_quota_bucket_max_objects.yaml
-        timeout: 300
       desc: test bucket quota max objects
       module: sanity_rgw.py
       name: test bucket quota max objects
@@ -265,7 +247,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
   - test:
       name: Bucket link and unlink
       desc: Bucket move between tenanted and non tenanted users
@@ -275,7 +256,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_link_unlink.yaml
-        timeout: 500
   - test:
       name: User and container access in same and different tenants
       desc: User and container access in same and different tenants
@@ -284,7 +264,6 @@ tests:
       config:
         script-name: test_multitenant_user_access.py
         config-file-name: test_multitenant_access.yaml
-        timeout: 300
   - test:
       name: Generate secret for tenant user
       desc: Generate secret for tenant user
@@ -293,7 +272,6 @@ tests:
       config:
         script-name: test_tenant_user_secret_key.py
         config-file-name: test_tenantuser_secretkey_gen.yaml
-        timeout: 300
   - test:
       name: Bucket radoslist
       desc: radoslist on all buckets
@@ -302,7 +280,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
 
   - test:
       name: Indexless buckets
@@ -313,7 +290,6 @@ tests:
         test-version: v2
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
-        timeout: 500
 
   - test:
       name: bucket request payer with object download
@@ -323,7 +299,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer_download.yaml
-        timeout: 300
   - test:
       name: Manual Resharding tests
       desc: Resharding test - manual
@@ -332,7 +307,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500
   - test:
       name: D3n-cache enable
       desc: D3n-cache enable
@@ -341,7 +315,6 @@ tests:
       config:
         script-name: test_d3n_cache.py
         config-file-name: test_d3n_cache_enable.yaml
-        timeout: 500
         run-on-rgw: true
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
@@ -351,7 +324,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
-        timeout: 300
   - test:
       name: test REST api operation
       desc: test user operation using REST API
@@ -360,7 +332,6 @@ tests:
       config:
         script-name: user_op_using_rest.py
         config-file-name: test_user_with_REST.yaml
-        timeout: 300
   - test:
       name: test s3cmd put operation with malformed bucket url
       desc: test s3cmd put operation with malformed bucket url
@@ -369,7 +340,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_put.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests for Prefix and tag based filter
       desc: Test object transition for Prefix and tag based filter and for more than one days
@@ -378,4 +348,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_prefix_and_TAG_rule.yaml
-        timeout: 300

--- a/suites/reef/rgw/sanity_rgw_multisite.yaml
+++ b/suites/reef/rgw/sanity_rgw_multisite.yaml
@@ -210,7 +210,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -227,7 +226,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -235,7 +233,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding on greenfield deployment
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -247,7 +244,6 @@ tests:
           config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
       desc: bucket create and delete operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -260,7 +256,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test_async_data_notifications_on_primary
       polarion-id: CEPH-83575231
       module: sanity_rgw_multisite.py
@@ -276,7 +271,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: test aws4 signature version on primary
       desc: test_Mbuckets_with_Nobjects_aws4 on primary
@@ -287,7 +281,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -299,7 +292,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: multipart upload on primary
       desc: test_Mbuckets_with_Nobjects_multipart on primary
@@ -311,7 +303,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
   - test:
       name: LargeObjGet_GC on primary
       desc: test_LargeObjGet_GC on primary
@@ -322,7 +313,6 @@ tests:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
-            timeout: 300
   - test:
       name: modify bucket policy on primary
       desc: test_bucket_policy_modify.yaml on primary
@@ -334,7 +324,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -346,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name:  datalog omap offload on secondary
       desc: Execute datalog omap offload on secondary
@@ -358,7 +346,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: datalog trim command with delete marker enabled on Primary
       desc: Execute datalog trim command with delete marker enabled on Primary
@@ -369,7 +356,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
   - test:
       clusters:
@@ -402,7 +388,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -414,7 +399,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -425,7 +409,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw_multisite.py
       name: sse-s3 per bucket encryption test
@@ -436,7 +419,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_multipart_object_download_after_transition
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_multipart_object_download_after_transition
@@ -451,7 +433,6 @@ tests:
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
@@ -462,7 +443,6 @@ tests:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_sse_kms_per_bucket_with_bucket_policy.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_with_bucket_policy
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_bucket_policy
@@ -473,7 +453,6 @@ tests:
           config:
             script-name: test_sts_using_boto.py
             config-file-name: test_sse_s3_per_object_with_sts.yaml
-            timeout: 300
       desc: test_sse_s3_per_object_with_sts
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_object_with_sts
@@ -496,7 +475,6 @@ tests:
               - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
               - "ceph orch apply -i /root/rgw_spec.yaml"
               - "sleep 20"
-            timeout: 120
         ceph-sec:
           config:
             role: rgw
@@ -509,7 +487,6 @@ tests:
               - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
               - "ceph orch apply -i /root/rgw_spec.yaml"
               - "sleep 20"
-            timeout: 120
       desc: Setting up certs, mount the certs path and redeploy rgw
       module: exec.py
       name: Setting up certs, mount the certs path and redeploy rgw
@@ -526,7 +503,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
         ceph-sec:
           config:
             cephadm: true
@@ -537,7 +513,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
       desc: Setting sse_kms configs with kmip backend for gklm
       module: exec.py
       name: Setting sse_kms configs with kmip backend for gklm
@@ -550,7 +525,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload
@@ -561,7 +535,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload
@@ -572,7 +545,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
@@ -583,7 +555,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_object.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_object
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_object
@@ -594,7 +565,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_object_versioninig_enabled
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_object_versioninig_enabled
@@ -611,7 +581,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
   - test:
       name: Bucket Granular Sync policy tests
@@ -624,7 +593,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: Basic ACLs Test
       desc: Test basic acls
@@ -637,7 +605,6 @@ tests:
             run-on-rgw: true
             script-name: test_acls.py
             config-file-name: test_acls.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -645,7 +612,6 @@ tests:
             config-file-name: test_user_with_REST.yaml
             script-name: user_op_using_rest.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: user operations using REST
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -660,4 +626,3 @@ tests:
           config:
             script-name: test_bucket_request_payer.py
             config-file-name: test_bucket_request_payer.yaml
-            timeout: 300

--- a/suites/reef/rgw/tier-1_rgw.yaml
+++ b/suites/reef/rgw/tier-1_rgw.yaml
@@ -89,7 +89,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects
@@ -101,7 +100,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with delete
@@ -113,7 +111,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with download
@@ -125,7 +122,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with multipart upload
@@ -141,7 +137,6 @@ tests:
               install_common: false
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_bi_purge.yaml
-              timeout: 300
 
   - test:
       name: enable bucket versioning
@@ -151,7 +146,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_enable.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration
       desc: Test object expiration for non current version expiration
@@ -160,7 +154,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests for Prefix filter and versioned buckets
       desc: Test object transition for Prefixand versioned buckets
@@ -169,7 +162,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_with_prefix_rule.yaml
-        timeout: 300
   - test:
       name: S3CMD small and multipart object download
       desc: S3CMD small and multipart object download or GET
@@ -178,4 +170,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300

--- a/suites/reef/rgw/tier-1_rgw_archive_ms_upgrade_61GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_archive_ms_upgrade_61GA_to_7x_latest.yaml
@@ -299,7 +299,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -312,7 +311,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       name: test to create "M" no of buckets on primary
       polarion-id: CEPH-9789
       desc: test metadata sync - create buckets
@@ -325,7 +323,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       name: enabling bucket versioning and uploading objects on secondary
       polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
       desc: test_versioning_objects_enable on secondary
@@ -338,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -351,7 +347,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -393,7 +388,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -401,7 +395,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec" , "ceph-arc"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -415,7 +408,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py

--- a/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
@@ -291,7 +291,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -309,7 +308,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       clusters:
@@ -318,7 +316,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -331,7 +328,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -345,7 +341,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -358,7 +353,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -371,7 +365,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -408,7 +401,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -420,7 +412,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -429,7 +420,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -442,7 +432,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -455,7 +444,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/reef/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -282,7 +282,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -298,7 +297,6 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_storage_class_symm.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -306,7 +304,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload on primary cluster
       module: sanity_rgw_multisite.py
@@ -319,7 +316,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload_multipart.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload with multipart objects on primary
       module: sanity_rgw_multisite.py
@@ -336,7 +332,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_owner_translation_direc.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       clusters:
@@ -344,7 +340,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload_versioned_bucket.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload on versioned bucket on primary
       module: sanity_rgw_multisite.py
@@ -361,7 +356,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
 
   - test:
       name: bucket granular sync policy on bucket with flow directional and storage class
@@ -373,7 +367,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_storage_class_direc.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket creation on primary for crash check
@@ -385,7 +379,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -398,5 +391,4 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]

--- a/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -257,7 +257,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -269,7 +268,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-pri" ]
       desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-9789
@@ -285,7 +283,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: delete buckets and objects on primary
       desc: test_Mbuckets_with_Nobjects_delete on primary
@@ -296,7 +293,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -308,7 +304,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: test sharding on primary
       desc: test_Mbuckets_with_Nobjects_sharding on primary
@@ -319,7 +314,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-            timeout: 300
 
   - test:
       name: replace bucket policy on primary
@@ -332,7 +326,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: suspend bucket versioning on primary
       desc: test_versioning_objects_suspend on secondary
@@ -344,7 +337,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: reverting object to one of the versions on primary
       desc: test_versioning_objects_copy on secondary
@@ -355,7 +347,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
   - test:
       name: enable bucket versioning on primary
       desc: test_versioning_enable on secondary
@@ -367,7 +358,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_enable.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
@@ -378,7 +368,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered.yaml
-            timeout: 300
   - test:
       name: listing flat unordered buckets on primary
       desc: test_bucket_listing_flat_unordered.yaml on secondary
@@ -389,7 +378,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
 
   - test:
       name: listing flat ordered versioned buckets on primary
@@ -401,7 +389,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
   - test:
       name: listing flat ordered buckets on secondary
       desc: test_bucket_listing_flat_ordered on secondary
@@ -413,7 +400,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: listing pseudo ordered dir only buckets on secondary
       desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
@@ -425,4 +411,3 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_5_3GA_to_7x_latest.yaml
@@ -284,7 +284,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -299,7 +298,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects
       module: sanity_rgw_multisite.py
       name: m buckets with n objects pre upgrade
@@ -313,7 +311,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -326,7 +323,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -339,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -357,7 +352,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
 #   # Performing cluster upgrade
 
@@ -384,7 +378,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
       name: swift versioning copy post upgrade
@@ -398,7 +391,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -411,7 +403,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -438,7 +429,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_6_1GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_6_1GA_to_7x_latest.yaml
@@ -283,7 +283,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -298,7 +297,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -311,7 +309,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -325,7 +322,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -338,7 +334,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -351,7 +346,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -364,7 +358,6 @@ tests:
             script-name: ../s3cmd/test_rgw_ops_log.py
             config-file-name: ../../s3cmd/multisite_configs/test_rgw_log_details.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: S3CMD tests, rgw log details pre upgrade
       module: sanity_rgw_multisite.py
       name: S3CMD tests, rgw log details pre upgrade
@@ -397,7 +390,6 @@ tests:
             script-name: ../s3cmd/test_rgw_ops_log.py
             config-file-name: ../../s3cmd/multisite_configs/test_rgw_log_details.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: S3CMD tests, rgw log details post upgrade
       module: sanity_rgw_multisite.py
       name: S3CMD tests, rgw log details post upgrade
@@ -410,7 +402,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -423,7 +414,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -436,7 +426,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade
@@ -448,7 +437,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets post upgrade

--- a/suites/reef/rgw/tier-1_rgw_ms_upgrade_7_0GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ms_upgrade_7_0GA_to_7x_latest.yaml
@@ -283,7 +283,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -301,7 +300,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   # - test:
   #     name: Delete object version with id null
@@ -314,7 +312,6 @@ tests:
   #         config:
   #           script-name: ../aws/test_delete_version_id_null.py
   #           config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
-  #           timeout: 300
 
   # Performing cluster upgrade
   - test:
@@ -347,7 +344,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -359,4 +355,3 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300

--- a/suites/reef/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/reef/rgw/tier-1_rgw_multisite.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -291,7 +290,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario in greenfield
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -305,7 +303,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario in greenfield
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -322,7 +319,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: delete versioned objects on secondary
       desc: test_versioning_objects_delete on secondary
@@ -333,7 +329,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
   - test:
       name: enabling bucket versioning and uploading objects on secondary
       desc: test_versioning_objects_enable on secondary
@@ -345,7 +340,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: delete bucket policy on secondary
       desc: test_bucket_policy_delete.yaml on secondary
@@ -357,7 +351,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: download objects on secondary
       desc: test_Mbuckets_with_Nobjects_download on secondary
@@ -369,7 +362,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
   - test:
       name: multipart upload on primary
       desc: test_Mbuckets_with_Nobjects_multipart on primary
@@ -381,7 +373,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
   - test:
       name: enable compression on secondary
       desc: test_Mbuckets_with_Nobjects_compression on secondary
@@ -393,5 +384,4 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
 

--- a/suites/reef/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_71x_latest.yaml
@@ -293,7 +293,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -311,7 +310,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
 
   - test:
@@ -321,11 +319,9 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
-      polarion-id: CEPH-9801
 
   - test:
       clusters:
@@ -334,11 +330,9 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
-      polarion-id: CEPH-11019
 
   # Bucket Listing Tests
 
@@ -348,7 +342,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -361,7 +354,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -374,7 +366,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -411,7 +402,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -423,7 +413,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -432,7 +421,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -445,7 +433,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -458,7 +445,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/reef/rgw/tier-1_rgw_sw_qat.yaml
+++ b/suites/reef/rgw/tier-1_rgw_sw_qat.yaml
@@ -109,7 +109,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -119,8 +118,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
-
   - test:
       name: compresstion_with_Zlib_type
       desc: test compresstion with Zlib
@@ -129,13 +126,11 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-        timeout: 300
 
   - test:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a regular bucket
@@ -145,7 +140,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-        timeout: 300
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -155,7 +149,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_object.yaml
-        timeout: 300
       desc: test_sse_s3_per_object_encryption
       module: sanity_rgw.py
       name: sse-s3 per object encryption test on a regular bucket

--- a/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
@@ -83,7 +83,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -93,7 +92,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -103,13 +101,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -123,13 +119,11 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations pre upgrade
@@ -139,7 +133,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
       desc: Test bucket stats and radoslist on all buckets
       module: sanity_rgw.py
       name: test bucket stats and radoslist
@@ -153,7 +146,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
-        timeout: 300
 
   - test:
       name: Upgrade cluster to latest 6.x ceph version
@@ -187,14 +179,12 @@ tests:
       config:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
-        timeout: 300
 
 # Post upgrade tests
   - test:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -208,7 +198,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
@@ -218,7 +207,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests post upgrade
@@ -228,7 +216,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -238,7 +225,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -248,13 +234,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw.py
       name: unordered listing of buckets post upgrade
@@ -277,7 +261,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled after upgrade
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket after upgrade

--- a/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
@@ -93,7 +93,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket
@@ -107,7 +106,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -117,7 +115,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -127,7 +124,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -137,13 +133,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -157,7 +151,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   # upgrade cluster
 
@@ -190,7 +183,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -204,7 +196,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -214,7 +205,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -224,13 +214,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw.py
       name: unordered listing of buckets post upgrade
@@ -240,7 +228,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations post upgrade
@@ -250,7 +237,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test

--- a/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
@@ -85,7 +85,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
 
   # upgrade cluster
   - test:
@@ -101,7 +100,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
         - test:
             name: Upgrade cluster to latest 7.x ceph version
             desc: Upgrade cluster to latest version
@@ -124,4 +122,3 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
@@ -89,7 +89,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -99,7 +98,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -109,7 +107,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -119,13 +116,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -139,7 +134,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   # upgrade cluster
   - test:
@@ -155,7 +149,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
         - test:
             name: Upgrade cluster to latest 7.1.x ceph version
             desc: Upgrade cluster to latest version
@@ -198,7 +191,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -208,7 +200,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -218,13 +209,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations post upgrade
@@ -246,7 +235,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test

--- a/suites/reef/rgw/tier-1_rgw_with_multi_realm.yaml
+++ b/suites/reef/rgw/tier-1_rgw_with_multi_realm.yaml
@@ -210,4 +210,3 @@ tests:
         test-version: v2
         script-name: test_byte_range.py
         config-file-name: test_byte_range.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -440,7 +440,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -454,7 +453,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-ter
-            timeout: 300
       desc: create non-tenanted user and copy user details on tertiary site
       module: sanity_rgw_multisite.py
       name: create non-tenanted user and copy user details on tertiary site
@@ -499,7 +497,6 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.sec.io"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -511,7 +508,6 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.pri.io"
-            timeout: 120
         ceph-ter:
           config:
             cephadm: true
@@ -523,7 +519,6 @@ tests:
               - "ceph config set client.rgw.shared.ter rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.ter rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.ter.io"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite tertiary site
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -556,5 +551,4 @@ tests:
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment

--- a/suites/reef/rgw/tier-2_rgw_cloud_transition.yaml
+++ b/suites/reef/rgw/tier-2_rgw_cloud_transition.yaml
@@ -161,7 +161,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_true.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition retain headobject
@@ -187,7 +186,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_false.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition no retain headobject
@@ -199,7 +197,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_multipart.yaml
-            timeout: 500
       desc: test cloud transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition multipart upload
@@ -234,7 +231,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:rgw.1}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on local site
       module: exec.py
       name: set sse-s3 vault configs on Local cluster
@@ -245,7 +241,6 @@ tests:
   #        config:
   #          script-name: test_cloud_transition.py
   #          config-file-name: test_cloud_transition_encrypted.yaml
-  #          timeout: 500
   #    desc: test cloud transition of ecnrypted objects
   #    module: sanity_rgw.py
   #    name: Test cloud transition of SSE-S3 encrypted objects
@@ -272,7 +267,6 @@ tests:
   #        config:
   #          script-name: test_cloud_transition.py
   #          config-file-name: test_cloud_transition_headobject_false.yaml
-  #          timeout: 500
   #    desc: test clould transition of compressed objects
   #    module: sanity_rgw.py
   #    name: Test cloud transition with compression enabled

--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -236,7 +236,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -249,7 +248,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -266,7 +264,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
   - test:
       name: notify on multisite replication create events with kafka_broker on arc site
       desc: notify on multisite replication create events with kafka_broker on arc site
@@ -292,7 +289,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_archive_delete_replication_from_pri.yaml
-            timeout: 300
 # adding the LC tests for object size filter before as they have failed in the end.
   - test:
       clusters:
@@ -300,7 +296,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_objects_size_noncurrent.yaml
-            timeout: 300
       desc: Test LC on archive for objects size expiration
       polarion-id: CEPH-83582000
       module: sanity_rgw_multisite.py
@@ -311,7 +306,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_objects_size_noncurrent_local.yaml
-            timeout: 300
       desc: Test LC on active for objects size expiration
       polarion-id: CEPH-83581990
       module: sanity_rgw_multisite.py
@@ -324,7 +318,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -336,7 +329,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec","ceph-arc" ]
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-9789
@@ -353,7 +345,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_archive_symmetrical.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy with directional flow having archive zone
@@ -365,7 +357,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_archive_directional.yaml
-            timeout: 300
+            timeout: 5500
 
 # Dynamic resharding test
   - test:
@@ -374,7 +366,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - dynamic resharding on primary and verify on secondary & archive cluster
       name: Dynamic Resharding - dynamic
@@ -387,7 +378,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - dynamic resharding on versioned bucket on primary and verify on secondary & archive cluster
       name: Dynamic Resharding with versioning on primary and verify on archive
@@ -400,7 +390,6 @@ tests:
           config:
             config-file-name: test_manual_resharding_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - manual resharding
       name: Manual Resharding on primary and verify on secondary & archive cluster
@@ -412,7 +401,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_bilog_trim_archive.yaml
-            timeout: 30
       desc: test no bilogs are generated at archive zone
       polarion-id: CEPH-83575468
       module: sanity_rgw_multisite.py
@@ -459,7 +447,6 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone secondary --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -473,7 +460,6 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone primary --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -487,7 +473,6 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone archive --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.arc}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: sse-s3 vault configs, and zlib compression
@@ -500,7 +485,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
-            timeout: 30
       desc: test multipart download at remote site
       polarion-id: CEPH-11357
       module: sanity_rgw_multisite.py
@@ -515,7 +499,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: test the workaround to sync only from one active zone
       module: exec.py
       name: test the workaround to sync only from one active zone
@@ -526,7 +509,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
-            timeout: 30
       desc: test multipart+encrypt object access at the archive site
       polarion-id: CEPH-83573390
       module: sanity_rgw_multisite.py
@@ -537,7 +519,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_current_expiration.yaml
-            timeout: 300
       desc: Test LC on archive for current versions
       polarion-id: CEPH-83575394
       module: sanity_rgw_multisite.py
@@ -549,7 +530,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_newer_noncurrent_expiration.yaml
-            timeout: 300
       desc: Test LC on archive for newer-noncurrent versions
       polarion-id: CEPH-83575919
       module: sanity_rgw_multisite.py
@@ -561,7 +541,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_noncurrent_expiration.yaml
-            timeout: 300
       desc: Test LC on archive for non-current versions
       polarion-id: CEPH-83575394
       module: sanity_rgw_multisite.py
@@ -572,7 +551,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_newer_noncurrent_expiration_local.yaml
-            timeout: 300
       desc: Test LC on active for newer noncurrents
       polarion-id: CEPH-83581997
       module: sanity_rgw_multisite.py

--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -308,7 +308,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -324,7 +323,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -369,7 +367,6 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -381,7 +378,6 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -393,7 +389,6 @@ tests:
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite archive
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -409,7 +404,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test M buckets compression on haproxy node
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -424,7 +418,6 @@ tests:
             script-name: test_data_sync_init_remote.py
             config-file-name: test_data_sync_init_remote_zone.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Test data sync init feature for multiple buckets resharded to 1999 shards
       module: sanity_rgw_multisite.py
       name: Test data sync init feature for multiple buckets resharded to 1999 shards
@@ -438,7 +431,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC from primary to secondary
       module: sanity_rgw_multisite.py
       name: test LC from primary to secondary
@@ -452,7 +444,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
+            timeout: 5000
       desc: test sync on bucket with 0 shards
       module: sanity_rgw_multisite.py
       name: test sync on bucket with 0 shards
@@ -464,7 +456,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_prefix_rule_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
             stat-all-buckets-at-archive: true
       desc: test LC transition on multisite, and bucket stats at archive
       module: sanity_rgw_multisite.py
@@ -478,7 +469,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_obj_acl_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC transition on multisite with object acl set
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite with object acl set
@@ -493,7 +483,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: test the workaround to sync only from one active zone
       module: exec.py
       name: test the workaround to sync only from one active zone
@@ -506,7 +495,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -519,7 +507,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -531,7 +518,6 @@ tests:
             cephadm: true
             commands:
               - "ceph orch stop rgw.shared.arc"
-            timeout: 120
       desc: Test full sync at archive, power off archive zone with IOs in active zone
       module: exec.py
       name: Test full sync at archive, power off archive zone with IOs in active zone
@@ -544,7 +530,6 @@ tests:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Upload 5000 objects via s3cmd to test full sync at archive
       polarion-id: CEPH-83575917
       module: sanity_rgw_multisite.py
@@ -559,7 +544,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from_all true"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: Sync to the archive zone from all active sites
       module: exec.py
       name: Sync to the archive zone from all active sites
@@ -571,7 +555,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
             test-bucket-pol-retained-archive: true
       desc: Test bucket policies are reatined at archive site post object uploads
       polarion-id: CEPH-83575576
@@ -584,7 +567,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend_archive_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test versioning suspend on archive
       module: sanity_rgw_multisite.py
       name: test versioning suspend on archive
@@ -599,7 +581,6 @@ tests:
             config-file-name: test_rgw_restore_index_versioned_buckets.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test rgw restore index tool on versioned bucket
       polarion-id: CEPH-83575473
       module: sanity_rgw_multisite.py
@@ -615,7 +596,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-sec:
           config:
             cephadm: true
@@ -625,7 +605,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -635,7 +614,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: enabled default encryption and zlib compression
       module: exec.py
       name: enabled default encryption and zlib compression
@@ -647,7 +625,6 @@ tests:
             script-name: test_s3_copy_encryption.py
             config-file-name: test_server_side_copy_object_via_encryption.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test server_side_copy_object_via_encryption
       polarion-id: CEPH-83575711
       module: sanity_rgw_multisite.py
@@ -660,7 +637,6 @@ tests:
             script-name: test_encrypted_bucket_chown.py
             config-file-name: test_encrypted_bucket_chown.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Change bucket ownership to a different user when encryption is enabled
       polarion-id: CEPH-83574621
       module: sanity_rgw_multisite.py
@@ -673,7 +649,6 @@ tests:
             script-name: test_encrypted_bucket_chown.py
             config-file-name: test_chown_before_encrypt.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Change bucket ownership to a different user and then encryption is enabled
       polarion-id: CEPH-83574618
       module: sanity_rgw_multisite.py

--- a/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -270,7 +270,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create user
@@ -281,7 +280,6 @@ tests:
           config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
       desc: bucket create and delete operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -294,7 +292,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test_async_data_notifications_on_primary
       polarion-id: CEPH-83575231
       module: sanity_rgw_multisite.py
@@ -307,7 +304,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
       desc: test_async_data_notifications_on_secondary
       polarion-id: CEPH-83575268
       module: sanity_rgw_multisite.py
@@ -347,7 +343,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -359,7 +354,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -367,7 +361,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-        timeout: 300
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw_multisite.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -380,7 +373,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw_multisite.py
       name: sse-s3 per bucket encryption test on a versiond bucket
@@ -393,7 +385,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_s3_per_object_with_versioning
       module: sanity_rgw_multisite.py
       name: est_sse_s3_per_object_with_versioning
@@ -406,7 +397,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_per_object_with_versioning
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_object_with_versioning
@@ -418,7 +408,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_with_versioning
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_versioning
@@ -431,7 +420,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object.yaml
-            timeout: 300
       desc: test_sse_kms_per_object
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_object
@@ -444,7 +432,6 @@ tests:
   #         config:
   #           script-name: test_check_sharding_enabled.py
   #           config-file-name: test_zonegroup_rename.yaml
-  #           timeout: 300
   #     desc: Test zonegroup rename in master
   #     module: sanity_rgw_multisite.py
   #     name: Perform zonegroup rename in master

--- a/suites/reef/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -296,7 +295,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
 
   # IO should fail on read only secondary
   - test:
@@ -309,7 +307,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_failed.yaml
-            timeout: 300
 
   # Failover Primary, make secondary writable
   - test:
@@ -335,7 +332,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
-            timeout: 300
       desc: test M buckets uploads on current primary zone
       module: sanity_rgw_multisite.py
       name: test M buckets uploads on current primary zone
@@ -420,4 +416,3 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
@@ -281,7 +281,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -297,7 +296,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_sync_policy.yaml
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy test for prefix and tag
@@ -310,7 +308,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy tests
@@ -323,7 +320,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -335,7 +331,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy tests
@@ -348,7 +343,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_bucket_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: bucket granular sync policy on bucket with flow symmetrical and owner translation
@@ -360,4 +354,3 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_owner_translation_symm.yaml
-            timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -204,7 +204,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -246,7 +245,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
-            timeout: 1200
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
   - test:
       clusters:
@@ -255,7 +253,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster
@@ -267,7 +264,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_tenanted_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment tenanted user
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster tenanted user
@@ -279,7 +275,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_versioning_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on versioned bucket
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster
@@ -291,7 +286,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_versioning_tenanted_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on versioned bucket and tenanted user
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on versioned bucket and tenanted user Primary cluster
@@ -302,7 +296,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: ["ceph-pri", "ceph-sec" ]
       desc: Resharding test - dynamic resharding on versioned bucket
       name: Dynamic Resharding on versioned buckets
@@ -314,7 +307,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_quota_exceed.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
       desc: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
       name: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
       polarion-id: CEPH-83574669
@@ -325,7 +317,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_sync_disable_enable.yaml
-            timeout: 300
       desc: Test sync enable and disable with manual resharding
       module: sanity_rgw_multisite.py
       name: Manual Resharding tests on Primary cluster
@@ -336,7 +327,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_zone_deletion.yaml
-            timeout: 300
       desc: Test zone deletion in master
       module: sanity_rgw_multisite.py
       name: Perform zone deletion in master
@@ -353,7 +343,6 @@ tests:
   #         config:
   #           script-name: ../aws/test_delete_version_id_null.py
   #           config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
-  #           timeout: 300
 
   - test:
       name: bucket granular sync policy with sync from differnt bucket
@@ -365,7 +354,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       clusters:
@@ -373,7 +362,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_realm_rename.yaml
-            timeout: 300
       desc: Test realm rename in master
       module: sanity_rgw_multisite.py
       name: Perform realm rename in master
@@ -389,4 +377,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/reef/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
@@ -212,7 +212,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -230,7 +229,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
 
   - test:
       name: notify put,delete events with kafka_broker_persistent
@@ -243,7 +241,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-            timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker_persistent
@@ -256,7 +253,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-            timeout: 300
 
   - test:
       name: notify copy events with kafka_none
@@ -269,7 +265,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_none_copy.yaml
-            timeout: 300
 
   - test:
       name: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
@@ -282,7 +277,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
-            timeout: 300
 
   - test:
       name: notify on multipart events with kafka_broker_persistent when kafka is down
@@ -295,7 +289,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
-            timeout: 300
 
   - test:
       name: notify on multisite replication create events with kafka_broker on pri site
@@ -308,7 +301,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
-            timeout: 300
 
   - test:
       name: notify on multisite replication create events with kafka_broker on sec site
@@ -321,7 +313,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
-            timeout: 300
 
 # please include test cases before below rename testcase as the process is disruptive currently
   # - test:
@@ -330,7 +321,6 @@ tests:
   #         config:
   #           script-name: test_check_sharding_enabled.py
   #           config-file-name: test_zone_rename.yaml
-  #           timeout: 300
   #     desc: Test zone rename in master
   #     module: sanity_rgw_multisite.py
   #     name: Perform zone rename in master

--- a/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -295,7 +294,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_sync_policy_extended.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   # - test:
   #     name: bucket granular sync policy with allowed allowed semantic
@@ -309,7 +307,7 @@ tests:
   #           script-name: test_multisite_bucket_granular_sync_policy.py
   #           config-file-name: test_multisite_granular_bucket_sync_policy.yaml
   #           verify-io-on-site: ["ceph-sec"]
-  #           timeout: 300
+  #           timeout: 5500
 
   - test:
       name: bucket granular sync policy on enabled enabled semantic with directional flow
@@ -321,7 +319,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_enable_enable.yaml
-            timeout: 300
+            timeout: 4000
 
   - test:
       name: bucket granular sync policy on allowed forbidden semantic with directional flow
@@ -333,7 +331,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_allowed_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden forbidden semantic with directional flow
@@ -345,7 +343,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   # - test:
   #     name: Test Changing datalog num shards not cause any crash
@@ -358,4 +356,3 @@ tests:
   #         config:
   #           script-name: test_Mbuckets_with_Nobjects.py
   #           config-file-name: test_changing_data_log_num_shards_cause_no_crash.yaml
-  #           timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_multisite_scenarios.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_scenarios.yaml
@@ -225,7 +225,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -265,7 +264,6 @@ tests:
             config-file-name: ../configs/test_byte_range.yaml
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
 
   - test:
       name: Test the byte ranges with get object on secondary zone and check multisite replication doesn't happen
@@ -280,7 +278,6 @@ tests:
             config-file-name: ../configs/test_byte_range.yaml
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-pri"]
-            timeout: 500
 
   - test:
       abort-on-fail: true
@@ -310,7 +307,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_enabled_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden allowed semantic with symmetrical and directional flow
@@ -322,7 +319,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_allowed.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden enabled semantic with directional and symmetrical flow
@@ -334,4 +331,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_enabled.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -82,7 +82,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test non-current deletion via s3cmd
@@ -92,7 +91,6 @@ tests:
       config:
         script-name: ../s3cmd/test_lifecycle_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle expiration of incomplete multipart
@@ -102,7 +100,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_incomplete_multipart.yaml
-        timeout: 300
 
   # Object lock no overwrite
   # - test:
@@ -114,7 +111,6 @@ tests:
   #     config:
   #       script-name: test_object_lock_no_overwrite.py
   #       config-file-name: test_object_lock_no_overwrite.yaml
-  #       timeout: 500
   - test:
       name: S3CMD small and multipart object download
       desc: S3CMD small and multipart object download or GET
@@ -123,7 +119,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Swift user with read access
@@ -133,7 +128,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_read.yaml
-        timeout: 300
 
   - test:
       name: Swift user with write access
@@ -143,7 +137,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_write.yaml
-        timeout: 300
 
   - test:
       name: Swift user with readwrite access
@@ -153,7 +146,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_readwrite.yaml
-        timeout: 300
 
   - test:
       name: Test rgw put bucket website with users of same and different tenant
@@ -163,7 +155,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500
 
   - test:
       name: Test rgw get bucket website with users of same and different tenant
@@ -173,7 +164,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500
 
   - test:
       name: Test LC with custom worktime
@@ -183,7 +173,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_custom_worktime.yaml
-        timeout: 300
 
   - test:
       name: Test Etag not empty for complete multipart upload in aws
@@ -193,7 +182,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
-        timeout: 500
 
   - test:
       name: Test S3 PUT requests with non ascii characters in body
@@ -203,7 +191,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_aws_non_ascii.yaml
-        timeout: 500
 
   - test:
       name: Test bucket listing with markers on versioned bucket
@@ -213,7 +200,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_versioned_list_marker.yaml
-        timeout: 500
 
   - test:
       name: Test LDAP auth for RGW
@@ -223,7 +209,6 @@ tests:
       config:
         script-name: ../aws/test_ldap_auth.py
         config-file-name: ../../aws/configs/test_ldap_auth.yaml
-        timeout: 300
         run-on-rgw: true
 
   # - test:
@@ -235,7 +220,6 @@ tests:
   #     config:
   #       script-name: test_bucket_lifecycle_object_expiration_transition.py
   #       config-file-name: test_lc_transition_with_lc_process.yaml
-  #       timeout: 500
 
   - test:
       name: Test LC transition without rule by lc process
@@ -245,7 +229,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
-        timeout: 500
 
   # - test:
   #     abort-on-fail: false

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -119,7 +119,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -129,7 +128,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
 
   # Swift basic operation
 
@@ -141,7 +139,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_modify_tenanted_subuser.yaml
-        timeout: 300
 
   - test:
        name: Swift bulk delete operation
@@ -151,7 +148,6 @@ tests:
        config:
            script-name: test_swift_bulk_delete.py
            config-file-name: test_swift_bulk_delete.yaml
-           timeout: 300
 
   - test:
       name: swift upload large object tests
@@ -161,7 +157,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_upload.yaml
-        timeout: 300
 
   - test:
       name: swift download large object tests
@@ -171,7 +166,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_download.yaml
-        timeout: 300
 
   - test:
       name: Get object with different tenant swift user with same name
@@ -181,7 +175,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
-        timeout: 300
 
   - test:
       name: delete container with different tenant swift user with same name
@@ -191,7 +184,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
-        timeout: 300
 
   - test:
       name: upload large object with same name using tenant swift user
@@ -201,7 +193,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_upload_large_obj_with_same_obj_name.yaml
-        timeout: 300
 
   # Versioning Tests
 
@@ -213,7 +204,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test overwrite by another user of versioned objects
@@ -223,7 +213,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Deletes on an object in versioning enabled or suspended container by a new user
@@ -233,7 +222,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_delete_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Versioning with copy objects and delete with different user
@@ -243,7 +231,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_delete_version_object_using_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test deleting the current version of the object
@@ -253,7 +240,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_delete_current_version_object.yaml
-        timeout: 300
 
   - test:
       name: Test copy versioned objects to another versioned bucket
@@ -263,7 +249,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_copy_version_object_to_version_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Write modify and read objects in the versioned bucket
@@ -273,7 +258,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_access_versioned_objects.yaml
-        timeout: 300
 
   # BucketPolicy Tests
   - test:
@@ -284,7 +268,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
-        timeout: 300
 
   - test:
       name: Get object and its version from same and different tenant users
@@ -295,7 +278,6 @@ tests:
         test-version: v2
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: get_object_and_its_versions_tenat_user.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with multiple statements
@@ -305,7 +287,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with conflicting statements
@@ -315,7 +296,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with condition blocks
@@ -325,7 +305,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy condition block with explicit deny
@@ -335,7 +314,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
-        timeout: 500
 
   # Bucket Lifecycle Tests
   - test:
@@ -346,7 +324,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: object expiration with expiration set to Date
@@ -356,7 +333,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_date.yaml
-        timeout: 300
 
   - test:
       name: object expiration for delete marker set
@@ -366,7 +342,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Read lifecycle configuration on a given bucket
@@ -376,7 +351,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_read.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing multiple object versions
@@ -386,7 +360,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_versioning.yaml
-        timeout: 300
 
   - test:
       name: Disable lifecycle configuration on a given bucket
@@ -396,7 +369,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_disable.yaml
-        timeout: 300
 
   - test:
       name: Modify lifecycle configuration on a given bucket
@@ -406,7 +378,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_modify.yaml
-        timeout: 300
 
   # Bucket Request Payer tests
   - test:
@@ -417,7 +388,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer.yaml
-        timeout: 300
 
   # v1 tests
   # ACLs tests
@@ -431,7 +401,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: test acls with copy objects on different users
@@ -443,7 +412,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_copy_obj.py
         config-file-name: test_acls_copy_obj.yaml
-        timeout: 300
 
   - test:
       name: acls reset
@@ -455,7 +423,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_reset.py
         config-file-name: test_acls_reset.yaml
-        timeout: 300
 
   - test:
       name: test acls on all users
@@ -467,7 +434,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_all_usrs.py
         config-file-name: test_acls_all_usrs.yaml
-        timeout: 300
 
   # multipart test
   - test:
@@ -480,7 +446,6 @@ tests:
         run-on-rgw: true
         script-name: test_multipart_upload_cancel.py
         config-file-name: test_multipart_upload_cancel.yaml
-        timeout: 300
 
   # User, Bucket rename, Bucket link and unlink
   - test:
@@ -491,7 +456,6 @@ tests:
       config:
         script-name: test_user_bucket_rename.py
         config-file-name: test_user_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket rename
@@ -502,7 +466,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_rename.yaml
-        timeout: 500
 
   # Multifactor Authentication tests
 
@@ -518,7 +481,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed
@@ -529,7 +491,6 @@ tests:
         test-version: v2
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa_incorrect_syntax.yaml
-        timeout: 500
 
   - test:
       name: Test s3_copy_obj on user with admin flag through AWS
@@ -539,7 +500,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_s3copyObj_admin_user.yaml
-        timeout: 500
 
   # testing rgw through curl
   - test:
@@ -550,7 +510,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_curl_transfer_encoding_chunked.yaml
-        timeout: 500
 
   - test:
       name: Test rgw bucket quota using CURL
@@ -560,7 +519,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_bucket_quota_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw user quota using CURL
       desc: Test rgw user quota using CURL
@@ -569,7 +527,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_user_quota_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw bucket quota conflict using CURL
       desc: Test rgw bucket quota conflict using CURL
@@ -578,7 +535,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
-        timeout: 500
 
   - test:
       name: Test bucket listing is not truncated
@@ -588,7 +544,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_list_not_truncated.yaml
-        timeout: 500
 
   - test:
       name: Test user modify with placement id
@@ -598,7 +553,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
-        timeout: 500
 
   # rate limits tests with s3cmd
   - test:
@@ -610,4 +564,3 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -233,7 +233,6 @@ tests:
             set-env: true
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
-            timeout: 300
 
   #  Dynamic resharding tests
   - test:
@@ -247,14 +246,12 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_greenfield.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -267,7 +264,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
       desc: Resharding test - dynamic resharding on versioned bucket
       name: Dynamic Resharding on versioned buckets
       polarion-id: CEPH-83571740
@@ -279,7 +275,6 @@ tests:
           config:
             script-name: test_quota_management.py
             config-file-name: test_quota_bucket_max_size.yaml
-            timeout: 300
       desc: test bucket quota max size (single site)
       module: sanity_rgw.py
       name: test bucket quota max size (single site)
@@ -291,7 +286,6 @@ tests:
           config:
             script-name: test_quota_management.py
             config-file-name: test_quota_user_max_objects.yaml
-            timeout: 300
       desc: test user quota max objects (single site)
       module: sanity_rgw.py
       name: test user quota max objects (single site)
@@ -303,7 +297,6 @@ tests:
           config:
             script-name: test_quota_management.py
             config-file-name: test_quota_user_max_size.yaml
-            timeout: 300
       desc: test user quota max size (single site)
       module: sanity_rgw.py
       name: test user quota max size (single site)
@@ -315,7 +308,6 @@ tests:
           config:
             script-name: test_dynamic_bucket_resharding.py
             config-file-name: test_bucket_index_shards.yaml
-            timeout: 300
       desc: test_metadata_integrity_with_0_num_shards (single site)
       module: sanity_rgw.py
       name: test_metadata_integrity_with_0_num_shards (single site)
@@ -412,7 +404,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       clusters:
@@ -421,7 +412,6 @@ tests:
             config-file-name: test_user_bucket_create.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: user and bucket create operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -434,7 +424,6 @@ tests:
             config-file-name: test_user_modify_op.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Modify suspend enable and delete user operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -447,7 +436,6 @@ tests:
             config-file-name: test_user_bucket_rename.yaml
             script-name: test_user_bucket_rename.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: rename user and bucket and link unlink bucket operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -463,7 +451,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
 
   - test:
@@ -476,7 +463,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_and_tag.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
 
   - test:
@@ -489,7 +475,6 @@ tests:
           config:
             script-name: test_bucket_lc_object_exp_multipart.py
             config-file-name: test_bucket_lc_object_exp_multipart.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
 
 # Log trimming tests
@@ -503,8 +488,8 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_mdlog_trimming.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
+            timeout: 5000
 
   - test:
       name: Datalog trimming test on primary
@@ -516,7 +501,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_datalog_trimming.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -529,7 +513,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_bilog_trimming.yaml
-            timeout: 300
 
   - test:
       name: bucket request payer
@@ -541,14 +524,12 @@ tests:
           config:
             script-name: test_bucket_request_payer.py
             config-file-name: test_bucket_request_payer.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-            timeout: 30
       desc: test LC cloud transition to IBM cos with retain true
       polarion-id: CEPH-83581972 #CEPH-83575498
       module: sanity_rgw_multisite.py
@@ -559,7 +540,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-            timeout: 30
       desc: test LC cloud transition to IBM cos with retain false
       polarion-id: CEPH-83581973 #CEPH-83581975
       module: sanity_rgw_multisite.py
@@ -570,7 +550,6 @@ tests:
           config:
             script-name: test_sts_using_boto.py
             config-file-name: test_sts_multisite.yaml
-            timeout: 30
       desc: test assume role at secondary, with s3 ops
       polarion-id: CEPH-83575592
       module: sanity_rgw_multisite.py
@@ -583,7 +562,6 @@ tests:
   #         config:
   #           script-name: test_check_sharding_enabled.py
   #           config-file-name: test_zone_rename.yaml
-  #           timeout: 300
   #     desc: Test zone rename in non master that is secondary
   #     module: sanity_rgw_multisite.py
   #     name: Perform zone rename in non master that is secondary

--- a/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
@@ -104,7 +104,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token
@@ -113,7 +112,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aud_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test azp fields in the web token
       desc: STS aswi Tests to test azp fields in the web token
@@ -122,7 +120,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_azp_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test sub fields in the web token
       desc: STS aswi Tests to test sub fields in the web token
@@ -131,7 +128,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_sub_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_PrincipalTag in role's permission policy
       desc: STS aswi Tests to test aws_PrincipalTag in role's permission policy
@@ -140,7 +136,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_principal_tag_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_RequestTag in role's trust policy
       desc: STS aswi Tests to test aws_RequestTag in the condition element of a role's trust policy
@@ -149,7 +144,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_request_tag_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_TagKeys in permission policy
       desc: STS aswi Tests to test aws_TagKeys in permission policy
@@ -158,7 +152,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_tagkeys_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_TagKeys in the trust policy
       desc: STS aswi Tests to test aws_TagKeys in the trust policy
@@ -167,7 +160,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_tagkeys_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test iam_ResourceTag in trust policy
       desc: STS aswi Tests to test iam_ResourceTag in trust policy
@@ -176,7 +168,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_iam_resource_tag_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test allow condition when s3_Resource Tag equals aws_Principal tag in role's permission policy
       desc: STS aswi Tests to test allow condition when s3_Resource Tag equals aws_Principal tag in role's permission policy
@@ -185,7 +176,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_res_equals_aws_princ_tag_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test s3_Resource Tag in role's permission policy
       desc: STS aswi Tests to test s3_Resource Tag in role's permission policy
@@ -194,7 +184,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
-        timeout: 500
 
   - test:
       abort-on-fail: true
@@ -215,4 +204,3 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_creds_expire_copy_in_progress.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
@@ -71,14 +71,12 @@ tests:
       config:
         script-name: test_d3n_cache.py
         config-file-name: test_d3n_cache_enable.yaml
-        timeout: 500
         run-on-rgw: true
 
   - test:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-        timeout: 300
         install_common: false
         run-on-rgw: true
       desc: test to create "M" no of buckets and "N" no of objects with multipart upload
@@ -90,7 +88,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects.yaml
-        timeout: 300
         install_common: false
         run-on-rgw: true
       desc: test to create "M" no of buckets and "N" no of objects
@@ -107,7 +104,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.
@@ -117,7 +113,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: Basic ACLs Test
@@ -129,7 +124,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: Test Rate limits on a User and Bucket level using s3cmd
@@ -140,7 +134,6 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests
@@ -150,4 +143,3 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -73,7 +73,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_broker_persistent and verify details of event record
@@ -84,7 +83,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
 
   # kafka broker type none with persistent flag enabled
 
@@ -97,7 +95,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_none_persistent
@@ -108,7 +105,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent
@@ -119,7 +115,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -132,7 +127,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_none
@@ -143,7 +137,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and verify timestamp of event record
@@ -154,7 +147,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_multipart.yaml
-        timeout: 300
 
   # kafka broker type broker
 
@@ -167,7 +159,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_broker
@@ -178,7 +169,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
@@ -189,7 +179,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_filter.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
@@ -200,7 +189,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
@@ -211,7 +199,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
-        timeout: 300
 
   - test:
       name: put empty bucket notifications
@@ -222,7 +209,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-        timeout: 300
 
   # test persistent bucket notifications when kafka server is unreachable
 
@@ -235,7 +221,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
@@ -246,7 +231,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
-        timeout: 300
 
   # test event time 0 fix for multipart uploads
 
@@ -259,7 +243,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker
@@ -270,7 +253,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_multipart.yaml
-        timeout: 300
 
   # Test Bucket notifications for lifecycle events
 
@@ -283,7 +265,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_object_exp_multipart_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration delete marker
@@ -294,7 +275,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration events
@@ -305,7 +285,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration with parallel lc processing
@@ -316,7 +295,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_parallel_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration non current objects with prefix rule
@@ -327,7 +305,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle transition events
@@ -340,8 +317,6 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_transition_notifications.yaml
 
-        timeout: 300
-
   - test:
       name: notify on lifecycle transition events with multipart objects
       desc: notify on lifecycle transition events with multipart objects
@@ -352,7 +327,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_multipart_transition_notifications.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
@@ -76,7 +76,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_PLAINTEXT PLAIN
@@ -87,7 +86,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_PLAINTEXT security type and SCRAM-SHA-256 mechanism
   - test:
@@ -99,7 +97,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_PLAINTEXT SCRAM-SHA-256
@@ -110,7 +107,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type and PLAIN mechanism
   - test:
@@ -122,7 +118,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_SSL PLAIN
@@ -133,7 +128,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type and SCRAM-SHA-256 mechanism
   - test:
@@ -145,7 +139,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
@@ -156,7 +149,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type broker
 
@@ -170,7 +162,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
@@ -181,7 +172,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
@@ -192,7 +182,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
@@ -203,7 +192,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type
   - test:
@@ -215,7 +203,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
@@ -226,7 +213,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker and SASL_SSL SCRAM-SHA-256
@@ -237,7 +223,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
@@ -248,7 +233,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -262,7 +246,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
@@ -273,7 +256,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
@@ -284,7 +266,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
@@ -295,7 +276,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
@@ -306,7 +286,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
@@ -317,7 +296,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
@@ -328,7 +306,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
@@ -339,7 +316,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type
   - test:
@@ -351,7 +327,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
@@ -362,7 +337,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_SSL PLAIN
@@ -373,7 +347,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
@@ -384,7 +357,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none and SASL_SSL SCRAM-SHA-256
@@ -395,7 +367,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
@@ -406,7 +377,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
@@ -417,7 +387,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
@@ -428,7 +397,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
@@ -76,7 +76,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SSL security
@@ -87,7 +86,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker_persistent and SSL security
@@ -98,7 +96,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker_persistent and SSL security
@@ -109,7 +106,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -122,7 +118,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SSL security
@@ -133,7 +128,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SSL security
@@ -144,7 +138,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
@@ -155,7 +148,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/reef/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -111,7 +111,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_dot.yaml
-        timeout: 300
       desc: test lc with prefix containing dot
       module: sanity_rgw.py
       name: test lc with prefix containing dot
@@ -121,7 +120,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_hyphen.yaml
-        timeout: 300
       desc: test lc with prefix containing hyphen
       module: sanity_rgw.py
       name: test lc with prefix containing hyphen
@@ -131,7 +129,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_slash.yaml
-        timeout: 300
       desc: test lc with prefix containing slash
       module: sanity_rgw.py
       name: test lc with prefix containing slash
@@ -141,7 +138,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_underscore.yaml
-        timeout: 300
       desc: test lc with prefix containing underscore
       module: sanity_rgw.py
       name: test lc with prefix containing underscore
@@ -155,7 +151,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_disable_object_exp.yaml
-        timeout: 300
 
 # bucket lifecycle transition tests
   - test:
@@ -166,7 +161,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_rules.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests multiple pool transition
       desc: Bucket Lifecycle Object_transition_tests multiple pool transition
@@ -184,7 +178,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_ecpool_with_prefix_rule.yaml
-        timeout: 300
 
   # bucket lifecycle with resharding
 
@@ -196,7 +189,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_dynamic_reshard.yaml
-        timeout: 300
 
   - test:
       name: test lifecycle expiration with manual resharding and Test if LC policy is applied via lc list and lc get
@@ -206,7 +198,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_manual_reshard.yaml
-        timeout: 300
 
   # bucket lifecycle expiration
 
@@ -218,7 +209,6 @@ tests:
       config:
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_object_exp_multipart.yaml
-        timeout: 300
 
   - test:
       name: Multipart object expiration through lc
@@ -228,7 +218,6 @@ tests:
       config:
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_multipart_object_expiration.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing only one object version
@@ -238,7 +227,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_current_version_object_expiration.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle expiration Tests
@@ -248,7 +236,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle Object_transition_tests for 100 buckets
@@ -258,7 +245,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Add a new lifecycle configuration to a bucket
@@ -268,13 +254,11 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_add_new_lc_to_bucket.yaml
-        timeout: 300
 
   - test:
       config:
         script-name: test_manual_lc_process_single_bucket.py
         config-file-name: test_lc_process_single_bucket_expired.yaml
-        timeout: 300
       desc: test LC process for a single bucket with expired objects
       module: sanity_rgw.py
       name: Test LC process for single bucket expired
@@ -284,7 +268,6 @@ tests:
       config:
         script-name: test_manual_lc_process_single_bucket.py
         config-file-name: test_lc_process_single_bucket_nonexpired.yaml
-        timeout: 300
       desc: test LC process for a single bucket with non expired objects
       module: sanity_rgw.py
       name: Test LC process for single bucket non-expired
@@ -299,4 +282,3 @@ tests:
         test-version: v2
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspended_delete.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -108,7 +108,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: S3CMD large object download with GC
@@ -118,7 +117,6 @@ tests:
       config:
         script-name: ../s3cmd/test_large_object_gc.py
         config-file-name: ../../s3cmd/configs/test_large_object_gc.yaml
-        timeout: 300
 
   - test:
       name: S3CMD object header size check
@@ -128,7 +126,6 @@ tests:
       config:
         script-name: ../s3cmd/test_header_size.py
         config-file-name: ../../s3cmd/configs/test_header_size.yaml
-        timeout: 300
 
   - test:
       name: S3CMD bucket stats consistency
@@ -138,7 +135,6 @@ tests:
       config:
         script-name: ../s3cmd/test_bucket_stats.py
         config-file-name: ../../s3cmd/configs/test_bucket_stats.yaml
-        timeout: 300
 
   - test:
       name: Test rgw opslog io though s3cmd
@@ -149,7 +145,6 @@ tests:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_opslog.yaml
         run-on-rgw: true # as logs generated on rgw nodes
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using s3cmd
@@ -159,7 +154,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
-        timeout: 300
 
   - test:
       name: S3CMD object download
@@ -169,7 +163,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit at global scope
@@ -179,7 +172,6 @@ tests:
       config:
         script-name: ../s3cmd/test_ratelimit_global.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for versioned buckets
@@ -189,7 +181,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for tenanted users
@@ -199,7 +190,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit Debt
@@ -209,7 +199,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_debt.yaml
-        timeout: 300
 
   - test:
       name: Test ratelimit on bucket owner change
@@ -220,7 +209,6 @@ tests:
       config:
         script-name: ../s3cmd/test_ratelimit_bucketowner.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_bucketowner.yaml
-        timeout: 300
 
 # Testing s3cmd malformed url
   - test:
@@ -231,7 +219,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_put.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd cp operation with malformed bucket url
@@ -241,7 +228,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_cp.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd del operation with malformed bucket url
@@ -251,7 +237,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_del.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd get operation with malformed bucket url
@@ -261,7 +246,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_get.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd ls operation with malformed bucket url
@@ -271,7 +255,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_ls.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd multipart operation with malformed bucket url
@@ -281,7 +264,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_multipart.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd mv operation with malformed bucket url
@@ -291,7 +273,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_mv.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd sync operation with malformed bucket url
@@ -301,7 +282,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_sync.yaml
-        timeout: 300
 
   - test:
       name: Test deletlifecycle rule via s3cmd
@@ -311,7 +291,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
-        timeout: 300
 
   - test:
       name: Test by adding almost 10K buckets to the resharding queue
@@ -321,7 +300,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_1k_bucket.yaml
-        timeout: 300
+        timeout: 5000
 
   - test:
       name: Test multipart upload with failed upload parts using s3cmd and boto3
@@ -331,4 +310,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-2_ssl_rgw_ecpool_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_ecpool_test.yaml
@@ -200,4 +200,3 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_governance.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -313,7 +313,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -330,7 +329,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
 
   - test:
       name: download objects on secondary
@@ -343,7 +341,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: test encryption on secondary
@@ -356,7 +353,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
 
   - test:
       name: Test large omap objects warnings via ceph status in a multisite
@@ -369,7 +365,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
 
   - test:
       name: LargeObjGet_GC test
@@ -381,7 +376,6 @@ tests:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
-            timeout: 300
 
   - test:
       name: enabling bucket versioning and uploading objects on secondary
@@ -394,7 +388,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: setting acls to versioned objects on secondary
@@ -407,7 +400,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: listing pseudo ordered dir only buckets on secondary
@@ -419,7 +411,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
 
   - test:
       name: create tenanted user
@@ -433,7 +424,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       name: modify bucket policy on secondary
@@ -446,4 +436,3 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300

--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -111,7 +111,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform assume role call with permissive session policies
@@ -122,7 +121,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_permissive_session_policy.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform assume role call with restrictive session policies
@@ -133,7 +131,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform Server Side Copy
@@ -144,7 +141,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_server_side_copy.py
         config-file-name: test_sts_using_boto_server_side_copy.yaml
-        timeout: 500
 
   - test:
       name: STS Tests for handling non-existent object condition
@@ -155,7 +151,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_unexisting_object.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
 
   - test:
       name: STS test with invalid arn in the role's policy
@@ -166,7 +161,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
-        timeout: 500
 
   - test:
       name: STS test with invalid principal in the role's policy
@@ -176,7 +170,6 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_invalid_principal.yaml
-        timeout: 500
 
   - test:
       name: reshard cancel command
@@ -187,7 +180,6 @@ tests:
         run-on-rgw: true
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled
@@ -198,7 +190,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard and max_dynamic_shard
@@ -209,7 +200,6 @@ tests:
         run-on-rgw: true
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard max_dynamic_shard and reshard_thread_interval
@@ -220,7 +210,6 @@ tests:
         run-on-rgw: true
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
-        timeout: 500
 
   - test:
       name: Bucket setlifeycle with invalid date in LC conf
@@ -231,7 +220,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_invalid_date.yaml
-        timeout: 300
 
   - test:
       name: LC enabled on bucket removes pre and post uploaded objects
@@ -242,7 +230,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_enable_object_exp.yaml
-        timeout: 300
 
   - test:
       name: Control functionality for RGW lifecycle
@@ -253,7 +240,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_rgw_enable_lc_threads.yaml
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using LC
@@ -264,7 +250,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Test NFS cluster and export create
@@ -275,7 +260,6 @@ tests:
         run-on-rgw: true
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
-        timeout: 300
 
   - test:
       abort-on-fail: true
@@ -298,7 +282,6 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-        timeout: 500
 
   - test:
       name: Test no crash during deleting bucket with aborted multipart upload
@@ -308,7 +291,6 @@ tests:
       config:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
-        timeout: 500
 
   - test:
       name: Test functionality of bucket check fix
@@ -318,7 +300,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
-        timeout: 500
 
   # - test:
   #     name: Test functionality of user stat reset
@@ -329,4 +310,3 @@ tests:
   #     config:
   #       script-name: test_Mbuckets_with_Nobjects.py
   #       config-file-name: test_user_stats_reset.yaml
-  #       timeout: 500

--- a/suites/reef/rgw/tier-2_ssl_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_test_bucket_notifications.yaml
@@ -78,4 +78,3 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-        timeout: 300

--- a/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -256,7 +256,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -284,7 +283,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Perform IOs and test bucket versioned at the colocated archive zone
       module: sanity_rgw_multisite.py
       name: Perform IOs and test bucket versioned at the colocated archive zone

--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -99,7 +99,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_action.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid conditional in condition blocks
@@ -109,7 +108,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_condition_key.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid effect
@@ -119,7 +117,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_effect.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid key
@@ -129,7 +126,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_key.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid principal
@@ -139,7 +135,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_principal.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid resource
@@ -149,7 +144,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_resource.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid version
@@ -159,7 +153,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_version.yaml
-        timeout: 500
 
   # Bucket lifecycle tests
 
@@ -171,7 +164,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_btw_exp_transition.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rule conflict between expiration days
@@ -181,7 +173,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_exp_days.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rule conflict between transition actions
@@ -191,7 +182,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_transition_actions.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rules with same ruleid but different rules
@@ -201,7 +191,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
-        timeout: 500
 
   - test:
       name: Test bucket lc reverse transition
@@ -211,7 +200,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_reverse_transition.yaml
-        timeout: 300
 
   # swift container operation
   - test:
@@ -222,7 +210,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_s3_and_swift_versioning.yaml
-        timeout: 500
 
   # test s3-select with query generation of incorrect syntax
 
@@ -247,7 +234,6 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth1.yaml
-        timeout: 3600
 
   - test:
       name: test s3select with depth2 queries on csv objects
@@ -257,7 +243,6 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth2.yaml
-        timeout: 3600
 
   - test:
       name: test s3select with depth1 queries on parquet objects
@@ -267,7 +252,6 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth1.yaml
-        timeout: 3600
 
   # - test:
   #     name: test s3select with depth2 queries on parquet objects
@@ -278,4 +262,3 @@ tests:
   #     config:
   #       script-name: test_s3select.py
   #       config-file-name: test_s3select_query_gen_parquet_depth2.yaml
-  #       timeout: 3600

--- a/suites/squid/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/squid/rgw/migrate_default_single_to_multisite.yaml
@@ -171,7 +171,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets compression on haproxy node
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -185,7 +184,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -240,7 +238,6 @@ tests:
             config-file-name: test_rgw_restore_index_versioned_buckets.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test rgw restore index tool on versioned bucket
       polarion-id: CEPH-83575473
       module: sanity_rgw_multisite.py
@@ -253,7 +250,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
       desc: Execute M buckets with N objects on primary and verify on secondary cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/sanity_rgw.yaml
+++ b/suites/squid/rgw/sanity_rgw.yaml
@@ -84,7 +84,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
         run-on-rgw: true
   - test:
       name: overwrite objects after suspending versioning
@@ -94,7 +93,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_re-upload.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for Prefix and tag based filter and for more than one days
       desc: Test object expiration for Prefix and tag based filter and for more than one days
@@ -103,7 +101,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_and_tag.yaml
-        timeout: 300
   - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
@@ -112,7 +109,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding.yaml
-        timeout: 500
   - test:
       name: object lock verification
       desc: object lock test
@@ -121,7 +117,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_compliance.yaml
-        timeout: 500
   - test:
       name: Test rgw through CURL
       desc: Test rgw through CURL
@@ -130,7 +125,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw multipart upload through curl
       desc: Test rgw multipart upload through curl
@@ -139,7 +133,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
-        timeout: 500
   - test:
       name: Test rename of large object using sts user through AWS
       desc: Test rename of large object using sts user through AWS
@@ -148,7 +141,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role on principle user and perform IOs
       desc: Perform assume role on principle user and perform IOs
@@ -159,7 +151,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: test bucket notifcation with empty configuration
       desc: verify empty bucket notification deletes the existing configuration
@@ -173,7 +164,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-        timeout: 300
   - test:
       name: Multipart upload with Bucket policy enabled
       desc: Perform multipart upload with Bucket policy enabled
@@ -183,7 +173,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
   - test:
       name: Test ACL Operations
       desc: Test ACL Operations
@@ -194,7 +183,6 @@ tests:
         test-version: v2
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
-        timeout: 300
   - test:
       name: S3CMD basic  operations
       desc: S3CMD basic  operations
@@ -203,7 +191,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
-        timeout: 300
   - test:
       name: Test Ratelimit for tenanted users
       desc: Test Ratelimit for tenanted users
@@ -212,7 +199,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
-        timeout: 300
   - test:
       name: test swift enable version on conatainer of different user
       desc: test swift enable version on conatainer of different user
@@ -221,7 +207,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_enable_version_with_different_user.yaml
-        timeout: 500
   - test:
       name: Add a lifecycle configuration to a bucket with tenant user
       desc: Apply lc configuration to bucket with tenant user and perform get lc with other users of tenant
@@ -230,7 +215,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucket_put_get_lifecycle_configuration_with_tenant_users.yaml
-        timeout: 300
   - test:
       name: Test the byte ranges with get object
       desc: Test the byte ranges with get_object
@@ -240,12 +224,10 @@ tests:
         test-version: v2
         script-name: test_byte_range.py
         config-file-name: test_byte_range.yaml
-        timeout: 500
   - test:
       config:
         script-name: test_quota_management.py
         config-file-name: test_quota_bucket_max_objects.yaml
-        timeout: 300
       desc: test bucket quota max objects
       module: sanity_rgw.py
       name: test bucket quota max objects
@@ -263,7 +245,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
   - test:
       name: Bucket link and unlink
       desc: Bucket move between tenanted and non tenanted users
@@ -273,7 +254,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_link_unlink.yaml
-        timeout: 500
   - test:
       name: User and container access in same and different tenants
       desc: User and container access in same and different tenants
@@ -282,7 +262,6 @@ tests:
       config:
         script-name: test_multitenant_user_access.py
         config-file-name: test_multitenant_access.yaml
-        timeout: 300
   - test:
       name: Generate secret for tenant user
       desc: Generate secret for tenant user
@@ -291,7 +270,6 @@ tests:
       config:
         script-name: test_tenant_user_secret_key.py
         config-file-name: test_tenantuser_secretkey_gen.yaml
-        timeout: 300
   - test:
       name: Bucket radoslist
       desc: radoslist on all buckets
@@ -300,7 +278,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
 
   - test:
       name: Indexless buckets
@@ -311,7 +288,6 @@ tests:
         test-version: v2
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
-        timeout: 500
 
   - test:
       name: bucket request payer with object download
@@ -321,7 +297,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer_download.yaml
-        timeout: 300
   - test:
       name: Manual Resharding tests
       desc: Resharding test - manual
@@ -330,7 +305,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500
   - test:
       name: D3n-cache enable
       desc: D3n-cache enable
@@ -339,7 +313,6 @@ tests:
       config:
         script-name: test_d3n_cache.py
         config-file-name: test_d3n_cache_enable.yaml
-        timeout: 500
         run-on-rgw: true
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
@@ -349,7 +322,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
-        timeout: 300
   - test:
       name: test REST api operation
       desc: test user operation using REST API
@@ -358,7 +330,6 @@ tests:
       config:
         script-name: user_op_using_rest.py
         config-file-name: test_user_with_REST.yaml
-        timeout: 300
   - test:
       name: test s3cmd put operation with malformed bucket url
       desc: test s3cmd put operation with malformed bucket url
@@ -367,7 +338,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_put.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests for Prefix and tag based filter
       desc: Test object transition for Prefix and tag based filter and for more than one days
@@ -376,4 +346,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_prefix_and_TAG_rule.yaml
-        timeout: 300

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -210,7 +210,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -227,7 +226,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -235,7 +233,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding on greenfield deployment
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -247,7 +244,6 @@ tests:
           config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
       desc: bucket create and delete operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -260,7 +256,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test_async_data_notifications_on_primary
       polarion-id: CEPH-83575231
       module: sanity_rgw_multisite.py
@@ -276,7 +271,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: test aws4 signature version on primary
       desc: test_Mbuckets_with_Nobjects_aws4 on primary
@@ -287,7 +281,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -299,7 +292,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: multipart upload on primary
       desc: test_Mbuckets_with_Nobjects_multipart on primary
@@ -311,7 +303,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
   - test:
       name: LargeObjGet_GC on primary
       desc: test_LargeObjGet_GC on primary
@@ -322,7 +313,6 @@ tests:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
-            timeout: 300
   - test:
       name: modify bucket policy on primary
       desc: test_bucket_policy_modify.yaml on primary
@@ -334,7 +324,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -346,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name:  datalog omap offload on secondary
       desc: Execute datalog omap offload on secondary
@@ -358,7 +346,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: datalog trim command with delete marker enabled on Primary
       desc: Execute datalog trim command with delete marker enabled on Primary
@@ -369,7 +356,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -401,7 +387,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -413,7 +398,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -424,7 +408,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw_multisite.py
       name: sse-s3 per bucket encryption test
@@ -435,7 +418,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_multipart_object_download_after_transition
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_multipart_object_download_after_transition
@@ -450,7 +432,6 @@ tests:
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
@@ -461,7 +442,6 @@ tests:
           config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_sse_kms_per_bucket_with_bucket_policy.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_with_bucket_policy
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_bucket_policy
@@ -472,7 +452,6 @@ tests:
           config:
             script-name: test_sts_using_boto.py
             config-file-name: test_sse_s3_per_object_with_sts.yaml
-            timeout: 300
       desc: test_sse_s3_per_object_with_sts
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_object_with_sts
@@ -495,7 +474,6 @@ tests:
               - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
               - "ceph orch apply -i /root/rgw_spec.yaml"
               - "sleep 20"
-            timeout: 120
         ceph-sec:
           config:
             role: rgw
@@ -508,7 +486,6 @@ tests:
               - "echo '\nextra_container_args:\n - \"-v /usr/local/gklm:/usr/local/gklm\"' >> /root/rgw_spec.yaml"
               - "ceph orch apply -i /root/rgw_spec.yaml"
               - "sleep 20"
-            timeout: 120
       desc: Setting up certs, mount the certs path and redeploy rgw
       module: exec.py
       name: Setting up certs, mount the certs path and redeploy rgw
@@ -525,7 +502,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
         ceph-sec:
           config:
             cephadm: true
@@ -536,7 +512,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_cert /usr/local/gklm/rgwselfsigned.cert"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_kmip_client_key /usr/local/gklm/rgwselfsigned.key"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
       desc: Setting sse_kms configs with kmip backend for gklm
       module: exec.py
       name: Setting sse_kms configs with kmip backend for gklm
@@ -549,7 +524,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload
@@ -560,7 +534,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload
@@ -571,7 +544,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
@@ -582,7 +554,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_object.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_object
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_object
@@ -593,7 +564,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_kmip_gklm_per_object_versioninig_enabled
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_object_versioninig_enabled
@@ -610,7 +580,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
   - test:
       name: Bucket Granular Sync policy tests
@@ -623,7 +592,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: Basic ACLs Test
       desc: Test basic acls
@@ -636,7 +604,6 @@ tests:
             run-on-rgw: true
             script-name: test_acls.py
             config-file-name: test_acls.yaml
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -644,7 +611,6 @@ tests:
             config-file-name: test_user_with_REST.yaml
             script-name: user_op_using_rest.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: user operations using REST
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -659,4 +625,3 @@ tests:
           config:
             script-name: test_bucket_request_payer.py
             config-file-name: test_bucket_request_payer.yaml
-            timeout: 300

--- a/suites/squid/rgw/tier-1_rgw.yaml
+++ b/suites/squid/rgw/tier-1_rgw.yaml
@@ -89,7 +89,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects
@@ -101,7 +100,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with delete
@@ -113,7 +111,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with download
@@ -125,7 +122,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              timeout: 300
               install_common: false
               run-on-rgw: true
             desc: test to create "M" no of buckets and "N" no of objects with multipart upload
@@ -141,7 +137,6 @@ tests:
               install_common: false
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_bi_purge.yaml
-              timeout: 300
 
   - test:
       name: enable bucket versioning
@@ -151,7 +146,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_enable.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration
       desc: Test object expiration for non current version expiration
@@ -160,7 +154,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests for Prefix filter and versioned buckets
       desc: Test object transition for Prefixand versioned buckets
@@ -169,7 +162,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_with_prefix_rule.yaml
-        timeout: 300
   - test:
       name: S3CMD small and multipart object download
       desc: S3CMD small and multipart object download or GET
@@ -178,4 +170,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300

--- a/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
@@ -299,7 +299,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -312,7 +311,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       name: test to create "M" no of buckets on primary
       polarion-id: CEPH-83575435
       desc: test metadata sync - create buckets
@@ -325,7 +323,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       name: enabling bucket versioning and uploading objects on secondary
       polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
       desc: test_versioning_objects_enable on secondary
@@ -338,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -351,7 +347,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -393,7 +388,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
-            timeout: 300
 
   - test:
       name: bucket granular sync policy with symmetrical flow having archive zone
@@ -405,7 +399,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_archive_symmetrical.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       clusters:
@@ -414,7 +408,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec" , "ceph-arc"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -428,7 +421,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade on new bucket
       abort-on-fail: true
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
@@ -287,7 +287,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -305,7 +304,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
 
   - test:
@@ -315,7 +313,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -328,7 +325,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -342,7 +338,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -355,7 +350,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -368,7 +362,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -405,7 +398,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -417,7 +409,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -426,7 +417,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -439,7 +429,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -452,7 +441,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -277,7 +277,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -293,7 +292,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_storage_class_symm.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       clusters:
@@ -301,7 +300,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload on primary cluster
       module: sanity_rgw_multisite.py
@@ -314,7 +312,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload_multipart.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload with multipart objects on primary
       module: sanity_rgw_multisite.py
@@ -331,7 +328,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_owner_translation_direc.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       clusters:
@@ -339,7 +336,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload_versioned_bucket.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload on versioned bucket on primary
       module: sanity_rgw_multisite.py
@@ -356,7 +352,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
 
   - test:
       name: bucket granular sync policy on bucket with flow directional and storage class
@@ -368,7 +363,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_storage_class_direc.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket creation on primary for crash check
@@ -380,7 +375,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -393,5 +387,4 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]

--- a/suites/squid/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -257,7 +257,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -269,7 +268,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-pri" ]
       desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-83575435
@@ -285,7 +283,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: delete buckets and objects on primary
       desc: test_Mbuckets_with_Nobjects_delete on primary
@@ -296,7 +293,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -308,7 +304,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: test sharding on primary
       desc: test_Mbuckets_with_Nobjects_sharding on primary
@@ -319,7 +314,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-            timeout: 300
 
   - test:
       name: replace bucket policy on primary
@@ -332,7 +326,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: suspend bucket versioning on primary
       desc: test_versioning_objects_suspend on secondary
@@ -344,7 +337,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: reverting object to one of the versions on primary
       desc: test_versioning_objects_copy on secondary
@@ -355,7 +347,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
   - test:
       name: enable bucket versioning on primary
       desc: test_versioning_enable on secondary
@@ -367,7 +358,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_enable.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
@@ -378,7 +368,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered.yaml
-            timeout: 300
   - test:
       name: listing flat unordered buckets on primary
       desc: test_bucket_listing_flat_unordered.yaml on secondary
@@ -389,7 +378,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
 
   - test:
       name: listing flat ordered versioned buckets on primary
@@ -401,7 +389,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
   - test:
       name: listing flat ordered buckets on secondary
       desc: test_bucket_listing_flat_ordered on secondary
@@ -413,7 +400,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: listing pseudo ordered dir only buckets on secondary
       desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
@@ -425,4 +411,3 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
@@ -284,7 +284,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -299,7 +298,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects
       module: sanity_rgw_multisite.py
       name: m buckets with n objects pre upgrade
@@ -313,7 +311,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -326,7 +323,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -344,7 +340,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
 #   # Performing cluster upgrade
 
@@ -371,7 +366,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_version_copy_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test restoring of versioned objects in swift
       module: sanity_rgw_multisite.py
       name: swift versioning copy post upgrade
@@ -385,7 +379,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -398,7 +391,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -283,7 +283,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -301,7 +300,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   # - test:
   #     name: Delete object version with id null
@@ -314,7 +312,6 @@ tests:
   #         config:
   #           script-name: ../aws/test_delete_version_id_null.py
   #           config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
-  #           timeout: 300
 
   - test:
       clusters:
@@ -323,7 +320,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -336,7 +332,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -350,7 +345,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -363,7 +357,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -376,7 +369,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -389,7 +381,6 @@ tests:
             script-name: ../s3cmd/test_rgw_ops_log.py
             config-file-name: ../../s3cmd/multisite_configs/test_rgw_log_details.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: S3CMD tests, rgw log details pre upgrade
       module: sanity_rgw_multisite.py
       name: S3CMD tests, rgw log details pre upgrade
@@ -422,7 +413,6 @@ tests:
             script-name: ../s3cmd/test_rgw_ops_log.py
             config-file-name: ../../s3cmd/multisite_configs/test_rgw_log_details.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: S3CMD tests, rgw log details post upgrade
       module: sanity_rgw_multisite.py
       name: S3CMD tests, rgw log details post upgrade
@@ -439,7 +429,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -451,7 +440,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -460,7 +448,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -473,7 +460,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -486,7 +472,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/squid/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/squid/rgw/tier-1_rgw_multisite.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -291,7 +290,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario in greenfield
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -308,7 +306,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: delete versioned objects on secondary
       desc: test_versioning_objects_delete on secondary
@@ -319,7 +316,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
   - test:
       name: enabling bucket versioning and uploading objects on secondary
       desc: test_versioning_objects_enable on secondary
@@ -331,7 +327,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: delete bucket policy on secondary
       desc: test_bucket_policy_delete.yaml on secondary
@@ -343,7 +338,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: download objects on secondary
       desc: test_Mbuckets_with_Nobjects_download on secondary
@@ -355,7 +349,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
   - test:
       name: multipart upload on primary
       desc: test_Mbuckets_with_Nobjects_multipart on primary
@@ -367,7 +360,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
   - test:
       name: enable compression on secondary
       desc: test_Mbuckets_with_Nobjects_compression on secondary
@@ -379,5 +371,3 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
-

--- a/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
@@ -293,7 +293,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -311,7 +310,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
 
   - test:
@@ -321,7 +319,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" buckets and "N" objects with multipart upload
       module: sanity_rgw_multisite.py
       name: multipart upload of M buckets with N objects
@@ -334,7 +331,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -348,7 +344,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -361,7 +356,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
@@ -374,7 +368,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -411,7 +404,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -423,7 +415,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -432,7 +423,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -445,7 +435,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test dynamic resharding brownfield scenario after upgrade
@@ -458,7 +447,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade

--- a/suites/squid/rgw/tier-1_rgw_sw_qat.yaml
+++ b/suites/squid/rgw/tier-1_rgw_sw_qat.yaml
@@ -109,7 +109,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -119,7 +118,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_Zlib_type
@@ -129,13 +127,11 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-        timeout: 300
 
   - test:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a regular bucket
@@ -145,7 +141,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-        timeout: 300
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -155,7 +150,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_object.yaml
-        timeout: 300
       desc: test_sse_s3_per_object_encryption
       module: sanity_rgw.py
       name: sse-s3 per object encryption test on a regular bucket

--- a/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
@@ -83,7 +83,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -93,7 +92,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -103,13 +101,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -123,13 +119,11 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations pre upgrade
@@ -139,7 +133,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
       desc: Test bucket stats and radoslist on all buckets
       module: sanity_rgw.py
       name: test bucket stats and radoslist
@@ -153,7 +146,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
-        timeout: 300
 
   - test:
       name: Upgrade cluster to latest 8.x ceph version
@@ -187,14 +179,12 @@ tests:
       config:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
-        timeout: 300
 
 # Post upgrade tests
   - test:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -208,7 +198,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
@@ -218,7 +207,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests post upgrade
@@ -228,7 +216,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -238,7 +225,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -248,7 +234,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   # configuring vault agent
   - test:
@@ -267,7 +252,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled after upgrade
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket after upgrade

--- a/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
@@ -85,7 +85,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -95,7 +94,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -105,7 +103,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -115,13 +112,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -135,7 +130,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   # upgrade cluster
   - test:
@@ -146,7 +140,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
 
   # upgrade cluster
   - test:
@@ -162,7 +155,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
         - test:
             name: Upgrade cluster to latest 8.x ceph version
             desc: Upgrade cluster to latest version
@@ -185,7 +177,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-        timeout: 500
   - test:
       desc: Retrieve the versions of the cluster
       module: exec.py
@@ -206,7 +197,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -216,7 +206,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -226,13 +215,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations post upgrade
@@ -254,7 +241,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
@@ -89,7 +89,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
-        timeout: 300
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -99,7 +98,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -109,7 +107,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -119,13 +116,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -139,7 +134,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   # upgrade cluster
   - test:
@@ -155,7 +149,6 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              timeout: 300
         - test:
             name: Upgrade cluster to latest 8.x ceph version
             desc: Upgrade cluster to latest version
@@ -198,7 +191,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -208,7 +200,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -218,13 +209,11 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-        timeout: 500
 
   - test:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_basic_ops.yaml
-        timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw.py
       name: swift basic operations post upgrade
@@ -246,7 +235,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test

--- a/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -440,7 +440,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -454,7 +453,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-ter
-            timeout: 300
       desc: create non-tenanted user and copy user details on tertiary site
       module: sanity_rgw_multisite.py
       name: create non-tenanted user and copy user details on tertiary site
@@ -499,7 +497,6 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.sec.io"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -511,7 +508,6 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.pri.io"
-            timeout: 120
         ceph-ter:
           config:
             cephadm: true
@@ -523,7 +519,6 @@ tests:
               - "ceph config set client.rgw.shared.ter rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.ter rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.ter.io"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite tertiary site
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -556,7 +551,6 @@ tests:
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
 
   - test:
@@ -565,7 +559,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-            timeout: 30
       desc: test LC cloud transition to IBM cos with retain true
       polarion-id: CEPH-83581972 #CEPH-83575498
       module: sanity_rgw_multisite.py
@@ -577,7 +570,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-            timeout: 30
       desc: test LC cloud transition to IBM cos with retain false
       polarion-id: CEPH-83581973 #CEPH-83581975
       module: sanity_rgw_multisite.py
@@ -589,7 +581,6 @@ tests:
           config:
             script-name: test_sts_using_boto.py
             config-file-name: test_sts_multisite.yaml
-            timeout: 30
       desc: test assume role at secondary, with s3 ops
       polarion-id: CEPH-83575592
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/tier-2_rgw_cloud_transition.yaml
+++ b/suites/squid/rgw/tier-2_rgw_cloud_transition.yaml
@@ -161,7 +161,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_true.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition retain headobject
@@ -187,7 +186,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_false.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition no retain headobject
@@ -199,7 +197,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_multipart.yaml
-            timeout: 500
       desc: test clould transition basic workflow
       module: sanity_rgw.py
       name: Test cloud transition multipart upload
@@ -234,7 +231,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:rgw.1} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:rgw.1}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on local site
       module: exec.py
       name: set sse-s3 vault configs on Local cluster
@@ -245,7 +241,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_encrypted.yaml
-            timeout: 500
       desc: test cloud transition of ecnrypted objects
       module: sanity_rgw.py
       name: Test cloud transition of SSE-S3 encrypted objects
@@ -272,7 +267,6 @@ tests:
           config:
             script-name: test_cloud_transition.py
             config-file-name: test_cloud_transition_headobject_false.yaml
-            timeout: 500
       desc: test clould transition of compressed objects
       module: sanity_rgw.py
       name: Test cloud transition with compression enabled

--- a/suites/squid/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -223,4 +223,3 @@ tests:
         test-version: v2
         script-name: test_byte_range.py
         config-file-name: test_byte_range.yaml
-        timeout: 500

--- a/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
@@ -236,7 +236,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -249,7 +248,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -266,7 +264,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
   - test:
       name: notify on multisite replication create events with kafka_broker on arc site
       desc: notify on multisite replication create events with kafka_broker on arc site
@@ -292,7 +289,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_archive_delete_replication_from_pri.yaml
-            timeout: 300
 # adding the LC tests for object size filter before as they have failed in the end.
   - test:
       clusters:
@@ -300,7 +296,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_objects_size_noncurrent.yaml
-            timeout: 300
       desc: Test LC on archive for objects size expiration
       polarion-id: CEPH-83582000
       module: sanity_rgw_multisite.py
@@ -311,7 +306,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_objects_size_noncurrent_local.yaml
-            timeout: 300
       desc: Test LC on active for objects size expiration
       polarion-id: CEPH-83581990
       module: sanity_rgw_multisite.py
@@ -324,7 +318,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -336,7 +329,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec","ceph-arc" ]
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-9789
@@ -353,7 +345,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_archive_directional.yaml
-            timeout: 300
+            timeout: 5500
 
 # Dynamic resharding test
   - test:
@@ -362,7 +354,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - dynamic resharding on primary and verify on secondary & archive cluster
       name: Dynamic Resharding - dynamic
@@ -375,7 +366,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - dynamic resharding on versioned bucket on primary and verify on secondary & archive cluster
       name: Dynamic Resharding with versioning on primary and verify on archive
@@ -388,7 +378,6 @@ tests:
           config:
             config-file-name: test_manual_resharding_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - manual resharding
       name: Manual Resharding on primary and verify on secondary & archive cluster
@@ -400,7 +389,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_bilog_trim_archive.yaml
-            timeout: 30
       desc: test no bilogs are generated at archive zone
       polarion-id: CEPH-83575468
       module: sanity_rgw_multisite.py
@@ -447,7 +435,6 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone secondary --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -461,7 +448,6 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone primary --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -475,7 +461,6 @@ tests:
               - "radosgw-admin zone placement modify --rgw-zone archive --placement-id default-placement  --compression zlib"
               - "radosgw-admin period update --commit"
               - "ceph orch restart {service_name:shared.arc}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: sse-s3 vault configs, and zlib compression
@@ -488,7 +473,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_bucket_enc_multipart_download_remote_site.yaml
-            timeout: 30
       desc: test multipart download at remote site
       polarion-id: CEPH-11357
       module: sanity_rgw_multisite.py
@@ -503,7 +487,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: test the workaround to sync only from one active zone
       module: exec.py
       name: test the workaround to sync only from one active zone
@@ -514,7 +497,6 @@ tests:
           config:
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
-            timeout: 30
       desc: test multipart+encrypt object access at the archive site
       polarion-id: CEPH-83573390
       module: sanity_rgw_multisite.py
@@ -525,7 +507,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_current_expiration.yaml
-            timeout: 300
       desc: Test LC on archive for current versions
       polarion-id: CEPH-83575394
       module: sanity_rgw_multisite.py
@@ -537,7 +518,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_newer_noncurrent_expiration.yaml
-            timeout: 300
       desc: Test LC on archive for newer-noncurrent versions
       polarion-id: CEPH-83575919
       module: sanity_rgw_multisite.py
@@ -549,7 +529,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_archive_noncurrent_expiration.yaml
-            timeout: 300
       desc: Test LC on archive for non-current versions
       polarion-id: CEPH-83575394
       module: sanity_rgw_multisite.py
@@ -560,7 +539,6 @@ tests:
           config:
             script-name: ../s3cmd/test_lifecycle_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd_lifecycle_newer_noncurrent_expiration_local.yaml
-            timeout: 300
       desc: Test LC on active for newer noncurrents
       polarion-id: CEPH-83581997
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -308,7 +308,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -324,7 +323,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -369,7 +367,6 @@ tests:
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -381,7 +378,6 @@ tests:
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -393,7 +389,6 @@ tests:
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite archive
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -409,7 +404,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test M buckets compression on haproxy node
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -424,7 +418,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets on haproxy node
@@ -438,7 +431,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC from primary to secondary
       module: sanity_rgw_multisite.py
       name: test LC from primary to secondary
@@ -452,21 +444,18 @@ tests:
             commands:
               - "ceph config set client.rgw.shared.sec rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
             commands:
               - "ceph config set client.rgw.shared.pri rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
             commands:
               - "ceph config set client.rgw.shared.arc rgw_sync_lease_period 10"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: Setting rgw_sync_lease_period to 100 on multisite archive
       module: exec.py
       name: Setting rgw_sync_lease_period to 100 on multisite archive
@@ -479,7 +468,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_0_shards_sync_test_haproxy.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
+            timeout: 5000
       desc: test sync on bucket with 0 shards
       module: sanity_rgw_multisite.py
       name: test sync on bucket with 0 shards
@@ -491,7 +480,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_prefix_rule_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
             stat-all-buckets-at-archive: true
       desc: test LC transition on multisite, and bucket stats at archive
       module: sanity_rgw_multisite.py
@@ -505,7 +493,6 @@ tests:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_transition_with_obj_acl_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test LC transition on multisite with object acl set
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite with object acl set
@@ -520,7 +507,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from primary --sync_from_all false"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: test the workaround to sync only from one active zone
       module: exec.py
       name: test the workaround to sync only from one active zone
@@ -533,7 +519,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -546,7 +531,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -558,7 +542,6 @@ tests:
             cephadm: true
             commands:
               - "ceph orch stop rgw.shared.arc"
-            timeout: 120
       desc: Test full sync at archive, power off archive zone with IOs in active zone
       module: exec.py
       name: Test full sync at archive, power off archive zone with IOs in active zone
@@ -571,7 +554,6 @@ tests:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/multisite_configs/test_s3cmd.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Upload 5000 objects via s3cmd to test full sync at archive
       polarion-id: CEPH-83575917
       module: sanity_rgw_multisite.py
@@ -586,7 +568,6 @@ tests:
               - "radosgw-admin zone modify --rgw-zone archive --sync_from_all true"
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
-            timeout: 120
       desc: Sync to the archive zone from all active sites
       module: exec.py
       name: Sync to the archive zone from all active sites
@@ -598,7 +579,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_bucket_pol_retain.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
-            timeout: 600
             test-bucket-pol-retained-archive: true
       desc: Test bucket policies are reatined at archive site post object uploads
       polarion-id: CEPH-83575576
@@ -611,7 +591,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend_archive_haproxy.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test versioning suspend on archive
       module: sanity_rgw_multisite.py
       name: test versioning suspend on archive
@@ -626,7 +605,6 @@ tests:
             config-file-name: test_rgw_restore_index_versioned_buckets.yaml
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
-            timeout: 300
       desc: test rgw restore index tool on versioned bucket
       polarion-id: CEPH-83575473
       module: sanity_rgw_multisite.py
@@ -642,7 +620,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.pri"
-            timeout: 120
         ceph-sec:
           config:
             cephadm: true
@@ -652,7 +629,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.sec"
-            timeout: 120
         ceph-arc:
           config:
             cephadm: true
@@ -662,7 +638,6 @@ tests:
               - "radosgw-admin period update --commit"
               - "radosgw-admin period get"
               - "ceph orch restart rgw.shared.arc"
-            timeout: 120
       desc: enabled default encryption and zlib compression
       module: exec.py
       name: enabled default encryption and zlib compression
@@ -674,7 +649,6 @@ tests:
             script-name: test_s3_copy_encryption.py
             config-file-name: test_server_side_copy_object_via_encryption.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: test server_side_copy_object_via_encryption
       polarion-id: CEPH-83575711
       module: sanity_rgw_multisite.py
@@ -687,7 +661,6 @@ tests:
             script-name: test_encrypted_bucket_chown.py
             config-file-name: test_encrypted_bucket_chown.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Change bucket ownership to a different user when encryption is enabled
       polarion-id: CEPH-83574621
       module: sanity_rgw_multisite.py
@@ -700,7 +673,6 @@ tests:
             script-name: test_encrypted_bucket_chown.py
             config-file-name: test_chown_before_encrypt.yaml
             run-on-haproxy: true
-            timeout: 300
       desc: Change bucket ownership to a different user and then encryption is enabled
       polarion-id: CEPH-83574618
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -270,7 +270,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create user
@@ -281,7 +280,6 @@ tests:
           config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
       desc: bucket create and delete operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -294,7 +292,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test_async_data_notifications_on_primary
       polarion-id: CEPH-83575231
       module: sanity_rgw_multisite.py
@@ -307,7 +304,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
       desc: test_async_data_notifications_on_secondary
       polarion-id: CEPH-83575268
       module: sanity_rgw_multisite.py
@@ -347,7 +343,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -359,7 +354,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -367,7 +361,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-        timeout: 300
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw_multisite.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -380,7 +373,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_s3_per_object_with_versioning
       module: sanity_rgw_multisite.py
       name: est_sse_s3_per_object_with_versioning
@@ -393,7 +385,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_per_object_with_versioning
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_object_with_versioning
@@ -405,7 +396,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_with_versioning
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_versioning
@@ -418,7 +408,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object.yaml
-            timeout: 300
       desc: test_sse_kms_per_object
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_object
@@ -431,7 +420,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_zonegroup_rename.yaml
-            timeout: 300
       desc: Test zonegroup rename in master
       module: sanity_rgw_multisite.py
       name: Perform zonegroup rename in master

--- a/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -296,7 +295,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
 
   # IO should fail on read only secondary
   - test:
@@ -309,7 +307,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_failed.yaml
-            timeout: 300
 
   # Failover Primary, make secondary writable
   - test:
@@ -335,7 +332,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
-            timeout: 300
       desc: test M buckets uploads on current primary zone
       module: sanity_rgw_multisite.py
       name: test M buckets uploads on current primary zone
@@ -420,4 +416,3 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300

--- a/suites/squid/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -294,7 +293,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_sync_policy.yaml
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy test for prefix and tag
@@ -307,7 +305,6 @@ tests:
             script-name: test_multisite_syncpolicy_prefix_tag.py
             config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy tests
@@ -320,7 +317,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: Granular multisite sync policy group transition
@@ -332,7 +328,6 @@ tests:
           config:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_sync_policy_state_change.yaml
-            timeout: 300
 
   - test:
       name: Bucket Granular Sync policy tests
@@ -345,7 +340,6 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_bucket_mirror_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: bucket granular sync policy on bucket with flow symmetrical and owner translation
@@ -357,4 +351,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_bucket_granularsync_owner_translation_symm.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -204,7 +204,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -246,7 +245,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
-            timeout: 1200
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
   - test:
       clusters:
@@ -255,7 +253,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_tenanted_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment tenanted user
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster tenanted user
@@ -267,7 +264,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_versioning_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on versioned bucket
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster
@@ -279,7 +275,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_versioning_tenanted_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on versioned bucket and tenanted user
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on versioned bucket and tenanted user Primary cluster
@@ -290,7 +285,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: ["ceph-pri", "ceph-sec" ]
       desc: Resharding test - dynamic resharding on versioned bucket
       name: Dynamic Resharding on versioned buckets
@@ -302,7 +296,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_quota_exceed.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
       desc: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
       name: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
       polarion-id: CEPH-83574669
@@ -313,7 +306,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_sync_disable_enable.yaml
-            timeout: 300
       desc: Test sync enable and disable with manual resharding
       module: sanity_rgw_multisite.py
       name: Manual Resharding tests on Primary cluster
@@ -324,7 +316,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_zone_deletion.yaml
-            timeout: 300
       desc: Test zone deletion in master
       module: sanity_rgw_multisite.py
       name: Perform zone deletion in master
@@ -341,7 +332,6 @@ tests:
           config:
             script-name: ../aws/test_delete_version_id_null.py
             config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
-            timeout: 300
 
   - test:
       name: bucket granular sync policy with sync from differnt bucket
@@ -353,7 +343,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_sync_from_diff_bucket.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       clusters:
@@ -361,7 +351,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_realm_rename.yaml
-            timeout: 300
       desc: Test realm rename in master
       module: sanity_rgw_multisite.py
       name: Perform realm rename in master
@@ -377,4 +366,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_sync_to_diff_bucket.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/squid/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
@@ -212,7 +212,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -230,7 +229,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
 
   - test:
       name: notify put,delete events with kafka_broker_persistent
@@ -243,7 +241,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-            timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker_persistent
@@ -256,7 +253,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-            timeout: 300
 
   - test:
       name: notify copy events with kafka_none
@@ -269,7 +265,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_none_copy.yaml
-            timeout: 300
 
   - test:
       name: notify on put,copy,delete events with kafka_broker_persistent when kafka is down
@@ -282,7 +277,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
-            timeout: 300
 
   - test:
       name: notify on multipart events with kafka_broker_persistent when kafka is down
@@ -295,7 +289,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
-            timeout: 300
 
   - test:
       name: notify on multisite replication create events with kafka_broker on pri site
@@ -308,7 +301,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml
-            timeout: 300
 
   - test:
       name: notify on multisite replication create events with kafka_broker on sec site
@@ -321,7 +313,6 @@ tests:
             run-on-rgw: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_sec.yaml
-            timeout: 300
 
 # please include test cases before below rename testcase as the process is disruptive currently
   - test:
@@ -330,7 +321,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_zone_rename.yaml
-            timeout: 300
       desc: Test zone rename in master
       module: sanity_rgw_multisite.py
       name: Perform zone rename in master

--- a/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -295,7 +294,7 @@ tests:
             script-name: test_multisite_sync_policy.py
             config-file-name: test_multisite_sync_policy_extended.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy with allowed allowed semantic
@@ -309,7 +308,7 @@ tests:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucket_sync_policy.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on enabled enabled semantic with directional flow
@@ -321,7 +320,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_enable_enable.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on allowed forbidden semantic with directional flow
@@ -333,7 +332,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_allowed_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden forbidden semantic with directional flow
@@ -345,7 +344,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: Test Changing datalog num shards not cause any crash
@@ -358,4 +357,3 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_changing_data_log_num_shards_cause_no_crash.yaml
-            timeout: 300

--- a/suites/squid/rgw/tier-2_rgw_multisite_scenarios.yaml
+++ b/suites/squid/rgw/tier-2_rgw_multisite_scenarios.yaml
@@ -225,7 +225,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -265,7 +264,6 @@ tests:
             config-file-name: ../configs/test_byte_range.yaml
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
 
   - test:
       name: Test the byte ranges with get object on secondary zone and check multisite replication doesn't happen
@@ -280,7 +278,6 @@ tests:
             config-file-name: ../configs/test_byte_range.yaml
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-pri"]
-            timeout: 500
 
   - test:
       abort-on-fail: true
@@ -310,7 +307,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_enabled_forbidden.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden allowed semantic with symmetrical and directional flow
@@ -322,7 +319,7 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_allowed.yaml
-            timeout: 300
+            timeout: 5500
 
   - test:
       name: bucket granular sync policy on forbidden enabled semantic with directional and symmetrical flow
@@ -334,4 +331,4 @@ tests:
           config:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_forbidden_enabled.yaml
-            timeout: 300
+            timeout: 5500

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -82,7 +82,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test non-current deletion via s3cmd
@@ -92,7 +91,6 @@ tests:
       config:
         script-name: ../s3cmd/test_lifecycle_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_lc_expiration_noncurrent_when_current_object_deleted_via_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle expiration of incomplete multipart
@@ -102,7 +100,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_incomplete_multipart.yaml
-        timeout: 300
 
   # Object lock no overwrite
   - test:
@@ -114,7 +111,6 @@ tests:
       config:
         script-name: test_object_lock_no_overwrite.py
         config-file-name: test_object_lock_no_overwrite.yaml
-        timeout: 500
   - test:
       name: S3CMD small and multipart object download
       desc: S3CMD small and multipart object download or GET
@@ -123,7 +119,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Swift user with read access
@@ -133,7 +128,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_read.yaml
-        timeout: 300
 
   - test:
       name: Swift user with write access
@@ -143,7 +137,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_write.yaml
-        timeout: 300
 
   - test:
       name: Swift user with readwrite access
@@ -153,8 +146,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_readwrite.yaml
-        timeout: 300
-
   - test:
       name: Test rgw put bucket website with users of same and different tenant
       desc: Test rgw put bucket website with users of same and different tenant
@@ -163,7 +154,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500
 
   - test:
       name: Test rgw get bucket website with users of same and different tenant
@@ -173,7 +163,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500
 
   - test:
       name: Test LC with custom worktime
@@ -183,7 +172,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_custom_worktime.yaml
-        timeout: 300
 
   - test:
       name: Test Etag not empty for complete multipart upload in aws
@@ -193,7 +181,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
-        timeout: 500
 
   - test:
       name: Test S3 PUT requests with non ascii characters in body
@@ -203,7 +190,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_aws_non_ascii.yaml
-        timeout: 500
 
   - test:
       name: Test bucket listing with markers on versioned bucket
@@ -213,7 +199,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_versioned_list_marker.yaml
-        timeout: 500
 
   - test:
       name: Test LDAP auth for RGW
@@ -223,7 +208,6 @@ tests:
       config:
         script-name: ../aws/test_ldap_auth.py
         config-file-name: ../../aws/configs/test_ldap_auth.yaml
-        timeout: 300
         run-on-rgw: true
 
   - test:
@@ -235,7 +219,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_with_lc_process.yaml
-        timeout: 500
 
   - test:
       name: Test LC transition without rule by lc process
@@ -245,7 +228,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
-        timeout: 500
 
   - test:
       abort-on-fail: false

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -119,7 +119,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -129,7 +128,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
 
   # Swift basic operation
 
@@ -141,7 +139,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_modify_tenanted_subuser.yaml
-        timeout: 300
 
   - test:
        name: Swift bulk delete operation
@@ -151,7 +148,6 @@ tests:
        config:
            script-name: test_swift_bulk_delete.py
            config-file-name: test_swift_bulk_delete.yaml
-           timeout: 300
 
   - test:
       name: swift upload large object tests
@@ -161,7 +157,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_upload.yaml
-        timeout: 300
 
   - test:
       name: swift download large object tests
@@ -171,7 +166,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_download.yaml
-        timeout: 300
 
   - test:
       name: Get object with different tenant swift user with same name
@@ -181,7 +175,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
-        timeout: 300
 
   - test:
       name: delete container with different tenant swift user with same name
@@ -191,7 +184,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
-        timeout: 300
 
   - test:
       name: upload large object with same name using tenant swift user
@@ -201,7 +193,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_upload_large_obj_with_same_obj_name.yaml
-        timeout: 300
 
   # Versioning Tests
 
@@ -213,7 +204,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test overwrite by another user of versioned objects
@@ -223,7 +213,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Versioning with copy objects and delete with different user
@@ -233,7 +222,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_delete_version_object_using_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test deleting the current version of the object
@@ -243,7 +231,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_delete_current_version_object.yaml
-        timeout: 300
 
   - test:
       name: Test copy versioned objects to another versioned bucket
@@ -253,7 +240,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_copy_version_object_to_version_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Write modify and read objects in the versioned bucket
@@ -263,7 +249,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_access_versioned_objects.yaml
-        timeout: 300
 
   # BucketPolicy Tests
   - test:
@@ -274,7 +259,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
-        timeout: 300
 
   - test:
       name: Get object and its version from same and different tenant users
@@ -285,7 +269,6 @@ tests:
         test-version: v2
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: get_object_and_its_versions_tenat_user.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with multiple statements
@@ -295,7 +278,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with conflicting statements
@@ -305,7 +287,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with condition blocks
@@ -315,7 +296,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy condition block with explicit deny
@@ -325,7 +305,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
-        timeout: 500
 
   # Bucket Lifecycle Tests
   - test:
@@ -336,7 +315,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: object expiration with expiration set to Date
@@ -346,7 +324,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_date.yaml
-        timeout: 300
 
   - test:
       name: object expiration for delete marker set
@@ -356,7 +333,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Read lifecycle configuration on a given bucket
@@ -366,7 +342,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_read.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing multiple object versions
@@ -376,7 +351,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_versioning.yaml
-        timeout: 300
 
   - test:
       name: Disable lifecycle configuration on a given bucket
@@ -386,7 +360,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_disable.yaml
-        timeout: 300
 
   - test:
       name: Modify lifecycle configuration on a given bucket
@@ -396,7 +369,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_modify.yaml
-        timeout: 300
 
   # Bucket Request Payer tests
   - test:
@@ -407,7 +379,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer.yaml
-        timeout: 300
 
   # v1 tests
   # ACLs tests
@@ -421,7 +392,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: test acls with copy objects on different users
@@ -433,7 +403,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_copy_obj.py
         config-file-name: test_acls_copy_obj.yaml
-        timeout: 300
 
   - test:
       name: acls reset
@@ -445,7 +414,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_reset.py
         config-file-name: test_acls_reset.yaml
-        timeout: 300
 
   - test:
       name: test acls on all users
@@ -457,7 +425,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_all_usrs.py
         config-file-name: test_acls_all_usrs.yaml
-        timeout: 300
 
   # multipart test
   - test:
@@ -470,7 +437,6 @@ tests:
         run-on-rgw: true
         script-name: test_multipart_upload_cancel.py
         config-file-name: test_multipart_upload_cancel.yaml
-        timeout: 300
 
   # User, Bucket rename, Bucket link and unlink
   - test:
@@ -481,7 +447,6 @@ tests:
       config:
         script-name: test_user_bucket_rename.py
         config-file-name: test_user_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket rename
@@ -492,7 +457,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_rename.yaml
-        timeout: 500
 
   # Multifactor Authentication tests
 
@@ -508,7 +472,6 @@ tests:
         extra-pkgs:
           9:
             - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.7-2.el9.x86_64.rpm
-        timeout: 500
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed
@@ -519,7 +482,6 @@ tests:
         test-version: v2
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa_incorrect_syntax.yaml
-        timeout: 500
 
   - test:
       name: Test s3_copy_obj on user with admin flag through AWS
@@ -529,7 +491,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_s3copyObj_admin_user.yaml
-        timeout: 500
 
   # testing rgw through curl
   - test:
@@ -540,7 +501,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_curl_transfer_encoding_chunked.yaml
-        timeout: 500
 
   - test:
       name: Test rgw bucket quota using CURL
@@ -550,7 +510,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_bucket_quota_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw user quota using CURL
       desc: Test rgw user quota using CURL
@@ -559,7 +518,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_user_quota_using_curl.yaml
-        timeout: 500
   - test:
       name: Test rgw bucket quota conflict using CURL
       desc: Test rgw bucket quota conflict using CURL
@@ -568,7 +526,6 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
-        timeout: 500
 
   - test:
       name: Test bucket listing is not truncated
@@ -578,7 +535,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_list_not_truncated.yaml
-        timeout: 500
 
   - test:
       name: Test user modify with placement id
@@ -588,7 +544,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
-        timeout: 500
 
   # rate limits tests with s3cmd
   - test:
@@ -600,4 +555,3 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300

--- a/suites/squid/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -233,7 +233,6 @@ tests:
             set-env: true
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
-            timeout: 300
 
   #  Dynamic resharding tests
   - test:
@@ -247,7 +246,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_greenfield.yaml
-            timeout: 300
 
   - test:
       clusters:
@@ -255,7 +253,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
       desc: Resharding test - dynamic resharding on versioned bucket
       name: Dynamic Resharding on versioned buckets
       polarion-id: CEPH-83571740
@@ -267,7 +264,6 @@ tests:
           config:
             script-name: test_quota_management.py
             config-file-name: test_quota_bucket_max_size.yaml
-            timeout: 300
       desc: test bucket quota max size (single site)
       module: sanity_rgw.py
       name: test bucket quota max size (single site)
@@ -279,7 +275,6 @@ tests:
           config:
             script-name: test_quota_management.py
             config-file-name: test_quota_user_max_objects.yaml
-            timeout: 300
       desc: test user quota max objects (single site)
       module: sanity_rgw.py
       name: test user quota max objects (single site)
@@ -291,7 +286,6 @@ tests:
           config:
             script-name: test_quota_management.py
             config-file-name: test_quota_user_max_size.yaml
-            timeout: 300
       desc: test user quota max size (single site)
       module: sanity_rgw.py
       name: test user quota max size (single site)
@@ -303,7 +297,6 @@ tests:
           config:
             script-name: test_dynamic_bucket_resharding.py
             config-file-name: test_bucket_index_shards.yaml
-            timeout: 300
       desc: test_metadata_integrity_with_0_num_shards (single site)
       module: sanity_rgw.py
       name: test_metadata_integrity_with_0_num_shards (single site)
@@ -399,7 +392,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       clusters:
@@ -408,7 +400,6 @@ tests:
             config-file-name: test_user_bucket_create.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: user and bucket create operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -421,7 +412,6 @@ tests:
             config-file-name: test_user_modify_op.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Modify suspend enable and delete user operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -434,7 +424,6 @@ tests:
             config-file-name: test_user_bucket_rename.yaml
             script-name: test_user_bucket_rename.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: rename user and bucket and link unlink bucket operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -450,7 +439,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
 
   - test:
@@ -463,7 +451,6 @@ tests:
           config:
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_and_tag.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
 
   - test:
@@ -476,7 +463,6 @@ tests:
           config:
             script-name: test_bucket_lc_object_exp_multipart.py
             config-file-name: test_bucket_lc_object_exp_multipart.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
 
 # Log trimming tests
@@ -490,8 +476,8 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_mdlog_trimming.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
+            timeout: 5000
 
   - test:
       name: Datalog trimming test on primary
@@ -503,7 +489,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_datalog_trimming.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -516,7 +501,6 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_bilog_trimming.yaml
-            timeout: 300
 
   - test:
       name: bucket request payer
@@ -528,4 +512,3 @@ tests:
           config:
             script-name: test_bucket_request_payer.py
             config-file-name: test_bucket_request_payer.yaml
-            timeout: 300

--- a/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
@@ -104,7 +104,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token
@@ -113,7 +112,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aud_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test azp fields in the web token
       desc: STS aswi Tests to test azp fields in the web token
@@ -122,7 +120,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_azp_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test sub fields in the web token
       desc: STS aswi Tests to test sub fields in the web token
@@ -131,7 +128,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_sub_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_PrincipalTag in role's permission policy
       desc: STS aswi Tests to test aws_PrincipalTag in role's permission policy
@@ -140,7 +136,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_principal_tag_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_RequestTag in role's trust policy
       desc: STS aswi Tests to test aws_RequestTag in the condition element of a role's trust policy
@@ -149,7 +144,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_request_tag_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_TagKeys in permission policy
       desc: STS aswi Tests to test aws_TagKeys in permission policy
@@ -158,7 +152,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_tagkeys_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_TagKeys in the trust policy
       desc: STS aswi Tests to test aws_TagKeys in the trust policy
@@ -167,7 +160,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_tagkeys_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test iam_ResourceTag in trust policy
       desc: STS aswi Tests to test iam_ResourceTag in trust policy
@@ -176,7 +168,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_iam_resource_tag_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test allow condition when s3_Resource Tag equals aws_Principal tag in role's permission policy
       desc: STS aswi Tests to test allow condition when s3_Resource Tag equals aws_Principal tag in role's permission policy
@@ -185,7 +176,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_res_equals_aws_princ_tag_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test s3_Resource Tag in role's permission policy
       desc: STS aswi Tests to test s3_Resource Tag in role's permission policy
@@ -194,7 +184,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
-        timeout: 500
 
   - test:
       abort-on-fail: true
@@ -215,4 +204,3 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_creds_expire_copy_in_progress.yaml
-        timeout: 500

--- a/suites/squid/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
@@ -71,14 +71,12 @@ tests:
       config:
         script-name: test_d3n_cache.py
         config-file-name: test_d3n_cache_enable.yaml
-        timeout: 500
         run-on-rgw: true
 
   - test:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-        timeout: 300
         install_common: false
         run-on-rgw: true
       desc: test to create "M" no of buckets and "N" no of objects with multipart upload
@@ -90,7 +88,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects.yaml
-        timeout: 300
         install_common: false
         run-on-rgw: true
       desc: test to create "M" no of buckets and "N" no of objects
@@ -107,7 +104,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.
@@ -117,7 +113,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: Basic ACLs Test
@@ -129,7 +124,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: Test Rate limits on a User and Bucket level using s3cmd
@@ -140,7 +134,6 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-        timeout: 300
 
   - test:
       name: Manual Resharding tests
@@ -150,4 +143,3 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -73,7 +73,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_broker_persistent and verify details of event record
@@ -84,7 +83,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml
-        timeout: 300
 
   # kafka broker type none with persistent flag enabled
 
@@ -97,7 +95,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_none_persistent
@@ -108,7 +105,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent
@@ -119,7 +115,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -132,7 +127,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_none
@@ -143,7 +137,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and verify timestamp of event record
@@ -154,7 +147,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_none_multipart.yaml
-        timeout: 300
 
   # kafka broker type broker
 
@@ -167,7 +159,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_delete.yaml
-        timeout: 300
 
   - test:
       name: notify copy events with kafka_broker
@@ -178,7 +169,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_copy.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent configured with metadata filter
@@ -189,7 +179,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_filter.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent on manually resharded buckets
@@ -200,7 +189,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_manual_reshard.yaml
-        timeout: 300
 
   - test:
       name: notify on copy, delete events with kafka_broker_persistent on dynamically resharded buckets
@@ -211,7 +199,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_dynamic_reshard.yaml
-        timeout: 300
 
   - test:
       name: put empty bucket notifications
@@ -222,7 +209,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-        timeout: 300
 
   # test persistent bucket notifications when kafka server is unreachable
 
@@ -235,7 +221,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: test kafka_broker_persistent notifications for multipart upload events when kafka server is down
@@ -246,7 +231,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_down_broker_persistent_multipart.yaml
-        timeout: 300
 
   # test event time 0 fix for multipart uploads
 
@@ -259,7 +243,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker
@@ -270,7 +253,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_multipart.yaml
-        timeout: 300
 
   # Test Bucket notifications for lifecycle events
 
@@ -283,7 +265,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_object_exp_multipart_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration delete marker
@@ -294,7 +275,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration events
@@ -305,7 +285,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration with parallel lc processing
@@ -316,7 +295,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_parallel_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle expiration non current objects with prefix rule
@@ -327,7 +305,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days_notifications.yaml
-        timeout: 300
 
   - test:
       name: notify on lifecycle transition events
@@ -340,8 +317,6 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_transition_notifications.yaml
 
-        timeout: 300
-
   - test:
       name: notify on lifecycle transition events with multipart objects
       desc: notify on lifecycle transition events with multipart objects
@@ -352,7 +327,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_multipart_transition_notifications.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
@@ -76,7 +76,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_PLAINTEXT PLAIN
@@ -87,7 +86,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_PLAINTEXT security type and SCRAM-SHA-256 mechanism
   - test:
@@ -99,7 +97,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_PLAINTEXT SCRAM-SHA-256
@@ -110,7 +107,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type and PLAIN mechanism
   - test:
@@ -122,7 +118,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_SSL PLAIN
@@ -133,7 +128,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type and SCRAM-SHA-256 mechanism
   - test:
@@ -145,7 +139,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with SASL_SSL SCRAM-SHA-256
@@ -156,7 +149,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type broker
 
@@ -170,7 +162,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT PLAIN
@@ -181,7 +172,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
@@ -192,7 +182,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_PLAINTEXT SCRAM-SHA-256
@@ -203,7 +192,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_broker_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type
   - test:
@@ -215,7 +203,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_SSL PLAIN
@@ -226,7 +213,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker and SASL_SSL SCRAM-SHA-256
@@ -237,7 +223,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SASL_SSL SCRAM-SHA-256
@@ -248,7 +233,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_broker_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -262,7 +246,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT PLAIN
@@ -273,7 +256,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
@@ -284,7 +266,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT PLAIN
@@ -295,7 +276,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_plain_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
@@ -306,7 +286,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_PLAINTEXT SCRAM-SHA-256
@@ -317,7 +296,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
@@ -328,7 +306,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_PLAINTEXT SCRAM-SHA-256
@@ -339,7 +316,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_plaintext_scram_sha_256_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   # Tests for SASL_SSL security type
   - test:
@@ -351,7 +327,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SASL_SSL PLAIN
@@ -362,7 +337,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_SSL PLAIN
@@ -373,7 +347,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL PLAIN
@@ -384,7 +357,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_plain_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none and SASL_SSL SCRAM-SHA-256
@@ -395,8 +367,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none.yaml
-        timeout: 300
-
   - test:
       name: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
       desc: notify on multipart upload events with kafka_none and SASL_SSL SCRAM-SHA-256
@@ -406,7 +376,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
@@ -417,7 +386,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SASL_SSL SCRAM-SHA-256
@@ -428,7 +396,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_sasl_ssl_scram_sha_256_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
@@ -76,7 +76,6 @@ tests:
         configure_kafka_security: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker and SSL security
@@ -87,7 +86,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_broker_persistent and SSL security
@@ -98,7 +96,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_broker_persistent and SSL security
@@ -109,7 +106,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_broker_persistent_multipart.yaml
-        timeout: 300
 
   # kafka broker type none
 
@@ -122,7 +118,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none and SSL security
@@ -133,7 +128,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_multipart.yaml
-        timeout: 300
 
   - test:
       name: notify put,copy,delete events with kafka_none_persistent and SSL security
@@ -144,7 +138,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_persistent.yaml
-        timeout: 300
 
   - test:
       name: notify on multipart upload events with kafka_none_persistent and SSL security
@@ -155,7 +148,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_ssl_kafka_none_persistent_multipart.yaml
-        timeout: 300
 
   - test:
       name: check-ceph-health

--- a/suites/squid/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -111,7 +111,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_dot.yaml
-        timeout: 300
       desc: test lc with prefix containing dot
       module: sanity_rgw.py
       name: test lc with prefix containing dot
@@ -121,7 +120,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_hyphen.yaml
-        timeout: 300
       desc: test lc with prefix containing hyphen
       module: sanity_rgw.py
       name: test lc with prefix containing hyphen
@@ -131,7 +129,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_slash.yaml
-        timeout: 300
       desc: test lc with prefix containing slash
       module: sanity_rgw.py
       name: test lc with prefix containing slash
@@ -141,7 +138,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_underscore.yaml
-        timeout: 300
       desc: test lc with prefix containing underscore
       module: sanity_rgw.py
       name: test lc with prefix containing underscore
@@ -155,7 +151,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_disable_object_exp.yaml
-        timeout: 300
 
 # bucket lifecycle transition tests
   - test:
@@ -166,7 +161,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_rules.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests multiple pool transition
       desc: Bucket Lifecycle Object_transition_tests multiple pool transition
@@ -184,7 +178,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_ecpool_with_prefix_rule.yaml
-        timeout: 300
 
   # bucket lifecycle with resharding
 
@@ -196,7 +189,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_dynamic_reshard.yaml
-        timeout: 300
 
   - test:
       name: test lifecycle expiration with manual resharding and Test if LC policy is applied via lc list and lc get
@@ -206,7 +198,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_manual_reshard.yaml
-        timeout: 300
 
   # bucket lifecycle expiration
 
@@ -218,7 +209,6 @@ tests:
       config:
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_object_exp_multipart.yaml
-        timeout: 300
 
   - test:
       name: Multipart object expiration through lc
@@ -228,7 +218,6 @@ tests:
       config:
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_multipart_object_expiration.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing only one object version
@@ -238,7 +227,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_current_version_object_expiration.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle expiration Tests
@@ -248,7 +236,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle Object_transition_tests for 100 buckets
@@ -258,7 +245,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Add a new lifecycle configuration to a bucket
@@ -268,13 +254,11 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_add_new_lc_to_bucket.yaml
-        timeout: 300
 
   - test:
       config:
         script-name: test_manual_lc_process_single_bucket.py
         config-file-name: test_lc_process_single_bucket_expired.yaml
-        timeout: 300
       desc: test LC process for a single bucket with expired objects
       module: sanity_rgw.py
       name: Test LC process for single bucket expired
@@ -284,7 +268,6 @@ tests:
       config:
         script-name: test_manual_lc_process_single_bucket.py
         config-file-name: test_lc_process_single_bucket_nonexpired.yaml
-        timeout: 300
       desc: test LC process for a single bucket with non expired objects
       module: sanity_rgw.py
       name: Test LC process for single bucket non-expired
@@ -299,4 +282,3 @@ tests:
         test-version: v2
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspended_delete.yaml
-        timeout: 500

--- a/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -9,7 +9,6 @@
 # config:
 #    script-name: test_s3cmd.py
 #    config-file-name: test_s3cmd.yaml
-#    timeout: 300
 #
 # some of the other config option for this yamls are
 #
@@ -108,7 +107,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: S3CMD large object download with GC
@@ -118,7 +116,6 @@ tests:
       config:
         script-name: ../s3cmd/test_large_object_gc.py
         config-file-name: ../../s3cmd/configs/test_large_object_gc.yaml
-        timeout: 300
 
   - test:
       name: S3CMD object header size check
@@ -128,7 +125,6 @@ tests:
       config:
         script-name: ../s3cmd/test_header_size.py
         config-file-name: ../../s3cmd/configs/test_header_size.yaml
-        timeout: 300
 
   - test:
       name: S3CMD bucket stats consistency
@@ -138,7 +134,6 @@ tests:
       config:
         script-name: ../s3cmd/test_bucket_stats.py
         config-file-name: ../../s3cmd/configs/test_bucket_stats.yaml
-        timeout: 300
 
   - test:
       name: Test rgw opslog io though s3cmd
@@ -149,7 +144,6 @@ tests:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_opslog.yaml
         run-on-rgw: true # as logs generated on rgw nodes
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using s3cmd
@@ -159,7 +153,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
-        timeout: 300
 
   - test:
       name: S3CMD object download
@@ -169,7 +162,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit at global scope
@@ -179,7 +171,6 @@ tests:
       config:
         script-name: ../s3cmd/test_ratelimit_global.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for versioned buckets
@@ -189,7 +180,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit for tenanted users
@@ -199,7 +189,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
-        timeout: 300
 
   - test:
       name: Test Ratelimit Debt
@@ -209,7 +198,6 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_debt.yaml
-        timeout: 300
 
   - test:
       name: Test ratelimit on bucket owner change
@@ -219,7 +207,6 @@ tests:
       config:
         script-name: ../s3cmd/test_ratelimit_bucketowner.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_bucketowner.yaml
-        timeout: 300
 
 # Testing s3cmd malformed url
   - test:
@@ -230,7 +217,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_put.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd cp operation with malformed bucket url
@@ -240,7 +226,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_cp.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd del operation with malformed bucket url
@@ -250,7 +235,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_del.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd get operation with malformed bucket url
@@ -260,7 +244,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_get.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd ls operation with malformed bucket url
@@ -270,7 +253,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_ls.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd multipart operation with malformed bucket url
@@ -280,7 +262,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_multipart.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd mv operation with malformed bucket url
@@ -290,7 +271,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_mv.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd sync operation with malformed bucket url
@@ -300,7 +280,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_sync.yaml
-        timeout: 300
 
   - test:
       name: Test deletlifecycle rule via s3cmd
@@ -310,7 +289,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
-        timeout: 300
 
   - test:
       name: Test by adding almost 10K buckets to the resharding queue
@@ -320,7 +298,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_1k_bucket.yaml
-        timeout: 300
+        timeout: 5000
 
   - test:
       name: Test multipart upload with failed upload parts using s3cmd and boto3
@@ -330,4 +308,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
-        timeout: 500

--- a/suites/squid/rgw/tier-2_ssl_rgw_ecpool_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ecpool_test.yaml
@@ -200,4 +200,3 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_governance.yaml
-        timeout: 500

--- a/suites/squid/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -313,7 +313,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -330,7 +329,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
 
   - test:
       name: download objects on secondary
@@ -343,7 +341,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: test encryption on secondary
@@ -356,7 +353,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
 
   - test:
       name: Test large omap objects warnings via ceph status in a multisite
@@ -369,7 +365,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
 
   - test:
       name: LargeObjGet_GC test
@@ -381,7 +376,6 @@ tests:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
-            timeout: 300
 
   - test:
       name: enabling bucket versioning and uploading objects on secondary
@@ -394,7 +388,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: setting acls to versioned objects on secondary
@@ -407,7 +400,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: listing pseudo ordered dir only buckets on secondary
@@ -419,7 +411,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
 
   - test:
       name: create tenanted user
@@ -433,7 +424,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       name: modify bucket policy on secondary
@@ -446,4 +436,3 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -111,7 +111,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform assume role call with permissive session policies
@@ -122,7 +121,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_permissive_session_policy.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform assume role call with restrictive session policies
@@ -133,7 +131,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform Server Side Copy
@@ -144,7 +141,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_server_side_copy.py
         config-file-name: test_sts_using_boto_server_side_copy.yaml
-        timeout: 500
 
   - test:
       name: STS Tests for handling non-existent object condition
@@ -155,7 +151,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto_unexisting_object.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
 
   - test:
       name: STS test with invalid arn in the role's policy
@@ -166,7 +161,6 @@ tests:
         run-on-rgw: true
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
-        timeout: 500
 
   - test:
       name: STS test with invalid principal in the role's policy
@@ -176,7 +170,6 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_invalid_principal.yaml
-        timeout: 500
 
   - test:
       name: reshard cancel command
@@ -187,7 +180,6 @@ tests:
         run-on-rgw: true
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled
@@ -198,7 +190,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard and max_dynamic_shard
@@ -209,7 +200,6 @@ tests:
         run-on-rgw: true
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard max_dynamic_shard and reshard_thread_interval
@@ -220,7 +210,6 @@ tests:
         run-on-rgw: true
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
-        timeout: 500
 
   - test:
       name: Bucket setlifeycle with invalid date in LC conf
@@ -231,7 +220,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_invalid_date.yaml
-        timeout: 300
 
   - test:
       name: LC enabled on bucket removes pre and post uploaded objects
@@ -242,7 +230,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_enable_object_exp.yaml
-        timeout: 300
 
   - test:
       name: Control functionality for RGW lifecycle
@@ -253,7 +240,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_rgw_enable_lc_threads.yaml
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using LC
@@ -264,7 +250,6 @@ tests:
         run-on-rgw: true
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Test NFS cluster and export create
@@ -275,7 +260,6 @@ tests:
         run-on-rgw: true
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
-        timeout: 300
 
   - test:
       abort-on-fail: true
@@ -298,7 +282,6 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-        timeout: 500
 
   - test:
       name: Test no crash during deleting bucket with aborted multipart upload
@@ -308,7 +291,6 @@ tests:
       config:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
-        timeout: 500
 
   - test:
       name: Test functionality of bucket check fix
@@ -318,7 +300,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
-        timeout: 500
 
   - test:
       name: Test functionality of user stat reset
@@ -329,7 +310,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_user_stats_reset.yaml
-        timeout: 500
 
   # kafka broker type broker with persistent flag enabled
   - test:
@@ -344,4 +324,3 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml
-        timeout: 300

--- a/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -256,7 +256,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -269,7 +268,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
-            timeout: 300
       desc: Perform IOs and test bucket versioned at the colocated archive zone
       module: sanity_rgw_multisite.py
       name: Perform IOs and test bucket versioned at the colocated archive zone

--- a/suites/squid/rgw/tier-4-rgw.yaml
+++ b/suites/squid/rgw/tier-4-rgw.yaml
@@ -99,7 +99,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_action.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid conditional in condition blocks
@@ -109,7 +108,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_condition_key.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid effect
@@ -119,7 +117,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_effect.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid key
@@ -129,7 +126,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_key.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid principal
@@ -139,7 +135,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_principal.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid resource
@@ -149,7 +144,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_resource.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid version
@@ -159,7 +153,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_version.yaml
-        timeout: 500
 
   # Bucket lifecycle tests
 
@@ -171,7 +164,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_btw_exp_transition.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rule conflict between expiration days
@@ -181,7 +173,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_exp_days.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rule conflict between transition actions
@@ -191,7 +182,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_transition_actions.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rules with same ruleid but different rules
@@ -201,7 +191,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
-        timeout: 500
 
   - test:
       name: Test bucket lc reverse transition
@@ -211,7 +200,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_reverse_transition.yaml
-        timeout: 300
 
   # swift container operation
   - test:
@@ -222,7 +210,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_s3_and_swift_versioning.yaml
-        timeout: 500
 
   # test s3-select with query generation of incorrect syntax
   - test:
@@ -233,7 +220,6 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth1.yaml
-        timeout: 3600
 
   - test:
       name: test s3select with depth2 queries on csv objects
@@ -243,7 +229,6 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth2.yaml
-        timeout: 3600
 
   - test:
       name: test s3select with depth1 queries on parquet objects
@@ -253,7 +238,6 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth1.yaml
-        timeout: 3600
 
   - test:
       name: test s3select with depth2 queries on parquet objects
@@ -264,4 +248,3 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth2.yaml
-        timeout: 3600

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -181,7 +181,7 @@ def run(ceph_cluster, **kw):
     script_dir = DIR[test_version]["script"]
     config_dir = DIR[test_version]["config"]
     lib_dir = DIR[test_version]["lib"]
-    # timeout = config.get("timeout", 300)
+    timeout = config.get("timeout", 3600)
 
     if test_config["config"]:
         log.info("creating custom config")
@@ -202,6 +202,7 @@ def run(ceph_cluster, **kw):
         + config_file_name
         + append_param,
         long_running=True,
+        timeout=timeout,
     )
 
     if run_io_verify:

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -196,7 +196,7 @@ def run(**kw):
     script_dir = TEST_DIR[test_version]["script"]
     config_dir = TEST_DIR[test_version]["config"]
     lib_dir = TEST_DIR[test_version]["lib"]
-    # timeout = config.get("timeout", 600)
+    timeout = config.get("timeout", 3600)
     # install extra package which are test specific
     distro_version_id = primary_rgw_node.distro_info["VERSION_ID"]
     if extra_pkgs:
@@ -243,6 +243,7 @@ def run(**kw):
         + config_file_name
         + append_param,
         long_running=True,
+        timeout=timeout,
     )
     if test_status == 0:
         copy_user_to_site = clusters.get(config.get("copy-user-info-to-site"))


### PR DESCRIPTION
# Description
Default timeout is 3600, for testcase which takes more than 3600s timeout has been added, for othere timeout is 3600s

testcasess like 
1. bucket Granular related
2.  test mdlog trimming on primary
3. disable and enable dynamic resharding for 10K buckets
4.  test_sync_on_bucket_with_0_shards_0 timeout https://issues.redhat.com/browse/RHCEPHQE-15378 

pass log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-1AOUWG/

All test logs located here: /tmp/cephci-run-CQOAV3

All test logs located here: /tmp/cephci-run-CQOAV3

TEST NAME                                 TEST DESCRIPTION                                                      DURATION                                      STATUS                                 COMMENTS
setup pre-requisites                       Install software pre-requisites for cluster deployment.                   0:11:05.749536                   
    Pass
deploy cluster                   RHCS cluster deployment using cephadm.                         0:25:45.582169                   Pass
configure client                 Configure the RGW client system                                0:00:55.847861                   Pass
setup multisite                  Setting up RGW multisite replication environment               0:03:11.252015                   Pass
get shared realm info on prima   Retrieve the configured environment details                    0:00:10.822430                   Pass
get shared realm info on secon   Retrieve the configured environment details                    0:00:12.137808                   Pass
create tenanted user             create tenanted user                                           0:30:21.169629                   Pass
Bucket generation verification   Bucket generation verification                                 0:25:40.231664                   Pass
Disable DBR feature on zonegro   Disable DBR feature on zonegroup                               0:26:45.288849                   Pass
Re-enable DBR feature on clust   Re-enable DBR feature on cluster an verify                     0:21:40.570059                   Pass
Dynamic Resharding tests on Pr   Test dynamic resharding on greenfield deployment               0:07:54.794191                   Pass
Dynamic Resharding tests on Pr   Test dynamic resharding on greenfield deployment tenanted us   0:05:47.962245                   Pass
Dynamic Resharding tests on Pr   Test dynamic resharding on versioned bucket                    0:08:37.606394                   Pass
Dynamic Resharding tests on ve   Test dynamic resharding on versioned bucket and tenanted use   0:08:38.283779                   Pass
Dynamic Resharding on versione   Resharding test - dynamic resharding on versioned bucket       0:20:50.177707                   Pass
test exceeding quota limit on    test exceeding quota limit on dynamically resharded bucket a   0:05:18.079560                   Pass
Manual Resharding tests on Pri   Test sync enable and disable with manual resharding            0:25:42.965222                   Pass
Perform zone deletion in maste   Test zone deletion in master                                   0:00:10.742936                   Pass
bucket granular sync policy wi   Test bucket granular sync with sync from differnt bucket       1:14:51.972629                   Pass
Perform realm rename in master   Test realm rename in master                                    0:00:12.786307                   Pass
bucket granular sync policy wi   Test bucket granular sync with sync to differnt bucket         1:14:58.860217                   Pass


2024-07-25 16:16:25,415 (cephci.sanity_rgw_multisite)

https://github.com/anrao19/cephci/blob/master/tests/rgw/sanity_rgw_multisite.py#L199
https://github.com/anrao19/cephci/blob/master/tests/rgw/sanity_rgw.py#L184 

bucket granular passed, but due to timeout
ceph.ceph.SocketTimeoutException: sudo venv/bin/python /home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/test_multisite_bucket_granular_sync_policy.py -c rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/s3_swift/multisite_configs/test_multisite_granular_bucketsync_forbidden_allowed.yaml --rgw-node 10.0.195.44 failed to complete within 3600s

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
