### PR TITLE
[TFA] s3cmd malformed url testcase rearrange

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -163,55 +163,6 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
 
-  - test:
-      name: Test Ratelimit at global scope
-      desc: Test Ratelimit at global scope
-      polarion-id: CEPH-83574915 # also CEPH-83574916 and CEPH-83574919
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_ratelimit_global.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
-      comments: known issue BZ 2301986
-
-  - test:
-      name: Test Ratelimit for versioned buckets
-      desc: Test Ratelimit for versioned buckets
-      polarion-id: CEPH-83574912
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_rate_limit.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
-      comments: known issue BZ 2301986
-
-  - test:
-      name: Test Ratelimit for tenanted users
-      desc: Test Ratelimit for tenanted users
-      polarion-id: CEPH-83574914
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_rate_limit.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
-      comments: known issue BZ 2301986
-
-  - test:
-      name: Test Ratelimit Debt
-      desc: Test Ratelimit Debt
-      polarion-id: CEPH-83574918
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_rate_limit.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_debt.yaml
-      comments: known issue BZ 2301986
-
-  - test:
-      name: Test ratelimit on bucket owner change
-      desc: Test ratelimit on bucket owner change
-      polarion-id: CEPH-83574920
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_ratelimit_bucketowner.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_bucketowner.yaml
-
 # Testing s3cmd malformed url
   - test:
       name: test s3cmd put operation with malformed bucket url
@@ -295,14 +246,14 @@ tests:
         config-file-name: ../../s3cmd/configs/test_deletelifecycle.yaml
 
   - test:
-      name: Test by adding almost 10K buckets to the resharding queue
-      desc: disable and enable dynamic resharding for 10K buckets
+      name: Test by adding almost 1K buckets to the resharding queue
+      desc: disable and enable dynamic resharding for 1K buckets
       polarion-id: CEPH-11478
       module: sanity_rgw.py
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_1k_bucket.yaml
-        timeout: 5000
+        timeout: 9000
 
   - test:
       name: Test multipart upload with failed upload parts using s3cmd and boto3
@@ -312,3 +263,52 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
+
+  - test:
+      name: Test Ratelimit at global scope
+      desc: Test Ratelimit at global scope
+      polarion-id: CEPH-83574915 # also CEPH-83574916 and CEPH-83574919
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_ratelimit_global.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
+      comments: known issue BZ 2301986
+
+  - test:
+      name: Test Ratelimit for versioned buckets
+      desc: Test Ratelimit for versioned buckets
+      polarion-id: CEPH-83574912
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_versioned_bucket.yaml
+      comments: known issue BZ 2301986
+
+  - test:
+      name: Test Ratelimit for tenanted users
+      desc: Test Ratelimit for tenanted users
+      polarion-id: CEPH-83574914
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_tenanted_user.yaml
+      comments: known issue BZ 2301986
+
+  - test:
+      name: Test Ratelimit Debt
+      desc: Test Ratelimit Debt
+      polarion-id: CEPH-83574918
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_debt.yaml
+      comments: known issue BZ 2301986
+
+  - test:
+      name: Test ratelimit on bucket owner change
+      desc: Test ratelimit on bucket owner change
+      polarion-id: CEPH-83574920
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_ratelimit_bucketowner.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_bucketowner.yaml


### PR DESCRIPTION
# Description
Post running ratelimit know issuw testcasese, s3cmd marlformed testcase got failed.
after rearanging testcase issue not seen
pass log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-SIAW0N/
failure log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.1.0-22/rgw/4/tier-2_rgw_test_using_s3cmd/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
