### PR TITLE
integrating rgw-admin notification commands test into cephci

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -224,6 +224,16 @@ tests:
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
         timeout: 300
 
+  - test:
+      name: remove bucket notifications using rgw-admin notification rm command
+      desc: remove bucket notifications using rgw-admin notification rm command
+      module: sanity_rgw.py
+      polarion-id: CEPH-83582345
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_rgw_admin_notif_rm.yaml
+
   # test persistent bucket notifications when kafka server is unreachable
 
   - test:

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -224,6 +224,16 @@ tests:
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
         timeout: 300
 
+  - test:
+      name: remove bucket notifications using rgw-admin notification rm command
+      desc: remove bucket notifications using rgw-admin notification rm command
+      module: sanity_rgw.py
+      polarion-id: CEPH-83582345
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_rgw_admin_notif_rm.yaml
+
   # test persistent bucket notifications when kafka server is unreachable
 
   - test:


### PR DESCRIPTION
depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/618

this PR is to add support for testing bucket notifications with radosgw-admin notification commands
7.1 feature bz: https://bugzilla.redhat.com/show_bug.cgi?id=2130292

also testing whether radosgw-admin topic list lists even auto-generated topic or not
bz: https://bugzilla.redhat.com/show_bug.cgi?id=1954461

polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582345

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_rgw_admin_notif_commands/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
