### PR TITLE
[TFA] update timeout for suites of pacific that runs in quincy and upstream

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -277,7 +277,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -294,7 +293,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name:  datalog omap offload with multipart objects on secondary
@@ -307,7 +305,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload_multipart.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name:  datalog omap offload on versioned bucket on secondary
@@ -320,7 +317,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload_versioned_bucket.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: datalog trim command with delete marker enabled on secondary
@@ -332,7 +328,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
   - test:
       name: Test DBR reshard list and cancel command on secondary
@@ -344,7 +339,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
 
   - test:
@@ -357,7 +351,6 @@ tests:
           config:
             script-name:  test_bucket_lifecycle_object_expiration_transition.py
             config-file-name:  test_lc_rule_prefix_and_tag.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
 
   - test:
@@ -370,8 +363,8 @@ tests:
           config:
             script-name:  test_bucket_lc_object_exp_multipart.py
             config-file-name:  test_bucket_lc_object_exp_multipart.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
+            timeout: 5000
 
   - test:
       name: Basic ACLs Test
@@ -385,7 +378,6 @@ tests:
             run-on-rgw: true
             script-name: test_acls.py
             config-file-name: test_acls.yaml
-            timeout: 300
 
 # please include test cases before below rename testcase as the process is disruptive currently
   # - test:
@@ -394,7 +386,6 @@ tests:
   #         config:
   #           script-name: test_check_sharding_enabled.py
   #           config-file-name: test_zonegroup_rename.yaml
-  #           timeout: 300
   #     desc: Test zonegroup rename in master
   #     module: sanity_rgw_multisite.py
   #     name: Perform zonegroup rename in master

--- a/suites/pacific/rgw/tier-1_rgw.yaml
+++ b/suites/pacific/rgw/tier-1_rgw.yaml
@@ -113,7 +113,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_enable.yaml
-        timeout: 300
   - test:
       name: overwrite objects after suspending versioning
       desc: test to overwrite objects after suspending versioning
@@ -122,7 +121,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_re-upload.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for Prefix and tag based filter and for more than one days
       desc: Test object expiration for Prefix and tag based filter and for more than one days
@@ -131,7 +129,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_and_tag.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration
       desc: Test object expiration for non current version expiration
@@ -140,7 +137,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests for Prefix filter and versioned buckets
       desc: Test object transition for Prefixand versioned buckets
@@ -149,7 +145,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_with_prefix_rule.yaml
-        timeout: 300
   - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
@@ -158,7 +153,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding.yaml
-        timeout: 500
   - test:
       name: swift versioning tests
       desc: Test versioned object in swift
@@ -167,7 +161,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_versioning.yaml
-        timeout: 500
   - test:
       name: swift versioning copy tests
       desc: restore versioned object in swift
@@ -176,7 +169,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_version_copy_op.yaml
-        timeout: 500
   - test:
       name: swift object expire tests
       desc: object expire in swift
@@ -185,7 +177,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_object_expire_op.yaml
-        timeout: 500
   - test:
       name: object lock verification
       desc: object lock test
@@ -194,7 +185,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_compliance.yaml
-        timeout: 500
   - test:
       name: S3CMD small and multipart object download
       desc: S3CMD small and multipart object download or GET
@@ -203,4 +193,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-        timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
@@ -210,4 +210,3 @@ tests:
         test-version: v2
         script-name: test_byte_range.py
         config-file-name: test_byte_range.yaml
-        timeout: 500

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-listing-versioning-on-primary.yaml
@@ -332,7 +332,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -348,7 +347,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
   - test:
       name: listing flat ordered buckets on primary
       desc: test_bucket_listing_flat_ordered on secondary
@@ -359,7 +357,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
   - test:
       name: listing flat unordered buckets on primary
       desc: test_bucket_listing_flat_unordered.yaml on secondary
@@ -370,7 +367,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
   - test:
       name: listing pseudo ordered dir only buckets on primary
       desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
@@ -381,7 +377,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
   - test:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
@@ -392,7 +387,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered.yaml
-            timeout: 300
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on primary
       desc: test_versioning_copy_objects on secondary
@@ -403,7 +397,6 @@ tests:
           config:
             script-name: test_versioning_copy_objects.py
             config-file-name: test_versioning_copy_objects.yaml
-            timeout: 300
   - test:
       name: enable bucket versioning on primary
       desc: test_versioning_enable on secondary
@@ -415,7 +408,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_enable.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: setting acls to versioned objects on primary
       desc: test_versioning_objects_acls on secondary
@@ -427,7 +419,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: reverting object to one of the versions on primary
       desc: test_versioning_objects_copy on secondary
@@ -438,7 +429,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
   - test:
       name: delete versioned objects on primary
       desc: test_versioning_objects_delete on secondary
@@ -449,7 +439,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
   - test:
       name: enabling bucket versioning and uploading objects on primary
       desc: test_versioning_objects_enable on secondary
@@ -461,7 +450,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: suspend bucket versioning on primary
       desc: test_versioning_objects_suspend on secondary
@@ -473,4 +461,3 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -276,7 +276,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -288,7 +287,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-14235
@@ -305,7 +303,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
   - test:
       name: test aws4 signature version on primary
       desc: test_Mbuckets_with_Nobjects_aws4 on primary
@@ -316,7 +313,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: delete buckets and objects on primary
       desc: test_Mbuckets_with_Nobjects_delete on primary
@@ -327,7 +323,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-            timeout: 300
   - test:
       name: download objects on primary
       desc: test_Mbuckets_with_Nobjects_download on primary
