### PR TITLE
minor change add known issue

### DIFF
--- a/suites/squid/rgw/sanity_rgw.yaml
+++ b/suites/squid/rgw/sanity_rgw.yaml
@@ -199,6 +199,7 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
+      comments: known issue BZ 2301986
   - test:
       name: test swift enable version on conatainer of different user
       desc: test swift enable version on conatainer of different user

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -555,3 +555,4 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
+      comments: known issue BZ 2301986

--- a/suites/squid/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
@@ -134,6 +134,7 @@ tests:
         run-on-rgw: true
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
+      comments: known issue BZ 2301986
 
   - test:
       name: Manual Resharding tests

--- a/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -171,6 +171,7 @@ tests:
       config:
         script-name: ../s3cmd/test_ratelimit_global.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
+      comments: known issue BZ 2301986
 
   - test:
       name: Test Ratelimit for versioned buckets
@@ -180,6 +181,7 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
+      comments: known issue BZ 2301986
 
   - test:
       name: Test Ratelimit for tenanted users
@@ -189,6 +191,7 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
+      comments: known issue BZ 2301986
 
   - test:
       name: Test Ratelimit Debt
@@ -198,6 +201,7 @@ tests:
       config:
         script-name: ../s3cmd/test_rate_limit.py
         config-file-name: ../../s3cmd/configs/test_ratelimit_debt.yaml
+      comments: known issue BZ 2301986
 
   - test:
       name: Test ratelimit on bucket owner change


### PR DESCRIPTION
Add known issue for Rate limit tests on squid 
BZ [Bug 2301986](https://bugzilla.redhat.com/show_bug.cgi?id=2301986) - [RGW]: User rate limit is not enforced when global rate limit is set