### PR TITLE
tfa-RHCEPHQE-15610: comment the known issue of md5sum mismatch on obj…

### DIFF
--- a/suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml
@@ -232,14 +232,15 @@ tests:
 
 # Post upgrade tests
 
-  - test:
-      config:
-        script-name: test_bucket_lifecycle_object_expiration_transition.py
-        config-file-name: test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
-      desc: test_sse_kms_per_bucket_multipart_object_download_after_transition
-      module: sanity_rgw.py
-      name: test_sse_kms_per_bucket_multipart_object_download_after_transition
-      polarion-id: CEPH-83586489
+#  - test:
+#      config:
+#        script-name: test_bucket_lifecycle_object_expiration_transition.py
+#        config-file-name: test_sse_kms_per_bucket_multipart_object_download_after_transition.yaml
+#      desc: test_sse_kms_per_bucket_multipart_object_download_after_transition
+#      module: sanity_rgw.py
+#      name: test_sse_kms_per_bucket_multipart_object_download_after_transition
+#      polarion-id: CEPH-83586489
+#      comments: known isse in 6.1, bug 2269342
   - test:
       config:
         script-name: test_Mbuckets_with_Nobjects.py


### PR DESCRIPTION
tfa-RHCEPHQE-15610: comment the known issue of md5sum mismatch on object download after transition in 6.1
https://issues.redhat.com/browse/RHCEPHQE-15610

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