@@ -339,7 +334,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary
@@ -351,7 +345,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: multipart upload on primary
       desc: test_Mbuckets_with_Nobjects_multipart on primary
@@ -363,7 +356,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
   - test:
       name: test Mbuckets on primary
       desc: test_Mbuckets on primary
@@ -375,7 +367,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
 
   - test:
       name: create tenanted user
@@ -389,7 +380,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       name: modify bucket policy on primary
@@ -402,7 +392,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
   - test:
       name: delete bucket policy  on primary
       desc: test_bucket_policy_delete.yaml on primary
@@ -414,7 +403,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
 
   - test:
       name: replace bucket policy on primary
@@ -427,4 +415,3 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bilog-crash-on-primary.yaml
@@ -277,7 +277,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -294,7 +293,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
   - test:
       name: bucket sync command crash check on secondary
@@ -306,5 +304,4 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_bucket_sync_cmd_crash.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-listing-versioning-on-secondary.yaml
@@ -293,7 +293,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -310,7 +309,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: listing flat ordered buckets on secondary
       desc: test_bucket_listing_flat_ordered on secondary
@@ -322,7 +320,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: listing flat unordered buckets on secondary
       desc: test_bucket_listing_flat_unordered.yaml on secondary
@@ -334,7 +331,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: listing pseudo ordered dir only buckets on secondary
       desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
@@ -346,7 +342,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: ordered listing of bucket with pseudo directories and objects
       desc: measure execution time for ordered listing of bucket with pseudo directories and objects
@@ -358,7 +353,6 @@ tests:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on secondary
       desc: test_versioning_copy_objects on secondary
@@ -370,7 +364,6 @@ tests:
             script-name: test_versioning_copy_objects.py
             config-file-name: test_versioning_copy_objects.yaml
             monitor-consistency-bucket-stats: true
-            timeout: 300
   - test:
       name: enable bucket versioning on secondary
       desc: test_versioning_enable on secondary
@@ -383,7 +376,6 @@ tests:
             config-file-name: test_versioning_enable.yaml
             monitor-consistency-bucket-stats: true
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: setting acls to versioned objects on secondary
       desc: test_versioning_objects_acls on secondary
@@ -395,7 +387,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: reverting object to one of the versions on secondary
       desc: test_versioning_objects_copy on secondary
@@ -406,7 +397,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
   - test:
       name: delete versioned objects on secondary
       desc: test_versioning_objects_delete on secondary
@@ -417,7 +407,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
   - test:
       name: enabling bucket versioning and uploading objects on secondary
       desc: test_versioning_objects_enable on secondary
@@ -429,7 +418,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: suspend bucket versioning on secondary
       desc: test_versioning_objects_suspend on secondary
@@ -441,7 +429,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   # - test:
   #     name: Delete object version with id null
@@ -454,4 +441,3 @@ tests:
   #         config:
   #           script-name: ../aws/test_delete_version_id_null.py
   #           config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
-  #           timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -237,7 +237,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -249,7 +248,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-pri" ]
       desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-9789
@@ -266,7 +264,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
   - test:
       name: test aws4 signature version on secondary
       desc: test_Mbuckets_with_Nobjects_aws4 on secondary
@@ -277,7 +274,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
   - test:
       name: delete buckets and objects on secondary
       desc: test_Mbuckets_with_Nobjects_delete on secondary
@@ -288,7 +284,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-            timeout: 300
   - test:
       name: download objects on secondary
       desc: test_Mbuckets_with_Nobjects_download on secondary
@@ -300,7 +295,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
   - test:
       name: test encryption on secondary
       desc: test_Mbuckets_with_Nobjects_enc on secondary
@@ -312,7 +306,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
   - test:
       name: multipart upload on secondary
       desc: test_Mbuckets_with_Nobjects_multipart on secondary
@@ -324,7 +317,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
   - test:
       name: test Mbuckets on secondary
       desc: test_Mbuckets on secondary
@@ -336,7 +328,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
 
   - test:
       name: create tenanted user
@@ -350,7 +341,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       name: modify bucket policy on secondary
@@ -363,7 +353,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: delete bucket policy on secondary
       desc: test_bucket_policy_delete.yaml on secondary
@@ -375,7 +364,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: replace bucket policy on secondary
@@ -388,4 +376,3 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
@@ -277,7 +277,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -289,7 +288,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload on primary cluster
       module: sanity_rgw_multisite.py
@@ -302,7 +300,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload_multipart.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload with multipart objects on primary
       module: sanity_rgw_multisite.py
@@ -315,7 +312,6 @@ tests:
           config:
             config-file-name: test_data_omap_offload_versioned_bucket.yaml
             script-name: test_data_omap_offload.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec" ]
       desc: Execute datalog omap offload on versioned bucket on primary
       module: sanity_rgw_multisite.py
@@ -332,7 +328,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -345,7 +340,6 @@ tests:
           config:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-            timeout: 300
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
 
   # - test:
@@ -359,4 +353,3 @@ tests:
   #         config:
   #           script-name: test_Mbuckets_with_Nobjects.py
   #           config-file-name: test_changing_data_log_num_shards_cause_no_crash.yaml
-  #           timeout: 300

--- a/suites/pacific/rgw/tier-1_rgw_multisite_multirealm_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_multirealm_upgrade-5-to-latest.yaml
@@ -352,7 +352,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -367,7 +366,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects pre upgrade
@@ -379,7 +377,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw_multisite.py
       name: ordered listing of buckets pre upgrade
