### PR TITLE
[TFA] disable sync testcase failed with "radosgw-admin" not found

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ingress_multi_realm.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ingress_multi_realm.yaml
@@ -196,6 +196,21 @@ tests:
   - test:
       abort-on-fail: true
       config:
+        command: add
+        id: client.1
+        node: node7
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
         node: node7
         sudo: True
         commands:


### PR DESCRIPTION
# Description
issue: 
2024-08-18 17:05:12,916 (cephci.exec) [ERROR] - cephci.RH.8.0.rhel-9.Weekly.19.1.0-22.rgw.4.cephci.tests.misc_env.exec.py:244 - radosgw-admin zonegroup get --rgw-zonegroup=south > /tmp/zonegroup_south_backup.json Error:  bash: line 1: radosgw-admin: command not found
failure log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.1.0-22/rgw/4/tier-2_rgw_ingress_multi_realm/disable_sync_between_zones_0.log

pass log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-0F9W7C/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
