### PR TITLE
Adding EC support to nfs tests

### DIFF
--- a/tests/cephfs/cephfs_nfs/2_node_nfs.py
+++ b/tests/cephfs/cephfs_nfs/2_node_nfs.py
@@ -46,7 +46,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -87,7 +93,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/data_backup_restore_bw_nfs_and_local_mounts.py
+++ b/tests/cephfs/cephfs_nfs/data_backup_restore_bw_nfs_and_local_mounts.py
@@ -38,7 +38,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         fs_util.setup_ssh_root_keys(clients)
         client1 = clients[0]
@@ -63,7 +69,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/existing_path_nfs_export.py
+++ b/tests/cephfs/cephfs_nfs/existing_path_nfs_export.py
@@ -40,7 +40,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -49,7 +55,10 @@ def run(ceph_cluster, **kw):
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
-        default_fs = "cephfs"
+        default_fs = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, default_fs)
+        if not fs_details:
+            fs_util.create_fs(client1, default_fs)
         client1.exec_command(sudo=True, cmd="ceph mgr module enable nfs")
         client1.exec_command(
             sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
@@ -90,7 +99,7 @@ def run(ceph_cluster, **kw):
         )
         export_path_1 = "/dir1"
         export_path_2 = "/dir2"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
 
         if "5.0" in rhbuild:
             client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/modifying_nfs_cluster_invalid_value.py
+++ b/tests/cephfs/cephfs_nfs/modifying_nfs_cluster_invalid_value.py
@@ -25,7 +25,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
@@ -53,7 +59,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_config_reset.py
+++ b/tests/cephfs/cephfs_nfs/nfs_config_reset.py
@@ -53,7 +53,13 @@ def run(ceph_cluster, **kw):
 
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -84,7 +90,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_id = 100
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         out, _ = clients[0].exec_command(
             cmd=f"ceph auth get-key client.{clients[0].node.hostname}", sudo=True
         )

--- a/tests/cephfs/cephfs_nfs/nfs_export_config.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_config.py
@@ -43,7 +43,13 @@ def run(ceph_cluster, **kw):
 
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -74,7 +80,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_id = 100
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         out, _ = clients[0].exec_command(
             cmd=f"ceph auth get-key client.{clients[0].node.hostname}", sudo=True
         )

--- a/tests/cephfs/cephfs_nfs/nfs_export_path.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_path.py
@@ -36,7 +36,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -61,7 +67,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_fuse_kernel_same_subvolume.py
+++ b/tests/cephfs/cephfs_nfs/nfs_fuse_kernel_same_subvolume.py
@@ -41,7 +41,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -51,7 +57,11 @@ def run(ceph_cluster, **kw):
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_server = nfs_servers[0].node.hostname
         nfs_name = "cephfs-nfs"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         client1.exec_command(
             sudo=True, cmd=f"ceph nfs cluster create {nfs_name} {nfs_server}"
         )
@@ -111,12 +121,13 @@ def run(ceph_cluster, **kw):
             kernel_mounting_dir_1,
             ",".join(mon_node_ips),
             sub_dir=f"{subvol_path.strip()}",
