### PR TITLE
Move mergify to check on 3.9.18

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
       - label!=work-in-progress
       - base=master
       - "approved-reviews-by=@red-hat-storage/cephci-top-level-reviewers"
-      - "check-success=tox (3.9.16)"
+      - "check-success=tox (3.9.18)"
       - check-success=WIP
     actions:
       merge:


### PR DESCRIPTION
# Description

With the recent move to check on 3.9.18 version of python, we need to move mergify also.

- [x] Unit testing