### PR TITLE
[Tier-3]CEPH-83575305 - Disable dynamic reshard on primary, and let it be enabled on secondary

### DIFF
--- a/suites/squid/rgw/baremetal/scale_rgw_multi_site.yaml
+++ b/suites/squid/rgw/baremetal/scale_rgw_multi_site.yaml
@@ -368,3 +368,106 @@ tests:
             module: push_cosbench_workload.py
             name: push cosbench cleanup workload from secondary
             polarion-id: CEPH-83575074
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.pri.io rgw_dynamic_resharding false"
+              - "ceph config set client.rgw.shared.pri.sync rgw_dynamic_resharding false"
+              - "ceph orch restart {service_name:shared.pri.io}"
+              - "ceph orch restart {service_name:shared.pri.sync}"
+      desc: Set rgw_dynamic_resharding to false
+      name: disable dynamic rehsarding from primary
+      polarion-id: CEPH-83575305
+      module: exec.py
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            controllers:
+              - clara001
+            drivers:
+              - clara001
+              - clara011
+              - clara012
+            workload_type: fill
+            bucket_prefix: bkt-dynamic-
+            number_of_buckets: 1
+            number_of_objects: 10000000
+            record_sync_on_site: ceph-sec
+      desc: post disabling dynamic resharding in primary create and upload 10M objects
+      module: push_cosbench_workload.py
+      name: push cosbench fill workload
+      polarion-id: CEPH-83575305
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin bucket stats --bucket bkt-dynamic-1 | egrep 'num_shards|num_objects'"
+              - "radosgw-admin bucket reshard --bucket bkt-dynamic-1 --num-shards 45"
+              - "radosgw-admin bucket stats --bucket bkt-dynamic-1 | egrep 'num_shards|num_objects'"
+              - "radosgw-admin sync status"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin bucket stats --bucket bkt-dynamic-1 | egrep 'num_shards|num_objects'"
+              - "radosgw-admin sync status"
+      desc: test manually resharding bucket bkt-dynamic-1 to 45
+      name: manually resharding bucket bkt-dynamic-1 to 45
+      polarion-id: CEPH-83575305
+      module: exec.py
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            controllers:
+              - clara001
+            drivers:
+              - clara001
+              - clara011
+              - clara012
+            workload_type: symmetrical
+            bucket_prefix: bkt-dynamic-
+            number_of_buckets: 1
+            number_of_objects: 10000000
+            object_prefix: new-obj-
+            record_sync_on_site: ceph-sec
+      desc: upload 1OM objects post manual resharding to 45
+      module: push_cosbench_workload.py
+      name: upload 1OM objects post manual resharding to 45
+      polarion-id: CEPH-83575305
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.pri.io rgw_dynamic_resharding true"
+              - "ceph config set client.rgw.shared.pri.sync rgw_dynamic_resharding true"
+              - "ceph orch restart {service_name:shared.pri.io}"
+              - "ceph orch restart {service_name:shared.pri.sync}"
+              - "radosgw-admin bucket stats --bucket bkt-dynamic-1 | egrep 'num_shards|num_objects'"
+              - "radosgw-admin sync status"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin bucket stats --bucket bkt-dynamic-1 | egrep 'num_shards|num_objects'"
+              - "radosgw-admin sync status"
+      desc: Set rgw_dynamic_resharding to true
+      name: enable dynamic rehsarding from primary
+      polarion-id: CEPH-83575305
+      module: exec.py

--- a/tests/misc_env/push_cosbench_workload.py
+++ b/tests/misc_env/push_cosbench_workload.py
@@ -49,7 +49,7 @@ fill_workload = """<?xml version="1.0" encoding="UTF-8" ?>
     </workstage>
 
     <workstage name="preparing_cluster">
-        <work type="prepare" workers="1" config="cprefix=bucket_prefix;containers=r(1,bucket_count);oprefix=pri-obj;
+        <work type="prepare" workers="1" config="cprefix=bucket_prefix;containers=r(1,bucket_count);oprefix=obj_prefix;
         objects=r(obj_num_start,objects_count);sizes=h(1|5|25,5|50|40,50|256|25,256|512|5,512|1024|3,1024|5120|1,5120|51200|1)KB"/>
     </workstage>
   </workflow>
@@ -68,15 +68,15 @@ hybrid_workload = """<?xml version="1.0" encoding="UTF-8" ?>
     <workstage name="MAIN">
         <work name="hybrid" workers="1" runtime="run_time" >
             <operation name="writeOP" type="write" ratio="36" config="cprefix=bucket_prefix;containers=u(1,2);
