### PR TITLE
TFA: RHCEPHQE-15386: IBM upgrade post swift_object_expiration cluster is in bad state.

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
@@ -403,17 +403,6 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
 
   - test:
-      name: Granular multisite sync policy group transition
-      desc: Test multisite sync policy group transition
-      polarion-id: CEPH-83575133
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_sync_policy.py
-            config-file-name: test_sync_policy_state_change.yaml
-
-  - test:
       clusters:
         ceph-pri:
           config:
@@ -448,3 +437,14 @@ tests:
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade
       polarion-id: CEPH-83574735
+
+  - test:
+      name: Granular multisite sync policy group transition
+      desc: Test multisite sync policy group transition
+      polarion-id: CEPH-83575133
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_sync_policy.py
+            config-file-name: test_sync_policy_state_change.yaml


### PR DESCRIPTION
# Description
IBM upgrade post swift_object_expiration cluster is in a bad state.

Passed log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X7HIOB/

Please ignore the non-tenanted user failure since it is done for an additional 3rd site that is not yet part of the multisite and does not have a ceph-common package.




