### PR TITLE
[8.0] New NVMe deployment support and suites modification

### DIFF
--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 128k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128kb-bs multi-volumes
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 128k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 10
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128kb-bs multi-volumes
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 128k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 1
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 128k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16kb-bs multi-volumes
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 16k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 10
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16kb-bs multi-volumes
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 16k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 1
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 16k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
@@ -81,7 +81,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -94,7 +93,6 @@ tests:
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
@@ -106,7 +104,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -131,7 +128,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -155,8 +151,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_exec:
           -   proto: librbd
               image:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
@@ -81,7 +81,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -94,7 +93,6 @@ tests:
                     count: 10
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
@@ -106,7 +104,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -131,7 +128,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -155,8 +151,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_exec:
           -   proto: librbd
               image:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
@@ -80,7 +80,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -93,7 +92,6 @@ tests:
                     count: 1
                 gw_node: node7            # gateway node
                 initiator_node: node11    # client node
-                install_gw: true
 
   - test:
       name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
@@ -105,7 +103,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -130,7 +127,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -154,8 +150,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_exec:
           -   proto: librbd
               image:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,6 @@ tests:
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
@@ -108,7 +106,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -135,7 +132,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -161,8 +157,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 16k
         io_exec:

--- a/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
+++ b/suites/reef/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
@@ -80,7 +80,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -93,7 +92,6 @@ tests:
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
 
   - test:
       name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
@@ -105,7 +103,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -130,7 +127,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -154,8 +150,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_exec:
           -   proto: librbd
               image:

--- a/suites/squid/nvmeof/tier-1_nvmeof_ha_sanity.yaml
+++ b/suites/squid/nvmeof/tier-1_nvmeof_ha_sanity.yaml
@@ -73,6 +73,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -125,6 +126,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-1_nvmeof_sanity.yaml
+++ b/suites/squid/nvmeof/tier-1_nvmeof_sanity.yaml
@@ -49,7 +49,7 @@ tests:
       module: test_cephadm.py
       name: deploy cluster
 
-##  Test cases to be executed
+#  Test cases to be executed
   - test:
       abort-on-fail: true
       config:
@@ -94,6 +94,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - rbd
+                - gw_group1
       desc: NVMeoF Gateway deployment using cephadm
       destroy-cluster: false
       do-not-skip-tc: true
@@ -105,6 +106,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-1_nvmeof_vmware_esx_sanity.yaml
+++ b/suites/squid/nvmeof/tier-1_nvmeof_vmware_esx_sanity.yaml
@@ -53,7 +53,7 @@ tests:
   #  Configure Initiators
   #  Run IO on NVMe Targets
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         verify_cluster_health: true
         steps:
@@ -73,6 +73,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - gw_group1
           - config:
               command: shell
               args:
@@ -105,7 +106,7 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         node: node5
         rbd_pool: rbd
@@ -153,7 +154,7 @@ tests:
       polarion-id: CEPH-83575783
 
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node5
         vmware_clients:
@@ -174,7 +175,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.gw_group1
            verify: true
       desc: Remove nvmeof service on GW node
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -70,12 +70,72 @@ tests:
   #  Configure Ceph NVMeoF gateway
   #  Configure Initiators
   #  Run IO on NVMe Targets
+  # NVMe 4-GW HA Test with mTLS configuration
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true
+        mtls: true
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            - count: 2
+              size: 5G
+              lb_group: node7
+            - count: 2
+              size: 5G
+              lb_group: node8
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node7
+          - tool: systemctl
+            nodes: node9
+      desc: NVMe 4-GW HA test Failover-Failback
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW HA test with mTLS configuration
+      polarion-id: CEPH-83594616
 
-  # 4 GW Single node failure
+  # Non-mTLS Tests
+  # NVMe 4-GW Single node failure(s)
   - test:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -132,6 +192,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -219,6 +280,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -280,6 +342,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -341,6 +404,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -412,6 +476,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -503,6 +568,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -596,6 +662,7 @@ tests:
       abort-on-fail: true
       config:
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-2_nvmeof_e2e_fips.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_e2e_fips.yaml
@@ -70,6 +70,7 @@ tests:
       abort-on-fail: true
       config:
         gw_node: node6
+        gw_group: gw_group1
         rbd_pool: rbd
         do_not_create_image: true
         rep-pool-only: true

--- a/suites/squid/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -74,6 +74,7 @@ tests:
           - gateway
         gw_node: node2
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -84,7 +85,7 @@ tests:
             serial: 1
             bdevs:
               count: 1