-            oprefix=pri-obj;objects=u(obj_num_start,objects_count);
+            oprefix=obj_prefix;objects=u(obj_num_start,objects_count);
             sizes=h(1|5|25,5|50|40,50|256|25,256|512|5,512|1024|3,1024|5120|1,5120|51200|1)KB" />
             <operation name="deleteOP" type="delete" ratio="5" config="cprefix=bucket_prefix;containers=u(3,4);
-            oprefix=pri-obj;objects=u(obj_num_start,objects_count);
+            oprefix=obj_prefix;objects=u(obj_num_start,objects_count);
             sizes=h(1|5|25,5|50|40,50|256|25,256|512|5,512|1024|3,1024|5120|1,5120|51200|1)KB" />
             <operation name="readOP" type="read" ratio="44" config="cprefix=bucket_prefix;containers=u(5,6);
-            oprefix=pri-obj;objects=u(obj_num_start,objects_count)" />
+            oprefix=obj_prefix;objects=u(obj_num_start,objects_count)" />
             <operation name="listOP" type="list" ratio="15" config="cprefix=bucket_prefix;containers=u(5,6);
-            oprefix=pri-obj;objects=u(obj_num_start,objects_count)" />
+            oprefix=obj_prefix;objects=u(obj_num_start,objects_count)" />
         </work>
     </workstage>
   </workflow>
@@ -114,7 +114,7 @@ fill_runtime_workload = """<?xml version="1.0" encoding="UTF-8" ?>
     <workstage name="MAIN">
         <work name="fill with runtime" workers="1" runtime="run_time" >
             <operation name="writeOP" type="write" ratio="100" config="cprefix=bucket_prefix;
-            containers=r(1,bucket_count);oprefix=pri-obj;objects=r(obj_num_start,objects_count);
+            containers=r(1,bucket_count);oprefix=obj_prefix;objects=r(obj_num_start,objects_count);
             sizes=h(1|5|25,5|50|40,50|256|25,256|512|5,512|1024|3,1024|5120|1,5120|51200|1)KB" />
         </work>
     </workstage>
@@ -137,7 +137,7 @@ def prepare_workload_config_file(ceph_cluster, client, rgw, controller, config):
         workload xml file name which is created on controller node
     """
     global fill_workload, avail_storage, hybrid_workload, bucket_prefix, symm_workload, bucket_count, cleanup_workload
-    global fill_runtime_workload, objects_count
+    global fill_runtime_workload, objects_count, obj_prefix
     workload_type = config.get("workload_type", "fill")
     if workload_type == "fill":
         workload_conf = fill_workload
@@ -150,7 +150,9 @@ def prepare_workload_config_file(ceph_cluster, client, rgw, controller, config):
     elif workload_type == "fill_runtime":
         workload_conf = fill_runtime_workload
     bucket_prefix = config.get("bucket_prefix", "pri-bkt")
+    obj_prefix = config.get("object_prefix", "pri-obj")
     workload_conf = workload_conf.replace("bucket_prefix", f"{bucket_prefix}")
+    workload_conf = workload_conf.replace("obj_prefix", f"{obj_prefix}")
     bucket_count = config.get("number_of_buckets", 6)
     workload_conf = workload_conf.replace("bucket_count", f"{bucket_count}")
     run_time = config.get("run_time", 3600)


### PR DESCRIPTION
# Description
 For logs dependent on scale setup, there is an issue with setup.
 will try to use mero, for mero reimage issue is there ticket is created : https://tracker.ceph.com/issues/67527
 
 
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
