### PR TITLE
[Rados] TFA fix for osd df stats & removal of superblock redundancy test

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -638,6 +638,7 @@ class RadosOrchestrator:
             pg_num = kwargs["pg_num"]
 
         else:
+            log.info("No argument provided, returning the acting set for PG 1.0")
             # Collecting the acting set for a random pool ID 1 from cluster
             pg_num = "1.0"
 

--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -140,7 +140,7 @@ tests:
         run_iteration: 3
         create_pool: true
         pool_name: test-osd-df
-        write_iteration: 4
+        write_iteration: 10
         delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -141,7 +141,7 @@ tests:
         run_iteration: 3
         create_pool: true
         pool_name: test-osd-df
-        write_iteration: 4
+        write_iteration: 10
         delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -143,7 +143,7 @@ tests:
         run_iteration: 3
         create_pool: true
         pool_name: test-osd-df
-        write_iteration: 4
+        write_iteration: 10
         delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864

--- a/suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -143,7 +143,7 @@ tests:
         run_iteration: 3
         create_pool: true
         pool_name: test-osd-df
-        write_iteration: 4
+        write_iteration: 10
         delete_pool: true
 
   # Below test is currently failing, BZ raised #2214864

--- a/suites/squid/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/squid/rados/tier-2_rados_test_bluestore.yaml
@@ -134,8 +134,9 @@ tests:
         bluestore_cache: true
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
-  - test:
-      name: BlueStore Superblock redundancy
-      module: test_bluestore_superblock.py
-      polarion-id: CEPH-83590892
-      desc: Verify OSD recovery when Bluestore superblock is corrupted
+# commented until the fix has been merged in Squid
+#  - test:
+#      name: BlueStore Superblock redundancy
+#      module: test_bluestore_superblock.py
+#      polarion-id: CEPH-83590892
+#      desc: Verify OSD recovery when Bluestore superblock is corrupted

--- a/tests/rados/test_mon_mgr_weight.py
+++ b/tests/rados/test_mon_mgr_weight.py
@@ -19,8 +19,8 @@ def run(ceph_cluster, **kw):
     Covers:
         - BZ-2236226
         - BZ-2269541
-    Should cover:
         - BZ-2269542
+    Should cover:
         - BZ-2269543
     Test to verify Mgr daemon does not crash when Monitor weights are out of place
     # Steps
@@ -40,8 +40,8 @@ def run(ceph_cluster, **kw):
     log.info("Running test case to verify Mgr stability when Mon weights are modified")
 
     try:
-        if not rhbuild.startswith("7"):
-            log.info("Test is not valid for Pacific & Quincy, BZ yet to be back-ported")
+        if rhbuild.startswith("5"):
+            log.info("Test is not valid for Pacific, BZ yet to be back-ported")
             return 0
 
         # fetch active MGR for the cluster

--- a/tests/rados/test_osd_df.py
+++ b/tests/rados/test_osd_df.py
@@ -109,10 +109,10 @@ def run_test(ceph_cluster, **kw):
 
         osd_map = rados_obj.get_osd_map(pool=pool_name, obj=object_name)
         acting_pg_set = osd_map["acting"]
-        log.info(f"Acting set for {object_name} in {pool_name}: {acting_pg_set}")
         if not acting_pg_set:
             log.error("Failed to retrieve acting pg set")
             return 1
+        log.info(f"Acting set for {object_name} in {pool_name}: {acting_pg_set}")
         verification_dict.update({"acting_pg_set": acting_pg_set})
 
         time.sleep(5)
@@ -151,11 +151,12 @@ def run_test(ceph_cluster, **kw):
         method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=1800)
 
         # Retrieve new acting pg set
-        new_acting_pg_set = rados_obj.get_pg_acting_set()
-        log.info(f"New acting set for {pool_name}: {new_acting_pg_set}")
+        osd_map = rados_obj.get_osd_map(pool=pool_name, obj=object_name)
+        new_acting_pg_set = osd_map["acting"]
         if not new_acting_pg_set:
             log.error("Failed to retrieve new acting pg set")
             return 1
+        log.info(f"New acting set for {pool_name}: {new_acting_pg_set}")
         verification_dict.update({"new_acting_pg_set": new_acting_pg_set})
 
         # Retrieve new acting osd hosts and all the osds on these hosts


### PR DESCRIPTION
This PR covers the following 3 changes:

- `test_osd_df.py`: A fix provided in test-osd-df test where an acting set was being fetched for PG 1 instead of the desired PG

- `test_bluestore_superblock.py`: Test has been commented until the feature has been merged in Squid

- `test_mon_mgr_weight.py`: Fix has been merged in Quincy (6.1z7), so this test should now run for Quincy

Logs:
 `test_mon_mgr_weight.py`: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-17ZD4U

Signed-off-by: Harsh Kumar <hakumar@redhat.com>