-              size: 10G
+              size: 5G
             listener_port: 5001
             allow_host: "*"
         initiators:                              # Configure Initiators with all pre-req
@@ -103,6 +104,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group2
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -119,7 +121,7 @@ tests:
             serial: 2
             bdevs:
               count: 1
-              size: 10G
+              size: 5G
             listener_port: 5002
             allow_host: "*"
         initiators:                            # Configure Initiators with all pre-req
@@ -138,6 +140,7 @@ tests:
       config:
         gw_node: node2
         rbd_pool: rbd
+        gw_group: 1group
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -154,7 +157,7 @@ tests:
             serial: 1
             bdevs:
               count: 1
-              size: 10G
+              size: 5G
             listener_port: 5006
             allow_host: "*"
         initiators:                             # Configure Initiators with all pre-req
@@ -173,6 +176,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: group
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -189,14 +193,14 @@ tests:
             serial: 3
             bdevs:
               count: 1
-              size: 10G
+              size: 5G
             listener_port: 5003
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode4
             serial: 4
             bdevs:
               count: 1
-              size: 10G
+              size: 5G
             listener_port: 5004
             allow_host: "*"
         initiators:                             # Configure Initiators with all pre-req
@@ -218,6 +222,7 @@ tests:
       config:
         gw_node: node6                       # Deploying multiple gateways on the cluster
         rbd_pool: rbd
+        gw_group: gw__group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -234,7 +239,7 @@ tests:
             serial: 1
             bdevs:
               count: 1
-              size: 10G
+              size: 5G
             listener_port: 5005
             allow_host: "*"
         initiators: # Configure Initiators with all pre-req
@@ -252,6 +257,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -265,10 +271,11 @@ tests:
       polarion-id: CEPH-83575812
 
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group2
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -286,6 +293,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -303,6 +311,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -94,6 +94,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - rbd
+                - gw_group1
       desc: NVMeoF Gateway deployment using cephadm
       destroy-cluster: false
       do-not-skip-tc: true
@@ -183,7 +184,7 @@ tests:
               command: add              # add Host access
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
-                host: "*"
+                host: '"*"'
           - config:
               service: host
               command: list             # List access hosts
@@ -194,7 +195,7 @@ tests:
               command: delete           # access host del
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
-                host: "*"
+                host: '"*"'
           - config:
               service: namespace
               command: add              # Namespace add
@@ -285,7 +286,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.rbd
+           service_name: nvmeof.rbd.gw_group1
            verify: true
       desc: NVMeoF Gateway deployment using cephadm
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_2-nvmeof-gw_128-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_2-nvmeof-gw_128-sub_ns.yaml
@@ -99,6 +99,7 @@ tests:
                   - node8
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -181,7 +182,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_2-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_2-nvmeof-gw_2-sub_ns.yaml
@@ -100,6 +100,7 @@ tests:
                   - node8
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -210,7 +211,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_2-nvmeof-gw_64-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_2-nvmeof-gw_64-sub_ns.yaml
@@ -99,6 +99,7 @@ tests:
                   - node8
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -181,7 +182,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_4-nvmeof-gw_128-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_4-nvmeof-gw_128-sub_ns.yaml
@@ -97,6 +97,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - group2
           - config:
               command: shell
               args:
@@ -181,7 +182,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group2
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_4-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_4-nvmeof-gw_2-sub_ns.yaml
@@ -98,6 +98,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -210,7 +211,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_4-nvmeof-gw_64-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_4-nvmeof-gw_64-sub_ns.yaml
@@ -97,6 +97,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -181,7 +182,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_6-nvmeof-gw_128-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_6-nvmeof-gw_128-sub_ns.yaml
@@ -103,6 +103,7 @@ tests:
                   - node10
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -189,7 +190,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_6-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_6-nvmeof-gw_2-sub_ns.yaml
@@ -103,6 +103,7 @@ tests:
                   - node10
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -189,7 +190,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_6-nvmeof-gw_64-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_6-nvmeof-gw_64-sub_ns.yaml
@@ -103,6 +103,7 @@ tests:
                   - node10
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -189,7 +190,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_8-nvmeof-gw_128-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_8-nvmeof-gw_128-sub_ns.yaml
@@ -105,6 +105,7 @@ tests:
                   - node10
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -193,7 +194,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_8-nvmeof-gw_2-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_8-nvmeof-gw_2-sub_ns.yaml
@@ -105,6 +105,7 @@ tests:
                   - node10
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -193,7 +194,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_8-nvmeof-gw_64-sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_8-nvmeof-gw_64-sub_ns.yaml
@@ -105,6 +105,7 @@ tests:
                   - node10
               pos_args:
                 - nvmeof_pool
