### PR TITLE
CEPH-83595766: Tier-3 test to verify BlueFS spillover health warning

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml
@@ -2,7 +2,7 @@
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
-# Conf: conf/pacific/rados/7-node-cluster.yaml
+# Conf: conf/pacific/rados/13-node-cluster.yaml
 # Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
@@ -189,6 +189,14 @@ tests:
       config:
         non-collocated: true
       desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
+
+  - test:
+      name: cbt utility bluefs spillover
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83595766
+      config:
+        bluefs-spillover: true
+      desc: Verify BlueFS Spillover warning with dedicated wal/db
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml
@@ -2,7 +2,7 @@
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
-# Conf: conf/quincy/rados/7-node-cluster.yaml
+# Conf: conf/quincy/rados/13-node-cluster.yaml
 # Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
@@ -189,6 +189,14 @@ tests:
       config:
         non-collocated: true
       desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
+
+  - test:
+      name: cbt utility bluefs spillover
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83595766
+      config:
+        bluefs-spillover: true
+      desc: Verify BlueFS Spillover warning with dedicated wal/db
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/reef/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/reef/rados/tier-2_rados_test_cot_cbt.yaml
@@ -2,7 +2,7 @@
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
-# Conf: conf/reef/rados/7-node-cluster.yaml
+# Conf: conf/reef/rados/13-node-cluster.yaml
 # Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
@@ -189,6 +189,14 @@ tests:
       config:
         non-collocated: true
       desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
+
+  - test:
+      name: cbt utility bluefs spillover
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83595766
+      config:
+        bluefs-spillover: true
+      desc: Verify BlueFS Spillover warning with dedicated wal/db
 
   - test:
       name: ceph-objectstore-tool utility

--- a/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
@@ -2,7 +2,7 @@
 #------------------------------------------------------------------------------------------
 #----- Tier-2 test to verify all functionalities of COT and CBT tool ------
 #------------------------------------------------------------------------------------------
-# Conf: conf/squid/rados/7-node-cluster.yaml
+# Conf: conf/squid/rados/13-node-cluster.yaml
 # Test suite is targeted only for OpenStack
 #===============================================================================================
 tests:
@@ -189,6 +189,14 @@ tests:
       config:
         non-collocated: true
       desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
+
+  - test:
+      name: cbt utility bluefs spillover
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83595766
+      config:
+        bluefs-spillover: true
+      desc: Verify BlueFS Spillover warning with dedicated wal/db
 
   - test:
       name: ceph-objectstore-tool utility


### PR DESCRIPTION
[CEPH-83595766](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83595766): Tier-3 test to generate BlueFS spillover warning for an OSD by adding a dedicated small sized WAL/DB device

Jira tracker: [RHCEPHQE-14425](https://issues.redhat.com/browse/RHCEPHQE-14425)
Bugzilla tracker: [2129414](https://bugzilla.redhat.com/show_bug.cgi?id=2129414)

Test modules added:
- `remove_osds_from_host` in `ceph/rados/serviceability_workflows.py`
- `tests/rados/test_bluestoretool_workflows.py`

Test suites modified:
- `suites/pacific/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/quincy/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/reef/rados/tier-2_rados_test_cot_cbt.yaml`
- `suites/squid/rados/tier-2_rados_test_cot_cbt.yaml`

Logs:
Pacific: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-JY3LSI/
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NFFZ8J/
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X5LVH7/
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BD1Z0Q/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>