### PR TITLE
RADOS TFA fixes and bugzilla automations

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -291,12 +291,15 @@ class RadosOrchestrator:
         log.error(f"pool {pool} not found")
         return {}
 
-    def host_maintenance_enter(self, hostname: str, retry: int = 10) -> bool:
+    def host_maintenance_enter(
+        self, hostname: str, retry: int = 10, yes_i_really_mean_it: bool = False
+    ) -> bool:
         """
         Adds the specified host into maintenance mode
         Args:
             hostname: name of the host which needs to be added into maintenance mode
             retry: max number of retries to put host into maintenance mode
+            yes_i_really_mean_it: Passes yes i really mean it flag during comand execution
         Returns:
             True -> Host successfully added to maintenance mode
             False -> Host Could not be added to maintenance mode
@@ -307,6 +310,8 @@ class RadosOrchestrator:
         while iteration <= retry:
             iteration += 1
             cmd = f"ceph orch host maintenance enter {hostname} --force"
+            if yes_i_really_mean_it and self.rhbuild.split(".")[0] >= "7":
+                cmd = f"ceph orch host maintenance enter {hostname} --force --yes-i-really-mean-it"
             try:
                 out, err = self.client.exec_command(cmd=cmd, sudo=True, timeout=600)
                 log.debug(f"o/p of maintenance enter cmd : {out}, err stream : {err}")
@@ -1745,6 +1750,305 @@ class RadosOrchestrator:
         orch_ps_out = self.run_ceph_command(cmd=cmd_)[0]
         log.debug(orch_ps_out)
         return orch_ps_out["status"], orch_ps_out["status_desc"]
+
+    def daemon_check_post_tests(
+        self, pre_test_orch_ps: dict, pre_crash_report: list = None
+    ) -> bool:
+        """
+        Method that compares the daemons & their placement beforw and after the test, to check if any daemon is
+        removed, added or placement is changed onto another host.
+
+        Args:
+            pre_test_orch_ps : output of "ceph orch ps" before the tests/ operations
+            pre_crash_report : output of "ceph crash ls" before the tests/ operations
+        Returns:
+            Pass -> True, fail -> False
+        """
+        # Load JSON data
+        orch_ps_data = pre_test_orch_ps
+        cmd = "ceph orch ps"
+        orch_ps_new_data = self.run_ceph_command(cmd=cmd)
+
+        # Function to collect daemon_name and hostname by daemon_type
+        def collect_daemon_info(data):
+            daemon_info = {}
+            for entry in data:
+                daemon_type = entry["daemon_type"]
+                daemon_name = entry["daemon_name"]
+                hostname = entry["hostname"]
+                if daemon_type not in daemon_info:
+                    daemon_info[daemon_type] = {}
+                daemon_info[daemon_type][daemon_name] = hostname
+            return daemon_info
+
+        # Collect daemon information from both JSON structures
+        orch_ps_daemons = collect_daemon_info(orch_ps_data)
+        orch_ps_new_daemons = collect_daemon_info(orch_ps_new_data)
+
+        # Compare daemons and print the results
+        all_match = True
+        for daemon_type, daemons in orch_ps_daemons.items():
+            if daemon_type in orch_ps_new_daemons:
+                log.debug(f"Verification for Daemon Type: {daemon_type}")
+                for daemon_name, hostname in daemons.items():
+                    log.debug(
+                        f"Verification for Daemon: {daemon_name} on host {hostname}"
+                    )
+                    if daemon_name in orch_ps_new_daemons[daemon_type]:
+                        log.debug(
+                            f"Daemon: {daemon_name} present post test."
+                            f" Checking if host is updated post tests"
+                        )
+                        new_hostname = orch_ps_new_daemons[daemon_type][daemon_name]
+                        log.debug(
+                            f"Daemon: {daemon_name} present post test."
+                            f"Old hostname {hostname} , New hostname : {new_hostname} fro daemon {daemon_name}"
+                            f" Checking if host is updated post tests"
+                        )
+                        is_same = hostname == new_hostname
+                        if not is_same:
+                            all_match = False
+                            log.error(f"Daemon Type: {daemon_type}")
+                            log.error(f"  Daemon Name: {daemon_name}")
+                            log.error(f"    Old Hostname: {hostname}")
+                            log.error(f"    New Hostname: {new_hostname}")
+                            log.error(f"    Same Hostname: {is_same}")
+                    else:
+                        all_match = False
+                        log.error(f"Daemon Type: {daemon_type}")
+                        log.error(f"  Daemon Name: {daemon_name}")
+                        log.error(f"    Old Hostname: {hostname}")
+                        log.error("    New Hostname: Not found")
+                        log.error("    Same Hostname: False")
+            else:
+                all_match = False
+                log.error(f"Daemon Type: {daemon_type} not found post tests")
+
+        # Check for missing daemons in orch_ps_new
+        for daemon_type, daemons in orch_ps_daemons.items():
+            if daemon_type not in orch_ps_new_daemons:
+                all_match = False
+                log.error(f"Daemon Type: {daemon_type} is missing post tests")
+            else:
+                for daemon_name in daemons:
+                    if daemon_name not in orch_ps_new_daemons[daemon_type]:
+                        all_match = False
+                        log.error(
+                            f"Daemon Name: {daemon_name} in "
+                            f"Daemon Type: {daemon_type} is missing in orch ps post tests."
+                        )
+
+        # Check for new daemons added in orch_ps post upgrade
+        for daemon_type, daemons in orch_ps_new_daemons.items():
+            if daemon_type not in orch_ps_daemons:
+                # all_match = False
+                log.error(f"New Daemon Type: {daemon_type} not present post upgrade")
+            else:
+                for daemon_name in daemons:
+                    if daemon_name not in orch_ps_daemons[daemon_type]:
+                        # Not failing the method if new daemons are added to the cluster post upgrade
+                        # all_match = False
+                        log.error(
+                            f"New Daemon Name: {daemon_name} in Daemon Type: {daemon_type} found post tests."
+                        )
+
+        if pre_crash_report:
+            # Checking for new crashes on the cluster since tests started
+            crashes = self.run_ceph_command(cmd="ceph crash ls")
+            # Convert lists to sets
+            set_crash1 = set(pre_crash_report)
+            set_crash2 = set(crashes)
+
+            new_crashes = list(set_crash2 - set_crash1)
+            log.debug(f"New crashes post start of test execution are : {new_crashes}")
+            if len(new_crashes) > 0:
+                log.error("New crashes observed on the cluster post starting the test")
+                all_match = False
+
+        return all_match
+
+    def compare_df_stats(self, pre_test_df_stats):
+        """
+        Method to compare the 'total_bytes', 'total_avail_bytes', 'total_used_bytes' in ceph before and after the tests,
+        and also check the 'stored', 'objects', 'stored_raw', 'avail_raw' for each pool on the cluster, to check if it's
+        same before and after the tests.
+
+        Note: If IO's are being run during the tests, this method cannot be used, as the method validates if the
+        two df stats outputs are same
+        Args:
+            pre_test_df_stats: Output of "ceph df detail" in json format collected before starting the tests
+        Returns:
+            Pass -> True, Fail -> False
+        """
+
+        def bytes_to_gb(value):
+            return round(value / (1024**3), 1)
+
+        def within_variance(old_value, new_value, variance=0.25):
+            if old_value == 0 and new_value == 0:
+                return True  # Both are zero, so they are the same
+            if old_value == 0 or new_value == 0:
+                return False  # One is zero and the other is not, so they differ
+            return abs(old_value - new_value) / old_value <= variance
+
+        df_stats_data = pre_test_df_stats
+        df_stats_new_data = self.run_ceph_command(cmd="ceph df detail")
+        check_pass = True
+
+        # Compare overall stats
+        overall_keys = ["total_bytes", "total_avail_bytes", "total_used_bytes"]
+        for key in overall_keys:
+            old_value_gb = bytes_to_gb(df_stats_data["stats"].get(key, 0))
+            new_value_gb = bytes_to_gb(df_stats_new_data["stats"].get(key, 0))
+            log.info(f"Value in {key}: old {old_value_gb} GB , new {new_value_gb} GB")
+            if not within_variance(old_value_gb, new_value_gb):
+                log.error(
+                    f"Difference in {key}: {old_value_gb} GB != {new_value_gb} GB"
+                )
+                check_pass = False
+
+        # Compare each pool
+        old_pools = {pool["name"]: pool["stats"] for pool in df_stats_data["pools"]}
+        new_pools = {pool["name"]: pool["stats"] for pool in df_stats_new_data["pools"]}
+
+        for pool_name, old_pool_stats in old_pools.items():
+            if pool_name in new_pools:
+                new_pool_stats = new_pools[pool_name]
+                pool_keys = ["stored", "objects", "stored_raw", "avail_raw"]
+                for key in pool_keys:
+                    old_value_gb = bytes_to_gb(old_pool_stats.get(key, 0))
+                    new_value_gb = bytes_to_gb(new_pool_stats.get(key, 0))
+                    log.info(
+                        f"Values in {key} for pool {pool_name}: old {old_value_gb} GB , new {new_value_gb} GB"
+                    )
+                    if not within_variance(old_value_gb, new_value_gb):
+                        log.error(
+                            f"Difference in {key} for pool {pool_name}: {old_value_gb} GB != {new_value_gb} GB"
+                        )
+                        check_pass = False
+        log.info(
+            "All compared values in the ceph df stats, and they are in the 5% variance"
+        )
+        return check_pass
+
+    def get_ideal_max_avail_pools(self, default_replica_size: int = 3) -> float:
+        """
+        Method to calculate the MAX_AVAIL on the pools on the cluster, by calculating the formula below
+        ([min(osd.avail for osd in OSD_up) - ( min(osd.avail for osd in OSD_up).total_size * (1 - full_ratio)) ] *
+        len(osd.avail for osd in OSD_up))/pool.size()
+
+        Args:
+            default_replica_size: replica size on the pools. default is 3
+
+        Returns:
+            MAX_AVAIL size calculated in float
+        """
+
+        def kb_to_gb(kb):
+            return round(kb / (1024 * 1024), 1)
+
+        def calculate_max_avail(
+            most_used_avail_gb, most_used_total_gb, full_ratio, replica_size, total_osds
+        ):
+            max_avail = (
+                (most_used_avail_gb - (most_used_total_gb * (1 - full_ratio)))
+                * total_osds
+            ) / replica_size
+            return round(max_avail, 1)
+
+        data = self.run_ceph_command(cmd="ceph osd df tree")
+        full_ratio = self.run_ceph_command(cmd="ceph osd dump")["full_ratio"]
+        replica_size = default_replica_size
+        total_osds = 0
+        most_used_osd = None
+        most_used_kb = 0
+        most_used_total_kb = 0
+        most_used_avail_kb = 0
+
+        for node in data["nodes"]:
+            if node["type"] == "osd":
+                total_osds += 1
+                if node["kb_used"] > most_used_kb:
+                    most_used_kb = node["kb_used"]
+                    most_used_osd = node
+                    most_used_total_kb = node[
+                        "kb"
+                    ]  # Assuming 'kb' represents the total size of the OSD
+                    most_used_avail_kb = node["kb_avail"]
+
+        most_used_avail_gb = kb_to_gb(most_used_avail_kb)
+        most_used_total_gb = kb_to_gb(most_used_total_kb)
+
+        log.debug(
+            f"total OSDs on cluster : {total_osds},\n"
+            f"Most used OSD : {most_used_osd}"
+            f"Most utilization on OSD avail space:  {most_used_avail_gb},\n"
+            f"most used OSD total space : {most_used_total_gb})"
+        )
+
+        max_avail = calculate_max_avail(
+            most_used_avail_gb, most_used_total_gb, full_ratio, replica_size, total_osds
+        )
+        log.info(f"max avail calculated is = {max_avail}")
+        return max_avail
+
+    def verify_max_avail(self, variance: float = 0.20):
+        """
+        method to verify if the max df calculated by the cluster is as expected on the pool
+        bug : https://bugzilla.redhat.com/show_bug.cgi?id=2109129
+
+        Args:
+            variance: % of acceptable difference between the calculated vs actual
+
+        Returns:
+            Pass -> true, Fail -> False
+        """
+
+        def kb_to_gb(kb):
+            return round(kb / (1024 * 1024), 1)
+
+        max_avail_by_pool = {}
+        size_by_pool = {}
+        check_pass = True
+        ceph_df = self.run_ceph_command(cmd="ceph df detail")
+        pool_detail = self.run_ceph_command(cmd="ceph osd pool ls detail")
+
+        # ceph df detail
+        for pool in ceph_df["pools"]:
+            pool_name = pool["name"]
+            max_avail = kb_to_gb(pool["stats"]["max_avail"])
+            max_avail_by_pool[pool_name] = max_avail
+
+        # ceph osd pool ls detail
+        for entry in pool_detail:
+            pool_name = entry["pool_name"]
+            size = entry["size"]
+            if entry["type"] != 1:
+                log.debug(f"pool : {pool_name} is a non replicated pool.")
+                break
+            size_by_pool[pool_name] = size
+
+        for pool in size_by_pool:
+            ideal_max_avail = self.get_ideal_max_avail_pools(
+                default_replica_size=size_by_pool[pool]
+            )
+            pool_max_avail = max_avail_by_pool[pool]
+            is_within_variance = (
+                lambda value, new_value, var: abs(value - new_value) / value <= variance
+            )
+
+            if not is_within_variance(ideal_max_avail, pool_max_avail, variance):
+                log.error(
+                    f"The MAX_AVAIL for pool : {pool} with size : {size_by_pool[pool]} is not same as expected.\n"
+                    f"Actual on cluster : {pool_max_avail}\n"
+                    f"Calculated value : {ideal_max_avail}\n"
+                )
+                check_pass = False
+
+            log.debug(
+                f"The MAX_AVAIL on the pool is as expected for pool : {pool} is as expected"
+            )
+        return check_pass
 
     def get_osd_stat(self):
         """

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -215,22 +215,14 @@ tests:
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
-      name: Upgrade ceph
-      desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83574982
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       config:
-        command: start
-        service: upgrade
-        base_cmd_args:
-          verbose: true
-        benchmark:
-          type: rados                      # future-use
-          pool_per_client: true
-          pg_num: 128
-          duration: 10
-        verify_cluster_health: true
-      destroy-cluster: false
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
 
   # Running basic rbd and rgw tests after upgrade

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -19,8 +19,8 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-          rhcs-version: 6.1
-          release: z4
+          rhcs-version: 5.3
+          release: rc
           mon-ip: node1
           orphan-initial-daemons: true
           registry-url: registry.redhat.io