+                - group1
           - config:
               command: shell
               args:
@@ -193,7 +194,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.group1
            verify: true
       desc: Remove nvmeof service on GW nodes
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_bdev_fio_operations.yaml
@@ -72,6 +72,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -89,6 +90,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group2
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_block_size.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -122,6 +120,7 @@ tests:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
+              gw_group: gw_group1
               initiator_node: node10   # client node
 
   - test:
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -149,6 +147,7 @@ tests:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
+              gw_group: gw_group1
               initiator_node: node10   # client node
 
   - test:
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 128k
         io_exec:
@@ -176,4 +173,5 @@ tests:
                 size: 10G
                 count: 1
               gw_node: node6          # gateway node
+              gw_group: gw_group1
               initiator_node: node10   # client node

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128k_blocksize_10vols.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128kb-bs multi-volumes
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -123,6 +121,7 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadNWrite IOType 128kb-bs multi volumes
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -150,6 +148,7 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random-ReadWrite IOType 128k-bs multi-volumes
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 128k
         io_exec:
@@ -177,3 +174,4 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_10vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 10
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128kb-bs multi-volumes
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -123,6 +121,7 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadNWrite IOType 128kb-bs multi volumes
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -150,6 +148,7 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random-ReadWrite IOType 128k-bs multi-volumes
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 128k
         io_exec:
@@ -177,3 +174,4 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_128kbs_1vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 128k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 1
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 128k blocksize
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -123,6 +121,7 @@ tests:
                 count: 1
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType 128k blocksize
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 128k
         io_exec:
@@ -150,6 +148,7 @@ tests:
                 count: 1
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 128k
         io_exec:
@@ -177,3 +174,4 @@ tests:
                 count: 1
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16kb-bs multi-volumes
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -123,6 +121,7 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadNWrite IOType 16kb-bs multi volumes
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -150,6 +148,7 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random-ReadWrite IOType 16k-bs multi-volumes
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 16k
         io_exec:
@@ -177,3 +174,4 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_10vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 10
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16kb-bs multi-volumes
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -123,6 +121,7 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadNWrite IOType 16kb-bs multi volumes
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -150,6 +148,7 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random-ReadWrite IOType 16k-bs multi-volumes
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 16k
         io_exec:
@@ -176,4 +173,5 @@ tests:
                 size: 25G
                 count: 10
               gw_node: node7          # gateway node
+              gw_group: gw_group1
               initiator_node: node11   # client node

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_16kbs_1vols_bm.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 1
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -122,6 +120,7 @@ tests:
                 size: 50G
                 count: 1
               gw_node: node7          # gateway node
+              gw_group: gw_group1
               initiator_node: node11   # client node
 
   - test:
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -149,6 +147,7 @@ tests:
                 size: 50G
                 count: 1
               gw_node: node7          # gateway node
+              gw_group: gw_group1
               initiator_node: node11   # client node
 
   - test:
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_overrides:
           bs: 16k
         io_exec:
@@ -177,3 +174,4 @@ tests:
                 count: 1
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols.yaml
@@ -81,7 +81,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -94,7 +93,7 @@ tests:
                     count: 10
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
@@ -106,7 +105,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -119,6 +117,7 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
@@ -131,7 +130,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -144,6 +142,7 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
@@ -155,8 +154,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_exec:
           -   proto: librbd
               image:
@@ -169,3 +166,4 @@ tests:
                 count: 10
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_10vols_bm.yaml
@@ -81,7 +81,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -94,7 +93,7 @@ tests:
                     count: 10
                 gw_node: node7          # gateway node
                 initiator_node: node11   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType with 4kbs 10vols
@@ -106,7 +105,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -119,6 +117,7 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType with 4kbs 10vols
@@ -131,7 +130,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -144,6 +142,7 @@ tests:
                 count: 10
               gw_node: node7          # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType with 4kbs 10vols
@@ -155,8 +154,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_exec:
           -   proto: librbd
               image:
@@ -169,3 +166,4 @@ tests:
                 count: 10
               gw_node: node7           # gateway node
               initiator_node: node11   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvme_4kbs_1vol_bm.yaml
@@ -80,7 +80,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -93,7 +92,7 @@ tests:
                     count: 1
                 gw_node: node7            # gateway node
                 initiator_node: node11    # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
