### PR TITLE
Modify nvmeof sanity test suite with hostnqn addition for host add to subsystem

### DIFF
--- a/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
+++ b/suites/reef/nvmeof/tier-1_nvmeof_sanity.yaml
@@ -123,6 +123,14 @@ tests:
               size: 10G
             listener_port: 5001
             allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              count: 1
+              size: 10G
+            listener_port: 5002
+            hosts:
+              - node10
         initiators:                             # Configure Initiators with all pre-req
           - subnqn: nqn.2016-06.io.spdk:cnode1
             listener_port: 5001

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -20,20 +20,30 @@ from utility.utils import generate_unique_id, run_fio
 LOG = Log(__name__)
 
 
-def configure_subsystems(rbd, pool, nvmegwcli, config):
+def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
     """Configure Ceph-NVMEoF Subsystems."""
     sub_args = {"subsystem": config["nqn"]}
     nvmegwcli.subsystem.add(
         **{"args": {**sub_args, **{"max-namespaces": config.get("max_ns", 32)}}}
     )
-
     listener_cfg = {
         "host-name": nvmegwcli.fetch_gateway_hostname(),
         "traddr": nvmegwcli.node.ip_address,
         "trsvcid": config["listener_port"],
     }
     nvmegwcli.listener.add(**{"args": {**listener_cfg, **sub_args}})
-    nvmegwcli.host.add(**{"args": {**sub_args, **{"host": repr(config["allow_host"])}}})
+    if config.get("allow_host"):
+        nvmegwcli.host.add(
+            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
+        )
+
+    if config.get("hosts"):
+        for host in config["hosts"]:
+            initiator_node = get_node_by_id(ceph_cluster, host)
+            initiator = Initiator(initiator_node)
+            host_nqn = initiator.nqn()
+            nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
+
     if config.get("bdevs"):
         name = generate_unique_id(length=4)
         with parallel() as p:
@@ -292,7 +302,12 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             with parallel() as p:
                 for subsys_args in config["subsystems"]:
                     p.spawn(
-                        configure_subsystems, rbd_obj, rbd_pool, nvmegwcli, subsys_args
+                        configure_subsystems,
+                        ceph_cluster,
+                        rbd_obj,
+                        rbd_pool,
+                        nvmegwcli,
+                        subsys_args,
                     )
 
         if config.get("initiators"):

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -56,7 +56,7 @@ def test_ceph_83575812(ceph_cluster, rbd, pool, config):
         "node": config["initiator_node"],
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -109,7 +109,7 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
         "node": config["initiator_node"],
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -212,7 +212,7 @@ def test_ceph_83575467(ceph_cluster, rbd, pool, config):
         "node": config["initiator_node"],
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create images
@@ -306,7 +306,7 @@ def test_ceph_83576085(ceph_cluster, rbd, pool, config):
     _file = f"{_dir}/test.log"
 
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -399,7 +399,7 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
     _file = f"{_dir}/test.log"
 
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -490,7 +490,7 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
     }
 
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -598,7 +598,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
     _file = f"{_dir}/test.log"
 
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -718,7 +718,7 @@ def test_ceph_83575813(ceph_cluster, rbd, pool, config):
     client = get_node_by_id(ceph_cluster, config["initiator_node"])
     initiator = Initiator(client)
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -817,7 +817,7 @@ def test_ceph_83575814(ceph_cluster, rbd, pool, config):
         "node": config.get("initiator_node"),
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
 
         # Create image
@@ -895,7 +895,7 @@ def test_ceph_83581753(ceph_cluster, rbd, pool, config):
         "node": config.get("initiator_node"),
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         list_args = {}
         list_args.setdefault("args", {}).update(
             {"subsystem": "nqn.2016-06.io.spdk:ceph-83581753"}
@@ -985,7 +985,7 @@ def test_ceph_83581945(ceph_cluster, rbd, pool, config):
         "node": config.get("initiator_node"),
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         list_args = {}
         list_args.setdefault("args", {}).update({"subsystem": subsystem["nqn"]})
         list_args.setdefault("base_cmd_args", {}).update({"format": "json"})
@@ -1092,7 +1092,7 @@ def test_ceph_83581755(ceph_cluster, rbd, pool, config):
         "node": config.get("initiator_node"),
     }
     try:
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         list_args = {}
         list_args.setdefault("args", {}).update({"subsystem": subsystem["nqn"]})
         list_args.setdefault("base_cmd_args", {}).update({"format": "json"})

