### PR TITLE
[Rados] Changing wait_for_device method across the board

### DIFF
--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -12,7 +12,7 @@ from ceph.ceph_admin import CephAdmin
 from ceph.rados import utils
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
-from tests.rados.rados_test_util import get_device_path, wait_for_device
+from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 
@@ -206,12 +206,12 @@ def run(ceph_cluster, **kw):
             assert utils.zap_device(
                 ceph_cluster, host=osd_host.hostname, device_path=dev_path
             )
-            assert wait_for_device(
+            assert wait_for_device_rados(
                 host=osd_host, osd_id=osd_id, action="remove", timeout=1000
             )
 
             out, _ = cephadm.shell(["ceph config set osd osd_crush_initial_weight 0"])
-            assert wait_for_device(host=osd_host, osd_id=osd_id, action="add")
+            assert wait_for_device_rados(host=osd_host, osd_id=osd_id, action="add")
             assert utils.set_osd_in(ceph_cluster, all=True)
             time.sleep(8)  # blind sleep to let osd stats show up
 

--- a/tests/rados/test_four_node_ecpool.py
+++ b/tests/rados/test_four_node_ecpool.py
@@ -18,7 +18,7 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from tests.rados.monitor_configurations import MonConfigMethods
-from tests.rados.rados_test_util import get_device_path, wait_for_device
+from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed, should_not_be_empty
@@ -332,7 +332,7 @@ def run(ceph_cluster, **kw):
         utils.osd_remove(ceph_cluster, target_osd)
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
         method_should_succeed(utils.zap_device, ceph_cluster, host.hostname, dev_path)
-        method_should_succeed(wait_for_device, host, target_osd, action="remove")
+        method_should_succeed(wait_for_device_rados, host, target_osd, action="remove")
 
         # Waiting for recovery to post OSD host addition
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
@@ -348,7 +348,7 @@ def run(ceph_cluster, **kw):
         # Adding the removed OSD back and checking the cluster status
         log.debug("Adding the removed OSD back and checking the cluster status")
         utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
-        method_should_succeed(wait_for_device, host, target_osd, action="add")
+        method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
         time.sleep(30)
         log.debug(
             "Completed addition of OSD post removal. Checking for inactive PGs post OSD addition"

--- a/tests/rados/test_osd_rebalance_snap.py
+++ b/tests/rados/test_osd_rebalance_snap.py
@@ -7,7 +7,7 @@ from ceph.rados.pool_workflows import PoolFunctions
 from tests.rados.rados_test_util import (
     create_pools,
     get_device_path,
-    wait_for_device,
+    wait_for_device_rados,
     write_to_pools,
 )
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
@@ -77,10 +77,10 @@ def run(ceph_cluster, **kw):
             wait_for_clean_pg_sets, rados_obj, timeout=timeout, test_pool=pool_name
         )
         method_should_succeed(utils.zap_device, ceph_cluster, host.hostname, dev_path)
-        method_should_succeed(wait_for_device, host, osd_id, action="remove")
+        method_should_succeed(wait_for_device_rados, host, osd_id, action="remove")
 
         utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
-        method_should_succeed(wait_for_device, host, osd_id, action="add")
+        method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
 
         snapshots = []
         if pool.get("snapshot", "False"):
@@ -127,7 +127,7 @@ def run(ceph_cluster, **kw):
         if osd_id not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)
             utils.add_osd(ceph_cluster, host.hostname, dev_path, osd_id)
-            method_should_succeed(wait_for_device, host, osd_id, action="add")
+            method_should_succeed(wait_for_device_rados, host, osd_id, action="add")
 
         utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=False)
         rados_obj.change_recovery_threads(config=pool, action="rm")

--- a/tests/rados/test_pg_split.py
+++ b/tests/rados/test_pg_split.py
@@ -9,7 +9,7 @@ from ceph.rados.pool_workflows import PoolFunctions
 from tests.rados.rados_test_util import (
     create_pools,
     get_device_path,
-    wait_for_device,
+    wait_for_device_rados,
     write_to_pools,
 )
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
@@ -135,12 +135,14 @@ def run(ceph_cluster, **kw):
             method_should_succeed(
                 utils.zap_device, ceph_cluster, host.hostname, dev_path
             )