@@ -222,6 +222,10 @@ tests:
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
 
   # Running basic rbd and rgw tests after upgrade

--- a/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -1,4 +1,4 @@
-# Use cluster-conf file: conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+# Use cluster-conf file: conf/baremetal/rados_extensa_1admin_5node_1client.yaml
 # Stretch mode tests performing site down scenarios
 
 tests:
@@ -111,9 +111,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        nodes:
-          - node6:
-              release: 6
+        node: node6
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -22,6 +22,7 @@ tests:
         base_cmd_args:
           verbose: true
         args:
+          # upgrade bug from 6.x to 7.x wrt warning : 2243570. Hence, testing with 5.x
           rhcs-version: 5.3
           release: rc
           mon-ip: node1
@@ -224,7 +225,12 @@ tests:
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
+      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
 
   # Running basic rbd and rgw tests after upgrade
   - test:

--- a/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -1,4 +1,4 @@
-# Use cluster-conf file: conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+# Use cluster-conf file: conf/baremetal/rados_extensa_1admin_5node_1client.yaml
 # Stretch mode tests performing site down scenarios
 
 tests:
@@ -111,9 +111,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        nodes:
-          - node6:
-              release: 7
+        node: node6
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -222,6 +222,10 @@ tests:
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
 
   # Running basic rbd and rgw tests after upgrade

