### PR TITLE
Adding minor fixes to nfs failure

### DIFF
--- a/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
+++ b/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
@@ -59,7 +59,7 @@ def run(ceph_cluster, **kw):
         bind = "/ceph"
         user_id = (
             f"nfs.{cluster_id}.{fs_name}"
-            if int(build.split(".")[0]) > 7
+            if int(build.split(".")[0]) == 7
             else f"nfs.{cluster_id}.{export_id}"
         )
 

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -3390,6 +3390,8 @@ os.system('sudo systemctl start  network')
                 ):
                     raise CommandFailed(f"All {service_name} are Not UP")
                 return True
+            else:
+                raise CommandFailed(f"All {service_name} are still UP")
         except JSONDecodeError:
             if "No services reported" not in out:
                 raise CommandFailed(f"All Services are not down.. {out}")

--- a/tests/cephfs/clients/validate_root_squash.py
+++ b/tests/cephfs/clients/validate_root_squash.py
@@ -192,7 +192,7 @@ def run(ceph_cluster, **kw):
                 fs_util,
                 clients[0],
                 fuse_mount_dir,
-                timeout=0,
+                timeout=300,
             )
             p.spawn(
                 start_io_time,
@@ -571,11 +571,13 @@ def run(ceph_cluster, **kw):
             stop_flag = True
             return 0
     except Exception as e:
+        global stop_flag
         stop_flag = True
         log.error(e)
         log.error(traceback.format_exc())
     finally:
         log.info("Cleanup In Progress")
+        global stop_flag
         stop_flag = True
         for cl in [client, client1]:
             log.info("Unmounting the mounts if created")


### PR DESCRIPTION
# Description
Adding minor fixes to nfs failure

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-229/cephfs/156/tier-2_cephfs_test-nfs/nfs_ls_export_verification_and_info_with_cluster_id_0.log

In 7.0 alone it has been followed f"nfs.{cluster_id}.{fs_name}"
in 6 and 8 it has been followed as f"nfs.{cluster_id}.{export_id}"

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
