### PR TITLE
[TFA][Ceph-Volume] Fix ceph-volume fails to get an inventory list test

### DIFF
--- a/tests/ceph_volume/test_ceph_volume_get_inventory_list.py
+++ b/tests/ceph_volume/test_ceph_volume_get_inventory_list.py
@@ -10,7 +10,6 @@ def get_inventory_list(node, output_format):
         "/run/lock/lvm:/run/lock/lvm:z",
         "/var/run/udev/:/var/run/udev/:z",
         "/dev:/dev",
-        "/etc/ceph:/etc/ceph:z",
         "/run/lvm/:/run/lvm/",
         "/var/lib/ceph/:/var/lib/ceph/:z",
         "/var/log/ceph/:/var/log/ceph/:z",


### PR DESCRIPTION
Issue:
The "Validate ceph-volume fails to get an inventory list issue" test fails with "cli.exceptions.OperationFailedError: Not able to list the ceph inventory even without json format"
The reason being the volume mentioned to be mounted "/etc/ceph:/etc/ceph:z" is not valid with the nodes we have

Solution:
Remove this volume in podman command and the test succeeds

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