+            extra_params=f",fs={fs_name}",
         )
         fuse_mounting_dir_1 = f"/mnt/cephfs_fuse{mounting_dir}_1/"
         fs_util.fuse_mount(
             [clients[0]],
             fuse_mounting_dir_1,
-            extra_params=f" -r {subvol_path.strip()}",
+            extra_params=f" -r {subvol_path.strip()} --client_fs {fs_name}",
         )
         client1.exec_command(
             sudo=True, cmd=f"mkdir -p {kernel_mounting_dir_1}/kernel_dir"

--- a/tests/cephfs/cephfs_nfs/nfs_ha_create_using_spec_ingress.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ha_create_using_spec_ingress.py
@@ -13,7 +13,13 @@ log = Log(__name__)
 
 def run(ceph_cluster, **kw):
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -95,7 +101,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         client1.exec_command(
             sudo=True,
             cmd=f"ceph nfs export create cephfs {nfs_ID} "

--- a/tests/cephfs/cephfs_nfs/nfs_ha_spec_file_add_host_while_IOs.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ha_spec_file_add_host_while_IOs.py
@@ -24,7 +24,13 @@ def run(ceph_cluster, **kw):
     8. Ingress conf applied successfully
     """
     try:
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
@@ -90,7 +96,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         client1.exec_command(
             sudo=True,
             cmd=f"ceph nfs export create cephfs {nfs_ID} "

--- a/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
+++ b/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
@@ -22,7 +22,13 @@ def run(ceph_cluster, **kw):
     try:
         tc = "CEPH-83573992"
         log.info(f"Running CephFS tests for BZ-{tc}")
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         build = config.get("build", config.get("rhbuild"))
         clients = ceph_cluster.get_ceph_objects("client")
@@ -55,7 +61,11 @@ def run(ceph_cluster, **kw):
         cluster_id = f"test-nfs_{rand}"
         path = "/"
         export_id = "1"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         bind = "/ceph"
         user_id = (
             f"nfs.{cluster_id}.{fs_name}"

--- a/tests/cephfs/cephfs_nfs/nfs_io_network_failures.py
+++ b/tests/cephfs/cephfs_nfs/nfs_io_network_failures.py
@@ -61,7 +61,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
         nfs_nodes = ceph_cluster.get_ceph_objects("nfs")
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -87,7 +93,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_mount_with_fstab.py
+++ b/tests/cephfs/cephfs_nfs/nfs_mount_with_fstab.py
@@ -46,7 +46,13 @@ def run(ceph_cluster, **kw):
 
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -80,7 +86,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_non_exist_export_path.py
+++ b/tests/cephfs/cephfs_nfs/nfs_non_exist_export_path.py
@@ -36,7 +36,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -68,7 +74,12 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/non_exist"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
+
         if "5.0" in rhbuild:
             out, rc = client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
+++ b/tests/cephfs/cephfs_nfs/nfs_ro_rw_access.py
@@ -45,7 +45,13 @@ def run(ceph_cluster, **kw):
 
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -79,7 +85,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/nfs_snaphshot_clone.py
+++ b/tests/cephfs/cephfs_nfs/nfs_snaphshot_clone.py
@@ -42,7 +42,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -57,7 +63,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )

--- a/tests/cephfs/cephfs_nfs/nfs_subvolume_subvolumegroup.py
+++ b/tests/cephfs/cephfs_nfs/nfs_subvolume_subvolumegroup.py
@@ -41,7 +41,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -56,7 +62,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )

--- a/tests/cephfs/cephfs_nfs/nfs_update_cluster_node_changes.py
+++ b/tests/cephfs/cephfs_nfs/nfs_update_cluster_node_changes.py
@@ -28,14 +28,22 @@ def run(ceph_cluster, **kw):
     try:
         tc = "CEPH-83574013"
         log.info(f"Running CephFS tests for {tc}")
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         config = kw.get("config")
         build = config.get("build", config.get("rhbuild"))
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
-        fs_details = fs_util.get_fs_info(client1)
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
         if not fs_details:
-            fs_util.create_fs(client1, "cephfs")
+            fs_util.create_fs(client1, fs_name)
         fs_util.auth_list([client1])
         fs_util.prepare_clients(clients, build)
         # clean up all the nfs cluster before testing

--- a/tests/cephfs/cephfs_nfs/read_only_nfs_export.py
+++ b/tests/cephfs/cephfs_nfs/read_only_nfs_export.py
@@ -37,7 +37,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -55,7 +61,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         nfs_mounting_dir_1 = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )

--- a/tests/cephfs/cephfs_nfs/recreate_same_name_nfs.py
+++ b/tests/cephfs/cephfs_nfs/recreate_same_name_nfs.py
@@ -42,7 +42,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -104,7 +110,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/test_all_nfs_vers_mount_and_perform_failover.py
+++ b/tests/cephfs/cephfs_nfs/test_all_nfs_vers_mount_and_perform_failover.py
@@ -37,13 +37,25 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
+
         clients = ceph_cluster.get_ceph_objects("client")
         fs_util_v1.prepare_clients(clients, build)
         fs_util_v1.auth_list(clients)
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         nfs_name = "cephfs-nfs"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        client1 = clients[0]
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         virtual_ip = "10.8.128.100"
         subnet = "21"
         port = "2049"
@@ -51,7 +63,7 @@ def run(ceph_cluster, **kw):
         nfs_v41 = "4.1"
         nfs_v42 = "4.2"
         nfs_v4 = "4"
-        client1 = clients[0]
+
         log.info("checking Pre-requisites")
         if not clients:
             log.info(

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_file_attributes_retention.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_file_attributes_retention.py
@@ -24,7 +24,13 @@ def run(ceph_cluster, **kw):
         tc = "CEPH-83575937"
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         build = config.get("build", config.get("rhbuild"))
@@ -48,7 +54,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_active_power_off.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_active_power_off.py
@@ -40,7 +40,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -88,7 +94,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         mount_dir = []
         for nfs_export in [nfs_export_name, nfs_export_name_2]:
             client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_cli.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_cli.py
@@ -33,7 +33,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -68,7 +74,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         client1.exec_command(
             sudo=True,
             cmd=f"ceph nfs export create cephfs {nfs_name} "

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_with_non_default_port.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_deployment_with_non_default_port.py
@@ -36,7 +36,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -85,7 +91,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         mount_dir = []
         for nfs_export in [nfs_export_name, nfs_export_name_2]:
             client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_failover.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_failover.py
@@ -38,7 +38,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -75,7 +81,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         mount_dir = []
         for nfs_export in [nfs_export_name, nfs_export_name_2]:
             client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_keeplive_services.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_keeplive_services.py
@@ -37,7 +37,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -110,7 +116,11 @@ spec:
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         mount_dir = []
         for nfs_export in [nfs_export_name, nfs_export_name_2]:
             client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_node_replacement.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_ha_node_replacement.py
@@ -45,7 +45,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -98,7 +104,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         mount_dir = []
         for nfs_export in [nfs_export_name, nfs_export_name_2]:
             client1.exec_command(

--- a/tests/cephfs/cephfs_nfs/test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
@@ -32,7 +32,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -54,7 +60,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,

--- a/tests/cephfs/cephfs_nfs/test_cephfs_upgrade_nfs_standalone_to_nfs_ha_cluster.py
+++ b/tests/cephfs/cephfs_nfs/test_cephfs_upgrade_nfs_standalone_to_nfs_ha_cluster.py
@@ -32,7 +32,13 @@ def run(ceph_cluster, **kw):
         log.info(f"Running cephfs {tc} test case")
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
-        fs_util_v1 = FsUtilsV1(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtilsV1.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util_v1.prepare_clients(clients, build)
@@ -83,7 +89,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util_v1.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util_v1.create_fs(client1, fs_name)
         client1.exec_command(
             sudo=True,
             cmd=f"ceph nfs export create cephfs {nfs_name} "

--- a/tests/cephfs/cephfs_nfs/zip_unzip_files_nfs.py
+++ b/tests/cephfs/cephfs_nfs/zip_unzip_files_nfs.py
@@ -38,7 +38,13 @@ def run(ceph_cluster, **kw):
         config = kw["config"]
         build = config.get("build", config.get("rhbuild"))
 
-        fs_util = FsUtils(ceph_cluster)
+        test_data = kw.get("test_data")
+        fs_util = FsUtils(ceph_cluster, test_data=test_data)
+        erasure = (
+            FsUtils.get_custom_config_value(test_data, "erasure")
+            if test_data
+            else False
+        )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
         fs_util.prepare_clients(clients, build)
@@ -67,7 +73,11 @@ def run(ceph_cluster, **kw):
             secrets.choice(string.digits) for i in range(3)
         )
         export_path = "/"
-        fs_name = "cephfs"
+        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_details = fs_util.get_fs_info(client1, fs_name)
+
+        if not fs_details:
+            fs_util.create_fs(client1, fs_name)
         nfs_mounting_dir = "/mnt/nfs_" + "".join(
             secrets.choice(string.ascii_uppercase + string.digits) for i in range(5)
         )


### PR DESCRIPTION
# Description
Adding EC support to nfs tests
Logs : 
With EC : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-CK6QLO/
With out EC: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6ZD6PW/

we are seeing 4 failures in both runs and all of them were socket timeout issues only


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