--- a/tests/nvmeof/test_io_perf.py
+++ b/tests/nvmeof/test_io_perf.py
@@ -491,7 +491,7 @@ def nvmeof(ceph_cluster, **args):
             "listener_port": subsystem["listener_port"],
             "node": args["initiator_node"],
         }
-        configure_subsystems(rbd, pool, nvmegwcli, subsystem)
+        configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         try:
             for i in range(args["image"]["count"]):
                 rbd.create_image(pool, f"{name}-image{i}", args["image"]["size"])


### PR DESCRIPTION
Added support for subsystem access through hostnqn of initiator by provisioning hostnqn to host add command

```
        subsystems:                             # Configure subsystems with all sub-entities
          - nqn: nqn.2016-06.io.spdk:cnode1
            serial: 1
            bdevs:
              count: 1
              size: 10G
            listener_port: 5001
            allow_host: "*"
          - nqn: nqn.2016-06.io.spdk:cnode2
            serial: 2
            bdevs:
              count: 1
              size: 10G
            listener_port: 5002
            hosts:
              - node10
```

```
2024-08-07 07:37:26,629 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1528 - long running command on 10.0.65.219 -- podman login --username cp --password eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJJQk0gTWFya2V0cGxhY2UiLCJlbnYiOiJzdGFnZSIsImlhdCI6MTcxMzc3NTQ1NSwianRpIjoiYzZmMTc5N2JiOTA4NGQ2YzkwZWUxNjQ3MzNhOWFmNDAifQ.DgpzR7VvRQ3ZUFwD_CCCH57gy3wuv_BRvva7F_sXCjE cp.stg.icr.io with 3600 seconds
2024-08-07 07:37:27,633 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.ceph.py:1553 - b'Login Succeeded!'
2024-08-07 07:37:27,633 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1560 - Command completed on 2024-08-07 07:37:27.633261
2024-08-07 07:37:27,633 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : subsystem add
2024-08-07 07:37:27,634 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 subsystem add  --subsystem nqn.2016-06.io.spdk:cnode1 --max-namespaces 32 on 10.0.65.219 timeout 600
2024-08-07 07:37:27,634 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : subsystem add
2024-08-07 07:37:27,635 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 subsystem add  --subsystem nqn.2016-06.io.spdk:cnode2 --max-namespaces 32 on 10.0.65.219 timeout 600
2024-08-07 07:37:28,865 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:28,865 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding subsystem nqn.2016-06.io.spdk:cnode2: Successful\n')
2024-08-07 07:37:28,865 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : gw info
2024-08-07 07:37:28,866 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --format json --server-address 10.0.65.219 --server-port 5500 gw info  on 10.0.65.219 timeout 600
2024-08-07 07:37:29,043 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:29,043 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding subsystem nqn.2016-06.io.spdk:cnode1: Successful\n')
2024-08-07 07:37:29,044 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : gw info
2024-08-07 07:37:29,044 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --format json --server-address 10.0.65.219 --server-port 5500 gw info  on 10.0.65.219 timeout 600
2024-08-07 07:37:29,918 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:29,918 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', '{\n    "cli_version": "1.2.17",\n    "version": "1.2.17",\n    "name": "client.nvmeof.rbd.ceph-nvme-1-wzk17m-node6.gllzxo",\n    "addr": "10.0.65.219",\n    "port": "5500",\n    "bool_status": true,\n    "error_message": "Success",\n    "spdk_version": "24.01.1",\n    "load_balancing_group": 1,\n    "hostname": "ceph-nvme-1-wzk17m-node6",\n    "group": "",\n    "status": 0\n}\n')
2024-08-07 07:37:29,918 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : listener add
2024-08-07 07:37:29,919 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 listener add  --host-name ceph-nvme-1-wzk17m-node6 --traddr 10.0.65.219 --trsvcid 5002 --subsystem nqn.2016-06.io.spdk:cnode2 on 10.0.65.219 timeout 600
2024-08-07 07:37:30,093 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:30,093 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', '{\n    "cli_version": "1.2.17",\n    "version": "1.2.17",\n    "name": "client.nvmeof.rbd.ceph-nvme-1-wzk17m-node6.gllzxo",\n    "addr": "10.0.65.219",\n    "port": "5500",\n    "bool_status": true,\n    "error_message": "Success",\n    "spdk_version": "24.01.1",\n    "load_balancing_group": 1,\n    "hostname": "ceph-nvme-1-wzk17m-node6",\n    "group": "",\n    "status": 0\n}\n')
2024-08-07 07:37:30,093 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : listener add
2024-08-07 07:37:30,093 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 listener add  --host-name ceph-nvme-1-wzk17m-node6 --traddr 10.0.65.219 --trsvcid 5001 --subsystem nqn.2016-06.io.spdk:cnode1 on 10.0.65.219 timeout 600
2024-08-07 07:37:30,935 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:30,935 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding nqn.2016-06.io.spdk:cnode2 listener at 10.0.65.219:5002: Successful\n')
2024-08-07 07:37:30,936 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command yum install -y nvme-cli fio on 10.0.64.123 timeout 600
2024-08-07 07:37:31,171 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:31,171 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding nqn.2016-06.io.spdk:cnode1 listener at 10.0.65.219:5001: Successful\n')
2024-08-07 07:37:31,171 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : host add
2024-08-07 07:37:31,171 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 host add  --subsystem nqn.2016-06.io.spdk:cnode1 --host '*' on 10.0.65.219 timeout 600
2024-08-07 07:37:32,134 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:32,135 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Allowing open host access to nqn.2016-06.io.spdk:cnode1: Successful\n')
2024-08-07 07:37:32,135 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command rbd create rbd/9LJ2-image0 --size 10G on 10.0.64.123 timeout 600
2024-08-07 07:37:32,278 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:32,278 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.rbd.rbd_utils.py:107 - Command execution complete
2024-08-07 07:37:32,278 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.parallel.py:89 - result is 0
2024-08-07 07:37:32,279 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : namespace add
2024-08-07 07:37:32,279 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 namespace add  --subsystem nqn.2016-06.io.spdk:cnode1 --rbd-pool rbd --rbd-image 9LJ2-image0 on 10.0.65.219 timeout 600
2024-08-07 07:37:33,076 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command modprobe nvme-fabrics on 10.0.64.123 timeout 600
2024-08-07 07:37:33,096 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command nvme show-hostnqn on 10.0.64.123 timeout 600
2024-08-07 07:37:33,115 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:33,116 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : host add
2024-08-07 07:37:33,116 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 host add  --subsystem nqn.2016-06.io.spdk:cnode2 --host nqn.2014-08.org.nvmexpress:uuid:a92ca03f-7c47-4940-adc2-483468d0326c on 10.0.65.219 timeout 600
2024-08-07 07:37:33,288 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:33,288 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding namespace 1 to nqn.2016-06.io.spdk:cnode1: Successful\n')
2024-08-07 07:37:33,289 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.parallel.py:89 - result is ('', 'Adding namespace 1 to nqn.2016-06.io.spdk:cnode1: Successful\n')
2024-08-07 07:37:34,051 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:34,052 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding host nqn.2014-08.org.nvmexpress:uuid:a92ca03f-7c47-4940-adc2-483468d0326c to nqn.2016-06.io.spdk:cnode2: Successful\n')
2024-08-07 07:37:34,052 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command rbd create rbd/T09U-image0 --size 10G on 10.0.64.123 timeout 600
2024-08-07 07:37:34,165 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:34,166 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.rbd.rbd_utils.py:107 - Command execution complete
2024-08-07 07:37:34,166 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.parallel.py:89 - result is 0
2024-08-07 07:37:34,166 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:16 - NVMe CLI command : namespace add
2024-08-07 07:37:34,166 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1596 - Running command podman run --quiet --rm cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.2.17-8  --server-address 10.0.65.219 --server-port 5500 namespace add  --subsystem nqn.2016-06.io.spdk:cnode2 --rbd-pool rbd --rbd-image T09U-image0 on 10.0.65.219 timeout 600
2024-08-07 07:37:35,158 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.ceph.py:1630 - Command completed successfully
2024-08-07 07:37:35,158 (cephci.test_ceph_nvmeof_gateway) [INFO] - cephci.nvmegw_cli.execute.py:36 - ('', 'Adding namespace 1 to nqn.2016-06.io.spdk:cnode2: Successful\n')
2024-08-07 07:37:35,158 (cephci.test_ceph_nvmeof_gateway) [DEBUG] - cephci.parallel.py:89 - result is ('', 'Adding namespace 1 to nqn.2016-06.io.spdk:cnode2: Successful\n')
```