### PR TITLE
Adding haproxy config in squid for archive-colocate zone

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -563,6 +563,7 @@ tests:
       polarion-id: CEPH-83581972 #CEPH-83575498
       module: sanity_rgw_multisite.py
       name: test LC cloud transition to IBM cos with retain true
+      comments: product bug with stats, bug 2308333 targeted 8.0
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -260,6 +260,19 @@ tests:
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
       polarion-id: CEPH-83575199
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node4
+            rgw_endpoints:
+              - node4:80
+
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
 
   - test:


### PR DESCRIPTION
# Description
Adding haproxy config in squid for archive-colocate zone
Somehow the haproxy configuration is missing in the cephci, hence the test got failed. 
Passed log after the haproxy config 

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GTF48U


Also adding known issue for product bug with retain head true](https://github.com/red-hat-storage/cephci/pull/4023/commits/87b85c1368bb9a476c48d1079b6cdbf06870a412)
<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