@@ -391,7 +388,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets with top level objects
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets pre upgrade
@@ -404,7 +400,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Test object operations with swift
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
@@ -417,7 +412,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Create bucket for Testing manual resharding brownfield scenario after upgrade
@@ -470,7 +464,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects post upgrade
@@ -482,7 +475,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
       desc: test the duration for ordered listing of versioned buckets
       module: sanity_rgw_multisite.py
       name: ordered listing of versioned buckets post upgrade
@@ -494,7 +486,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
       desc: test duration for unordered listing of buckets
       module: sanity_rgw_multisite.py
       name: unordered listing of buckets post upgrade
@@ -507,7 +498,6 @@ tests:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
       desc: test object expiration with swift
       module: sanity_rgw_multisite.py
       name: swift object expiration post upgrade
@@ -525,7 +515,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
 
   - test:
       clusters:
@@ -534,7 +523,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_brownfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade
       module: sanity_rgw_multisite.py
       name: Test manual resharding brownfield scenario after upgrade
@@ -547,7 +535,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding brownfield scenario after upgrade on new bucket
       module: sanity_rgw_multisite.py
       name: Manual Resharding tests on Primary cluster

--- a/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_test-lc-multiple-bucket.yaml
@@ -112,7 +112,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Bucket Lifecycle Object_transition_tests for 100 buckets
@@ -122,7 +121,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Enable lifecycle and disable it on a bucket before objects expires
@@ -132,7 +130,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_disable_object_exp.yaml
-        timeout: 300
 
   - test:
       name: Add a new lifecycle configuration to a bucket
@@ -142,7 +139,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_add_new_lc_to_bucket.yaml
-        timeout: 300
 
   - test:
       name: Add a lifecycle configuration to a bucket with tenant user
@@ -152,4 +148,3 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucket_put_get_lifecycle_configuration_with_tenant_users.yaml
-        timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml
+++ b/suites/pacific/rgw/tier-2_rgw-single-bucket-process.yaml
@@ -97,7 +97,6 @@ tests:
       config:
         script-name: test_manual_lc_process_single_bucket.py
         config-file-name: test_lc_process_single_bucket_expired.yaml
-        timeout: 300
       desc: test LC process for a single bucket with expired objects
       module: sanity_rgw.py
       name: Test LC process for single bucket expired
@@ -107,7 +106,6 @@ tests:
       config:
         script-name: test_manual_lc_process_single_bucket.py
         config-file-name: test_lc_process_single_bucket_nonexpired.yaml
-        timeout: 300
       desc: test LC process for a single bucket with non expired objects
       module: sanity_rgw.py
       name: Test LC process for single bucket non-expired
@@ -122,7 +120,6 @@ tests:
         test-version: v2
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspended_delete.yaml
-        timeout: 500
 
   - test:
       name: Get object and its version from same and different tenant users
@@ -133,4 +130,3 @@ tests:
         test-version: v2
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: get_object_and_its_versions_tenat_user.yaml
-        timeout: 500

--- a/suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_bucket_lc_multipart_object_expired.yaml
@@ -116,7 +116,6 @@ tests:
       config:
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_object_exp_multipart.yaml
-        timeout: 300
 
   - test:
       name: lifecycle with version enabled bucket containing only one object version
@@ -126,7 +125,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_current_version_object_expiration.yaml
-        timeout: 300
 
   - test:
       name: Multipart object expiration through lc
@@ -136,4 +134,3 @@ tests:
       config:
         script-name: test_bucket_lc_object_exp_multipart.py
         config-file-name: test_bucket_lc_multipart_object_expiration.yaml
-        timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms-archive.yaml
@@ -237,7 +237,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-arc
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -249,8 +248,8 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec","ceph-arc" ]
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py
@@ -263,7 +262,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - dynamic resharding on primary and verify on secondary & archive cluster
       name: Dynamic Resharding - dynamic
@@ -276,7 +274,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - dynamic resharding on versioned bucket on primary and verify on secondary & archive cluster
       name: Dynamic Resharding with versioning on primary and verify on archive
@@ -289,7 +286,6 @@ tests:
           config:
             config-file-name: test_manual_resharding_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: [ "ceph-sec", "ceph-arc" ]
       desc: Resharding test - manual resharding
       name: Manual Resharding on primary and verify on secondary & archive cluster

--- a/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms-dynamic-bucket-resharding.yaml
@@ -209,7 +209,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create tenanted user
       module: sanity_rgw_multisite.py
       name: create tenanted user
@@ -228,7 +227,6 @@ tests:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_check_sharding_enabled_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
   - test:
       clusters:
         ceph-pri:
@@ -236,7 +234,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster
@@ -248,7 +245,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_tenanted_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on greenfield deployment tenanted user
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster tenanted user
@@ -260,7 +256,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_versioning_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on versioned bucket
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on Primary cluster
@@ -272,7 +267,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_dbr_versioning_tenanted_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test dynamic resharding on versioned bucket and tenanted user
       module: sanity_rgw_multisite.py
       name: Dynamic Resharding tests on versioned bucket and tenanted user Primary cluster
@@ -285,7 +279,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_manual_resharding_greenfield.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec"]
-            timeout: 300
       desc: Test manual resharding on greenfield deployment
       abort-on-fail: true
       module: sanity_rgw_multisite.py
@@ -298,7 +291,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
             verify-io-on-site: ["ceph-pri", "ceph-sec" ]
       desc: Resharding test - dynamic resharding on versioned bucket
       name: Dynamic Resharding on versioned buckets
