### PR TITLE
TFA FIX- Scheduled scrub and Inconsistent object in EC pool

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3961,9 +3961,10 @@ class RadosOrchestrator:
             client_node: client object
             pool_name: pool name
             no_of_objects: no of objcts to convert in to inconsistent objects
-        Returns: After converting the object in to inconsistent,method returns the pg id
+        Returns: After converting the object in to inconsistent,method returns the pg id and object count
                  If it fail returns None
         """
+        # Creating more number of objects
         for obj_num in range(no_of_objects):
             object_name = f"object_{obj_num}"
             cmd_create_obj = f"rados -p {pool_name} put {object_name} /etc/group"
@@ -4016,7 +4017,7 @@ class RadosOrchestrator:
         obj_count = len(inconsistent_details["inconsistents"])
         log.info(f"The inconsistent object count is -{obj_count}")
         log.info(f"The inconsistent object is created in the pg{pg_id}")
-        return pg_id
+        return pg_id, obj_count
 
     def set_unmanaged_flag(self, daemon):
         """

--- a/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
@@ -160,7 +160,7 @@ tests:
         scenario: "beginTime and endTime gt currentTime"
       delete_pools:
         - scrub_pool
-
+      comments: Active Bug#2312538
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371

--- a/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
@@ -175,6 +175,7 @@ tests:
         scenario: "beginTime and endTime gt currentTime"
       delete_pools:
         - scrub_pool
+      comments: Active Bug#2312538
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371

--- a/suites/squid/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/squid/rados/tier-2_rados_test-scrubbing.yaml
@@ -175,6 +175,7 @@ tests:
         scenario: "beginTime and endTime gt currentTime"
       delete_pools:
         - scrub_pool
+      comments: Active Bug#2312538
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371

--- a/tests/rados/scheduled_scrub_scenarios.py
+++ b/tests/rados/scheduled_scrub_scenarios.py
@@ -10,6 +10,7 @@ import time
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.rados_scrub import RadosScrubber
 from tests.rados.monitor_configurations import MonConfigMethods
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed
 
