### PR TITLE
[tfa][dmfg] Fix AttributeError for string split method applied on list

### DIFF
--- a/tests/cephadm/test_verify_log_rotate_tcmu_runner.py
+++ b/tests/cephadm/test_verify_log_rotate_tcmu_runner.py
@@ -26,8 +26,8 @@ def run(ceph_cluster, **kw):
     rotate_conf = [entry for entry in out.split("\n") if "killall" in entry]
 
     # Verify tcmu-runner is part of killall and pkill
-    for lists in rotate_conf.split(" || "):
-        if "tcmu-runner" not in lists:
+    for item in rotate_conf[0].split(" || ")[:-1]:
+        if "tcmu-runner" not in item:
             raise OperationFailedError(
                 "Tcmu-runner is not in killall/pkill entries. Ref : #2204505"
             )


### PR DESCRIPTION
# Description

Problem:
The suite `suites/reef/cephadm/tier4-service-operations.yaml` was failing for the test "Verify the logrotate config created by cephadm take into account tcmu-runner"

Reason for Failure:
The test failed for the below error :
`    for lists in rotate_conf.split(" || "):`
`AttributeError: 'list' object has no attribute 'split'`

Here the rotate_conf is a list and we cannot perform split operation on it.

Solution:
Perform split operation on the list item instead of the entire list.

Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GU2PCV
