### PR TITLE
TFA fix for squid version

### DIFF
--- a/tests/cephfs/cephfs_utils.py
+++ b/tests/cephfs/cephfs_utils.py
@@ -3,6 +3,7 @@ import random
 import re
 import string
 import time
+from distutils.version import LooseVersion
 
 from ceph.ceph import CommandFailed
 from utility.log import Log
@@ -83,7 +84,7 @@ class FsUtils(object):
                 + self.mon_node_ip[-1].strip("/0")
             )
             self.mon_node_ip = self.mon_node_ip.split(" ")
-            if build.startswith(("4", "5", "6", "7")):
+            if LooseVersion(build) > LooseVersion("3"):
                 self.mon_node_ip[0] = re.search(
                     r"\W+v\w+:(\d+.\d+.\d+.\d+:\d+)/0,v\w+:(\d+.\d+.\d+.\d+:\d+)/0\W",
                     self.mon_node_ip[0],


### PR DESCRIPTION
# Description
Kernel Mount command is failing as it is picking Mon IPs in []
Now we have changed it to LooseVersion and it fixed for all the later releases than 3
 
Failed Logs : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.0-4/cephfs/4/tier-2_cephfs_test-clients/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
