### PR TITLE
[TFA] Remove testcase realated to Bug-2298084 as this RFE wont fix for quincy

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_cephadm.yaml
@@ -200,7 +200,7 @@ tests:
       module: exec.py
       name: disable sync between zones
       polarion-id: CEPH-83581229
-      comments: Known issue BZ-2303415 targeted to 6.1z7
+      comments: Known issue BZ-2303415 targeted to 6.1z8
 
   - test:
       name: Test the byte ranges with get object

--- a/suites/pacific/rgw/tier-2_rgw_multisite_scenarios.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_multisite_scenarios.yaml
@@ -250,7 +250,7 @@ tests:
       module: exec.py
       name: disable multisite sync between zones
       polarion-id: CEPH-83581229
-      comments: Known issue BZ-2303415 targeted to 6.1z7
+      comments: Known issue BZ-2303415 targeted to 6.1z8
 
   - test:
       name: Test the byte ranges with get object on primary zone and check multisite replication doesn't happen

--- a/suites/quincy/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_multisite_archive_with_haproxy.yaml
@@ -623,18 +623,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name: test_s3_copy_encryption.py
-            run-on-haproxy: true
-            config-file-name: test_server_side_copy_object_via_encryption.yaml
-      desc: test server_side_copy_object_via_encryption
-      module: sanity_rgw_multisite.py
-      name: test server_side_copy_object_via_encryption
-      polarion-id: CEPH-83575711
-      comment: Known issue Bug-2298084 targeted tp 6.1z7 fixed in 7
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             script-name: test_encrypted_bucket_chown.py
             run-on-haproxy: true
             config-file-name: test_encrypted_bucket_chown.yaml


### PR DESCRIPTION
# Description
[TFA] Remove testcase realated to Bug-2298084 as this RFE wont fix for quincy
BZ : [Bug 2298084](https://bugzilla.redhat.com/show_bug.cgi?id=2298084) - [RFE] Implement Server side encryption support for s3 COPY operation, closed as wont fix
this is a rfe from 7.1 which was fixed, we raised this to have back ported to 6.1.
this is closed as wont fix, since its an rfe of 7.1 and rfe will not be back ported to lower versions.

updated target of bz : 2303415


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
