### PR TITLE
Support s3tests from ceph-squid branch

### DIFF
--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -177,7 +177,7 @@ def execute_s3_tests(node: CephNode, build: str, encryption: bool = False) -> in
         extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616,!encryption'"
         tests = "s3tests"
 
-        if not build.startswith("7"):
+        if not build.split(".")[0] >= "7":
             extra_args = "-a '!fails_on_rgw,!fails_strict_rfc2616"
 
             if not encryption:


### PR DESCRIPTION
# Description
Support s3tests from ceph-squid branch 
to avoid failure seen in: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-XEXUZ9/execute_s3tests_0.log

failure seen here is due to:
ceph-squid has all of the new account tests. it expects new [iam root] and [iam alt root] sections in the config file
created enhancement ticket to implement this







Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
