### PR TITLE
Remove known issue BZ2302940 since BZ is verified

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -863,7 +863,7 @@ tests:
       name: Test user modify with placement id
       desc: Test user modify with placement id
       polarion-id: CEPH-83575880
-      comment: Known issue Bug-2245699
+      comments: Known issue Bug-2245699
       module: sanity_rgw.py
       config:
         script-name: user_create.py

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -160,7 +160,7 @@ tests:
       name: Bucket Lifecycle Object_transition_tests to ec pool
       desc: Test Bucket Lifecycle Object_transition_tests to ec pool
       polarion-id: CEPH-83574470
-      comment: Known issue Bug-2172838
+      comments: Known issue Bug-2172838
       module: sanity_rgw.py
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py

--- a/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -286,7 +286,7 @@ tests:
       module: sanity_rgw_multisite.py
       name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard
       polarion-id: CEPH-83586489
-      comment: Known issue Bug-2298084 targeted tp 6.1z7
+      comments: Known issue Bug-2298084 targeted tp 6.1z7
 
   - test:
       name: notify put,delete events with kafka_broker_persistent

--- a/suites/reef/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -173,7 +173,7 @@ tests:
       name: Bucket Lifecycle Object_transition_tests to ec pool
       desc: Test Bucket Lifecycle Object_transition_tests to ec pool
       polarion-id: CEPH-83574470
-      comment: Known issue Bug-2172838
+      comments: Known issue Bug-2172838
       module: sanity_rgw.py
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py

--- a/suites/squid/rgw/sanity_rgw.yaml
+++ b/suites/squid/rgw/sanity_rgw.yaml
@@ -321,7 +321,6 @@ tests:
       desc: Test GetBucketLocation bucket policy for users in same tenant
       polarion-id: CEPH-11623
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_bucketlocation_using_bucketpolicy_with_tenantuser.yaml

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -446,7 +446,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_bucket_policy
       polarion-id: CEPH-83586489
-      comments: known issue (bz-2302940)
   - test:
       clusters:
         ceph-pri:

--- a/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -655,7 +655,7 @@ tests:
       polarion-id: CEPH-83575711
       module: sanity_rgw_multisite.py
       name: test server_side_copy_object_via_encryption
-      comment: Known issue Bug-2300284 targeted to 8.0 fixed in 7
+      comments: Known issue Bug-2300284 targeted to 8.0 fixed in 7
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -75,7 +75,7 @@ tests:
       desc: BucketNotification with users in same tenant and different tenant
       polarion-id: CEPH-11204
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
+      comments: known issue (bz-2309013)
       config:
         run-on-rgw: true
         extra-pkgs:
@@ -152,7 +152,6 @@ tests:
       desc: Test rgw put bucket website with users of same and different tenant
       polarion-id: CEPH-11148
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_bucket_website_with_tenant_same_and_different_user.yaml
@@ -162,7 +161,6 @@ tests:
       desc: Test rgw get bucket website with users of same and different tenant
       polarion-id: CEPH-11150
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_get_bucket_website_with_tenant_same_and_different_user.yaml

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -265,7 +265,6 @@ tests:
       desc: Test ListBucketVersions bucket policy for users in same tenant
       polarion-id: CEPH-11574
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_listbucketversion_with_bucketpolicy_for_tenant_user.yaml
@@ -275,7 +274,6 @@ tests:
       desc: test get object and its version from same and different tenant users
       polarion-id: CEPH-11516
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         test-version: v2
         script-name: test_bucket_policy_with_tenant_user.py
@@ -286,7 +284,6 @@ tests:
       desc: test bucket policy with multiple statements
       polarion-id: CEPH-11216
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_multiple_statements.yaml
@@ -305,7 +302,6 @@ tests:
       desc: test bucket policy with condition blocks
       polarion-id: CEPH-11589
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition.yaml
@@ -315,7 +311,6 @@ tests:
       desc: test bucket policy condition block with explicit deny
       polarion-id: CEPH-11590
       module: sanity_rgw.py
-      comments: known issue (bz-2302940)
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_condition_explicit_deny.yaml

--- a/suites/squid/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -173,7 +173,7 @@ tests:
       name: Bucket Lifecycle Object_transition_tests to ec pool
       desc: Test Bucket Lifecycle Object_transition_tests to ec pool
       polarion-id: CEPH-83574470
-      comment: Known issue Bug-2172838
+      comments: Known issue Bug-2172838
       module: sanity_rgw.py
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py


### PR DESCRIPTION
# Description

Remove known issue BZ2302940 since BZ is verified

Pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.0-61/rgw/15/tier-2_rgw_regression_extended/

http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.0-61/rgw/15/tier-2_rgw_regression_test/

however seen one observation with event record output format:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.0-61/rgw/15/tier-2_rgw_regression_extended/Test_BucketNotification_with_users_in_same_tenant_and_different_tenant_0.log

https://bugzilla.redhat.com/show_bug.cgi?id=2309013
Added known issue

2. there were some typo in comment,
it suppose to be comments: that changes are done here

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
