### PR TITLE
setuptools 72.0.0 has caused a disruption to gate checks.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-        - '3.9.16'
+        - '3.9.18'
         - '3.8.15'
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,18 @@
 envlist = py39, py38, py39-coverage
 
 [testenv]
-deps =
-    -r{toxinidir}/test_requirements.txt
 commands =
+    python -m pip install --no-cache-dir --no-build-isolation -r{toxinidir}/test_requirements.txt
     pytest unittests
     flake8
     isort -c .
     black --check --diff .
     yamllint -d relaxed --no-warnings .
 
-
 [testenv:py39-coverage]
 basepython =
     python3.9
 deps =
-    -r{toxinidir}/test_requirements.txt
     coverage
 commands =
     coverage run -m pytest -vv --strict


### PR DESCRIPTION
Due to https://github.com/pypa/setuptools/pull/4458, our py gate jobs are failing with the below error

```
 × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      <string>:18: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      Traceback (most recent call last):
        File "/home/jenkins/test/cephci/.venv/lib64/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/jenkins/test/cephci/.venv/lib64/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/jenkins/test/cephci/.venv/lib64/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-cjg8mgr4/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-cjg8mgr4/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-cjg8mgr4/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-cjg8mgr4/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 20, in <module>
      ModuleNotFoundError: No module named 'setuptools.command.test'
      [end of output]
```