### PR TITLE
Modify nvmeof sanity test suite with hostnqn addition for host add to subsystem

### DIFF
--- a/ceph/ceph_admin/shell.py
+++ b/ceph/ceph_admin/shell.py
@@ -22,6 +22,7 @@ class ShellMixin:
         check_status: bool = True,
         timeout: int = 600,
         long_running: bool = False,
+        print_output: bool = True,
     ):
         """
         Ceph orchestrator shell interface to run ceph commands.
@@ -32,6 +33,7 @@ class ShellMixin:
             check_status (Bool): check command status
             timeout (Int): Maximum time allowed for execution.
             long_running (Bool): Long running command (default: False)
+            print_output ( Bool): Flag to decide whether the output should be printed in log or not
 
         Returns:
             out (Str), err (Str) stdout and stderr response
@@ -55,5 +57,6 @@ class ShellMixin:
         )
 
         if isinstance(out, tuple):
-            LOG.debug(out[0])
+            if print_output:
+                LOG.debug(out[0])
         return out

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3815,6 +3815,11 @@ class RadosOrchestrator:
         if not daemon_id:
             return self.run_ceph_command(cmd=base_cmd, client_exec=True)
 
+        if daemon_type == "osd" and daemon_id:
+            return self.run_ceph_command(
+                cmd=f"{base_cmd} {daemon_type}.{daemon_id}", client_exec=True
+            )
+
         out = self.run_ceph_command(cmd=f"{base_cmd} {daemon_id}", client_exec=True)
         if out is None:
             log.error(

--- a/conf/squid/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/squid/rados/stretch-mode-host-location-attrs.yaml
@@ -70,8 +70,5 @@ globals:
         no-of-volumes: 4
         disk-size: 25
       node8:
-        image-name:
-          openstack: RHEL-9.3.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         role:
           - client

--- a/suites/pacific/rgw/tier-1-extn_rgw.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw.yaml
@@ -108,7 +108,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_list_not_truncated.yaml
-        timeout: 500
 
   - test:
       name: STS Tests to perform assume role on principle user and perform IOs
@@ -119,7 +118,6 @@ tests:
         test-version: v2
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role call with permissive session policies
       desc: Perform assume role call with permissive session policies
@@ -128,7 +126,6 @@ tests:
       config:
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_permissive_session_policy.yaml
-        timeout: 500
   - test:
       name: STS Tests to perform assume role call with restrictive session policies
       desc: Perform assume role call with restrictive session policies
@@ -137,7 +134,22 @@ tests:
       config:
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
-        timeout: 500
+  - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
   - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
@@ -146,7 +158,6 @@ tests:
       config:
         script-name: test_sts_using_boto_server_side_copy.py
         config-file-name: test_sts_using_boto_server_side_copy.yaml
-        timeout: 500
   - test:
       name: STS Tests for handling non-existent object condition
       desc: STS test using boto for handling non-existent object condition
@@ -155,7 +166,6 @@ tests:
       config:
         script-name: test_sts_using_boto_unexisting_object.py
         config-file-name: test_sts_using_boto.yaml
-        timeout: 500
   - test:
       name: STS test with invalid arn in the role's policy
       desc: STS test with invalid arn in the role's policy
@@ -164,7 +174,6 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_using_boto_invalid_arn_policy.yaml
-        timeout: 500
   - test:
       name: STS test with invalid principal in the role's policy
       desc: STS test with invalid principal in the role's policy
@@ -173,7 +182,7 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sts_invalid_principal.yaml
-        timeout: 500
+
   - test:
       name: reshard cancel command
       desc: reshard cancel command
@@ -182,7 +191,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-        timeout: 500
 
   - test:
       name: Multipart upload with Bucket policy enabled
@@ -192,7 +200,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_with_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard and max_dynamic_shard
@@ -202,7 +209,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_and_max_dynamic_shard.yaml
-        timeout: 500
 
   - test:
       name: DBR tests with custom objs_per_shard max_dynamic_shard and reshard_thread_interval
@@ -212,7 +218,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dbr_with_custom_objs_per_shard_max_dynamic_shard_and_reshard_thread_interval.yaml
-        timeout: 500
 
   - test:
       name: Bucket setlifeycle with invalid date in LC conf
@@ -222,7 +227,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_invalid_date.yaml
-        timeout: 300
 
   - test:
       name: LC enabled on bucket removes pre and post uploaded objects
@@ -232,7 +236,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_enable_object_exp.yaml
-        timeout: 300
 
   - test:
       name: Control functionality for RGW lifecycle
@@ -242,7 +245,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_rgw_enable_lc_threads.yaml
-        timeout: 300
 
   - test:
       name: Test ACL Operations
@@ -253,7 +255,6 @@ tests:
         test-version: v2
         script-name: test_acl_ops.py
         config-file-name: test_acl_ops.yaml
-        timeout: 300
 
   - test:
       name: Test single delete marker for versioned object using LC
@@ -263,7 +264,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Test no crash during deleting bucket with aborted multipart upload
@@ -273,7 +273,6 @@ tests:
       config:
         script-name: test_LargeObjGet_GC.py
         config-file-name: test_bucket_remove_with_multipart_abort.yaml
-        timeout: 500
 
   - test:
       name: Test functionality of bucket check fix
@@ -283,7 +282,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bucket_check_fix.yaml
-        timeout: 500
 
   # - test:
   #     name: Test functionality of user stat reset
@@ -294,7 +292,6 @@ tests:
   #     config:
   #       script-name: test_Mbuckets_with_Nobjects.py
   #       config-file-name: test_user_stats_reset.yaml
-  #       timeout: 500
 
   - test:
       name: Test NFS cluster and export create
@@ -305,7 +302,6 @@ tests:
         run-on-rgw: true
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
-        timeout: 300
 
   - test:
       abort-on-fail: true

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -141,7 +141,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_zlib_type
@@ -151,7 +150,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_zstd_type
@@ -161,7 +159,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-        timeout: 300
 
   - test:
       name: compresstion_with_snappy_type
@@ -171,7 +168,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-        timeout: 300
 
   - test:
       name: Mbuckets_with_Nobjects with sharing enabled
@@ -181,7 +177,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-        timeout: 300
 
   # REST API test
   - test:
@@ -192,7 +187,6 @@ tests:
       config:
         script-name: user_op_using_rest.py
         config-file-name: test_user_with_REST.yaml
-        timeout: 300
 
   # Swift basic operation
 
@@ -204,7 +198,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_modify_tenanted_subuser.yaml
-        timeout: 300
 
   - test:
        name: Swift bulk delete operation
@@ -214,7 +207,6 @@ tests:
        config:
            script-name: test_swift_bulk_delete.py
            config-file-name: test_swift_bulk_delete.yaml
-           timeout: 300
 
   - test:
       name: swift upload large object tests
@@ -224,7 +216,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_upload.yaml
-        timeout: 300
 
   - test:
       name: swift download large object tests
@@ -234,7 +225,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_large_download.yaml
-        timeout: 300
 
   - test:
       name: Get object with different tenant swift user with same name
@@ -244,7 +234,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_get_objects_from_tenant_swift_user.yaml
-        timeout: 300
 
   - test:
       name: delete container with different tenant swift user with same name
@@ -254,7 +243,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_delete_container_from_user_of_diff_tenant.yaml
-        timeout: 300
 
   - test:
       name: upload large object with same name using tenant swift user
@@ -264,7 +252,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_upload_large_obj_with_same_obj_name.yaml
-        timeout: 300
 
   # Versioning Tests
 
@@ -276,7 +263,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_enable.yaml
-        timeout: 300
 
   - test:
       name: Test versioning of objects copy
@@ -286,7 +272,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_copy.yaml
-        timeout: 300
 
   - test:
       name: Test suspension of object versioning
@@ -296,7 +281,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test deletion of object versions
@@ -306,7 +290,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_delete.yaml
-        timeout: 300
 
   - test:
       name: Test suspension of versioning
@@ -316,7 +299,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_suspend.yaml
-        timeout: 300
 
   - test:
       name: Test overwrite by another user of versioned objects
@@ -326,7 +308,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: GET object acl info operations on different object versions
@@ -336,7 +317,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_acls.yaml
-        timeout: 300
 
   - test:
       name: Deletes on an object in versioning enabled or suspended container by a new user
@@ -346,7 +326,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_delete_from_another_user.yaml
-        timeout: 300
 
   - test:
       name: Versioning with copy objects
@@ -356,7 +335,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_versioning_copy_objects.yaml
-        timeout: 300
 
   # BucketPolicy Tests
   - test:
@@ -367,7 +345,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_replace.yaml
-        timeout: 300
 
   - test:
       name: Delete bucket policy
@@ -377,7 +354,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_delete.yaml
-        timeout: 300
 
   - test:
       name: Modify existing bucket policy to add a new policy in addition existing policy
@@ -387,7 +363,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_modify.yaml
-        timeout: 300
 
   - test:
       name: ListBucketVersions with bucket policy for users in same tenant
@@ -397,7 +372,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
-        timeout: 300
 
   - test:
       name: GetBucketLocation with bucket policy for users in same tenant
@@ -407,7 +381,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml
-        timeout: 300
 
   - test:
       name: test bucket policy with multiple statements
@@ -417,7 +390,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with conflicting statements
@@ -427,7 +399,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_conflicting_statements.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with condition blocks
@@ -437,7 +408,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy condition block with explicit deny
@@ -447,7 +417,15 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
-        timeout: 500
+
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
 
   # Bucket Lifecycle Tests
 
@@ -459,7 +437,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-        timeout: 300
 
   - test:
       name: object expiration with expiration set to Date
@@ -469,7 +446,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_date.yaml
-        timeout: 300
 
   - test:
       name: object expiration for delete marker set
@@ -479,7 +455,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_delete_marker.yaml
-        timeout: 300
 
   - test:
       name: Read lifecycle configuration on a given bucket
@@ -489,7 +464,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_read.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing multiple object versions
@@ -499,7 +473,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_versioning.yaml
-        timeout: 300
 
   - test:
       name: Disable lifecycle configuration on a given bucket
@@ -509,7 +482,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_disable.yaml
-        timeout: 300
 
   - test:
       name: Modify lifecycle configuration on a given bucket
@@ -519,7 +491,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lifecycle_config_modify.yaml
-        timeout: 300
 
   # Multi Tenant Tests
 
@@ -531,7 +502,6 @@ tests:
       config:
         script-name: test_multitenant_user_access.py
         config-file-name: test_multitenant_access.yaml
-        timeout: 300
 
   - test:
       name: Generate secret for tenant user
@@ -541,7 +511,6 @@ tests:
       config:
         script-name: test_tenant_user_secret_key.py
         config-file-name: test_tenantuser_secretkey_gen.yaml
-        timeout: 300
 
   # Bucket Listing Tests
   - test:
@@ -552,7 +521,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
-        timeout: 300
 
   - test:
       name: ordered listing of versionsed bucket with top level objects
@@ -562,7 +530,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-        timeout: 300
 
   - test:
       name: unordered listing of bucket with top level objects
@@ -572,7 +539,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_unordered.yaml
-        timeout: 300
 
   - test:
       name: ordered listing of bucket with pseudo directories and objects
@@ -582,7 +548,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_pseudo_ordered.yaml
-        timeout: 300
 
   - test:
       name: ordered listing of bucket with pseudo directories only
@@ -592,7 +557,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-        timeout: 300
 
   - test:
       name: Bucket radoslist
@@ -602,7 +566,6 @@ tests:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_radoslist.yaml
-        timeout: 300
 
   # Bucket Request Payer tests
 
@@ -614,7 +577,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer.yaml
-        timeout: 300
 
   - test:
       name: bucket request payer with object download
@@ -624,7 +586,6 @@ tests:
       config:
         script-name: test_bucket_request_payer.py
         config-file-name: test_bucket_request_payer_download.yaml
-        timeout: 300
 
   #resharding tests
   - test:
@@ -635,7 +596,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding.yaml
-        timeout: 500
 
   # AWS4 Auth tests
   - test:
@@ -646,7 +606,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-        timeout: 300
 
   # v1 tests
   # ACLs tests
@@ -661,7 +620,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls.py
         config-file-name: test_acls.yaml
-        timeout: 300
 
   - test:
       name: test acls on all users
@@ -673,7 +631,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_all_usrs.py
         config-file-name: test_acls_all_usrs.yaml
-        timeout: 300
 
   - test:
       name: test acls with copy objects on different users
@@ -685,7 +642,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_copy_obj.py
         config-file-name: test_acls_copy_obj.yaml
-        timeout: 300
 
   - test:
       name: acls reset
@@ -697,7 +653,6 @@ tests:
         run-on-rgw: true
         script-name: test_acls_reset.py
         config-file-name: test_acls_reset.yaml
-        timeout: 300
 
   # multipart test
 
@@ -711,7 +666,6 @@ tests:
         run-on-rgw: true
         script-name: test_multipart_upload_cancel.py
         config-file-name: test_multipart_upload_cancel.yaml
-        timeout: 300
 
   # User, Bucket rename, Bucket link and unlink
 
@@ -723,7 +677,6 @@ tests:
       config:
         script-name: test_user_bucket_rename.py
         config-file-name: test_user_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket rename
@@ -734,7 +687,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_rename.yaml
-        timeout: 500
 
   - test:
       name: Bucket link and unlink
@@ -745,7 +697,6 @@ tests:
         test-version: v2
         script-name: test_user_bucket_rename.py
         config-file-name: test_bucket_link_unlink.yaml
-        timeout: 500
 
   # Multifactor Authentication tests
   - test:
@@ -760,7 +711,6 @@ tests:
         extra-pkgs:
           8:
             - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.2-3.el8.x86_64.rpm
-        timeout: 500
 
   - test:
       name: multipart versioned object deletion with mfa token
@@ -774,7 +724,6 @@ tests:
         extra-pkgs:
           8:
             - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.2-3.el8.x86_64.rpm
-        timeout: 500
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed
@@ -788,7 +737,6 @@ tests:
         extra-pkgs:
           8:
             - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.2-3.el8.x86_64.rpm
-        timeout: 500
 
   - test:
       abort-on-fail: true
@@ -826,7 +774,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-        timeout: 300
 
   # Index-less buckets
 
@@ -839,7 +786,6 @@ tests:
         test-version: v2
         script-name: test_indexless_buckets.py
         config-file-name: test_indexless_buckets_s3.yaml
-        timeout: 500
 
   - test:
       name: Versioning with copy objects and delete with differnt user
@@ -849,7 +795,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_delete_version_object_using_different_user.yaml
-        timeout: 300
 
   - test:
       name: Test deleting the current version of the object
@@ -859,7 +804,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_delete_current_version_object.yaml
-        timeout: 300
 
   - test:
       name: Test copy versioned objects to another versioned bucket
@@ -869,7 +813,6 @@ tests:
       config:
         script-name: test_versioning_copy_objects.py
         config-file-name: test_copy_version_object_to_version_bucket.yaml
-        timeout: 300
 
   - test:
       name: Test Write modify and read objects in the versioned bucket
@@ -879,7 +822,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_access_versioned_objects.yaml
-        timeout: 300
 
   - test:
       name: object lock verification
@@ -889,7 +831,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_governance.yaml
-        timeout: 500
 
   - test:
       name: object level retention test Compliance
@@ -899,7 +840,6 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_compliance.yaml
-        timeout: 500
 
   - test:
       name: object level retention test Governance mode
@@ -909,7 +849,6 @@ tests:
       config:
         script-name: test_object_level_retention.py
         config-file-name: test_object_level_governance.yaml
-        timeout: 500
 
   - test:
       name: NFS export delete
@@ -919,7 +858,6 @@ tests:
       config:
         script-name: ../nfs_ganesha/nfs_cluster.py
         config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
-        timeout: 500
 
   - test:
       name: Test user modify with placement id
@@ -930,7 +868,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
-        timeout: 500
 
   - test:
       name: Bucket Lifecycle expiration of incomplete multipart
@@ -940,7 +877,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_incomplete_multipart.yaml
-        timeout: 300
 
   - test:
       name: Swift user with read access
@@ -950,7 +886,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_read.yaml
-        timeout: 300
 
   - test:
       name: Swift user with write access
@@ -960,7 +895,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_write.yaml
-        timeout: 300
 
   - test:
       name: Swift user with readwrite access
@@ -970,7 +904,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_user_access_readwrite.yaml
-        timeout: 300
 
   - test:
       name: Test LC with custom worktime
@@ -980,7 +913,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_custom_worktime.yaml
-        timeout: 300
 
   - test:
       name: Test Etag not empty for complete multipart upload in aws
@@ -990,7 +922,6 @@ tests:
       config:
         script-name: ../aws/test_aws.py
         config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
-        timeout: 500
 
   # - test:
   #     name: Test LC transition with rule by lc process
@@ -1001,7 +932,6 @@ tests:
   #     config:
   #       script-name: test_bucket_lifecycle_object_expiration_transition.py
   #       config-file-name: test_lc_transition_with_lc_process.yaml
-  #       timeout: 500
 
   - test:
       name: Test LC transition without rule by lc process
@@ -1011,4 +941,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
-        timeout: 500

--- a/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
@@ -186,6 +186,24 @@ tests:
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
 
   - test:
+      name: STS aswi Tests to veify role policy allow actions
+      desc: STS aswi Tests to veify role policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_allow_actions.yaml
+
+  - test:
+      name: STS aswi Tests to veify role policy deny actions
+      desc: STS aswi Tests to veify role policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
+
+  - test:
       abort-on-fail: true
       config:
         roles:

--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -129,6 +129,22 @@ tests:
         script-name: test_sts_using_boto_session_policy.py
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
   - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
+  - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
       polarion-id: CEPH-83574522

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -345,6 +345,15 @@ tests:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
 
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.

--- a/suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -172,27 +172,6 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Verify quiesce ops in parallel to multi-MDS failover"
-      destroy-cluster: false
-      module: snapshot_clone.cg_snap_test.py
-      name: "cg_snap_interop_workflow_1"
-      polarion-id: CEPH-83581472
-      config:
-       test_name: cg_snap_interop_workflow_1
-      comments: product bug bz-2273569
-  -
-    test:
-      abort-on-fail: false
-      desc: "Enable ceph debug logs"
-      module: cephfs_logs_util.py
-      name: cephfs-enable-logs
-      config:
-       ENABLE_LOGS : 1
-       daemon_list : ['mds','osd','mgr','client']
-       daemon_dbg_level : {'mds':10,'osd':5,'mgr':5,'client':10}
-  -
-    test:
-      abort-on-fail: false
       desc: "Verify parallel quiesce calls to same quiesce set members"
       destroy-cluster: false
       module: snapshot_clone.cg_snap_test.py
@@ -223,9 +202,11 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Disable ceph debug logs"
-      module: cephfs_logs_util.py
-      name: cephfs-disable-logs
+      desc: "Verify quiesce ops in parallel to multi-MDS failover"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_interop_workflow_1"
+      polarion-id: CEPH-83581472
       config:
-       DISABLE_LOGS : 1
-       daemon_list : ['mds','osd','mgr','client']
+       test_name: cg_snap_interop_workflow_1
+      comments: product bug bz-2273569

--- a/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
@@ -123,6 +123,14 @@ tests:
               size: 10G
             listener_port: 5001
             allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5002
+            hosts:
+              - node10
         initiators:                             # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001

--- a/suites/reef/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/reef/rados/tier-2_rados_test_parameters.yaml
@@ -16,14 +16,20 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
-      abort-on-fail: true
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
       config:
         verify_cluster_health: true
         steps:
           - config:
               command: bootstrap
               service: cephadm
+              base_cmd_args:
+                verbose: true
               args:
                 mon-ip: node1
           - config:
@@ -32,23 +38,29 @@ tests:
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
-              service: osd
-              args:
-                all-available-devices: true
-          - config:
-              command: apply
-              service: rgw
-              pos_args:
-                - rgw.1
+              service: mgr
               args:
                 placement:
-                  label: rgw
-      desc: RHCS cluster deployment using cephadm.
-      destroy-cluster: false
-      module: test_cephadm.py
-      name: deploy cluster
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
 
   - test:
       name: Configure client admin
@@ -62,11 +74,95 @@ tests:
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node
-        caps: # authorize client capabilities
+        caps:                             # authorize client capabilities
           mon: "allow *"
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size before OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        pre_deployment_config_changes: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size After OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        post_deployment_config_verification: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
   - test:
       name: Ceph MSGRV2 paramter check in 7.x
       desc: MSGRV2 parameter check in 7.x
@@ -75,6 +171,7 @@ tests:
       config:
         scenario: msgrv2_6x
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock sleep parameter check
       desc: Mclock sleep parameter check
@@ -83,6 +180,7 @@ tests:
       config:
         scenario: mclock_sleep
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock default,reservation,limit and weight parameter check
       desc: Mclock default,reservation,limit and weight parameter check
@@ -91,6 +189,7 @@ tests:
       config:
         scenario: mclock_chg_chk
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Check RocksDB compression default value
       desc: Check that RocksDB compression value is kLZ4Compression

--- a/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
@@ -403,17 +403,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
 
   - test:
-      name: Granular multisite sync policy group transition
-      desc: Test multisite sync policy group transition
-      polarion-id: CEPH-83575133
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_sync_policy.py
-            config-file-name: test_sync_policy_state_change.yaml
-
-  - test:
       clusters:
         ceph-pri:
           config:
@@ -448,3 +437,14 @@ tests:
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade
       polarion-id: CEPH-83574735
+
+  - test:
+      name: Granular multisite sync policy group transition
+      desc: Test multisite sync policy group transition
+      polarion-id: CEPH-83575133
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_sync_policy.py
+            config-file-name: test_sync_policy_state_change.yaml

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -315,6 +315,15 @@ tests:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
 
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.

--- a/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/reef/rgw/tier-2_rgw_sts_aswi.yaml
@@ -186,6 +186,24 @@ tests:
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
 
   - test:
+      name: STS aswi Tests to veify role policy allow actions
+      desc: STS aswi Tests to veify role policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_allow_actions.yaml
+
+  - test:
+      name: STS aswi Tests to veify role policy deny actions
+      desc: STS aswi Tests to veify role policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
+
+  - test:
       abort-on-fail: true
       config:
         roles:

--- a/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -133,6 +133,44 @@ tests:
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
 
   - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
+
+#  - test:
+#      name: STS test to verify session policy allow put object and deny abort_multipart_upload
+#      desc: STS test to verify session policy allow put object and deny abort_multipart_upload
+#      polarion-id: CEPH-83593390
+#      comments: Known issue BZ-2302541 targeted to 8.1
+#      module: sanity_rgw.py
+#      config:
+#        script-name: test_sts_using_boto_session_policy.py
+#        config-file-name: test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
+#
+#  - test:
+#      name: STS test to verify session policy deny sns topic actions
+#      desc: STS test to verify session policy deny sns topic actions
+#      polarion-id: CEPH-83593390
+#      comments: Known issue BZ-2293233 targeted to 8.1
+#      module: sanity_rgw.py
+#      config:
+#        script-name: test_sts_using_boto_session_policy.py
+#        config-file-name: test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+
+  - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
       polarion-id: CEPH-83574522

--- a/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -172,27 +172,6 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Verify quiesce ops in parallel to multi-MDS failover"
-      destroy-cluster: false
-      module: snapshot_clone.cg_snap_test.py
-      name: "cg_snap_interop_workflow_1"
-      polarion-id: CEPH-83581472
-      config:
-       test_name: cg_snap_interop_workflow_1
-      comments: product bug bz-2273569
-  -
-    test:
-      abort-on-fail: false
-      desc: "Enable ceph debug logs"
-      module: cephfs_logs_util.py
-      name: cephfs-enable-logs
-      config:
-       ENABLE_LOGS : 1
-       daemon_list : ['mds','osd','mgr','client']
-       daemon_dbg_level : {'mds':10,'osd':5,'mgr':5,'client':10}
-  -
-    test:
-      abort-on-fail: false
       desc: "Verify parallel quiesce calls to same quiesce set members"
       destroy-cluster: false
       module: snapshot_clone.cg_snap_test.py
@@ -223,9 +202,11 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Disable ceph debug logs"
-      module: cephfs_logs_util.py
-      name: cephfs-disable-logs
+      desc: "Verify quiesce ops in parallel to multi-MDS failover"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_interop_workflow_1"
+      polarion-id: CEPH-83581472
       config:
-       DISABLE_LOGS : 1
-       daemon_list : ['mds','osd','mgr','client']
+       test_name: cg_snap_interop_workflow_1
+      comments: product bug bz-2273569

--- a/suites/squid/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/squid/rados/tier-2_rados_test_parameters.yaml
@@ -5,7 +5,7 @@
 #--------------------------------------------------------------------------------
 # Test Steps:
 #--------------------------------------------------------------------------------
-# - Deploy RHCS 7 cluster in RHEL 9
+# - Deploy RHCS 8 cluster in RHEL 9
 # - Check the MSGRV2 parameters
 # - Check the MSGRV2 paramters and Mclock parameters
 #--------------------------------------------------------------------------------
@@ -16,14 +16,20 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
-      abort-on-fail: true
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
       config:
         verify_cluster_health: true
         steps:
           - config:
               command: bootstrap
               service: cephadm
+              base_cmd_args:
+                verbose: true
               args:
                 mon-ip: node1
           - config:
@@ -32,23 +38,29 @@ tests:
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
-              service: osd
-              args:
-                all-available-devices: true
-          - config:
-              command: apply
-              service: rgw
-              pos_args:
-                - rgw.1
+              service: mgr
               args:
                 placement:
-                  label: rgw
-      desc: RHCS cluster deployment using cephadm.
-      destroy-cluster: false
-      module: test_cephadm.py
-      name: deploy cluster
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
 
   - test:
       name: Configure client admin
@@ -62,19 +74,104 @@ tests:
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node
-        caps: # authorize client capabilities
+        caps:                             # authorize client capabilities
           mon: "allow *"
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
   - test:
-      name: Ceph MSGRV2 paramter check in 7.x
-      desc: MSGRV2 parameter check in 7.x
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size before OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        pre_deployment_config_changes: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size After OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        post_deployment_config_verification: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: Ceph MSGRV2 paramter check in 8.x
+      desc: MSGRV2 parameter check in 8.x
       polarion-id: CEPH-83574890
       module: test_config_parameter_chk.py
       config:
         scenario: msgrv2_6x
         ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock sleep parameter check
       desc: Mclock sleep parameter check
@@ -83,6 +180,7 @@ tests:
       config:
         scenario: mclock_sleep
         ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock default,reservation,limit and weight parameter check
       desc: Mclock default,reservation,limit and weight parameter check
@@ -91,6 +189,7 @@ tests:
       config:
         scenario: mclock_chg_chk
         ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Check RocksDB compression default value
       desc: Check that RocksDB compression value is kLZ4Compression

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -306,6 +306,15 @@ tests:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml
 
+  - test:
+      name: test bucket policy deny actions
+      desc: test bucket policy deny actions
+      polarion-id: CEPH-11216
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_bucket_policy_deny_actions.yaml
+
   # Bucket Lifecycle Tests
   - test:
       name: object expiration for versioned buckets with filter Prefix test multiple rules.

--- a/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
@@ -186,6 +186,24 @@ tests:
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
 
   - test:
+      name: STS aswi Tests to veify role policy allow actions
+      desc: STS aswi Tests to veify role policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_allow_actions.yaml
+
+  - test:
+      name: STS aswi Tests to veify role policy deny actions
+      desc: STS aswi Tests to veify role policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_aswi.py
+        config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
+
+  - test:
       abort-on-fail: true
       config:
         roles:

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -133,6 +133,44 @@ tests:
         config-file-name: test_sts_using_boto_restricted_session_policy.yaml
 
   - test:
+      name: STS test to verify session policy allow actions
+      desc: STS test to verify session policy allow actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_actions.yaml
+
+  - test:
+      name: STS test to verify session policy deny actions
+      desc: STS test to verify session policy deny actions
+      polarion-id: CEPH-83593390
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_actions.yaml
+
+  - test:
+      name: STS test to verify session policy allow put object and deny abort_multipart_upload
+      desc: STS test to verify session policy allow put object and deny abort_multipart_upload
+      polarion-id: CEPH-83593390
+      comments: Known issue BZ-2302541 targeted to 8.1
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_allow_put_object_and_deny_abort_multipart.yaml
+
+  - test:
+      name: STS test to verify session policy deny sns topic actions
+      desc: STS test to verify session policy deny sns topic actions
+      polarion-id: CEPH-83593390
+      comments: Known issue BZ-2293233 targeted to 8.1
+      module: sanity_rgw.py
+      config:
+        script-name: test_sts_using_boto_session_policy.py
+        config-file-name: test_sts_using_boto_verify_session_policy_deny_sns_topic_actions.yaml
+
+  - test:
       name: STS Tests to perform Server Side Copy
       desc: Perform Server Side Copy
       polarion-id: CEPH-83574522

--- a/suites/squid/smb/tier-0-smb.yaml
+++ b/suites/squid/smb/tier-0-smb.yaml
@@ -80,7 +80,7 @@ tests:
       name: Deploy samba with auth_mode 'user' using imperative style(CLI Commands)
       desc: Deploy samba with auth_mode 'user' using imperative style(CLI Commands)
       module: smb_deployment_imperative_method
-      polarion-id:
+      polarion-id: CEPH-83593843
       config:
         cephfs_volume: cephfs
         smb_subvolume_group: smb
@@ -97,7 +97,7 @@ tests:
       name: Deploy samba with auth_mode 'AD' using imperative style(CLI Commands)
       desc: Deploy samba with auth_mode 'Active Directory(AD)' using imperative style(CLI Commands)
       module: smb_deployment_imperative_method
-      polarion-id:
+      polarion-id: CEPH-83593844
       config:
         cephfs_volume: cephfs
         smb_subvolume_group: smb
@@ -116,7 +116,7 @@ tests:
       name: Deploy samba with auth_mode 'user' using declarative style(Spec File)
       desc: Deploy samba with auth_mode 'user' using declarative style(Spec File)
       module: smb_deployment_declarative_method.py
-      polarion-id:
+      polarion-id: CEPH-83593845
       config:
         file_type: yaml
         file_mount: /tmp
@@ -155,7 +155,7 @@ tests:
       name: Deploy samba with auth_mode 'AD' using declarative style(Spec File)
       desc: Deploy samba with auth_mode 'Active Directory(AD)' using declarative style(Spec File)
       module: smb_deployment_declarative_method.py
-      polarion-id:
+      polarion-id: CEPH-83593846
       config:
         file_type: yaml
         file_mount: /tmp

--- a/suites/squid/smb/tier-1-smb-500-shares-declarative.yaml
+++ b/suites/squid/smb/tier-1-smb-500-shares-declarative.yaml
@@ -80,7 +80,7 @@ tests:
       name: Deploy samba with 500 shares using declarative style(Spec File)
       desc: Deploy samba with 500 shares using auth_mode 'user'
       module: smb_deployment_multi_shares_declarative_method.py
-      polarion-id:
+      polarion-id: CEPH-83593846
       config:
         file_type: yaml
         file_mount: /tmp

--- a/suites/squid/smb/tier-1-smb-500-shares.yaml
+++ b/suites/squid/smb/tier-1-smb-500-shares.yaml
@@ -80,7 +80,7 @@ tests:
       name: Deploy samba with 500 shares
       desc: Deploy samba with 500 shares using auth_mode 'user'
       module: smb_deployment_500_shares.py
-      polarion-id:
+      polarion-id: CEPH-83593847
       config:
         cephfs_volume: cephfs
         smb_subvolume_group: smb

--- a/suites/squid/smb/tier-1-smb-ad-dc.yaml
+++ b/suites/squid/smb/tier-1-smb-ad-dc.yaml
@@ -86,7 +86,7 @@ tests:
       name: Deploy Active Directory and join domain to perform AD basic operations
       desc: Deploy samba with auth_mode 'Active Directory(AD)' and perform basic AD operations
       module: smb_ad_dc.py
-      polarion-id:
+      polarion-id: CEPH-83594037
       config:
         cephfs_volume: cephfs
         smb_subvolume_group: smb

--- a/suites/squid/smb/tier-2-smb-load.yaml
+++ b/suites/squid/smb/tier-2-smb-load.yaml
@@ -86,7 +86,7 @@ tests:
       name: Ceph samba load test
       desc: Setup Ceph cluster with SMB, run load test and check process id
       module: smb_multi_connection.py
-      polarion-id:
+      polarion-id: CEPH-83593850
       config:
         cephfs_volume: cephfs
         smb_subvolume_group: smb

--- a/suites/squid/smb/tier-2-smb-multi-connections.yaml
+++ b/suites/squid/smb/tier-2-smb-multi-connections.yaml
@@ -80,7 +80,7 @@ tests:
       name: samba with client multi-connections
       desc: Load Testing - samba with client multi-connections
       module: smb_multi_connection.py
-      polarion-id:
+      polarion-id: CEPH-83593849
       config:
         cephfs_volume: cephfs
         smb_subvolume_group: smb

--- a/tests/cephfs/snapshot_clone/cephfs_cg_io.py
+++ b/tests/cephfs/snapshot_clone/cephfs_cg_io.py
@@ -572,7 +572,16 @@ class CG_snap_IO(object):
                                 f"time_before_state:{time_before_state},end_time:{end_time}"
                             )
                             log.info(f"age_ref:{age_ref},curr_time:{curr_time}")
-                            if float(time_before_state) > float(end_time):
+                            osd_unhealthy = 0
+                            ceph_health, _ = client.exec_command("ceph health detail")
+                            log.info(ceph_health)
+                            if "Slow OSD" in ceph_health:
+                                osd_unhealthy = 1
+                            if osd_unhealthy == 1:
+                                log.info(
+                                    f"Ceph had {ceph_health} when {io_mod} {io_type} failed in {state}.Ignoring.."
+                                )
+                            elif float(time_before_state) > float(end_time):
                                 log.info(
                                     f"WARN: {io_mod} {io_type} fails in QS state {state} on {qs_member}"
                                 )

--- a/tests/cephfs/snapshot_clone/cg_snap_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_test.py
@@ -127,9 +127,7 @@ def run(ceph_cluster, **kw):
         fs_util_v1.prepare_clients(qs_clients, build)
         default_fs = config.get("fs_name", "cephfs")
         qs_cnt_def = random.randrange(5, 11)
-        # qs_cnt_def = 2
         qs_cnt = config.get("qs_cnt", qs_cnt_def)
-        restore_mds = 0
         nfs_exists = 0
         fs_util_v1.auth_list(qs_clients)
 
@@ -284,8 +282,6 @@ def run(ceph_cluster, **kw):
             test_status = cg_snap_test_func(cg_test_params)
 
             if test_status == 1:
-                if test_name == "cg_snap_interop_workflow_1":
-                    restore_mds = 1
                 assert False, f"Test {test_name} failed"
             else:
                 log.info(f"Test {test_name} passed \n")
@@ -325,19 +321,7 @@ def run(ceph_cluster, **kw):
             log.error("Failed to set fragmentation size to default")
 
         log.info(f"FS fragmentation size:{new_frag_size}")
-        if restore_mds == 1:
-            mds_cnt = len(mds_nodes)
-            cmd = f'ceph orch apply mds {default_fs} --placement="{mds_cnt}'
 
-            for mds_node in mds_nodes:
-                cmd += f" {mds_node.node.hostname}"
-            cmd += '"'
-            log.info("Restoring MDS config")
-            out, rc = client1.exec_command(sudo=True, cmd=cmd)
-            client1.exec_command(
-                sudo=True,
-                cmd=f"ceph fs set {default_fs} max_mds 2",
-            )
         if nfs_exists == 1:
             client1.exec_command(
                 sudo=True,
@@ -2216,17 +2200,13 @@ def cg_snap_interop_1(cg_test_params):
         mnt_pt_list.append(qs_member_dict1[qs_member]["mount_point"])
     cg_snap_util.cleanup_cg_io(client, mnt_pt_list, del_data=0)
     mnt_pt_list.clear()
-    cmd = f'ceph orch apply mds {fs_name} --placement="{len(mds_nodes)}'
-
-    for mds_nodes_iter in mds_nodes:
-        cmd += f" {mds_nodes_iter.node.hostname}"
-    cmd += '"'
-    log.info(f"Restoring MDS config - {mds_cnt} MDS, Active - {max_mds_val}")
-    out, rc = client.exec_command(sudo=True, cmd=cmd)
     client.exec_command(
         sudo=True,
-        cmd=f"ceph fs set {fs_name} max_mds {max_mds_val}",
+        cmd=f"ceph fs set {fs_name} max_mds 2",
     )
+    if wait_for_healthy_ceph(client1, fs_util, 300) == 0:
+        log.error("Ceph cluster is not healthy after max_mds set to 2")
+        test_fail += 1
     if cg_test_io_status.value == 1:
         log.error(
             f"CG IO test exits with failure during quiesce test on qs_set-{qs_id_val}"

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -20,20 +20,30 @@ from utility.utils import generate_unique_id, run_fio
 LOG = Log(__name__)
 
 
-def configure_subsystems(rbd, pool, nvmegwcli, config):
+def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
     """Configure Ceph-NVMEoF Subsystems."""
     sub_args = {"subsystem": config["nqn"]}
     nvmegwcli.subsystem.add(
         **{"args": {**sub_args, **{"max-namespaces": config.get("max_ns", 32)}}}
     )
-
     listener_cfg = {
         "host-name": nvmegwcli.fetch_gateway_hostname(),
         "traddr": nvmegwcli.node.ip_address,
         "trsvcid": config["listener_port"],
     }
     nvmegwcli.listener.add(**{"args": {**listener_cfg, **sub_args}})
-    nvmegwcli.host.add(**{"args": {**sub_args, **{"host": repr(config["allow_host"])}}})
+    if config.get("allow_host"):
+        nvmegwcli.host.add(
+            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
+        )
+
+    if config.get("hosts"):
+        for host in config["hosts"]:
+            initiator_node = get_node_by_id(ceph_cluster, host)
+            initiator = Initiator(initiator_node)
+            host_nqn = initiator.nqn()
+            nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
+
     if config.get("bdevs"):
         name = generate_unique_id(length=4)
         with parallel() as p:
@@ -292,7 +302,12 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             with parallel() as p:
                 for subsys_args in config["subsystems"]:
                     p.spawn(
-                        configure_subsystems, rbd_obj, rbd_pool, nvmegwcli, subsys_args
+                        configure_subsystems,
+                        ceph_cluster,
+                        rbd_obj,
+                        rbd_pool,
+                        nvmegwcli,
+                        subsys_args,
                     )
 
         if config.get("initiators"):

--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -1,0 +1,256 @@
+"""
+Module to test bluestore_min_alloc_size functionality on RHCS 7.0 and above clusters
+
+"""
+
+import re
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados import utils
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.log import Log
+from utility.utils import method_should_succeed, should_not_be_empty
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Module to test bluestore_min_alloc_size functionality on RHCS 7.0 and above clusters
+    Bugzilla automated : 2264726
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    custom_min_alloc_size = config.get("custom_min_alloc_size", 8192)
+    default_min_alloc_size = config.get("default_min_alloc_size", 4096)
+
+    regex = r"\s*(\d.\d)-rhel-\d"
+    build = (re.search(regex, config.get("build", config.get("rhbuild")))).groups()[0]
+    if not float(build) >= 7.0:
+        log.info(
+            "Test running on version less than 7.0, skipping verifying Reads Balancer functionality"
+        )
+        return 0
+
+    try:
+        if config.get("pre_deployment_config_changes"):
+            log.info(
+                "Updating the configs on the cluster before OSD deployment on the cluster"
+            )
+            min_alloc_size_hdd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+            )
+
+            min_alloc_size_ssd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_ssd")
+            )
+
+            if not min_alloc_size_hdd == min_alloc_size_ssd == 4096:
+                log.error(
+                    f"min_alloc_size does not match the expected default value of 4096"
+                    f"min_alloc_size_ssd on cluster: {min_alloc_size_ssd}"
+                    f"min_alloc_size_hdd on cluster: {min_alloc_size_hdd}"
+                )
+                raise Exception("non-default values for min_alloc_size on cluster")
+
+            log.info(
+                "Verified the default value of min_alloc_size. Modifying the value before OSD deployments"
+            )
+
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_hdd",
+                value=custom_min_alloc_size,
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_ssd",
+                value=custom_min_alloc_size,
+            )
+            time.sleep(10)
+
+            min_alloc_size_hdd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+            )
+
+            min_alloc_size_ssd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_ssd")
+            )
+            if not min_alloc_size_hdd == min_alloc_size_ssd == custom_min_alloc_size:
+                log.error(
+                    f"min_alloc_size does not match the expected custom value of {custom_min_alloc_size}"
+                    f"min_alloc_size_ssd on cluster: {min_alloc_size_ssd}"
+                    f"min_alloc_size_hdd on cluster: {min_alloc_size_hdd}"
+                )
+                raise Exception("Value not updated for min_alloc_size on cluster")
+
+            log.info("Successfully modified the value of min_alloc_size")
+            return 0
+
+        if config.get("post_deployment_config_verification"):
+            min_alloc_size_hdd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+            )
+
+            min_alloc_size_ssd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_ssd")
+            )
+
+            # Getting random OSDs and checking their alloc size
+            pg_set = rados_obj.get_pg_acting_set()
+            for osd_id in pg_set:
+                osd_meta = rados_obj.get_daemon_metadata(
+                    daemon_type="osd", daemon_id=osd_id
+                )
+
+                if (
+                    not min_alloc_size_hdd
+                    == min_alloc_size_ssd
+                    == custom_min_alloc_size
+                    == int(osd_meta["bluestore_min_alloc_size"])
+                ):
+                    log.error(
+                        f"min_alloc_size does not match the expected updated value of {custom_min_alloc_size}\n"
+                        f"min_alloc_size_ssd on cluster: {min_alloc_size_ssd}\n"
+                        f"min_alloc_size_hdd on cluster: {min_alloc_size_hdd}\n"
+                        f"min_alloc_size on osd {osd_id} metadata: {osd_meta['bluestore_min_alloc_size']}\n"
+                    )
+                    raise Exception(
+                        "default values for min_alloc_size on cluster post changing"
+                    )
+
+                log.info(
+                    f"OSDs successfully deployed with the new alloc size, and verified the size on OSD: {osd_id}"
+                )
+
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_hdd",
+                value=default_min_alloc_size,
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_ssd",
+                value=default_min_alloc_size,
+            )
+            time.sleep(10)
+
+            def remove_osd_check_metadata(target_osd, alloc_size):
+                log.debug(
+                    f"Ceph osd tree before OSD removal : \n\n {rados_obj.run_ceph_command(cmd='ceph osd tree')} \n\n"
+                )
+                test_host = rados_obj.fetch_host_node(
+                    daemon_type="osd", daemon_id=target_osd
+                )
+                should_not_be_empty(test_host, "Failed to fetch host details")
+                dev_path = get_device_path(test_host, target_osd)
+                log.debug(
+                    f"osd device path  : {dev_path}, osd_id : {target_osd}, hostname : {test_host.hostname}"
+                )
+                utils.set_osd_devices_unmanaged(
+                    ceph_cluster, target_osd, unmanaged=True
+                )
+                method_should_succeed(utils.set_osd_out, ceph_cluster, target_osd)
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
+                log.debug("Cluster clean post draining of OSD for removal")
+                utils.osd_remove(ceph_cluster, target_osd)
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
+                method_should_succeed(
+                    utils.zap_device, ceph_cluster, test_host.hostname, dev_path
+                )
+                method_should_succeed(
+                    wait_for_device_rados, test_host, target_osd, action="remove"
+                )
+                # Waiting for recovery to post OSD host removal
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
+
+                # Adding the removed OSD back and checking the cluster status
+                log.debug("Adding the removed OSD back and checking the cluster status")
+                utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
+                method_should_succeed(
+                    wait_for_device_rados, test_host, target_osd, action="add"
+                )
+                time.sleep(30)
+                log.debug(
+                    "Completed addition of OSD post removal. Checking bluestore_min_alloc_size value post OSD addition"
+                )
+                osd_meta = rados_obj.get_daemon_metadata(
+                    daemon_type="osd", daemon_id=target_osd
+                )
+                if int(osd_meta["bluestore_min_alloc_size"]) != alloc_size:
+                    log.error(
+                        f"bluestore_min_alloc_size not set to {alloc_size} "
+                        f"after updating the config and OSD : {target_osd} redeployment"
+                        f"OSD Metadata : {osd_meta}"
+                    )
+                    return False
+
+                log.info(
+                    "bluestore_min_alloc_size correctly displayed "
+                    "in OSD metadata post modification and redeployment"
+                )
+                return True
+
+            rm_osd = pg_set[0]
+            log.debug(f"Selected OSD for removal : {rm_osd}")
+            try:
+                if not remove_osd_check_metadata(
+                    target_osd=rm_osd, alloc_size=default_min_alloc_size
+                ):
+                    log.error(
+                        f"OSD : {rm_osd} could not be redeployed with alloc size {default_min_alloc_size}"
+                    )
+                    return 1
+                log.info(
+                    f"OSD : {rm_osd} successfully redeployed with alloc size {default_min_alloc_size}"
+                )
+            except Exception as err:
+                log.error(f"Hit Exception during OSD redeployment : {err}")
+                return 1
+            log.info(
+                f"Redeploying OSD : {rm_osd} with alloc size {custom_min_alloc_size}, So that the cluster alloc_size is"
+                f"Homogeneous among all OSDs"
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_hdd",
+                value=custom_min_alloc_size,
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_ssd",
+                value=custom_min_alloc_size,
+            )
+            try:
+                if not remove_osd_check_metadata(
+                    target_osd=rm_osd, alloc_size=custom_min_alloc_size
+                ):
+                    log.error(
+                        f"OSD : {rm_osd} could not be redeployed with alloc size {custom_min_alloc_size}"
+                    )
+                    return 1
+                log.info(
+                    f"OSD : {rm_osd} successfully redeployed with alloc size {custom_min_alloc_size}"
+                )
+            except Exception as err:
+                log.error(f"Hit Exception during OSD redeployment : {err}")
+                return 1
+            log.info("All tests completed. Pass")
+            return 0
+    except Exception as err:
+        log.error(f"Hit exception during execution. Error: {err} ")
+
+    finally:
+        rados_obj.rados_pool_cleanup()
+        time.sleep(60)
+        # log cluster health
+        rados_obj.log_cluster_health()

--- a/tests/rados/test_norecovery_flag_functionality.py
+++ b/tests/rados/test_norecovery_flag_functionality.py
@@ -38,69 +38,116 @@ def run(ceph_cluster, **kw):
     pool_name = replicated_config["pool_name"]
 
     try:
+
+        def check_pg_increase(pool_name):
+            """
+            Method to check if the PG count has reached desired counts
+            """
+            pg_num_final = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_final")
+            endtime = datetime.datetime.now() + datetime.timedelta(seconds=1800)
+            pg_increased = False
+            while datetime.datetime.now() < endtime:
+                current_pg_num = rados_obj.get_pool_property(
+                    pool=pool_name, props="pg_num"
+                )["pg_num"]
+                if pg_num_final != current_pg_num:
+                    log.debug(
+                        f"PG count on the pool not reached desired levels,"
+                        f"current count : {current_pg_num}, target count : {pg_num_final}"
+                        f" sleeping for 10 seconds and checking again"
+                    )
+                    time.sleep(10)
+                else:
+                    log.info("PG count on the pool has reached desired levels")
+                    pg_increased = True
+                    break
+            return pg_increased
+
         log.info(
             "Scenario1: Verify that the pg_num should not  increase after setting the norecover flag"
         )
         method_should_succeed(wait_for_clean_pg_sets, rados_obj)
         utils.configure_osd_flag(ceph_cluster, "set", "norecover")
+        time.sleep(10)
+
         log.info("Scenario1:The norecover is set on the cluster")
         if not rados_obj.create_pool(pool_name=pool_name, pg_num=8):
             log.error("Failed to create the  Pool")
             return 1
+
         log.info(f"Scenario1:The pool-{pool_name} is created")
-        old_pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        log.info(f"The current pg number is -{old_pg_num}")
+        old_pg_num = rados_obj.get_pool_property(pool=pool_name, props="pg_num")[
+            "pg_num"
+        ]
+
+        log.debug(f"The current pg number is -{old_pg_num}")
         rados_obj.log_cluster_health()
         rados_obj.bench_write(
             pool_name=pool_name, byte_size=1024, rados_write_duration=10
         )
         rados_obj.log_cluster_health()
-        status = check_status(pool_obj, old_pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if not status:
+        pg_num_final = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_final")
+        if not check_status(pool_obj, old_pg_num, pool_name):
             log.error(
-                f"Scenario1:The pg number is increased to after setting the norecover flag -{pg_num}"
+                f"Scenario1: The pg number is increased to after setting the norecover flag post pool creation with "
+                f"{old_pg_num} PGs"
             )
             return 1
         log.info(
-            f"Scenario1:The pg number is not increased after setting the norecover flag.The pg_num is - {pg_num}"
+            f"Scenario1:The pg number is not increased after setting the norecover flag post pool creation."
+            f"The pg_num is - {old_pg_num} on the pool. Target : {pg_num_final}"
+            f"Proceeding to unset the norecover flag on the cluster"
         )
+
         # unset the norecover flag
         utils.configure_osd_flag(ceph_cluster, "unset", "norecover")
-        log.info("Scenario1:The norecover is unset on the cluster")
-        status = check_status(pool_obj, old_pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if status:
+
+        log.info(
+            "Scenario1: The norecover is unset on the cluster, and verifying "
+            "if the PG count on the pool automatically increases to desired value"
+        )
+
+        if check_status(pool_obj, old_pg_num, pool_name):
             log.error(
-                f"Scenario1:The pg number is not increased to after unsetting the norecover flag."
-                f"The pg number is -{pg_num}"
+                "Scenario1:The pg number is not increased to after unsetting the norecover flag."
             )
             return 1
+
+        if not check_pg_increase(pool_name=pool_name):
+            log.error(
+                "PG count not increased on the pool post removal of norecover flag."
+                "Test Failed"
+            )
+            return 1
+
         log.info(
             f"Scenario1:The pg number is increased after unsetting the norecover flag."
-            f"The pg number is -{pg_num}"
+            f"The pg number now is -{pg_num_final}"
         )
         delete_and_healthCheck(rados_obj, pool_name)
+        time.sleep(20)
         log.info("=========Scenario1: Test completed===========")
         log.info(
             "Scenario2: Verify that the pg_num should not decrease after setting the norecover flag"
         )
+
         if not rados_obj.create_pool(pool_name=pool_name, bulk="bulk"):
-            log.error("Failed to create the  Pool")
+            log.error("Failed to create the  Pool for scenario 2")
             return 1
-        endtime = datetime.datetime.now() + datetime.timedelta(seconds=180)
-        while datetime.datetime.now() < endtime:
-            target_pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-            final_pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_final")
-            if final_pg_num == target_pg_num:
-                log.info(
-                    f"Scenario2:-The pool pg num is increased to the - {final_pg_num}"
-                )
-                break
-            time.sleep(20)
-        old_pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        log.info(f"Scenario2:The current pg number is -{old_pg_num}")
+
+        if not check_pg_increase(pool_name=pool_name):
+            log.error(
+                "PG count not increased on the pool upon creation of pool with bulk flag"
+                "Test Failed"
+            )
+            return 1
+        old_pg_num = rados_obj.get_pool_property(pool=pool_name, props="pg_num")[
+            "pg_num"
+        ]
+
+        log.info(f" The current pg number is -{old_pg_num} with bulk flag enabled")
         utils.configure_osd_flag(ceph_cluster, "set", "norecover")
+        time.sleep(5)
         log.info("Scenario2:The norecover is set on the cluster")
         # Removed the bulk flag
         pool_obj.rm_bulk_flag(pool_name=pool_name)
@@ -108,125 +155,62 @@ def run(ceph_cluster, **kw):
         rados_obj.bench_write(
             pool_name=pool_name, byte_size=1024, rados_write_duration=10
         )
-        rados_obj.log_cluster_health()
-        status = check_status(pool_obj, old_pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if not status:
+
+        if not check_status(pool_obj, old_pg_num, pool_name):
             log.error(
-                f"Scenario2:The pg number is decreased to after setting the norecover flag "
-                f"-{pg_num}"
+                "Scenario2:The pg number is decreased to after "
+                "setting the norecover flag on the pool with bulk flag removed"
             )
             return 1
         log.info(
-            f"Scenario2:The pg number is not decreased after setting the norecover flag.The pg_num is-{pg_num}"
+            "Scenario2:The pg number is not decreased after setting the norecover flag."
+            "Removing the bulk flag on the pool to check if the PG count would increase now"
         )
+
         utils.configure_osd_flag(ceph_cluster, "unset", "norecover")
         log.info("The norecover is unset on the cluster")
-        status = check_status(pool_obj, pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if status:
-            expected_pg_num = pool_obj.get_pg_autoscaler_value(
-                pool_name, "pg_num_final"
+
+        if check_status(pool_obj, old_pg_num, pool_name):
+            log.error(
+                "Scenario2:The pg number is not decreased to after unsetting the norecover flag."
+                "on the pool where bulk flag was removed"
             )
-            log.info(f"The expected pg number is -{expected_pg_num}")
-            if pg_num != expected_pg_num:
-                log.error(
-                    f"Scenario2:The pg number is not decreased to after unsetting the norecover flag."
-                    f"The pg number is -{pg_num}"
-                )
-                return 1
+            return 1
+
+        if not check_pg_increase(pool_name=pool_name):
+            log.error(
+                "PG count not increased on the pool upon creation of pool with bulk flag"
+                "Test Failed"
+            )
+            return 1
         log.info(
-            f"Scenario2:The pg number is decreased after unsetting the norecover flag."
-            f"The pg number is -{pg_num}"
+            "Scenario2:The pg number is decreased after unsetting the norecover"
+            " flag upon bulk flag addition/ removal complete"
         )
         delete_and_healthCheck(rados_obj, pool_name)
         log.info("=========Scenario2: Test completed===========")
+        time.sleep(20)
+
         log.info(
             "Scenario3:Modify the pg number manually and verify that the pg_num should not increase "
             "after setting the norecover flag"
+            "Checking if the below scenarios are valid via bugzilla "
+            "comment here : https://bugzilla.redhat.com/show_bug.cgi?id=2134786#c48"
+            "comment here : https://bugzilla.redhat.com/show_bug.cgi?id=2134786#c49"
+            "As explained,  We don't want to restrict users from manually changing the PG count."
+            "Removing scenarios 3 & 4"
         )
-        utils.configure_osd_flag(ceph_cluster, "set", "norecover")
-        log.info("Scenario3:The norecover is set on the cluster")
-        if not rados_obj.create_pool(pool_name=pool_name, pg_num=8):
-            log.error("Scenario3:Failed to create the  Pool")
-            return 1
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        status = check_status(pool_obj, pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if not status:
-            log.error(
-                f"Scenario3:The pg_num increased after setting the norecover flag .The pg_num is-{pg_num} "
-            )
-            return 1
-        log.info(
-            f"Scenario3:The pg_num is not increased after setting the recovery flag.The pg_num is -{pg_num}"
-        )
-        utils.configure_osd_flag(ceph_cluster, "unset", "norecover")
-        log.info("Scenario3:The norecover is unset on the cluster")
-        status = check_status(pool_obj, pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if status:
-            log.error(
-                f"Scenario3:The pg_num not increased after unsetting the norecover flag .The pg_num is-{pg_num} "
-            )
-            return 1
-        log.info(
-            f"Scenario3:The pg_num is increased after unsetting the recover flag.The pg_num is -{pg_num}"
-        )
-        method_should_succeed(wait_for_clean_pg_sets, rados_obj)
-        log.info("=========Scenario3: Test completed===========")
-        log.info(
-            "Scenario4:Modify the pg number manually and verify that the pg_num should not decrease "
-            "after setting the norecover flag"
-        )
-        rados_obj.set_pool_property(pool=pool_name, props="pg_num", value=512)
-        utils.configure_osd_flag(ceph_cluster, "set", "norecover")
-        log.info("Scenario4:The norecover is set on the cluster")
-        old_pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        log.info(f"Scenario4:The pg_num after setting the norecover flg is - {pg_num}")
-        rados_obj.log_cluster_health()
-        rados_obj.bench_write(
-            pool_name=pool_name, byte_size=1024, rados_write_duration=10
-        )
-        rados_obj.log_cluster_health()
-        status = check_status(pool_obj, old_pg_num, pool_name)
-
-        if not status:
-            pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-            log.error(
-                f"Scenario4:The pg number is decreased to after setting the norecover flag "
-                f"-{pg_num}"
-            )
-            return 1
-        log.info(
-            "Scenario4:The pg number is not decreased after setting the norecover flag"
-        )
-        utils.configure_osd_flag(ceph_cluster, "unset", "norecover")
-        log.info("Scenario4:The norecover is unset on the cluster")
-        status = check_status(pool_obj, old_pg_num, pool_name)
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        if status:
-            log.error(
-                f"Scenario4:The pg number is not decreased to after unsetting the norecover flag."
-                f"The pg number is -{pg_num}"
-            )
-            return 1
-        log.info(
-            f"Scenario4:The pg number is decreased after unsetting the norecover flag."
-            f"The pg number is -{pg_num}"
-        )
-        delete_and_healthCheck(rados_obj, pool_name)
-        log.info("=========Scenario4: Test completed===========")
         log.info(
             "Scenario5:Checking the recovery of cluster after setting norecover flag"
         )
         utils.configure_osd_flag(ceph_cluster, "set", "norecover")
         log.info("Scenario5:The norecover is set on the cluster")
-        if not rados_obj.create_pool(pool_name=pool_name, pg_num=16):
+        time.sleep(10)
+        if not rados_obj.create_pool(pool_name=pool_name, pg_num=8):
             log.error("Failed to create the  Pool")
             return 1
         log.info(f"Scenario5:The pool-{pool_name} is created")
-        pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
+        pg_num = rados_obj.get_pool_property(pool=pool_name, props="pg_num")["pg_num"]
         log.info(
             f"Scenario5:The pg_num before creating data in the {pool_name} is - {pg_num}"
         )
@@ -247,7 +231,9 @@ def run(ceph_cluster, **kw):
             if memory_used >= 14:
                 break
             time.sleep(10)
-        new_pg_num = pool_obj.get_pg_autoscaler_value(pool_name, "pg_num_target")
+        new_pg_num = rados_obj.get_pool_property(pool=pool_name, props="pg_num")[
+            "pg_num"
+        ]
         log.info(
             f"Scenario5:The pg_num after creating data in the {pool_name} is - {pg_num}"
         )
@@ -266,12 +252,11 @@ def run(ceph_cluster, **kw):
         log.info(traceback.format_exc())
         return 1
     finally:
-        log.info("Execution of finally block")
-        if config.get("delete_pool"):
-            method_should_succeed(rados_obj.delete_pool, pool_name)
-            log.info(f"deleted the {pool_name} pool successfully")
+        log.info("\n\n\n\nExecution of finally block\n\n\n\n")
+        rados_obj.rados_pool_cleanup()
         utils.configure_osd_flag(ceph_cluster, "unset", "norecover")
         log.info("The norecover is unset on the cluster")
+        time.sleep(20)
         # log cluster health
         rados_obj.log_cluster_health()
     return 0
@@ -289,14 +274,21 @@ def check_status(pool_object, current_pg_num, pool_name):
              False -> PG number is changed
 
     """