@@ -311,7 +303,6 @@ tests:
           config:
             config-file-name: test_dynamic_resharding_quota_exceed.yaml
             script-name: test_dynamic_bucket_resharding.py
-            timeout: 300
       desc: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
       name: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary
       polarion-id: CEPH-83574669
@@ -323,7 +314,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_multisite_sync_disable_enable.yaml
-            timeout: 300
       desc: Test sync enable and disable with manual resharding
       module: sanity_rgw_multisite.py
       name: Manual Resharding tests on Primary cluster
@@ -334,7 +324,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_zone_deletion.yaml
-            timeout: 300
       desc: Test zone deletion in master
       module: sanity_rgw_multisite.py
       name: Perform zone deletion in master
@@ -345,7 +334,6 @@ tests:
           config:
             script-name: test_check_sharding_enabled.py
             config-file-name: test_realm_rename.yaml
-            timeout: 300
       desc: Test realm rename in master
       module: sanity_rgw_multisite.py
       name: Perform realm rename in master

--- a/suites/pacific/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -278,7 +278,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -296,7 +295,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
 
   # IO should fail on read only secondary
   - test:
@@ -309,7 +307,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_failed.yaml
-            timeout: 300
 
   # Failover Primary, make secondary writable
   - test:
@@ -335,7 +332,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects.yaml
-            timeout: 300
       desc: test M buckets uploads on current primary zone
       module: sanity_rgw_multisite.py
       name: test M buckets uploads on current primary zone
@@ -420,4 +416,3 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_multisite_scenarios.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_multisite_scenarios.yaml
@@ -225,7 +225,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -265,7 +264,6 @@ tests:
             config-file-name: ../configs/test_byte_range.yaml
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-sec"]
-            timeout: 500
 
   - test:
       name: Test the byte ranges with get object on secondary zone and check multisite replication doesn't happen
@@ -280,4 +278,3 @@ tests:
             config-file-name: ../configs/test_byte_range.yaml
             multisite-replication-disabled: True
             verify-io-on-site: ["ceph-pri"]
-            timeout: 500

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool-ms-bucket-listing-versioning-on-secondary.yaml
@@ -313,7 +313,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -329,7 +328,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-            timeout: 300
 
   - test:
       name: listing flat ordered buckets on secondary
@@ -341,7 +339,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            timeout: 300
 
   - test:
       name: listing flat unordered buckets on secondary
@@ -353,7 +350,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_unordered.yaml
-            timeout: 300
 
   - test:
       name: listing pseudo ordered dir only buckets on secondary
@@ -365,7 +361,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
-            timeout: 300
 
   - test:
       name: ordered listing of bucket with pseudo directories and objects
@@ -377,7 +372,6 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered.yaml
-            timeout: 300
 
   - test:
       name: Test Copy of objects with Versioned and non-versionsed buckets on secondary
@@ -389,7 +383,6 @@ tests:
           config:
             script-name: test_versioning_copy_objects.py
             config-file-name: test_versioning_copy_objects.yaml
-            timeout: 300
 
   - test:
       name: enable bucket versioning on secondary
@@ -402,7 +395,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: setting acls to versioned objects on secondary
@@ -415,7 +407,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_acls.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: reverting object to one of the versions on secondary
@@ -427,7 +418,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_copy.yaml
-            timeout: 300
 
   - test:
       name: delete versioned objects on secondary
@@ -439,7 +429,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_delete.yaml
-            timeout: 300
 
   - test:
       name: enabling bucket versioning and uploading objects on secondary
@@ -452,7 +441,6 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: suspend bucket versioning on secondary
@@ -465,4 +453,3 @@ tests:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_suspend.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ssl_ecpool_ms-bucket-objects-gc-policy-on-secondary.yaml
@@ -313,7 +313,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -325,7 +324,6 @@ tests:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
             verify-io-on-site: [ "ceph-pri" ]
       desc: Execute M buckets with N objects on secondary cluster
       module: sanity_rgw_multisite.py
@@ -343,7 +341,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-            timeout: 300
 
   - test:
       name: test aws4 signature version on secondary
@@ -355,7 +352,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-            timeout: 300
 
   - test:
       name: delete buckets and objects on secondary
@@ -367,7 +363,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-            timeout: 300
 
   - test:
       name: download objects on secondary
@@ -380,7 +375,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            timeout: 300
 
   - test:
       name: test encryption on secondary
@@ -393,7 +387,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-            timeout: 300
 
   - test:
       name: multipart upload on secondary
@@ -406,7 +399,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            timeout: 300
 
   - test:
       name: Test large omap objects warnings via ceph status in a multisite
@@ -419,7 +411,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets.yaml
-            timeout: 300
 
   - test:
       name: test sharding on primary
@@ -431,7 +422,6 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_sharding.yaml
-            timeout: 300
 
   - test:
       name: LargeObjGet_GC test
@@ -443,7 +433,6 @@ tests:
           config:
             script-name: test_LargeObjGet_GC.py
             config-file-name: test_LargeObjGet_GC.yaml
-            timeout: 300
 
   - test:
       name: create tenanted user
@@ -457,7 +446,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
 
   - test:
       name: modify bucket policy on secondary
@@ -470,7 +458,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: delete bucket policy on secondary
@@ -483,7 +470,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_delete.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name: replace bucket policy on secondary
@@ -496,4 +482,3 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_replace.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_sts_aswi.yaml
@@ -104,7 +104,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aud claim in the web token
       desc: STS aswi Tests to test aud claim in the web token
