### PR TITLE
fixing tfa too many open files for s3select on squid and adding known issue for curl multipart etag empty on quincy

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
@@ -130,7 +130,6 @@ tests:
               install_start_kafka: true
               script-name: test_bucket_notifications.py
               config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-              timeout: 300
         - test:
             name: test_bi_purge for a bucket
             desc: test bi_purge should not error
@@ -140,7 +139,6 @@ tests:
               install_common: false
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_bi_purge.yaml
-              timeout: 300
  # STS tests
   - test:
       name: Test rename of large object using sts user through AWS
@@ -150,7 +148,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
   - test:
       name: Test s3_copy_obj on user with admin flag through AWS
       desc: TESCO-Segfault with s3CopyObj with admin user
@@ -159,7 +156,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_s3copyObj_admin_user.yaml
-        timeout: 500
 
  # testing rgw through curl
   - test:
@@ -170,7 +166,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-        timeout: 500
 
   - test:
       name: Test rgw put object through curl using transfer_encoding chunked
@@ -180,17 +175,16 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_curl_transfer_encoding_chunked.yaml
-        timeout: 500
 
   - test:
       name: Test rgw multipart upload through curl
       desc: Test rgw multipart upload through curl
       polarion-id: CEPH-9801
       module: sanity_rgw.py
+      comments: known issue (BZ2266793) targeted to 6.1z7
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: Test rgw put bucket website with users of same and different tenant
@@ -200,7 +194,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500
 
   - test:
       name: Test rgw get bucket website with users of same and different tenant
@@ -210,4 +203,3 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500

--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -224,7 +224,6 @@ tests:
       desc: increase ulimit number of open files to 16384
       module: exec.py
       name: increase ulimit number of open files to 16384
-      polarion-id: CEPH-10362
 
   - test:
       name: test s3select with depth1 queries on csv objects

--- a/suites/squid/rgw/tier-4-rgw.yaml
+++ b/suites/squid/rgw/tier-4-rgw.yaml
@@ -212,6 +212,19 @@ tests:
         config-file-name: test_s3_and_swift_versioning.yaml
 
   # test s3-select with query generation of incorrect syntax
+
+  - test:
+      abort-on-fail: true
+      config:
+        role: client
+        sudo: True
+        commands:
+          - "echo '\n\n# increase limit on number of open files\n*               soft    nofile          16384\n*               hard    nofile          16384' >> /etc/security/limits.conf"
+          - "echo 'ulimit -n 16384' >> /etc/profile"
+      desc: increase ulimit number of open files to 16384
+      module: exec.py
+      name: increase ulimit number of open files to 16384
+
   - test:
       name: test s3select with depth1 queries on csv objects
       desc: test s3select with depth1 queries of incorrect syntax for checking rgw crashes on csv objects
@@ -229,6 +242,25 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth2.yaml
+
+  - test:
+      name: test s3select with depth1 queries on parquet objects
+      desc: test s3select with depth1 queries of incorrect syntax for checking rgw crashes on parquet objects
+      polarion-id: CEPH-83575176
+      module: sanity_rgw.py
+      config:
+        script-name: test_s3select.py
+        config-file-name: test_s3select_query_gen_parquet_depth1.yaml
+
+  - test:
+      name: test s3select with depth2 queries on parquet objects
+      desc: test s3select with depth2 queries of incorrect syntax for checking rgw crashes on parquet objects
+      polarion-id: CEPH-83575176
+      module: sanity_rgw.py
+      comments: known issue (BZ2290775) targeted to 8.1
+      config:
+        script-name: test_s3select.py
+        config-file-name: test_s3select_query_gen_parquet_depth2.yaml
 
   - test:
       name: test s3select with depth1 queries on parquet objects


### PR DESCRIPTION
this issue is fixed on reef in this PR: https://github.com/red-hat-storage/cephci/pull/3742
adding fix in squid suites

also adding known issue for etag empty test with curl on quincy
bz:https://bugzilla.redhat.com/show_bug.cgi?id=2266793


tfa tickets:
https://issues.redhat.com/browse/RHCEPHQE-15401
https://issues.redhat.com/browse/RHCEPHQE-15385

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