@@ -26,90 +27,27 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosScrubber(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
-    # Creating ec pool
-    ec_config = config.get("replicated_pool")
-    pool_name = ec_config["pool_name"]
 
-    if not rados_obj.create_pool(name=pool_name, **ec_config):
-        log.error("Failed to create the  Pool")
-        return 1
-    rados_obj.bench_write(pool_name=pool_name, rados_write_duration=60)
+    test_scenarios = ["scrub", "deep-scrub"]
 
-    pg_id = rados_obj.get_pgid(pool_name=pool_name)
-    log.info(f"The pg id is -{pg_id}")
+    for test_input in test_scenarios:
+        # Creating replicated pool
+        rp_config = config.get("replicated_pool")
+        pool_name = rp_config["pool_name"]
 
-    try:
-        (
-            scrub_begin_hour,
-            scrub_begin_weekday,
-            scrub_end_hour,
-            scrub_end_weekday,
-        ) = rados_obj.add_begin_end_hours(0, 1)
-
-        # Scenario to verify that scrub start and end hours are same
-        # CEPH-9362
-        if config.get("scenario") == "begin_end_time_equal":
-            log.info(f'{"Setting scrub start and end hour same"}')
-            scrub_end_hour = scrub_begin_hour
-
-        # Begin time is greater than end hour  and current time less than end hour
-        # CEPH-9363&CEPH-9364
-        if config.get("scenario") == "beginTime gt endTime":
-            log.info(
-                f'{"Setting scrub start time is greater than end hour and current time less than end hour"}'
+        if not rados_obj.create_pool(name=pool_name, **rp_config):
+            log.error("Failed to create the  Pool")
+            return 1
+        rados_obj.bench_write(pool_name=pool_name, rados_write_duration=10)
+        pg_id = rados_obj.get_pgid(pool_name=pool_name)
+        log.info(f"The pg id is -{pg_id}")
+        flag = wait_for_clean_pg_sets(rados_obj)
+        if not flag:
+            log.error(
+                "The cluster did not reach active + Clean state after add capacity"
             )
-            scrub_end_hour, scrub_begin_hour = scrub_begin_hour, scrub_end_hour
-
-        # set begin_hour > end_hour and current_time > end_hour
-        # CEPH-9365&CEPH-9366
-        if config.get("scenario") == "beginTime gt endTime lt currentTime":
-            (
-                scrub_begin_hour,
-                scrub_begin_weekday,
-                scrub_end_hour,
-                scrub_end_weekday,
-            ) = rados_obj.add_begin_end_hours(-1, -1)
-            log.info(
-                f'{"Setting scrub start is greater then end_hour and current time is greater than end hour"}'
-            )
-        # set begin hour and end hour greater than current time
-        # CEPH-9367 & CEPH 9368
-        if (
-            config.get("scenario") == "beginTime and endTime gt currentTime"
-            or config.get("scenario") == "decreaseTime"
-        ):
-            (
-                scrub_begin_hour,
-                scrub_begin_weekday,
-                scrub_end_hour,
-                scrub_end_weekday,
-            ) = rados_obj.add_begin_end_hours(2, 3)
-            log.info(
-                f'{"Setting scrub start is greater then end_hour and current time is greater than end hour"}'
-            )
-        # unset the scrub.CEPH-9374
-        if config.get("scenario") == "unsetScrub":
-            rados_obj.set_osd_flags("set", "noscrub")
-            log.info("Set no scrub flag")
-            rados_obj.set_osd_flags("set", "nodeep-scrub")
-            log.info("Set no deep scrub flag")
-
-        # Setting the scrub parameters
-        rados_obj.set_osd_configuration(
-            "osd_scrub_min_interval", osd_scrub_min_interval
-        )
-        rados_obj.set_osd_configuration(
-            "osd_scrub_max_interval", osd_scrub_max_interval
-        )
-        rados_obj.set_osd_configuration(
-            "osd_deep_scrub_interval", osd_deep_scrub_interval
-        )
-        rados_obj.set_osd_configuration("osd_scrub_begin_week_day", scrub_begin_weekday)
-        rados_obj.set_osd_configuration("osd_scrub_end_week_day", scrub_end_weekday)
-        rados_obj.set_osd_configuration("osd_scrub_begin_hour", scrub_begin_hour)
-        rados_obj.set_osd_configuration("osd_scrub_end_hour", scrub_end_hour)
-
-        if config.get("scenario") == "decreaseTime":
+            return 1
+        try:
             (
                 scrub_begin_hour,
                 scrub_begin_weekday,
@@ -117,6 +55,66 @@ def run(ceph_cluster, **kw):
                 scrub_end_weekday,
             ) = rados_obj.add_begin_end_hours(0, 1)
 
+            # Scenario to verify that scrub start and end hours are same
+            # CEPH-9362
+            if config.get("scenario") == "begin_end_time_equal":
+                log.info(f'{"Setting scrub start and end hour same"}')
+                scrub_end_hour = scrub_begin_hour
+
+            # Begin time is greater than end hour  and current time less than end hour
+            # CEPH-9363&CEPH-9364
+
+            if config.get("scenario") == "beginTime gt endTime":
+                log.info(
+                    f'{"Setting scrub start time is greater than end hour and current time less than end hour"}'
+                )
+                scrub_end_hour, scrub_begin_hour = scrub_begin_hour, scrub_end_hour
+
+            # set begin_hour > end_hour and current_time > end_hour
+            # CEPH-9365&CEPH-9366
+            if config.get("scenario") == "beginTime gt endTime lt currentTime":
+                (
+                    scrub_begin_hour,
+                    scrub_begin_weekday,
+                    scrub_end_hour,
+                    scrub_end_weekday,
+                ) = rados_obj.add_begin_end_hours(-1, -1)
+                log.info(
+                    f'{"Setting scrub start is greater then end_hour and current time is greater than end hour"}'
+                )
+
+            # set begin hour and end hour greater than current time
+            # CEPH-9367 & CEPH 9368
+            if (
+                config.get("scenario") == "beginTime and endTime gt currentTime"
+                or config.get("scenario") == "decreaseTime"
+            ):
+                (
+                    scrub_begin_hour,
+                    scrub_begin_weekday,
+                    scrub_end_hour,
+                    scrub_end_weekday,
+                ) = rados_obj.add_begin_end_hours(2, 3)
+                log.info(
+                    f'{"Setting scrub start is greater then end_hour and current time is greater than end hour"}'
+                )
+            # unset the scrub.CEPH-9374
+            if config.get("scenario") == "unsetScrub":
+                rados_obj.set_osd_flags("set", "noscrub")
+                log.info("Set no scrub flag")
+                rados_obj.set_osd_flags("set", "nodeep-scrub")
+                log.info("Set no deep scrub flag")
+
+            # Setting the scrub parameters
+            rados_obj.set_osd_configuration(
+                "osd_scrub_min_interval", osd_scrub_min_interval
+            )
+            rados_obj.set_osd_configuration(
+                "osd_scrub_max_interval", osd_scrub_max_interval
+            )
+            rados_obj.set_osd_configuration(
+                "osd_deep_scrub_interval", osd_deep_scrub_interval
+            )
             rados_obj.set_osd_configuration(
                 "osd_scrub_begin_week_day", scrub_begin_weekday
             )
@@ -124,68 +122,72 @@ def run(ceph_cluster, **kw):
             rados_obj.set_osd_configuration("osd_scrub_begin_hour", scrub_begin_hour)
             rados_obj.set_osd_configuration("osd_scrub_end_hour", scrub_end_hour)
 
-        try:
-            scrub_status = rados_obj.start_check_scrub_complete(
-                pg_id=pg_id[-1], user_initiated=False, wait_time=3600
-            )
+            if config.get("scenario") == "decreaseTime":
+                (
+                    scrub_begin_hour,
+                    scrub_begin_weekday,
+                    scrub_end_hour,
+                    scrub_end_weekday,
+                ) = rados_obj.add_begin_end_hours(0, 1)
+
+                rados_obj.set_osd_configuration(
+                    "osd_scrub_begin_week_day", scrub_begin_weekday
+                )
+                rados_obj.set_osd_configuration(
+                    "osd_scrub_end_week_day", scrub_end_weekday
+                )
+                rados_obj.set_osd_configuration(
+                    "osd_scrub_begin_hour", scrub_begin_hour
+                )
+                rados_obj.set_osd_configuration("osd_scrub_end_hour", scrub_end_hour)
+
+            status = chk_scrub_or_deepScrub_status(rados_obj, test_input, pg_id[-1])
+            # Checking the failure case
+            if status is False and (
+                config.get("scenario") == "default"
+                or config.get("scenario") == "begin_end_time_equal"
+                or config.get("scenario") == "beginTime gt endTime lt currentTime"
+                or config.get("scenario") == "decreaseTime"
+                or config.get("scenario") == "beginTime gt endTime"
+            ):
+                log.info(f"{test_input} validation failed")
+                return 1
+
+            if (
+                config.get("scenario") == "beginTime and endTime gt currentTime"
+                or config.get("scenario") == "unsetScrub"
+            ) and status is True:
+                log.info(f"{test_input} validation Failed")
+                return 1
+            method_should_succeed(rados_obj.delete_pool, pool_name)
+            time.sleep(10)
+            flag = wait_for_clean_pg_sets(rados_obj)
+            if not flag:
+                log.error(
+                    "The cluster did not reach active + Clean state after add capacity"
+                )
+                return 1
         except Exception as err:
-            log.error(f"The error is-{err}")
-            scrub_status = False
-
-        if scrub_status is True and (
-            config.get("scenario") == "default"
-            or config.get("scenario") == "begin_end_time_equal"
-            or config.get("scenario") == "beginTime gt endTime"
-            or config.get("scenario") == "decreaseTime"
-        ):
-            log.info(f'{"Scrubbing validation is success"}')
-            return 0
-
-        try:
-            deep_scrub_status = rados_obj.start_check_deep_scrub_complete(
-                pg_id=pg_id[-1], user_initiated=False, wait_time=3600
-            )
-        except Exception as err:
-            log.error(f"The error is-{err}")
-            deep_scrub_status = False
-
-        log.info(f" The deep-scrub execution status is -{deep_scrub_status}")
-
-        if (
-            config.get("scenario") == "beginTime gt endTime lt currentTime"
-            or config.get("scenario") == "beginTime and endTime gt currentTime"
-            or (
-                config.get("scenario") == "unsetScrub"
-                and (deep_scrub_status is False or scrub_status is False)
-            )
-        ):
-            log.info(f'{"Scrubbing validation is success"}')
-            return 0
-        log.error(f'{"Scrubbing  validation failed"}')
-        return 1
-    except Exception as err:
-        exc_type, exc_obj, exc_tb = sys.exc_info()
-        fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
-        sys.stderr.write("ERRORED DESC\t::%s:\n" % str(err))
-        sys.stderr.write("ERRORED MODULE\t::%s:\n" % str(exc_type))
-        sys.stderr.write("ERRORED FILE\t::%s:\n" % str(fname))
-        sys.stderr.write("ERRORED LINE\t::%s:\n" % str(exc_tb.tb_lineno))
-        return 1
-    finally:
-        log.info(
-            "\n \n ************** Execution of finally block begins here *************** \n \n"
-        )
-        method_should_succeed(rados_obj.delete_pool, pool_name)
-        remove_parameter_configuration(mon_obj)
-        rados_obj.set_osd_flags("unset", "noscrub")
-        rados_obj.set_osd_flags("unset", "nodeep-scrub")
-        time.sleep(10)
-        # log cluster health
-        rados_obj.log_cluster_health()
-        # check for crashes after test execution
-        if rados_obj.check_crash_status():
-            log.error("Test failed due to crash at the end of test")
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
+            sys.stderr.write("ERRORED DESC\t::%s:\n" % str(err))
+            sys.stderr.write("ERRORED MODULE\t::%s:\n" % str(exc_type))
+            sys.stderr.write("ERRORED FILE\t::%s:\n" % str(fname))
+            sys.stderr.write("ERRORED LINE\t::%s:\n" % str(exc_tb.tb_lineno))
             return 1
+        finally:
+            log.info(
+                "\n \n ************** Execution of finally block begins here *************** \n \n"
+            )
+            method_should_succeed(rados_obj.delete_pool, pool_name)
+            remove_parameter_configuration(mon_obj)
+            rados_obj.set_osd_flags("unset", "noscrub")
+            rados_obj.set_osd_flags("unset", "nodeep-scrub")
+            time.sleep(10)
+            # log cluster health
+            rados_obj.log_cluster_health()
+    log.error(f'{"Schedule scrub & deep-scrub validation success"}')
+    return 0
 
 
 def remove_parameter_configuration(mon_obj):
@@ -202,3 +204,35 @@ def remove_parameter_configuration(mon_obj):
     mon_obj.remove_config(section="osd", name="osd_scrub_end_week_day")
     mon_obj.remove_config(section="osd", name="osd_scrub_begin_hour")
     mon_obj.remove_config(section="osd", name="osd_scrub_end_hour")
+
+
+def chk_scrub_or_deepScrub_status(rados_object, action, pg_id):
+    """
+    Method to check that the scrub or deep-scrub is completed
+    Args:
+        rados_object: Rados object
+        action: To perform scrub or deep-scrub
+        pg_id: pg id
+
+    Returns: True if scrub or deep-scrub started
+             False if scrub or deep-scrub not started
+    """
+    if action == "scrub":
+        try:
+            status = rados_object.start_check_scrub_complete(
+                pg_id=pg_id, user_initiated=False, wait_time=5400
+            )
+            log.info("Verification of the scrub is completed")
+        except Exception as err:
+            log.error(f"The error is-{err}")
+            status = False
+    else:
+        try:
+            status = rados_object.start_check_deep_scrub_complete(
+                pg_id=pg_id, user_initiated=False, wait_time=5400
+            )
+            log.info("Verification of the deep-scrub is completed")
+        except Exception as err:
+            log.error(f"The error is-{err}")
+            status = False
+    return status


### PR DESCRIPTION
# Description

Jira Tickets:
    1. https://issues.redhat.com/browse/RHCEPHQE-15248
    2. https://issues.redhat.com/browse/RHCEPHQE-15398

1. The issue with the existing code is -
set begin_hour > end_hour and current_time > end_hour     Expected behavior- scrubbing should begin within the interval specified
           
2. In the automation script, I was checking the wrong place, and I modified the code.
begin_hour > end_hour 
                 Expected behavior- scrubbing should not start in this time period
                 Actual behavior - The scrubbing is getting started 

          Log - 1. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N5381Y
                    2. http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-TL67H1/

3. Previously I was not checking scrub and deep-scrub scenarios, I included the logic that the script verifies scrub and deep-scrub functionality.

4. Failure cases-
Each test case first checks the scrub scenario if it passes then executes the deep-scrub scenario. so

                      The maximum wait time for the failure case is 2 hours during the deep-scrub checking.
                       The minimum time for the failure is less than an hour during the scrub checking.
                       The maximum time to the negative scenarios is two hours this includes both scrub and deep-scrub functionality checks.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