@@ -113,7 +112,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aud_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test azp fields in the web token
       desc: STS aswi Tests to test azp fields in the web token
@@ -122,7 +120,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_azp_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test sub fields in the web token
       desc: STS aswi Tests to test sub fields in the web token
@@ -131,7 +128,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_sub_claim.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_PrincipalTag in role's permission policy
       desc: STS aswi Tests to test aws_PrincipalTag in role's permission policy
@@ -140,7 +136,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_principal_tag_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_RequestTag in role's trust policy
       desc: STS aswi Tests to test aws_RequestTag in the condition element of a role's trust policy
@@ -149,7 +144,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_request_tag_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_TagKeys in permission policy
       desc: STS aswi Tests to test aws_TagKeys in permission policy
@@ -158,7 +152,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_tagkeys_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test aws_TagKeys in the trust policy
       desc: STS aswi Tests to test aws_TagKeys in the trust policy
@@ -167,7 +160,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_aws_tagkeys_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test iam_ResourceTag in trust policy
       desc: STS aswi Tests to test iam_ResourceTag in trust policy
@@ -176,7 +168,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_iam_resource_tag_trust_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test allow condition when s3_Resource Tag equals aws_Principal tag in role's permission policy
       desc: STS aswi Tests to test allow condition when s3_Resource Tag equals aws_Principal tag in role's permission policy
@@ -185,7 +176,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_res_equals_aws_princ_tag_role_policy.yaml
-        timeout: 500
   - test:
       name: STS aswi Tests to test s3_Resource Tag in role's permission policy
       desc: STS aswi Tests to test s3_Resource Tag in role's permission policy
@@ -194,7 +184,6 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_s3_resource_tag_role_policy.yaml
-        timeout: 500
 
   - test:
       abort-on-fail: true
@@ -215,4 +204,3 @@ tests:
       config:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_creds_expire_copy_in_progress.yaml
-        timeout: 500

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -99,7 +99,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_dot.yaml
-        timeout: 300
       desc: test lc with prefix containing dot
       module: sanity_rgw.py
       name: test lc with prefix containing dot
@@ -109,7 +108,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_hyphen.yaml
-        timeout: 300
       desc: test lc with prefix containing hyphen
       module: sanity_rgw.py
       name: test lc with prefix containing hyphen
@@ -119,7 +117,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_slash.yaml
-        timeout: 300
       desc: test lc with prefix containing slash
       module: sanity_rgw.py
       name: test lc with prefix containing slash
@@ -129,7 +126,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_prefix_underscore.yaml
-        timeout: 300
       desc: test lc with prefix containing underscore
       module: sanity_rgw.py
       name: test lc with prefix containing underscore
@@ -144,7 +140,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_prefix_and_TAG_rule.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests multiple rules and different storage class
       desc: Test Object_transition_tests multiple rules and different storage class
@@ -153,7 +148,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_rules.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_transition_tests multiple pool transition
       desc: Bucket Lifecycle Object_transition_tests multiple pool transition
@@ -171,7 +165,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_ecpool_with_prefix_rule.yaml
-        timeout: 300
 
   # bucket lifecycle with resharding
 
@@ -183,7 +176,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_dynamic_reshard.yaml
-        timeout: 300
 
   - test:
       name: test lifecycle expiration with manual resharding and Test if LC policy is applied via lc list and lc get
@@ -193,4 +185,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_expiration_manual_reshard.yaml
-        timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-multisite-async-data-notification.yaml
@@ -209,7 +209,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create user
@@ -220,7 +219,6 @@ tests:
           config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
       desc: bucket create and delete operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -233,7 +231,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: test_async_data_notifications_on_primary
       polarion-id: CEPH-83575231
       module: sanity_rgw_multisite.py
@@ -246,7 +243,6 @@ tests:
             config-file-name: test_multisite_async_data_notifications.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
       desc: test_async_data_notifications_on_secondary
       polarion-id: CEPH-83575268
       module: sanity_rgw_multisite.py
@@ -286,7 +282,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.sec}"
-            timeout: 120
         ceph-pri:
           config:
             cephadm: true
@@ -298,7 +293,6 @@ tests:
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
               - "ceph orch restart {service_name:shared.pri}"
-            timeout: 120
       desc: Setting vault configs for sse-s3 on multisite
       module: exec.py
       name: set sse-s3 vault configs on multisite
@@ -310,7 +304,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw_multisite.py
       name: sse-s3 per bucket encryption test
@@ -322,7 +315,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw_multisite.py
       name: sse-s3 per bucket encryption test on a versiond bucket
@@ -334,7 +326,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_s3_per_object_with_versioning
       module: sanity_rgw_multisite.py
       name: est_sse_s3_per_object_with_versioning
@@ -346,7 +337,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object_versioninig_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_per_object_with_versioning
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_object_with_versioning
@@ -358,7 +348,6 @@ tests:
             set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_bucket_encryption_version_enabled.yaml
-            timeout: 300
       desc: test_sse_kms_per_bucket_with_versioning
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_versioning

--- a/suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-multisite-metadata-sync.yaml
@@ -272,7 +272,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
@@ -283,7 +282,6 @@ tests:
           config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            timeout: 300
       desc: bucket create and delete operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -295,7 +293,6 @@ tests:
             config-file-name: test_user_bucket_create.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: user and bucket create operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -307,7 +304,6 @@ tests:
             config-file-name: test_user_modify_op.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: Modify suspend enable and delete user operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -319,7 +315,6 @@ tests:
             config-file-name: test_user_bucket_rename.yaml
             script-name: test_user_bucket_rename.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: rename user and bucket and link unlink bucket operation
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -331,7 +326,6 @@ tests:
             config-file-name: test_user_with_REST.yaml
             script-name: user_op_using_rest.py
             verify-io-on-site: ["ceph-sec"]