+    log.debug(
+        f"Checking for 300 seconds if the PG count on the pool: {pool_name} changes"
+    )
     endtime = datetime.datetime.now() + datetime.timedelta(seconds=300)
     while datetime.datetime.now() < endtime:
         time.sleep(10)
-        new_pg_num = pool_object.get_pg_autoscaler_value(pool_name, "pg_num_target")
-        log.info(f"The {pool_name} pg number is -{new_pg_num}")
+        new_pg_num = pool_object.rados_obj.get_pool_property(
+            pool=pool_name, props="pg_num"
+        )["pg_num"]
+        log.info(f"The pool : {pool_name} has pg number - {new_pg_num}")
         if new_pg_num != current_pg_num:
+            log.error(f"PG count on the pool: {pool_name} has changed on the pool")
             return False
         time.sleep(30)
+    log.debug(f"PG count on the pool: {pool_name} has not changed on the pool")
     return True
 
 

--- a/tests/rados/test_osd_full.py
+++ b/tests/rados/test_osd_full.py
@@ -468,7 +468,7 @@ def run(ceph_cluster, **kw):
                 }
                 bench_obj.write(client=client_node, pool_name=pool_name, **full_config)
 
-                time.sleep(7)  # blind sleep to let all objs show up in ceph df stats
+                time.sleep(20)  # blind sleep to let all objs show up in ceph df stats
                 pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
                 if pool_stat["stats"]["objects"] != full_objs + 1:
                     log.error(f"Pool {pool_name} is not having {full_objs+1} objects")

