### PR TITLE
[test][dmfg] Verify rgw realm/zone deployment using spec file

### DIFF
--- a/suites/quincy/cephadm/customer_bz/tier4-deploy-rgw-using-spec-file.yaml
+++ b/suites/quincy/cephadm/customer_bz/tier4-deploy-rgw-using-spec-file.yaml
@@ -1,0 +1,87 @@
+#===============================================================================================
+#-------------------------------------
+#-----    Smoke Test suite     ------
+#-------------------------------------
+# Conf: conf/quincy/cephadm/tier-0.yaml
+# Smoke test cases for
+#    - Bootstrap
+#    - Deploy services
+#    - Deploy custom RGW using spec file
+#===============================================================================================
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          - config:
+              args:
+                - "ceph fs volume create cephfs"
+              command: shell
+          - config:
+              args:
+                placement:
+                  label: mds
+              base_cmd_args:
+                verbose: true
+              command: apply
+              pos_args:
+                - cephfs
+              service: mds
+          - config:
+              args:
+                - "ceph osd pool create rbd"
+              command: shell
+          - config:
+              args:
+                - "rbd pool init rbd"
+              command: shell
+      desc: bootstrap and deploy services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: Deploy cluster using cephadm
+
+  - test:
+      name: Deploy custom RGW using spec file
+      desc: Deploy custom RGW realm/zone using orchestrator and a specification file (customer_bz)
+      polarion-id: CEPH-83594641
+      module: test_deploy_rgw_using_spec.py
+      config:
+        specs:
+          rgw_realm: mytestrealm
+          rgw_zonegroup: mytestzonegroup
+          rgw_zone: mytestzone
+          placement:
+              count: 2
+          spec:
+            rgw_frontend_port: 5500

--- a/tests/cephadm/test_deploy_rgw_using_spec.py
+++ b/tests/cephadm/test_deploy_rgw_using_spec.py
@@ -1,0 +1,38 @@
+from cli.cephadm.cephadm import CephAdm
+from cli.exceptions import OperationFailedError
+from cli.utilities.utils import create_yaml_config
+
+
+def run(ceph_cluster, **kw):
+    """
+    Validate the change in retention time for Prometheus
+    """
+    config = kw.get("config", {})
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+    specs = config.get("specs")
+    realm_name = specs.get("rgw_realm")
+
+    # Enable MGR module
+    CephAdm(installer).ceph.mgr.module.enable("rgw")
+
+    # Bootstrap rgw using new spec file
+    file = create_yaml_config(installer, specs)
+    conf = {"in-file": file}
+    out = CephAdm(installer, mount=file).ceph.rgw.realm.bootstrap(**conf)
+    if "Realm(s) created correctly" not in out:
+        raise OperationFailedError(
+            "Failed to perform rgw realm bootstrap using spec file"
+        )
+
+    # Validate rgw realm tokens
+    tokens = CephAdm(installer).ceph.rgw.realm.tokens()
+    if not tokens:
+        raise OperationFailedError(
+            "Failed: No realm tokens are listed even after rgw bootstrap"
+        )
+    if realm_name not in tokens:
+        raise OperationFailedError(
+            "Failed: The recently created realm token is not listed"
+        )
+
+    return 0


### PR DESCRIPTION
# Description
This test validates the deployment of rgw realm/zones using the orchestrator with a spec file using the below command:
`ceph rgw realm bootstrap --in-file rgw_realm.yaml`

### Changes
Added test file and suite for the test

### Logs
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PCDKT2/Deploy_custom_RGW_using_spec_file_0.log
