### PR TITLE
Reduce retries checking for ceph health to be ok

### DIFF
--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -3492,7 +3492,7 @@ os.system('sudo systemctl start  network')
         if spec_frontend_port not in status_ports:
             raise CommandFailed(f"The frontend port{port} is not matching")
 
-    @retry(CommandFailed, tries=10, delay=30)
+    @retry(CommandFailed, tries=4, delay=30)
     def get_ceph_health_status(self, client, validate=True, status=["HEALTH_OK"]):
         """
         Validate if the Ceph Health is OK or in WARN/ERROR State.


### PR DESCRIPTION
# Description

JIRA: https://issues.redhat.com/browse/RHCEPHQE-15813

Issue:

Squid Regression pipeline jobs:
https://ocs3xstage-jenkins-csb-rhgsocs3x.apps.ocp-c1.prod.psi.redhat.com/job/qe-squid-cephfs-regression-openstack/14
https://ocs3xstage-jenkins-csb-rhgsocs3x.apps.ocp-c1.prod.psi.redhat.com/job/qe-squid-cephfs-regression-openstack/15/console
In both cases, ceph cluster becomes unhealthy during nfs mount as nfs daemon errors, but test script waiting for healthy ceph doesn't exit before 15360 secs as it uses get_ceph_health_status of fsutilsV1 and it includes retry logic with params, retries = 10 , delay = 30. Here for every retry, delay value is doubled, 30secs is just the starting value. So until 10 retries, it waits for 15360 secs.
2024-08-29 17:00:00,291 (cephci.snapshot_clone.cg_snap_test) [WARNING] - cephci.RH.8.0.rhel-9.Regression.19.1.0-61.cephfs.15.cephci.utility.retry.py:28 - Ceph Cluster is in HEALTH_WARN State, Retrying in 30 seconds...
2024-08-29 19:07:33,975 (cephci.snapshot_clone.cg_snap_test) [WARNING] - cephci.RH.8.0.rhel-9.Regression.19.1.0-61.cephfs.15.cephci.utility.retry.py:28 - Ceph Cluster is in HEALTH_WARN State, Retrying in 7680 seconds...

back to test script at 21:15:34,
2024-08-29 21:15:34,427 (cephci.snapshot_clone.cg_snap_test) [INFO] - cephci.RH.8.0.rhel-9.Regression.19.1.0-61.cephfs.15.cephci.tests.cephfs.snapshot_clone.cg_snap_test.py:2859 - Ceph Cluster is in HEALTH_WARN State

So it was waiting from 17:00:00 till 21:15:34,  ~4hrs ..15360secs
retry logic implemented through utility.retry.
Instead of changing here as its by used many others, I will reduce retry count to 4 so that it waits max for 240secs and exits in fsutils.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