-            method_should_succeed(wait_for_device, host, target_osd, action="remove")
+            method_should_succeed(
+                wait_for_device_rados, host, target_osd, action="remove"
+            )
             time.sleep(60)
 
             # Adding the removed OSD back and checking the cluster status
             utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
-            method_should_succeed(wait_for_device, host, target_osd, action="add")
+            method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
             time.sleep(20)
 
             utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=False)
@@ -310,7 +312,9 @@ def run(ceph_cluster, **kw):
                     ceph_cluster, target_osd, unmanaged=True
                 )
                 utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
-                method_should_succeed(wait_for_device, host, target_osd, action="add")
+                method_should_succeed(
+                    wait_for_device_rados, host, target_osd, action="add"
+                )
             utils.set_osd_devices_unmanaged(ceph_cluster, target_osd, unmanaged=False)
 
         if config.get("delete_pools"):

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -23,7 +23,7 @@ from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.monitor_workflows import MonitorWorkflows
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
 from ceph.utils import get_node_by_id
-from tests.rados.rados_test_util import get_device_path, wait_for_device
+from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_data_migration_bw_pools import create_given_pool
 from utility.log import Log
@@ -229,7 +229,9 @@ def run(ceph_cluster, **kw) -> int:
             method_should_succeed(
                 utils.zap_device, ceph_cluster, host.hostname, dev_path
             )
-            method_should_succeed(wait_for_device, host, target_osd, action="remove")
+            method_should_succeed(
+                wait_for_device_rados, host, target_osd, action="remove"
+            )
 
             # Checking cluster health after OSD removal
             method_should_succeed(rados_obj.run_pool_sanity_check)
@@ -239,7 +241,7 @@ def run(ceph_cluster, **kw) -> int:
 
             # Adding the removed OSD back and checking the cluster status
             utils.add_osd(ceph_cluster, host.hostname, dev_path, target_osd)
-            method_should_succeed(wait_for_device, host, target_osd, action="add")
+            method_should_succeed(wait_for_device_rados, host, target_osd, action="add")
             time.sleep(10)
 
             # Checking cluster health after OSD removal

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -18,7 +18,7 @@ from ceph.rados import utils
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
 from ceph.rados.serviceability_workflows import ServiceabilityMethods
-from tests.rados.rados_test_util import get_device_path, wait_for_device
+from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from tests.rados.test_stretch_site_down import (
     get_stretch_site_hosts,
@@ -161,7 +161,9 @@ def run(ceph_cluster, **kw):
         method_should_succeed(
             utils.zap_device, ceph_cluster, test_host.hostname, dev_path
         )
-        method_should_succeed(wait_for_device, test_host, target_osd, action="remove")
+        method_should_succeed(
+            wait_for_device_rados, test_host, target_osd, action="remove"
+        )
 
         # Waiting for recovery to post OSD host removal
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
@@ -188,7 +190,9 @@ def run(ceph_cluster, **kw):
         # Adding the removed OSD back and checking the cluster status
         log.debug("Adding the removed OSD back and checking the cluster status")
         utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
-        method_should_succeed(wait_for_device, test_host, target_osd, action="add")
+        method_should_succeed(
+            wait_for_device_rados, test_host, target_osd, action="add"
+        )
         time.sleep(30)
         log.debug(
             "Completed addition of OSD post removal. Checking for inactive PGs post OSD addition"


### PR DESCRIPTION
A new method to wait_for_device was introduced with an earlier PR but it was intended that the stability of new code be tested before implementing it across the board.

After monitoring the working of the new method wait_for_device_rados, it was decided that the old method can be replaced with the new one, this PR addresses the same

Signed-off-by: Harsh Kumar <hakumar@redhat.com>