### PR TITLE
long_running fix unbound variable exception

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1523,6 +1523,7 @@ class CephNode(object):
         ssh = self.rssh if kw.get("sudo") else self.ssh
         cmd = kw["cmd"]
         timeout = None if kw.get("timeout") == "notimeout" else kw.get("timeout", 3600)
+        _end_time = None
 
         logger.info(
             f"long running command on {self.ip_address} -- {cmd} with {timeout} seconds"


### PR DESCRIPTION
# Description

This patch fixes unbound variable exception being thrown when timeout is None.

- [x] unit testing completed

*Error*
```
  File "/home/jenkins/ceph-builds/openstack/IBM/7.1/rhel-9/Regression/18.2.1-228/nvmeotcp/161/cephci/ceph/ceph.py", line 1554, in long_running
    check_timeout(_end_time, timeout)
UnboundLocalError: local variable '_end_time' referenced before assignment 
```