### PR TITLE
Change in conf file to use second client for IO

### DIFF
--- a/suites/quincy/cephfs/tier-4_cephfs_system.yaml
+++ b/suites/quincy/cephfs/tier-4_cephfs_system.yaml
@@ -2,7 +2,7 @@
 #=======================================================================================================================
 # Tier-level: 4
 # Test-Suite: tier-4_cephfs_system.yaml
-# Conf file : conf/quincy/cephfs/tier_0_fs.yaml
+# Conf file : conf/quincy/cephfs/tier-2_cephfs_upgrade.yaml
 # Test-Case Covered:
 #   CEPH-11261: MON node power failure, with client IO
 #   CEPH-11263: MDS node power failure, with client IO
@@ -18,6 +18,7 @@
 #   CEPH-83572891: MDS admin socket dump testing
 #   CEPH-83572890: MDS admin socket perf flush log testing
 #.  CEPH-83591709: MDS Standy-Replay system testing
+#   CEPH-83594640: MDS Cache Trimming and Client Caps Recall test
 #=======================================================================================================================
 tests:
   -
@@ -114,8 +115,22 @@ tests:
         id: client.1
         install_packages:
           - ceph-common
-        node: node7
+        node: node8
       desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
       destroy-cluster: false
       module: test_client.py
       name: "configure client"
@@ -228,6 +243,12 @@ tests:
       module: cephfs_system.mds_failover_standby_replay_systemic_test.py
       polarion-id: CEPH-83591709
       name: "mds_failover_standby_replay_systemic_test"
+  - test:
+      abort-on-fail: false
+      desc: "MDS Cache Trimming and Client Caps Recall test"
+      module: cephfs_system.mds_cache_trimming_caps_recall.py
+      polarion-id: CEPH-83594640
+      name: "mds_cache_trimming_caps_recall"
   - test:
       abort-on-fail: false
       desc: "Fill the cluster with 95 percentage and delete the contents"

--- a/suites/reef/cephfs/tier-4_cephfs_system.yaml
+++ b/suites/reef/cephfs/tier-4_cephfs_system.yaml
@@ -2,7 +2,7 @@
 #=======================================================================================================================
 # Tier-level: 4
 # Test-Suite: tier-4_cephfs_system.yaml
-# Conf file : conf/reef/cephfs/tier_0_fs.yaml
+# Conf file : conf/reef/cephfs/tier-2_cephfs_upgrade.yaml
 # Test-Case Covered:
 #   CEPH-11261: MON node power failure, with client IO
 #   CEPH-11263: MDS node power failure, with client IO
@@ -18,6 +18,7 @@
 #   CEPH-83572891: MDS admin socket dump testing
 #   CEPH-83572890: MDS admin socket perf flush log testing
 #   CEPH-83591709: MDS Standby-Replay System testing
+#.  CEPH-83594640: MDS Cache Trimming and Client Caps Recall test
 #=======================================================================================================================
 tests:
   -
@@ -114,8 +115,22 @@ tests:
         id: client.1
         install_packages:
           - ceph-common
-        node: node7
+        node: node8
       desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
       destroy-cluster: false
       module: test_client.py
       name: "configure client"

--- a/suites/squid/cephfs/tier-4_cephfs_system.yaml
+++ b/suites/squid/cephfs/tier-4_cephfs_system.yaml
@@ -2,7 +2,7 @@
 #=======================================================================================================================
 # Tier-level: 4
 # Test-Suite: tier-4_cephfs_system.yaml
-# Conf file : conf/reef/cephfs/tier_0_fs.yaml
+# Conf file : conf/reef/cephfs/tier-2_cephfs_upgrade.yaml
 # Test-Case Covered:
 #   CEPH-11261: MON node power failure, with client IO
 #   CEPH-11263: MDS node power failure, with client IO
@@ -18,6 +18,7 @@
 #   CEPH-83572891: MDS admin socket dump testing
 #   CEPH-83572890: MDS admin socket perf flush log testing
 #.  CEPH-83591709: MDS Standy-Replay system testing
+#   CEPH-83594640: MDS Cache Trimming and Client Caps Recall test
 #=======================================================================================================================
 tests:
   -
@@ -114,8 +115,22 @@ tests:
         id: client.1
         install_packages:
           - ceph-common
-        node: node7
+        node: node8
       desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+        node: node9
+      desc: "Configure the Cephfs client system 2"
       destroy-cluster: false
       module: test_client.py
       name: "configure client"


### PR DESCRIPTION
# Description

Reason for change in conf file: Suite tier-4_cephfs_system.yaml uses tier-0_fs.yaml as conf file provisioning one client. Tests in tier-4_cephfs_system.yaml perform continuous IO on client, so need to use client other than clients[0] which is used for ceph cmds, to avoid slowness in cmd response due to IO load.

Fix description : using tier-2_cephfs_upgrade.yaml as conf file for suite tier-4_cephfs_system.yaml, it provisions 5 MDS,OSDs on 4 nodes and 2 clients, thats required systemic test automations

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