@@ -105,7 +104,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -117,6 +115,7 @@ tests:
                 size: 50G
                 count: 1
               gw_node: node7          # gateway node
+              gw_group: gw_group1
               initiator_node: node11   # client node
 
   - test:
@@ -130,7 +129,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -142,6 +140,7 @@ tests:
                 size: 50G
                 count: 1
               gw_node: node7          # gateway node
+              gw_group: gw_group1
               initiator_node: node11   # client node
 
   - test:
@@ -154,8 +153,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node7
         io_exec:
           -   proto: librbd
               image:
@@ -167,4 +164,5 @@ tests:
                 size: 50G
                 count: 1
               gw_node: node7          # gateway node
+              gw_group: gw_group1
               initiator_node: node11   # client node

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_16k_block_size.yaml
@@ -83,7 +83,6 @@ tests:
         io_overrides:
           bs: 16k
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -96,7 +95,7 @@ tests:
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF ReadWrite IOType 16k blocksize
@@ -108,7 +107,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -123,6 +121,7 @@ tests:
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random WriteNRead IOType 16k blocksize
@@ -135,7 +134,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_overrides:
           bs: 16k
         io_exec:
@@ -150,6 +148,7 @@ tests:
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random ReadWrite IOType
@@ -161,8 +160,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_overrides:
           bs: 16k
         io_exec:
@@ -177,3 +174,4 @@ tests:
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_librbd_vs_nvmeof_4kbs_1vol.yaml
@@ -80,7 +80,6 @@ tests:
           - FIO_WRITE_BS_4k_IODepth8_LIBAIO
           - FIO_READ_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
             -   proto: librbd
                 image:
@@ -93,7 +92,7 @@ tests:
                     count: 1
                 gw_node: node6          # gateway node
                 initiator_node: node10   # client node
-                install_gw: true
+                gw_group: gw_group1
 
   - test:
       name: libRBD-VS-NVMeoF ReadWrite-IOType 4k-block-size single-10G-vol
@@ -105,7 +104,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -118,6 +116,7 @@ tests:
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random-WRITE-READ-IOType 4kblocksize single-10G-vol
@@ -130,7 +129,6 @@ tests:
           - FIO_RandWRITE_BS_4k_IODepth8_LIBAIO
           - FIO_RandREAD_BS_4k_IODepth8_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: true
         io_exec:
           -   proto: librbd
               image:
@@ -143,6 +141,7 @@ tests:
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1
 
   - test:
       name: libRBD VS NVMeoF Random-READWRITE-IOType 4kblocksize single-10G-vol
@@ -154,8 +153,6 @@ tests:
         io_profiles:
           - FIO_RW_BS_4k_IODepth8_RandRWRatio70R_LIBAIO
         rbd_pool: rbd
-        do_not_delete_pool: false
-        delete_gateway: node6
         io_exec:
           -   proto: librbd
               image:
@@ -168,3 +165,4 @@ tests:
                 count: 1
               gw_node: node6          # gateway node
               initiator_node: node10   # client node
+              gw_group: gw_group1

--- a/suites/squid/nvmeof/tier-3_nvmeof_namespace_limit.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_namespace_limit.yaml
@@ -86,6 +86,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - gw_group1
           - config:
               command: shell
               args:
@@ -296,7 +297,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.gw_group1
            verify: true
       desc: Remove nvmeof service on GW node
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_nvmeof_restart_operations.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_restart_operations.yaml
@@ -72,6 +72,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -90,6 +91,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-3_nvmeof_scale_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_scale_ns.yaml
@@ -83,6 +83,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - gw_group1
           - config:
               command: shell
               args:
@@ -183,7 +184,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.gw_group1
            verify: true
       desc: Remove nvmeof service on GW node
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-3_nvmeof_scale_sub_ns.yaml
+++ b/suites/squid/nvmeof/tier-3_nvmeof_scale_sub_ns.yaml
@@ -84,6 +84,7 @@ tests:
                   label: nvmeof-gw
               pos_args:
                 - nvmeof_pool
+                - gw_group1
           - config:
               command: shell
               args:
@@ -333,7 +334,7 @@ tests:
          command: remove
          service: nvmeof
          args:
-           service_name: nvmeof.nvmeof_pool
+           service_name: nvmeof.nvmeof_pool.gw_group1
            verify: true
       desc: Remove nvmeof service on GW node
       destroy-cluster: false

