### PR TITLE
cephci integration of CEPH-83574876 - Verify 'bi put` uses right buck…

### DIFF
--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -334,3 +334,12 @@ tests:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_list_not_truncated.yaml
         timeout: 500
+
+  - test:
+      name: Test bi put with incomplete multipart upload
+      desc: Test bi put with incomplete multipart upload
+      polarion-id: CEPH-83574876
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_bi_put_with_incomplete_multipart_upload.yaml

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -282,3 +282,12 @@ tests:
       module: java_s3tests.py
       name: execute Java Maven test suite
       polarion-id: CEPH-83586289
+
+  - test:
+      name: Test bi put with incomplete multipart upload
+      desc: Test bi put with incomplete multipart upload
+      polarion-id: CEPH-83574876
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_bi_put_with_incomplete_multipart_upload.yaml

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -282,3 +282,12 @@ tests:
       module: java_s3tests.py
       name: execute Java Maven test suite
       polarion-id: CEPH-83586289
+
+  - test:
+      name: Test bi put with incomplete multipart upload
+      desc: Test bi put with incomplete multipart upload
+      polarion-id: CEPH-83574876
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_bi_put_with_incomplete_multipart_upload.yaml


### PR DESCRIPTION
…et index shard


# Description

cephci integration of CEPH-83574876
 Verify 'bi put` uses right bucket index shard
 
 Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-9N40GN/
 Dependent on ceph-qe-script  pr: https://github.com/red-hat-storage/ceph-qe-scripts/pull/620

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