--- a/suites/squid/rados/tier-2_rados_test_omap.yaml
+++ b/suites/squid/rados/tier-2_rados_test_omap.yaml
@@ -178,6 +178,9 @@ tests:
       module: test_omap_entries.py
       polarion-id: CEPH-83571702
       config:
+        # Pool created to  verify the Bug#2249003
+        crash_config:
+          pool_name: re_pool_crash
         # EC pool config is commented out because omaps can be written only on RE pools
         omap_config:
           small_omap:

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -86,6 +86,31 @@ tests:
                 - "ceph osd tree"
 
   - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
       name: RGW Service deployment
       desc: RGW Service deployment
       module: test_cephadm.py
@@ -109,7 +134,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        nodes: node8
+        node: node8
         install_packages:
           - ceph-common
           - ceph-base
@@ -141,6 +166,148 @@ tests:
       desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
       abort-on-fail: true
 
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        rados_write_duration: 200
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: test stretch Cluster site down - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83574975
+      config:
+        pool_name: test_stretch_pool6
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site down with delay - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83571705
+      config:
+        pool_name: test_stretch_pool9
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+        add_network_delay: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site down - Arbiter site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83574974
+      config:
+        pool_name: test_stretch_pool5
+        shutdown_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is shut down
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - arbiter site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool2
+        affected_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site reboot - Data site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool3
+        affected_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the data site is rebooted
+
+  - test:
+      name: test stretch Cluster site reboot - Arbiter site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool4
+        affected_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the arbiter site is rebooted
+
+  - test:
+      name: Mon replacement on Data site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool5
+        replacement_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        add_mon_without_location: true
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - Data site
+
+  - test:
+      name: Mon replacement on Arbiter site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool6
+        replacement_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - Arbiter site
+
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
   - test:
@@ -154,3 +321,46 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
       comments: Active bug - 2249962
+
+  - test:
+      name: OSD and host replacement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test stretch Cluster osd and Host replacement
+
+  - test:
+      name: Netsplit Scenarios data-arbiter sites
+      module: test_stretch_netsplit_scenarios.py
+      polarion-id: CEPH-83574979
+      config:
+        pool_name: test_stretch_pool7
+        netsplit_site: arbiter
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+
+  - test:
+      name: Negative scenarios - post-deployment
+      module: test_stretch_negative_scenarios.py
+      polarion-id: CEPH-83584499
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: arbiter
+      desc: Perform post-deployment negative tests on stretch mode
+
+  - test:
+      name: test stretch Cluster maintenance mode - data site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool1
+        affected_site: DC1
+        tiebreaker_mon_site_name: arbiter
+        delete_pool: true
+      desc: Test the cluster when the Data site is moved to maintenance mode
+      abort-on-fail: true

--- a/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -1,4 +1,4 @@
-# Use cluster-conf file: conf/squid/rados/stretch-mode-host-location-attrs.yaml
+# Use cluster-conf file: conf/baremetal/rados_extensa_1admin_5node_1client.yaml
 # Stretch mode tests performing site down scenarios
 
 tests:
@@ -111,7 +111,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        nodes: node6
+        node: node6
         install_packages:
           - ceph-common
           - ceph-base

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -347,7 +347,11 @@ def wait_for_clean_pg_sets(
             log.debug(f"Checking for active + clean PGs on pool: {test_pool}")
             pool_pg_ids = rados_obj.get_pgid(pool_name=test_pool)
             for pg_id in pool_pg_ids:
-                pg_state = rados_obj.get_pg_state(pg_id=pg_id)
+                try:
+                    pg_state = rados_obj.get_pg_state(pg_id=pg_id)
+                except Exception as err:
+                    log.error(f"PGID : {pg_id} was not found, err: {err}")
+                    continue
                 if any(key in health_warnings for key in pg_state.split("+")):
                     all_pg_active_clean = False
                     log.debug(

--- a/tests/rados/test_omap_entries.py
+++ b/tests/rados/test_omap_entries.py
@@ -32,7 +32,10 @@ def run(ceph_cluster, **kw):
     client_node = ceph_cluster.get_nodes(role="client")[0]
 
     omap_target_configs = config["omap_config"]
-    crash_pool_name = config["crash_config"]["pool_name"]
+    if config.get("crash_config"):
+        crash_pool_name = config["crash_config"]["pool_name"]
+    else:
+        crash_pool_name = "test_crash_pool"
     if not rados_obj.create_pool(pool_name=crash_pool_name):
         log.error(f"Failed to create pool-{crash_pool_name}")
         return 1


### PR DESCRIPTION
1. Added --yes-i-really-mean-it flag option for maintenance mode
2. Added new method to check if all daemons are present pre and post tests/ upgrade
3. Added new methods in core workflows to calculate MAX_AVAIL, daemon existence before and after upgrade, raw, used checks for pool and cluster level.
4. Removed custom builds from Baremetal Stretch mode client deployment. Now the client versions would be the same as Ceph version.
5. Updated the log parsing in the scrub tests, So that now the log lines would be identified correctly for EC pools.
6. Updated the method to collect the size of Mon DB on the cluster, ignoring the temp files created in the directory.