-            timeout: 300
       desc: user operations using REST
       polarion-id: CEPH-83574811
       module: sanity_rgw_multisite.py
@@ -344,7 +338,6 @@ tests:
   #         config:
   #           script-name: test_check_sharding_enabled.py
   #           config-file-name: test_zone_rename.yaml
-  #           timeout: 300
   #     desc: Test zone rename in non master that is secondary
   #     module: sanity_rgw_multisite.py
   #     name: Perform zone rename in non master that is secondary

--- a/suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-quota-management.yaml
@@ -102,7 +102,6 @@ tests:
       config:
         script-name: test_quota_management.py
         config-file-name: test_quota_bucket_max_objects.yaml
-        timeout: 300
       desc: test bucket quota max objects
       module: sanity_rgw.py
       name: test bucket quota max objects
@@ -112,7 +111,6 @@ tests:
       config:
         script-name: test_quota_management.py
         config-file-name: test_quota_bucket_max_size.yaml
-        timeout: 300
       desc: test bucket quota max size
       module: sanity_rgw.py
       name: test bucket quota max size
@@ -122,7 +120,6 @@ tests:
       config:
         script-name: test_quota_management.py
         config-file-name: test_quota_user_max_objects.yaml
-        timeout: 300
       desc: test user quota max objects
       module: sanity_rgw.py
       name: test user quota max objects
@@ -132,7 +129,6 @@ tests:
       config:
         script-name: test_quota_management.py
         config-file-name: test_quota_user_max_size.yaml
-        timeout: 300
       desc: test user quota max size
       module: sanity_rgw.py
       name: test user quota max size

--- a/suites/pacific/rgw/tier-2_rgw_test-s3cmd-malformed-url.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-s3cmd-malformed-url.yaml
@@ -68,7 +68,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_put.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd cp operation with malformed bucket url
@@ -78,7 +77,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_cp.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd del operation with malformed bucket url
@@ -88,7 +86,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_del.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd get operation with malformed bucket url
@@ -98,7 +95,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_get.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd ls operation with malformed bucket url
@@ -108,7 +104,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_ls.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd multipart operation with malformed bucket url
@@ -118,7 +113,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_multipart.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd mv operation with malformed bucket url
@@ -128,7 +122,6 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_mv.yaml
-        timeout: 300
 
   - test:
       name: test s3cmd sync operation with malformed bucket url
@@ -138,4 +131,3 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd_malformed_url.py
         config-file-name: ../../s3cmd/configs/test_s3cmd_malformed_url_sync.yaml
-        timeout: 300

--- a/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
@@ -130,7 +130,6 @@ tests:
               install_start_kafka: true
               script-name: test_bucket_notifications.py
               config-file-name: test_empty_bucket_notification_kafka_broker.yaml
-              timeout: 300
         - test:
             name: test_bi_purge for a bucket
             desc: test bi_purge should not error
@@ -140,7 +139,6 @@ tests:
               install_common: false
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_bi_purge.yaml
-              timeout: 300
  # STS tests
   - test:
       name: Test rename of large object using sts user through AWS
@@ -150,7 +148,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_sts_rename_large_object.yaml
-        timeout: 500
   - test:
       name: Test s3_copy_obj on user with admin flag through AWS
       desc: TESCO-Segfault with s3CopyObj with admin user
@@ -159,7 +156,6 @@ tests:
       config:
         script-name: ../aws/test_sts_rename_large_object.py
         config-file-name: ../../aws/configs/test_s3copyObj_admin_user.yaml
-        timeout: 500
 
  # testing rgw through curl
   - test:
@@ -170,7 +166,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-        timeout: 500
 
   - test:
       name: Test rgw put object through curl using transfer_encoding chunked
@@ -180,7 +175,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_curl_transfer_encoding_chunked.yaml
-        timeout: 500
 
   - test:
       name: Test rgw multipart upload through curl
@@ -190,7 +184,6 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_curl_multipart_upload.yaml
-        timeout: 500
 
   - test:
       name: Test rgw put bucket website with users of same and different tenant
@@ -200,7 +193,6 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500
 
   - test:
       name: Test rgw get bucket website with users of same and different tenant
@@ -210,4 +202,3 @@ tests:
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml
-        timeout: 500

--- a/suites/pacific/rgw/tier-2_sse_s3_encryption.yaml
+++ b/suites/pacific/rgw/tier-2_sse_s3_encryption.yaml
@@ -90,7 +90,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_normal_object_upload
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test
@@ -100,7 +99,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_version_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_bucket_encryption_version_enabled
       module: sanity_rgw.py
       name: sse-s3 per bucket encryption test on a versiond bucket
@@ -110,7 +108,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_object.yaml
-        timeout: 300
       desc: test_sse_s3_per_object
       module: sanity_rgw.py
       name: sse-s3 per object encryption test
@@ -120,7 +117,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_object_versioninig_enabled.yaml
-        timeout: 300
       desc: test_sse_s3_per_object_with_versioning
       module: sanity_rgw.py
       name: test_sse_s3_per_object_with_versioning
