### PR TITLE
TFA-FIX-Added the number of objects parameter as a user input

### DIFF
--- a/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -437,6 +437,7 @@ tests:
       config:
         verify_client_pg_access:
           num_snapshots: 20
+          num_objects: 250
           configurations:
             pool-1:
               profile_name: ec86_12

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -437,6 +437,7 @@ tests:
       config:
         verify_client_pg_access:
           num_snapshots: 20
+          num_objects: 250
           configurations:
             pool-1:
               profile_name: ec86_12

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -438,6 +438,7 @@ tests:
       config:
         verify_client_pg_access:
           num_snapshots: 20
+          num_objects: 250
           configurations:
             pool-1:
               profile_name: ec86_12


### PR DESCRIPTION
# Description

Deleting the approximately 1000 objects is a laborious task for the script. The num_objects user parameter (number of objects) was added as part of the fix, and its value is 250.
 
Jira Task - https://issues.redhat.com/browse/RHCEPHQE-12871


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