--- a/suites/squid/nvmeof/tier-4_nvmeof_namespace_operations.yaml
+++ b/suites/squid/nvmeof/tier-4_nvmeof_namespace_operations.yaml
@@ -72,6 +72,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/suites/squid/nvmeof/tier-4_nvmeof_neg_tests.yaml
+++ b/suites/squid/nvmeof/tier-4_nvmeof_neg_tests.yaml
@@ -71,6 +71,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -88,6 +89,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:
@@ -105,6 +107,7 @@ tests:
       config:
         gw_node: node6
         rbd_pool: rbd
+        gw_group: gw_group1
         do_not_create_image: true
         rep-pool-only: true
         rep_pool_config:

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -7,7 +7,7 @@ from ceph.nvmegw_cli import NVMeGWCLI
 from ceph.nvmeof.initiator import Initiator
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
-from tests.cephadm import test_nvmeof, test_orch
+from tests.nvmeof.workflows.nvme_utils import delete_nvme_service, deploy_nvme_service
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.utils import generate_unique_id
@@ -152,15 +152,7 @@ def teardown(ceph_cluster, rbd_obj, nvmegwcli, config):
 
     # Delete the gateway
     if "gateway" in config["cleanup"]:
-        cfg = {
-            "no_cluster_state": False,
-            "config": {
-                "command": "remove",
-                "service": "nvmeof",
-                "args": {"service_name": f"nvmeof.{config['rbd_pool']}"},
-            },
-        }
-        test_orch.run(ceph_cluster, **cfg)
+        delete_nvme_service(ceph_cluster, config)
 
     # Delete the pool
     if "pool" in config["cleanup"]:
@@ -206,16 +198,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
     try:
         if config.get("install"):
-            cfg = {
-                "no_cluster_state": False,
-                "config": {
-                    "command": "apply",
-                    "service": "nvmeof",
-                    "args": {"placement": {"nodes": [gw_node.hostname]}},
-                    "pos_args": [rbd_pool],
-                },
-            }
-            test_nvmeof.run(ceph_cluster, **cfg)
+            deploy_nvme_service(ceph_cluster, config)
         if config.get("subsystems"):
             with parallel() as p:
                 for subsys_args in config["subsystems"]:

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -12,7 +12,7 @@ from ceph.nvmegw_cli import NVMeGWCLI
 from ceph.nvmeof.initiator import Initiator
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
-from tests.cephadm import test_nvmeof, test_orch
+from tests.nvmeof.workflows.nvme_utils import delete_nvme_service, deploy_nvme_service
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.utils import generate_unique_id, run_fio
@@ -189,15 +189,7 @@ def teardown(ceph_cluster, rbd_obj, nvmegwcli, config):
 
     # Delete the gateway
     if "gateway" in config["cleanup"]:
-        cfg = {
-            "no_cluster_state": False,
-            "config": {
-                "command": "remove",
-                "service": "nvmeof",
-                "args": {"service_name": f"nvmeof.{config['rbd_pool']}"},
-            },
-        }
-        test_orch.run(ceph_cluster, **cfg)
+        delete_nvme_service(ceph_cluster, config)
 
     # Delete the pool
     if "pool" in config["cleanup"]:
@@ -287,16 +279,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
     try:
         if config.get("install"):
-            cfg = {
-                "no_cluster_state": False,
-                "config": {
-                    "command": "apply",
-                    "service": "nvmeof",
-                    "args": {"placement": {"nodes": [gw_node.hostname]}},
-                    "pos_args": [rbd_pool],
-                },
-            }
-            test_nvmeof.run(ceph_cluster, **cfg)
+            deploy_nvme_service(ceph_cluster, config)
 
         if config.get("subsystems"):
             with parallel() as p:

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -19,12 +19,13 @@ from ceph.rados.monitor_workflows import MonitorWorkflows
 from ceph.rbd.workflows.cluster_operations import operation, osd_remove_and_add_back
 from ceph.utils import get_node_by_id
 from cli.utilities.utils import reboot_node
-from tests.cephadm import test_nvmeof, test_orch
+from tests.cephadm import test_orch
 from tests.nvmeof.test_ceph_nvmeof_gateway import (
     configure_subsystems,
     initiators,
     teardown,
 )
+from tests.nvmeof.workflows.nvme_utils import deploy_nvme_service
 from tests.rbd.rbd_utils import initial_rbd_config
 from utility.log import Log
 from utility.retry import retry
