### PR TITLE
CEPH-83594645: Ensure client connection over v1 port does not crash

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3123,14 +3123,21 @@ class RadosOrchestrator:
             host_node: node object of the host which needs to be converted
         Returns: None
         """
+        installer_node = self.ceph_cluster.get_nodes(role="installer")[0]
         # copy /etc/ceph/ files to input host
-        ceph_conf, _ = self.node.shell(["cat /etc/ceph/ceph.conf"])
-        ceph_keyring, _ = self.node.shell(["cat /etc/ceph/ceph.keyring"])
+        ceph_conf, _ = installer_node.exec_command(
+            cmd="cat /etc/ceph/ceph.conf", sudo=True
+        )
+        ceph_keyring, _ = installer_node.exec_command(
+            cmd="cat /etc/ceph/ceph.client.admin.keyring", sudo=True
+        )
         host_node.exec_command(sudo=True, cmd="mkdir -p /etc/ceph")
 
         for cont in [ceph_conf, ceph_keyring]:
             file_name = (
-                "/etc/ceph/ceph.conf" if cont == ceph_conf else "/etc/ceph/ceph.keyring"
+                "/etc/ceph/ceph.conf"
+                if cont == ceph_conf
+                else "/etc/ceph/ceph.client.admin.keyring"
             )
             file_ = host_node.remote_file(sudo=True, file_name=file_name, file_mode="w")
             file_.write(cont)

--- a/suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-bugfixes.yaml
@@ -12,6 +12,7 @@
 #     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
 #     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
+#     8. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
 #===============================================================================================
 tests:
   - test:
@@ -177,3 +178,9 @@ tests:
         slow-osd-heartbeat: true
       polarion-id: CEPH-83590688
       desc: Generate Slow OSD heartbeats by inducing network delay
+
+  - test:
+      name: Client connection over v1 port
+      module: test_v1client.py
+      polarion-id: CEPH-83594645
+      desc: Ensure client connection over v1 port does not crash

--- a/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
@@ -13,6 +13,7 @@
 #     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
+#     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
 #===============================================================================================
 tests:
   - test:
@@ -183,3 +184,9 @@ tests:
         slow-osd-heartbeat: true
       polarion-id: CEPH-83590688
       desc: Generate Slow OSD heartbeats by inducing network delay
+
+  - test:
+      name: Client connection over v1 port
+      module: test_v1client.py
+      polarion-id: CEPH-83594645
+      desc: Ensure client connection over v1 port does not crash

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -13,6 +13,7 @@
 #     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
+#     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
 #===============================================================================================
 tests:
   - test:
@@ -198,4 +199,8 @@ tests:
       polarion-id: CEPH-83590688
       desc: Generate Slow OSD heartbeats by inducing network delay
 
-
+  - test:
+      name: Client connection over v1 port
+      module: test_v1client.py
+      polarion-id: CEPH-83594645
+      desc: Ensure client connection over v1 port does not crash

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -13,6 +13,7 @@
 #     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
+#     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
 #===============================================================================================
 tests:
   - test:
@@ -169,3 +170,9 @@ tests:
         slow-osd-heartbeat: true
       polarion-id: CEPH-83590688
       desc: Generate Slow OSD heartbeats by inducing network delay
+
+  - test:
+      name: Client connection over v1 port
+      module: test_v1client.py
+      polarion-id: CEPH-83594645
+      desc: Ensure client connection over v1 port does not crash

--- a/tests/rados/test_v1client.py
+++ b/tests/rados/test_v1client.py
@@ -1,0 +1,125 @@
+"""
+Module to verify client connection over v1 port does not result in crashes
+"""
+
+import datetime
+import random
+import re
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83594645
+    Covers:
+        - BZ-2237038
+    Test to verify client connection over v1 port does not result in crashes
+    Steps
+    1. Deploy a ceph cluster
+    2. Choose a node at random which is not already configured as a client
+    3. Copy client keyring and ceph conf file having only v1 ports
+    4. Install ceph-common package
+    5. Run ceph command using new client and monitor any crash
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    log.info(
+        "Running test case to verify client connection over v1 port does not result in crashes"
+    )
+
+    try:
+        """
+        If you use a client that does not support reading options from the configuration database,
+        or if you still need to use ceph.conf to change your cluster configuration for other reasons,
+        run the following command:
+               ceph config set mgr mgr/cephadm/manage_etc_ceph_ceph_conf false
+        You must maintain and distribute the ceph.conf file across the storage cluster.
+        Ref: https://red.ht/46YnXif
+        """
+
+        # set ceph_conf mgr setting to false
+        assert mon_obj.set_config(
+            section="mgr", name="mgr/cephadm/manage_etc_ceph_ceph_conf", value="false"
+        )
+
+        # logging any existing crashes on the cluster
+        crash_list = rados_obj.do_crash_ls()
+        if crash_list:
+            log.error(
+                "!!!ERROR: Crash exists on the cluster at the start of the test \n\n:"
+                f"{crash_list}"
+            )
+            log.info(
+                "As the existing crash may or may not be related, proceeding with the execution"
+            )
+
+        # choose an osd host at random
+        osd_hosts = rados_obj.ceph_cluster.get_nodes(role="osd")
+        osd_host = random.choice(osd_hosts)
+
+        rados_obj.configure_host_as_client(host_node=osd_host)
+
+        # modify the conf file and remove references to v2
+        ceph_conf, _ = osd_host.exec_command(cmd="cat /etc/ceph/ceph.conf", sudo=True)
+        # Use regex to remove only the v2 parts within the square brackets
+        ceph_conf_v1 = re.sub(r"v2:[^,]+,?", "", ceph_conf)
+        # Remove any trailing commas left by the removal
+        ceph_conf_v1 = re.sub(r",\]", "]", ceph_conf_v1)
+        file_name = "/etc/ceph/ceph.conf"
+        file_ = osd_host.remote_file(sudo=True, file_name=file_name, file_mode="w")
+        file_.write(ceph_conf_v1)
+        file_.flush()
+        file_.close()
+
+        # print the content of modified ceph.conf from the chosen host
+        conf_from_node, _ = osd_host.exec_command(
+            cmd="cat /etc/ceph/ceph.conf", sudo=True
+        )
+        log.info(conf_from_node)
+
+        assert "v2" not in conf_from_node
+
+        # check for any crashes on the cluster for 120 secs
+        timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=120)
+        while datetime.datetime.now() < timeout_time:
+            # run a set of ceph commands
+            cmds = ["ceph status", "ceph osd tree", "ceph df"]
+            for cmd in cmds:
+                log.info(f"Running cmd: {cmd}")
+                log.info(osd_host.exec_command(cmd=cmd, sudo=True)[0])
+            # list any reported crashes on the cluster, should not have any
+            crash_list = rados_obj.do_crash_ls()
+            if len(crash_list) != 0:
+                log.error(
+                    f"Verification failed, crash observed on the cluster : \n {crash_list}"
+                )
+                raise Exception("Verification failed, crash observed on the cluster")
+            log.info("No crashes reported on the cluster yet")
+            time.sleep(30)
+
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        log.info(
+            "\n \n ************** Execution of finally block begins here *************** \n \n"
+        )
+        mon_obj.remove_config(
+            section="mgr", name="mgr/cephadm/manage_etc_ceph_ceph_conf"
+        )
+        # log cluster health
+        rados_obj.log_cluster_health()
+
+    log.info("V1 client connection verified successfully")
+    return 0


### PR DESCRIPTION
[CEPH-83594645](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83594645): Tier-2 test to verify client connections over V1 interface and/or port do not result in crash

Jira tracker: [RHCEPHQE-14409](https://issues.redhat.com/browse/RHCEPHQE-14409)

Bugzilla tracker - [2237038](https://bugzilla.redhat.com/show_bug.cgi?id=2237038)

Steps:
    1. Deploy a ceph cluster
    2. Choose a node at random which is not already configured as a client
    3. Copy client keyring and ceph conf file having only v1 ports
    4. Install ceph-common package
    5. Run ceph command using new client and monitor any crash

Test modules added:
- `tests/rados/test_v1client.py`

Test suites modified:
- `suites/squid/rados/tier-2_rados_test-bugfixes.yaml`
- `suites/reef/rados/tier-2_rados_test-bugfixes.yaml`

Logs:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PZNVTV/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-3MAUK3/
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PJBUS2/
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QBAK65/

Signed-off-by: Harsh Kumar [hakumar@redhat.com](mailto:hakumar@redhat.com)