@@ -130,7 +126,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
-        timeout: 300
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -140,7 +135,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_kms_per_object_versioninig_enabled.yaml
-        timeout: 300
       desc: test_sse_kms_per_object_with_versioning
       module: sanity_rgw.py
       name: test_sse_kms_per_object_with_versioning
@@ -150,7 +144,6 @@ tests:
       config:
         script-name: test_sse_s3_kms_with_vault.py
         config-file-name: test_sse_kms_per_object.yaml
-        timeout: 300
       desc: test_sse_kms_per_object
       module: sanity_rgw.py
       name: test_sse_kms_per_object
@@ -163,7 +156,6 @@ tests:
         install_start_kafka: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_sse_kms_per_bucket_with_bucket_policy.yaml
-        timeout: 300
       desc: test_sse_kms_per_bucket_with_bucket_policy
       module: sanity_rgw.py
       name: test_sse_kms_per_bucket_with_bucket_policy
@@ -172,7 +164,6 @@ tests:
       config:
         script-name: test_sts_using_boto.py
         config-file-name: test_sse_s3_per_object_with_sts.yaml
-        timeout: 300
       desc: test_sse_s3_per_object_with_sts
       module: sanity_rgw.py
       name: test_sse_s3_per_object_with_sts
@@ -182,7 +173,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_bucket_index_shards.yaml
-        timeout: 300
       desc: test_metadata_integrity_with_0_num_shards
       module: sanity_rgw.py
       name: test_metadata_integrity_with_0_num_shards

--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -99,7 +99,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_action.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid conditional in condition blocks
@@ -109,7 +108,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_condition_key.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid effect
@@ -119,7 +117,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_effect.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid key
@@ -129,7 +126,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_key.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid principal
@@ -139,7 +135,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_principal.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid resource
@@ -149,7 +144,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_resource.yaml
-        timeout: 500
 
   - test:
       name: test bucket policy with invalid version
@@ -159,7 +153,6 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_version.yaml
-        timeout: 500
 
   # Bucket lifecycle tests
 
@@ -171,7 +164,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_btw_exp_transition.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rule conflict between expiration days
@@ -181,7 +173,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_exp_days.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rule conflict between transition actions
@@ -191,7 +182,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_transition_actions.yaml
-        timeout: 500
 
   - test:
       name: test bucket lc rules with same ruleid but different rules
@@ -201,7 +191,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
-        timeout: 500
 
   - test:
       name: Test bucket lc reverse transition
@@ -211,7 +200,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_reverse_transition.yaml
-        timeout: 300
 
   # swift container operation
   - test:
@@ -222,7 +210,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_enable_version_with_different_user.yaml
-        timeout: 500
   - test:
       name: swift enabling versioning on a bucket that is S3 versioned
       desc: test swift enabling versioning on a bucket that is S3 versioned
@@ -231,4 +218,3 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_s3_and_swift_versioning.yaml
-        timeout: 500

--- a/suites/quincy/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -532,6 +532,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -544,6 +545,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
+            timeout: 5000
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node

--- a/suites/quincy/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/quincy/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -216,7 +216,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -233,7 +232,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name:  datalog omap offload with multipart objects on secondary
@@ -246,7 +244,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload_multipart.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name:  datalog omap offload on versioned bucket on secondary
@@ -259,7 +256,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload_versioned_bucket.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: datalog trim command with delete marker enabled on secondary
       desc: Execute datalog trim command with delete marker enabled on secondary
@@ -270,7 +266,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]
   - test:
       name: Test DBR reshard list and cancel command on secondary
@@ -282,5 +277,4 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]

--- a/suites/quincy/upstream/tier-1_rgw_and_lc.yaml
+++ b/suites/quincy/upstream/tier-1_rgw_and_lc.yaml
@@ -71,7 +71,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_enable.yaml
-        timeout: 300
   - test:
       name: overwrite objects after suspending versioning
       desc: test to overwrite objects after suspending versioning
@@ -80,7 +79,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_re-upload.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for Prefix and tag based filter and for more than one days
       desc: Test object expiration for Prefix and tag based filter and for more than one days
@@ -89,7 +87,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_and_tag.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration
       desc: Test object expiration for non current version expiration
@@ -98,7 +95,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
-        timeout: 300
   - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
@@ -107,7 +103,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding.yaml
-        timeout: 500
   - test:
       name: swift versioning tests
       desc: Test versioned object in swift
@@ -116,7 +111,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_versioning.yaml
-        timeout: 500
   - test:
       name: swift versioning copy tests
       desc: restore versioned object in swift
@@ -125,7 +119,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_version_copy_op.yaml
-        timeout: 500
   - test:
       name: swift object expire tests
       desc: object expire in swift
@@ -134,7 +127,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_object_expire_op.yaml
-        timeout: 500
   - test:
       name: object lock verification
       desc: object lock test
@@ -143,7 +135,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_compliance.yaml
-        timeout: 500
 
   - test:
       name: Bucket Lifecycle expiration Tests
@@ -153,7 +144,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Enable lifecycle and disable it on a bucket before objects expires
@@ -163,5 +153,4 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_disable_object_exp.yaml
-        timeout: 300
 

--- a/suites/reef/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/reef/rgw/migrate_default_single_to_multisite.yaml
@@ -182,6 +182,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
+            timeout: 5000
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -248,6 +249,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py

--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -330,6 +330,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: [ "ceph-sec","ceph-arc" ]
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py

--- a/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -418,6 +418,7 @@ tests:
             script-name: test_data_sync_init_remote.py
             config-file-name: test_data_sync_init_remote_zone.yaml
             run-on-haproxy: true
