### PR TITLE
integrating rgw user cap user-info-without-keys tests into cephci

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -544,6 +544,14 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
+  - test:
+      name: Test rgw user capability user-info-without-keys using curl
+      desc: Test rgw user capability user-info-without-keys using curl
+      polarion-id: CEPH-83582351
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_user_cap_user_info_without_keys.yaml
 
   - test:
       name: Test bucket listing is not truncated

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -535,6 +535,14 @@ tests:
       config:
         script-name: ../curl/test_quota_using_curl.py
         config-file-name: ../../curl/configs/test_quota_mgmt_conflict_bucket_quota_using_curl.yaml
+  - test:
+      name: Test rgw user capability user-info-without-keys using curl
+      desc: Test rgw user capability user-info-without-keys using curl
+      polarion-id: CEPH-83582351
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_rgw_using_curl.py
+        config-file-name: ../../curl/configs/test_rgw_user_cap_user_info_without_keys.yaml
 
   - test:
       name: Test bucket listing is not truncated


### PR DESCRIPTION
depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/624

this PR is to test rgw user capability user-info-without-keys which is added in rhcs7.1

polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83582351

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_rgw_user_cap_user_info_without_keys/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