--- a/tests/rados/test_osd_replicated_inconsistency_scenario.py
+++ b/tests/rados/test_osd_replicated_inconsistency_scenario.py
@@ -248,7 +248,9 @@ def create_pool_inconsistent_object(
         try:
             # Create inconsistency objects
             try:
-                pg_id = rados_object.create_inconsistent_object(pool_name, obj)
+                pg_id = rados_object.create_inconsistent_object(
+                    pool_name, obj, num_keys=1
+                )
                 pg_id_list.append(pg_id)
             except Exception as err:
                 log.info(


### PR DESCRIPTION

Added support for subsystem access through hostnqn of initiator by provisioning hostnqn to host add command

```
        install: true                           # Run SPDK with all pre-requisites
        cleanup:
          - subsystems
          - initiators
          - pool
          - gateway
        subsystems:                             # Configure subsystems with all sub-entities
          - nqn: nqn.2016-06.io.spdk:cnode1
            serial: 1
            bdevs:
              count: 1
              size: 10G
            listener_port: 5001
            initiator_node: node10

```

```
2024-08-01 14:03:51,251 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : subsystem add
2024-08-01 14:03:51,251 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --server-address 10.0.65.76 --server-port 5500 subsystem add  --subsystem nqn.2016-06.io.spdk:cnode1 --max-namespaces 32 on 10.0.65.76 timeout 600
2024-08-01 14:03:51,881 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:51,881 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding subsystem nqn.2016-06.io.spdk:cnode1: Successful\n')
2024-08-01 14:03:51,881 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : gw info
2024-08-01 14:03:51,881 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.65.76 --server-port 5500 gw info  on 10.0.65.76 timeout 600
2024-08-01 14:03:52,204 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command modprobe nvme-fabrics on 10.0.64.95 timeout 600
2024-08-01 14:03:52,222 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command nvme show-hostnqn on 10.0.64.95 timeout 600
2024-08-01 14:03:52,241 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:52,241 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : subsystem add
2024-08-01 14:03:52,242 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --server-address 10.0.65.76 --server-port 5500 subsystem add  --subsystem nqn.2016-06.io.spdk:cnode2 --max-namespaces 32 on 10.0.65.76 timeout 600
2024-08-01 14:03:52,477 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:52,477 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', '{\n    "cli_version": "1.2.17",\n    "version": "1.2.17",\n    "name": "client.nvmeof.rbd.ceph-nvme-1-45d5ez-node6.mzxgwu",\n    "addr": "10.0.65.76",\n    "port": "5500",\n    "bool_status": true,\n    "error_message": "Success",\n    "spdk_version": "24.01",\n    "load_balancing_group": 1,\n    "hostname": "ceph-nvme-1-45d5ez-node6",\n    "group": "",\n    "status": 0\n}\n')
2024-08-01 14:03:52,478 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : listener add
2024-08-01 14:03:52,478 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --server-address 10.0.65.76 --server-port 5500 listener add  --host-name ceph-nvme-1-45d5ez-node6 --traddr 10.0.65.76 --trsvcid 5001 --subsystem nqn.2016-06.io.spdk:cnode1 on 10.0.65.76 timeout 600
2024-08-01 14:03:52,778 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:52,778 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding subsystem nqn.2016-06.io.spdk:cnode2: Successful\n')
2024-08-01 14:03:52,778 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : gw info
2024-08-01 14:03:52,779 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.65.76 --server-port 5500 gw info  on 10.0.65.76 timeout 600
2024-08-01 14:03:53,031 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:53,031 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding nqn.2016-06.io.spdk:cnode1 listener at 10.0.65.76:5001: Successful\n')
2024-08-01 14:03:53,031 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : host add
2024-08-01 14:03:53,031 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --server-address 10.0.65.76 --server-port 5500 host add  --subsystem nqn.2016-06.io.spdk:cnode1 --host nqn.2014-08.org.nvmexpress:uuid:db2db797-95a8-4655-a87b-31f59d416008 on 10.0.65.76 timeout 600
2024-08-01 14:03:53,299 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:53,300 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', '{\n    "cli_version": "1.2.17",\n    "version": "1.2.17",\n    "name": "client.nvmeof.rbd.ceph-nvme-1-45d5ez-node6.mzxgwu",\n    "addr": "10.0.65.76",\n    "port": "5500",\n    "bool_status": true,\n    "error_message": "Success",\n    "spdk_version": "24.01",\n    "load_balancing_group": 1,\n    "hostname": "ceph-nvme-1-45d5ez-node6",\n    "group": "",\n    "status": 0\n}\n')
2024-08-01 14:03:53,300 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : listener add
2024-08-01 14:03:53,300 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --server-address 10.0.65.76 --server-port 5500 listener add  --host-name ceph-nvme-1-45d5ez-node6 --traddr 10.0.65.76 --trsvcid 5002 --subsystem nqn.2016-06.io.spdk:cnode2 on 10.0.65.76 timeout 600
2024-08-01 14:03:53,567 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:53,567 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding host nqn.2014-08.org.nvmexpress:uuid:db2db797-95a8-4655-a87b-31f59d416008 to nqn.2016-06.io.spdk:cnode1: Successful\n')
2024-08-01 14:03:53,955 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:53,955 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding nqn.2016-06.io.spdk:cnode2 listener at 10.0.65.76:5002: Successful\n')
2024-08-01 14:03:53,955 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : host add
2024-08-01 14:03:53,955 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm quay.io/ceph/nvmeof-cli:latest  --server-address 10.0.65.76 --server-port 5500 host add  --subsystem nqn.2016-06.io.spdk:cnode2 --host nqn.2014-08.org.nvmexpress:uuid:db2db797-95a8-4655-a87b-31f59d416008 on 10.0.65.76 timeout 600
2024-08-01 14:03:54,605 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-01 14:03:54,606 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding host nqn.2014-08.org.nvmexpress:uuid:db2db797-95a8-4655-a87b-31f59d416008 to nqn.2016-06.io.spdk:cnode2: Successful\n')
2024-08-01 14:03:54,607 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman --version | awk {'print $3'} on 10.0.66.187 timeout 600
2024-08-01 14:03:54,646 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.:1053 - Podman Version 4.6.1
2024-08-01 14:03:54,646 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command docker --version | awk {'print $3'} on 10.0.66.187 timeout 600
2024-08-01 14:03:54,704 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command ceph --version | awk '{print $3}' on 10.0.64.95 timeout 600
2024-08-01 14:03:54,805 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.:1069 - ceph Version 19.0.0-5313-ge5d33fa4
2024-08-01 14:03:54,805 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.:919 - Test <module 'test_ceph_nvmeof_gateway' from '/root/new1/cephci/tests/nvmeof/test_ceph_nvmeof_gateway.py'> passed
Test <module 'test_ceph_nvmeof_gateway' from '/root/new1/cephci/tests/nvmeof/test_ceph_nvmeof_gateway.py'> passed
All test logs located here: /tmp/cephci-run-N8PTDH
```