+            timeout: 5000
       desc: Test data sync init feature for multiple buckets resharded to 1999 shards
       module: sanity_rgw_multisite.py
       name: Test data sync init feature for multiple buckets resharded to 1999 shards
@@ -495,6 +496,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -507,6 +509,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
+            timeout: 5000
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -476,6 +476,7 @@ tests:
             script-name: test_bucket_lc_object_exp_multipart.py
             config-file-name: test_bucket_lc_object_exp_multipart.yaml
             verify-io-on-site: ["ceph-pri"]
+            timeout: 5000
 
 # Log trimming tests
   - test:

--- a/suites/squid/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/squid/rgw/migrate_default_single_to_multisite.yaml
@@ -184,6 +184,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
+            timeout: 5000
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
@@ -250,6 +251,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
@@ -330,6 +330,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: [ "ceph-sec","ceph-arc" ]
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-9789
       module: sanity_rgw_multisite.py

--- a/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -519,6 +519,7 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
             script-name: test_Mbuckets_with_Nobjects.py
             run-on-haproxy: true
+            timeout: 5000
       desc: Execute M buckets with N objects on primary and verify on secondary & archive cluster
       polarion-id: CEPH-83575575
       module: sanity_rgw_multisite.py
@@ -531,6 +532,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
             run-on-haproxy: true
+            timeout: 5000
       desc: test M buckets multipart uploads on haproxy node
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node

--- a/suites/squid/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -464,6 +464,7 @@ tests:
             script-name: test_bucket_lc_object_exp_multipart.py
             config-file-name: test_bucket_lc_object_exp_multipart.yaml
             verify-io-on-site: ["ceph-pri"]
+            timeout: 5000
 
 # Log trimming tests
   - test:

--- a/suites/squid/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/squid/upstream/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -216,7 +216,6 @@ tests:
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec
-            timeout: 300
       desc: create non-tenanted user
       polarion-id: CEPH-83575199
       module: sanity_rgw_multisite.py
@@ -233,7 +232,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name:  datalog omap offload with multipart objects on secondary
@@ -246,7 +244,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload_multipart.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
 
   - test:
       name:  datalog omap offload on versioned bucket on secondary
@@ -259,7 +256,6 @@ tests:
             script-name: test_data_omap_offload.py
             config-file-name: test_data_omap_offload_versioned_bucket.yaml
             verify-io-on-site: ["ceph-pri"]
-            timeout: 300
   - test:
       name: datalog trim command with delete marker enabled on secondary
       desc: Execute datalog trim command with delete marker enabled on secondary
@@ -270,7 +266,6 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_datalog_trim_command.yaml
-            timeout: 300
   - test:
       name: Test DBR reshard list and cancel command on secondary
       desc: Test DBR reshard list and cancel command on secondary
@@ -281,5 +276,4 @@ tests:
           config:
             script-name:  test_Mbuckets_with_Nobjects.py
             config-file-name:  test_Mbuckets_with_Nobjects_reshard_cancel_cmd.yaml
-            timeout: 300
             verify-io-on-site: ["ceph-pri"]

--- a/suites/squid/upstream/tier-1_rgw_and_lc.yaml
+++ b/suites/squid/upstream/tier-1_rgw_and_lc.yaml
@@ -71,7 +71,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_enable.yaml
-        timeout: 300
   - test:
       name: overwrite objects after suspending versioning
       desc: test to overwrite objects after suspending versioning
@@ -80,7 +79,6 @@ tests:
       config:
         script-name: test_versioning_with_objects.py
         config-file-name: test_versioning_objects_suspend_re-upload.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for Prefix and tag based filter and for more than one days
       desc: Test object expiration for Prefix and tag based filter and for more than one days
@@ -89,7 +87,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_and_tag.yaml
-        timeout: 300
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration
       desc: Test object expiration for non current version expiration
@@ -98,7 +95,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_prefix_non_current_days.yaml
-        timeout: 300
   - test:
       name: Dynamic Resharding tests
       desc: Resharding test - dynamic
@@ -107,7 +103,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding.yaml
-        timeout: 500
   - test:
       name: swift versioning tests
       desc: Test versioned object in swift
@@ -116,7 +111,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_versioning.yaml
-        timeout: 500
   - test:
       name: swift versioning copy tests
       desc: restore versioned object in swift
@@ -125,7 +119,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_version_copy_op.yaml
-        timeout: 500
   - test:
       name: swift object expire tests
       desc: object expire in swift
@@ -134,7 +127,6 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_swift_object_expire_op.yaml
-        timeout: 500
   - test:
       name: object lock verification
       desc: object lock test
@@ -143,7 +135,6 @@ tests:
       config:
         script-name: test_object_lock.py
         config-file-name: test_object_lock_compliance.yaml
-        timeout: 500
 
   - test:
       name: Bucket Lifecycle expiration Tests
@@ -153,7 +144,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_bucket_lc_multiple_bucket.yaml
-        timeout: 300
 
   - test:
       name: Enable lifecycle and disable it on a bucket before objects expires
@@ -163,5 +153,4 @@ tests:
       config:
         script-name: test_bucket_lifecycle_config_ops.py
         config-file-name: test_bucket_lc_disable_object_exp.yaml
-        timeout: 300
 


### PR DESCRIPTION
# Description
Previously on quincy, reef and squids are update with timeout, but not pacific as there wont be any build.
Since some pacific  suites runs as part of quincy issue seen. I suue also observed in upstream stuites
This pr also includes timeout update for some quincy, reef and squids test case where timeout is more than default timeout3600s


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