@@ -84,7 +85,8 @@ def test_ceph_83575812(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83576084(ceph_cluster, rbd, pool, config):
@@ -187,7 +189,8 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83575467(ceph_cluster, rbd, pool, config):
@@ -243,13 +246,18 @@ def test_ceph_83575467(ceph_cluster, rbd, pool, config):
         gw_info_bkp = json.loads(gw_info_bkp.strip())["subsystems"]
 
         # restart nvmeof service
+        group = config.get("gw_group", "")
+        service_name = f"nvmeof.{pool}"
+        if group:
+            service_name = f"{service_name}.{group}"
         restart_cfg = {
+            "no_cluster_state": False,
             "config": {
-                "service": f"nvmeof.{pool}",
+                "service": service_name,
                 "command": "restart",
-                "args": {"verify": True},
-                "pos_args": [f"nvmeof.{pool}"],
-            }
+                "args": {"verify": True, "service_name": service_name},
+                "pos_args": [service_name],
+            },
         }
         test_orch.run(ceph_cluster, **restart_cfg)
         gw_info = list_subsystems(**sub_args)
@@ -269,7 +277,8 @@ def test_ceph_83575467(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83576085(ceph_cluster, rbd, pool, config):
@@ -362,7 +371,8 @@ def test_ceph_83576085(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83576087(ceph_cluster, rbd, pool, config):
@@ -464,7 +474,8 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83576093(ceph_cluster, rbd, pool, config):
@@ -547,9 +558,12 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
         if not reboot_node(gw_node):
             raise Exception("Host did not started post reboot!!!!!")
 
+        service_name = f"nvmeof.{pool}"
+        gw_group = config.get("gw_group")
+        service_name = f"{service_name}.{gw_group}" if gw_group else service_name
         check_service_exists(
             ceph_cluster.get_nodes(role="installer")[0],
-            service_name=f"nvmeof.{pool}",
+            service_name=service_name,
             service_type="nvmeof",
         )
         client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
@@ -566,7 +580,8 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83575455(ceph_cluster, rbd, pool, config):
@@ -690,7 +705,8 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83575813(ceph_cluster, rbd, pool, config):
@@ -779,7 +795,8 @@ def test_ceph_83575813(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83575814(ceph_cluster, rbd, pool, config):
@@ -860,7 +877,8 @@ def test_ceph_83575814(ceph_cluster, rbd, pool, config):
             "cleanup": ["disconnect_all", "gateway", "pool"],
             "rbd_pool": pool,
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
 
 
 def test_ceph_83581753(ceph_cluster, rbd, pool, config):
@@ -951,7 +969,8 @@ def test_ceph_83581753(ceph_cluster, rbd, pool, config):
             "rbd_pool": pool,
             "subsystems": [subsystem],
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
         return 0
 
 
@@ -1058,7 +1077,8 @@ def test_ceph_83581945(ceph_cluster, rbd, pool, config):
             "rbd_pool": pool,
             "subsystems": [subsystem],
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
         return 0
 
 
@@ -1138,7 +1158,8 @@ def test_ceph_83581755(ceph_cluster, rbd, pool, config):
             "rbd_pool": pool,
             "subsystems": [subsystem],
         }
-        teardown(ceph_cluster, rbd, nvmegwcli, cleanup_cfg)
+        config.update(cleanup_cfg)
+        teardown(ceph_cluster, rbd, nvmegwcli, config)
         return 0
 
 
@@ -1180,17 +1201,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             break
 
     try:
-        gw_node = get_node_by_id(ceph_cluster, config["gw_node"])
-        cfg = {
-            "no_cluster_state": False,
-            "config": {
-                "command": "apply",
-                "service": "nvmeof",
-                "args": {"placement": {"nodes": [gw_node.hostname]}},
-                "pos_args": [rbd_pool],
-            },
-        }
-        test_nvmeof.run(ceph_cluster, **cfg)
+        deploy_nvme_service(ceph_cluster, config)
         operation_mapping = {
             "CEPH-83575812": test_ceph_83575812,
             "CEPH-83576084": test_ceph_83576084,

--- a/tests/nvmeof/workflows/ha.py
+++ b/tests/nvmeof/workflows/ha.py
@@ -38,6 +38,7 @@ class HighAvailability:
         self.config = config
         self.gateways = []
         self.mtls = config.get("mtls")
+        self.gateway_group = config.get("gw_group", "")
         self.orch = Orch(cluster=self.cluster, **{})
         self.daemon = Daemon(cluster=self.cluster, **{})
         self.nvme_pool = config["rbd_pool"]
@@ -109,7 +110,7 @@ class HighAvailability:
         """Fetch ANA states and convert into python dict."""
 
         out, _ = self.orch.shell(
-            args=["ceph", "nvme-gw", "show", self.nvme_pool, repr(gw_group)]
+            args=["ceph", "nvme-gw", "show", self.nvme_pool, repr(self.gateway_group)]
         )
         states = {}
         for data in out.split("}"):
@@ -234,7 +235,7 @@ class HighAvailability:
         out = json.loads(out)
         if out[0]["status"] == 1:
             return True
-        elif out[0]["status"] == -1:
+        elif out[0]["status"] in [-1, 0]:
             return False
 
     def ceph_daemon(self, gateway, action, wait_for_active_state=True):

--- a/tests/nvmeof/workflows/nvme_utils.py
+++ b/tests/nvmeof/workflows/nvme_utils.py
@@ -1,0 +1,145 @@
+from ceph.utils import get_nodes_by_ids
+from tests.cephadm import test_nvmeof
+
+
+class NVMeDeployArgumentError(Exception):
+    pass
+
+
+class NVMeDeployConfigParamRequired(Exception):
+    pass
+
+
+def apply_nvme_sdk_cli_support(ceph_cluster, config):
+    """Configure NVMe deployment CLI w.r.t release support.
+
+    This definition helps to select deployment CLI as supported
+     from a downstream release perspective.
+
+    Currently,
+     7.x - Only RBD pool name has to be provided as positional arg
+     8.0 - Along RBD pool name, the Gateway group name has to be provided.
+
+    And in future any change in deployment could be handled here.
+
+    Args:
+      ceph_cluster: Ceph cluster object
+      config: test case configuration parameters
+
+    ::Example:
+        config:
+            rbd_pool: rbd               # rbd pool name
+            gw_group: gateway_group1    # NVMe Gateway group name
+    """
+
+    release = ceph_cluster.rhcs_version
+    rbd_pool = config.get("rbd_pool") or config.get("pool")
+    if not rbd_pool:
+        raise NVMeDeployConfigParamRequired(
+            "Please provide RBD pool name nodes via rbd_pool or pool"
+        )
+
+    gw_nodes = config.get("gw_nodes", None) or config.get("gw_node", None)
+
+    if not gw_nodes:
+        raise NVMeDeployConfigParamRequired(
+            "Please provide gateway nodes via gw_nodes or gw_node"
+        )
+
+    if not isinstance(gw_nodes, list):
+        gw_nodes = [gw_nodes]
+
+    gw_nodes = get_nodes_by_ids(ceph_cluster, gw_nodes)
+    is_spec_or_mtls = config.get("mtls", False)
+    gw_group = config.get("gw_group")
+
+    cfg = {
+        "no_cluster_state": False,
+        "config": {
+            "command": "apply",
+            "service": "nvmeof",
+            "args": {"placement": {"nodes": [i.hostname for i in gw_nodes]}},
+            "pos_args": [rbd_pool],
+        },
+    }
+    if is_spec_or_mtls:
+        cfg = {
+            "no_cluster_state": False,
+            "config": {
+                "command": "apply_spec",
+                "service": "nvmeof",
+                "validate-spec-services": True,
+                "specs": [
+                    {
+                        "service_type": "nvmeof",
+                        "service_id": rbd_pool,
+                        "mtls": True,
+                        "placement": {"nodes": [i.hostname for i in gw_nodes]},
+                        "spec": {
+                            "pool": rbd_pool,
+                            "enable_auth": True,
+                        },
+                    }
+                ],
+            },
+        }
+
+    if release <= ("7.1"):
+        return cfg
+    elif release == "8.0":
+        if not gw_group:
+            raise NVMeDeployArgumentError("Gateway group not provided..")
+
+        if is_spec_or_mtls:
+            cfg["config"]["specs"][0]["service_id"] = f"{rbd_pool}.{gw_group}"
+            cfg["config"]["specs"][0]["spec"]["group"] = gw_group
+        else:
+            cfg["config"]["pos_args"].append(gw_group)
+        return cfg
+
+
+def deploy_nvme_service(ceph_cluster, config):
+    """Deploy NVMe Service with apply or with spec
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        config: Test case config
+
+    Test case config should have below important params,
+    - rbd_pool
+    - gw_nodes
+    - gw_group      # optional, as per release
+    - mtls          # optional
+    """
+    _cfg = apply_nvme_sdk_cli_support(ceph_cluster, config)
+    test_nvmeof.run(ceph_cluster, **_cfg)
+
+
+def delete_nvme_service(ceph_cluster, config):
+    """Delete the NVMe gateway service.
+
+    Args:
+        ceph_cluster: Ceph cluster object
+        config: Test case config
+
+    Test case config should have below important params,
+    - rbd_pool
+    - gw_nodes
+    - gw_group      # optional, as per release
+    - mtls          # optional
+    """
+    gw_group = config.get("gw_group", "")
+    service_name = f"nvmeof.{config['rbd_pool']}"
+    service_name = f"{service_name}.{gw_group}" if gw_group else service_name
+    cfg = {
+        "no_cluster_state": False,
+        "config": {
+            "command": "remove",
+            "service": "nvmeof",
+            "args": {
+                "service_name": service_name,
+                "verify": True,
+            },
+        },
+    }
+    test_nvmeof.run(ceph_cluster, **cfg)

--- a/utility/systemctl.py
+++ b/utility/systemctl.py
@@ -29,6 +29,7 @@ class SystemCtl:
             "--type=service",
             "--no-legend",
             "--no-pager",
+            "--all",
             repr(regex),
             "--output=json-pretty",
         ]


### PR DESCRIPTION
# Description
New NVMe deployment support and suites modification for 8.0 builds
Testing the changes which solves the new  feature support.

###  Will consider scale test suites in following PRs

```
def apply_nvme_sdk_cli_support(ceph_cluster, config):
    """Configure NVMe deployment CLI w.r.t release support.
    
    This definition helps to select deployment CLI as supported 
     from a downstream release perspective.

    Currently,
     7.x - Only RBD pool name has to be provided as positional arg
     8.0 - Along RBD pool name, the Gateway group name has to be provided.
    
    And in future any change in deployment could be handled here.

    Args:
      ceph_cluster: Ceph cluster object
      config: test case configuration parameters

    ::Example:
        config:
            rbd_pool: rbd               # rbd pool name
            gw_group: gateway_group1    # NVMe Gateway group name
    """

    release = ceph_cluster.rhcs_version
    rbd_pool = config["rbd_pool"]
    gw_nodes = config.get("gw_nodes", None) or config.get("gw_node", None)

    if not gw_nodes:
        raise NVMeDeployConfigParamRequired("Please provide gateway nodes via gw_nodes or gw_node")

    if not isinstance(gw_nodes, list):
        gw_nodes = [gw_nodes]

    gw_nodes = get_nodes_by_ids(ceph_cluster, gw_nodes)
    is_spec_or_mtls = config.get("mtls", False)
    gw_group = config.get("gw_group")

    cfg = {
        "no_cluster_state": False,
        "config": {
            "command": "apply",
            "service": "nvmeof",
            "args": {"placement": {"nodes": [i.hostname for i in gw_nodes]}},
            "pos_args": [rbd_pool],
        },
    }
    if is_spec_or_mtls:
        cfg = {
            "no_cluster_state": False,
            "config": {
                "command": "apply_spec",
                "service": "nvmeof",
                "validate-spec-services": True,
                "specs": [
                    {
                        "service_type": "nvmeof",
                        "service_id": rbd_pool,
                        "mtls": True,
                        "placement": {"nodes": [i.hostname for i in gw_nodes]},
                        "spec": {
                            "pool": rbd_pool,
                            "enable_auth": True,
                        },
                    }
                ],
            },
        }

    if release <= ("7.1"):
        return cfg
    elif release == "8.0":
        if not gw_group:
            raise NVMeDeployArgumentError("Gateway group not provided..")

        if is_spec_or_mtls:
            cfg["config"]["specs"][0]["service_id"] = f"{rbd_pool}.{gw_group}"
            cfg["config"]["specs"][0]["spec"]["group"] = gw_group
        else:
            cfg["config"]["pos_args"].append(gw_group)
        return cfg
```

**Sanity:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-sanity-01/

**4-GW-HA-Tests:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-4node-HA-tests-14/

**HA-Sanity:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-ha-sanity-00/

**Bdev-Operations:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-bdev-ops-00/

**GW-Operations:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-gw-ops-01/

**Restart Operations:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-restart-ops-02/

**Negative tests:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-tier-4-neg-tests-00/

**Perf-Comparison-tests:**
http://magna002.ceph.redhat.com/ceph-qe-logs/Sunil-Kumar/8-0-librbd-vs-nvmeof-128kbs-06/
