### PR TITLE
Fixing upgarde and squid issue

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -577,6 +577,7 @@ class FsUtils(object):
             sleep(300)
             return 0
 
+    @retry(CommandFailed, tries=3, delay=10)
     def config_blacklist_manual_evict(self, active_mds, rank, service_name, **kwargs):
         """
         Configure black list on osd and manually evict client
@@ -605,10 +606,14 @@ class FsUtils(object):
             clients = self.ceph_cluster.get_ceph_objects("client")
             ip_add = self.manual_evict(clients[0], rank)
             out, rc = clients[0].exec_command(sudo=True, cmd="ceph osd blacklist ls")
-            print(out)
+            log.info(out)
             log.info(f"{ip_add} which is evicated manually")
             if ip_add not in out:
                 return 0
+            else:
+                raise CommandFailed(
+                    f"{ip_add} which is evicated manually not yet blocklisted . {out}"
+                )
 
     def validate_fs_info(self, client, fs_name="cephfs"):
         """


### PR DESCRIPTION
# Description
Fixing upgarde and squid issue
Fixed following failures : 

regression : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.0-45/cephfs/11/tier-2_cephfs_test-clients/Client_eviction_0.log
Upgrade : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Upgrade/19.1.0-45/7/tier-0_cephfs_upgrade_6x_to_8x/

Passed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YODSCC/




Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
