### PR TITLE
Reduce retries checking for ceph health to be ok in mds scrub test sc…

### DIFF
--- a/tests/cephfs/clients/mds_scrub_after_failover.py
+++ b/tests/cephfs/clients/mds_scrub_after_failover.py
@@ -129,7 +129,7 @@ def run(ceph_cluster, **kw):
         if result["return_code"] != 0:
             log.error("Error while scrubbing")
             return 1
-        retry_health = retry(CommandFailed, tries=10, delay=30)(
+        retry_health = retry(CommandFailed, tries=4, delay=30)(
             fs_util.get_ceph_health_status
         )
         retry_health(client1)


### PR DESCRIPTION
…ript
In script tests/cephfs/clients/mds_scrub_after_failover.py we are waiting for healthy ceph using retry logic as below that can cause wait time as 15360secs in case ceph remains unhealthy, which is long wait.
Modifying retry params to reduce wait time to <300secs.
As changes are minor, have not executed script with changes.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
