### PR TITLE
Verification of bluestore_min_alloc_size before and after OSD deployment

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3815,6 +3815,11 @@ class RadosOrchestrator:
         if not daemon_id:
             return self.run_ceph_command(cmd=base_cmd, client_exec=True)
 
+        if daemon_type == "osd" and daemon_id:
+            return self.run_ceph_command(
+                cmd=f"{base_cmd} {daemon_type}.{daemon_id}", client_exec=True
+            )
+
         out = self.run_ceph_command(cmd=f"{base_cmd} {daemon_id}", client_exec=True)
         if out is None:
             log.error(

--- a/conf/squid/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/squid/rados/stretch-mode-host-location-attrs.yaml
@@ -70,8 +70,5 @@ globals:
         no-of-volumes: 4
         disk-size: 25
       node8:
-        image-name:
-          openstack: RHEL-9.3.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         role:
           - client

--- a/suites/reef/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/reef/rados/tier-2_rados_test_parameters.yaml
@@ -16,14 +16,20 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
-      abort-on-fail: true
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
       config:
         verify_cluster_health: true
         steps:
           - config:
               command: bootstrap
               service: cephadm
+              base_cmd_args:
+                verbose: true
               args:
                 mon-ip: node1
           - config:
@@ -32,23 +38,29 @@ tests:
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
-              service: osd
-              args:
-                all-available-devices: true
-          - config:
-              command: apply
-              service: rgw
-              pos_args:
-                - rgw.1
+              service: mgr
               args:
                 placement:
-                  label: rgw
-      desc: RHCS cluster deployment using cephadm.
-      destroy-cluster: false
-      module: test_cephadm.py
-      name: deploy cluster
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
 
   - test:
       name: Configure client admin
@@ -62,11 +74,95 @@ tests:
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node
-        caps: # authorize client capabilities
+        caps:                             # authorize client capabilities
           mon: "allow *"
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size before OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        pre_deployment_config_changes: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size After OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        post_deployment_config_verification: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
   - test:
       name: Ceph MSGRV2 paramter check in 7.x
       desc: MSGRV2 parameter check in 7.x
@@ -75,6 +171,7 @@ tests:
       config:
         scenario: msgrv2_6x
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock sleep parameter check
       desc: Mclock sleep parameter check
@@ -83,6 +180,7 @@ tests:
       config:
         scenario: mclock_sleep
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock default,reservation,limit and weight parameter check
       desc: Mclock default,reservation,limit and weight parameter check
@@ -91,6 +189,7 @@ tests:
       config:
         scenario: mclock_chg_chk
         ini-file: conf/reef/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Check RocksDB compression default value
       desc: Check that RocksDB compression value is kLZ4Compression

--- a/suites/squid/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/squid/rados/tier-2_rados_test_parameters.yaml
@@ -5,7 +5,7 @@
 #--------------------------------------------------------------------------------
 # Test Steps:
 #--------------------------------------------------------------------------------
-# - Deploy RHCS 7 cluster in RHEL 9
+# - Deploy RHCS 8 cluster in RHEL 9
 # - Check the MSGRV2 parameters
 # - Check the MSGRV2 paramters and Mclock parameters
 #--------------------------------------------------------------------------------
@@ -16,14 +16,20 @@ tests:
       desc: Setup phase to deploy the required pre-requisites for running the tests.
       module: install_prereq.py
       abort-on-fail: true
+
   - test:
-      abort-on-fail: true
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
       config:
         verify_cluster_health: true
         steps:
           - config:
               command: bootstrap
               service: cephadm
+              base_cmd_args:
+                verbose: true
               args:
                 mon-ip: node1
           - config:
@@ -32,23 +38,29 @@ tests:
               args:
                 attach_ip_address: true
                 labels: apply-all-labels
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Mgr and Mon deployment
+      desc: Add Mgr and Mon daemons
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
           - config:
               command: apply
-              service: osd
-              args:
-                all-available-devices: true
-          - config:
-              command: apply
-              service: rgw
-              pos_args:
-                - rgw.1
+              service: mgr
               args:
                 placement:
-                  label: rgw
-      desc: RHCS cluster deployment using cephadm.
-      destroy-cluster: false
-      module: test_cephadm.py
-      name: deploy cluster
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
 
   - test:
       name: Configure client admin
@@ -62,19 +74,104 @@ tests:
         install_packages:
           - ceph-common
         copy_admin_keyring: true          # Copy admin keyring to node
-        caps: # authorize client capabilities
+        caps:                             # authorize client capabilities
           mon: "allow *"
           osd: "allow *"
           mds: "allow *"
           mgr: "allow *"
+
   - test:
-      name: Ceph MSGRV2 paramter check in 7.x
-      desc: MSGRV2 parameter check in 7.x
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size before OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        pre_deployment_config_changes: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: OSD deployment
+      desc: Add OSD services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83573746
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: osd
+                  service_id: osds
+                  encrypted: "true"                     # boolean as string
+                  placement:
+                    label: osd
+                  spec:
+                    data_devices:
+                      all: "true"
+
+  - test:
+      name: MDS Service deployment with spec
+      desc: Add MDS services using spec file
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: mds
+                  service_id: cephfs
+                  placement:
+                    label: mds
+
+  - test:
+      name: RGW Service deployment
+      desc: RGW Service deployment
+      module: test_cephadm.py
+      polarion-id: CEPH-83574728
+      config:
+        steps:
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+  - test:
+      name: Ceph bluestore_min_alloc_size tests
+      desc: Modification of Ceph bluestore_min_alloc_size After OSD deployment
+      polarion-id: CEPH-83594019
+      module: test_bluestore_min_alloc_size.py
+      config:
+        post_deployment_config_verification: true
+        custom_min_alloc_size: 8192
+        default_min_alloc_size: 4096
+
+  - test:
+      name: Ceph MSGRV2 paramter check in 8.x
+      desc: MSGRV2 parameter check in 8.x
       polarion-id: CEPH-83574890
       module: test_config_parameter_chk.py
       config:
         scenario: msgrv2_6x
         ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock sleep parameter check
       desc: Mclock sleep parameter check
@@ -83,6 +180,7 @@ tests:
       config:
         scenario: mclock_sleep
         ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Mclock default,reservation,limit and weight parameter check
       desc: Mclock default,reservation,limit and weight parameter check
@@ -91,6 +189,7 @@ tests:
       config:
         scenario: mclock_chg_chk
         ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
   - test:
       name: Check RocksDB compression default value
       desc: Check that RocksDB compression value is kLZ4Compression

--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -1,0 +1,256 @@
+"""
+Module to test bluestore_min_alloc_size functionality on RHCS 7.0 and above clusters
+
+"""
+
+import re
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados import utils
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.log import Log
+from utility.utils import method_should_succeed, should_not_be_empty
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Module to test bluestore_min_alloc_size functionality on RHCS 7.0 and above clusters
+    Bugzilla automated : 2264726
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    custom_min_alloc_size = config.get("custom_min_alloc_size", 8192)
+    default_min_alloc_size = config.get("default_min_alloc_size", 4096)
+
+    regex = r"\s*(\d.\d)-rhel-\d"
+    build = (re.search(regex, config.get("build", config.get("rhbuild")))).groups()[0]
+    if not float(build) >= 7.0:
+        log.info(
+            "Test running on version less than 7.0, skipping verifying Reads Balancer functionality"
+        )
+        return 0
+
+    try:
+        if config.get("pre_deployment_config_changes"):
+            log.info(
+                "Updating the configs on the cluster before OSD deployment on the cluster"
+            )
+            min_alloc_size_hdd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+            )
+
+            min_alloc_size_ssd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_ssd")
+            )
+
+            if not min_alloc_size_hdd == min_alloc_size_ssd == 4096:
+                log.error(
+                    f"min_alloc_size does not match the expected default value of 4096"
+                    f"min_alloc_size_ssd on cluster: {min_alloc_size_ssd}"
+                    f"min_alloc_size_hdd on cluster: {min_alloc_size_hdd}"
+                )
+                raise Exception("non-default values for min_alloc_size on cluster")
+
+            log.info(
+                "Verified the default value of min_alloc_size. Modifying the value before OSD deployments"
+            )
+
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_hdd",
+                value=custom_min_alloc_size,
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_ssd",
+                value=custom_min_alloc_size,
+            )
+            time.sleep(10)
+
+            min_alloc_size_hdd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+            )
+
+            min_alloc_size_ssd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_ssd")
+            )
+            if not min_alloc_size_hdd == min_alloc_size_ssd == custom_min_alloc_size:
+                log.error(
+                    f"min_alloc_size does not match the expected custom value of {custom_min_alloc_size}"
+                    f"min_alloc_size_ssd on cluster: {min_alloc_size_ssd}"
+                    f"min_alloc_size_hdd on cluster: {min_alloc_size_hdd}"
+                )
+                raise Exception("Value not updated for min_alloc_size on cluster")
+
+            log.info("Successfully modified the value of min_alloc_size")
+            return 0
+
+        if config.get("post_deployment_config_verification"):
+            min_alloc_size_hdd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_hdd")
+            )
+
+            min_alloc_size_ssd = int(
+                mon_obj.get_config(section="osd", param="bluestore_min_alloc_size_ssd")
+            )
+
+            # Getting random OSDs and checking their alloc size
+            pg_set = rados_obj.get_pg_acting_set()
+            for osd_id in pg_set:
+                osd_meta = rados_obj.get_daemon_metadata(
+                    daemon_type="osd", daemon_id=osd_id
+                )
+
+                if (
+                    not min_alloc_size_hdd
+                    == min_alloc_size_ssd
+                    == custom_min_alloc_size
+                    == int(osd_meta["bluestore_min_alloc_size"])
+                ):
+                    log.error(
+                        f"min_alloc_size does not match the expected updated value of {custom_min_alloc_size}\n"
+                        f"min_alloc_size_ssd on cluster: {min_alloc_size_ssd}\n"
+                        f"min_alloc_size_hdd on cluster: {min_alloc_size_hdd}\n"
+                        f"min_alloc_size on osd {osd_id} metadata: {osd_meta['bluestore_min_alloc_size']}\n"
+                    )
+                    raise Exception(
+                        "default values for min_alloc_size on cluster post changing"
+                    )
+
+                log.info(
+                    f"OSDs successfully deployed with the new alloc size, and verified the size on OSD: {osd_id}"
+                )
+
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_hdd",
+                value=default_min_alloc_size,
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_ssd",
+                value=default_min_alloc_size,
+            )
+            time.sleep(10)
+
+            def remove_osd_check_metadata(target_osd, alloc_size):
+                log.debug(
+                    f"Ceph osd tree before OSD removal : \n\n {rados_obj.run_ceph_command(cmd='ceph osd tree')} \n\n"
+                )
+                test_host = rados_obj.fetch_host_node(
+                    daemon_type="osd", daemon_id=target_osd
+                )
+                should_not_be_empty(test_host, "Failed to fetch host details")
+                dev_path = get_device_path(test_host, target_osd)
+                log.debug(
+                    f"osd device path  : {dev_path}, osd_id : {target_osd}, hostname : {test_host.hostname}"
+                )
+                utils.set_osd_devices_unmanaged(
+                    ceph_cluster, target_osd, unmanaged=True
+                )
+                method_should_succeed(utils.set_osd_out, ceph_cluster, target_osd)
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
+                log.debug("Cluster clean post draining of OSD for removal")
+                utils.osd_remove(ceph_cluster, target_osd)
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
+                method_should_succeed(
+                    utils.zap_device, ceph_cluster, test_host.hostname, dev_path
+                )
+                method_should_succeed(
+                    wait_for_device_rados, test_host, target_osd, action="remove"
+                )
+                # Waiting for recovery to post OSD host removal
+                method_should_succeed(wait_for_clean_pg_sets, rados_obj, timeout=12000)
+
+                # Adding the removed OSD back and checking the cluster status
+                log.debug("Adding the removed OSD back and checking the cluster status")
+                utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
+                method_should_succeed(
+                    wait_for_device_rados, test_host, target_osd, action="add"
+                )
+                time.sleep(30)
+                log.debug(
+                    "Completed addition of OSD post removal. Checking bluestore_min_alloc_size value post OSD addition"
+                )
+                osd_meta = rados_obj.get_daemon_metadata(
+                    daemon_type="osd", daemon_id=target_osd
+                )
+                if int(osd_meta["bluestore_min_alloc_size"]) != alloc_size:
+                    log.error(
+                        f"bluestore_min_alloc_size not set to {alloc_size} "
+                        f"after updating the config and OSD : {target_osd} redeployment"
+                        f"OSD Metadata : {osd_meta}"
+                    )
+                    return False
+
+                log.info(
+                    "bluestore_min_alloc_size correctly displayed "
+                    "in OSD metadata post modification and redeployment"
+                )
+                return True
+
+            rm_osd = pg_set[0]
+            log.debug(f"Selected OSD for removal : {rm_osd}")
+            try:
+                if not remove_osd_check_metadata(
+                    target_osd=rm_osd, alloc_size=default_min_alloc_size
+                ):
+                    log.error(
+                        f"OSD : {rm_osd} could not be redeployed with alloc size {default_min_alloc_size}"
+                    )
+                    return 1
+                log.info(
+                    f"OSD : {rm_osd} successfully redeployed with alloc size {default_min_alloc_size}"
+                )
+            except Exception as err:
+                log.error(f"Hit Exception during OSD redeployment : {err}")
+                return 1
+            log.info(
+                f"Redeploying OSD : {rm_osd} with alloc size {custom_min_alloc_size}, So that the cluster alloc_size is"
+                f"Homogeneous among all OSDs"
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_hdd",
+                value=custom_min_alloc_size,
+            )
+            mon_obj.set_config(
+                section="osd",
+                name="bluestore_min_alloc_size_ssd",
+                value=custom_min_alloc_size,
+            )
+            try:
+                if not remove_osd_check_metadata(
+                    target_osd=rm_osd, alloc_size=custom_min_alloc_size
+                ):
+                    log.error(
+                        f"OSD : {rm_osd} could not be redeployed with alloc size {custom_min_alloc_size}"
+                    )
+                    return 1
+                log.info(
+                    f"OSD : {rm_osd} successfully redeployed with alloc size {custom_min_alloc_size}"
+                )
+            except Exception as err:
+                log.error(f"Hit Exception during OSD redeployment : {err}")
+                return 1
+            log.info("All tests completed. Pass")
+            return 0
+    except Exception as err:
+        log.error(f"Hit exception during execution. Error: {err} ")
+
+    finally:
+        rados_obj.rados_pool_cleanup()
+        time.sleep(60)
+        # log cluster health
+        rados_obj.log_cluster_health()


### PR DESCRIPTION
# Description
steps:
1. Modify bluestore_min_alloc_size_hdd & bluestore_min_alloc_size_ssd before OSD deployment.
2. Modify bluestore_min_alloc_size_hdd & bluestore_min_alloc_size_ssd post OSD deployment.

Check if both 1 & 2 are valid.

Check the values set via:
1. config get
2.  ceph osd metadata osd.1 | grep bluestore_min_alloc_size

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
