### PR TITLE
[Tier-1] Cluster deployment to stop the RGW io sending multisite sync data

### DIFF
--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -544,20 +544,23 @@ class GenerateServiceSpec:
         if node_names:
             spec["placement"]["hosts"] = self.get_hostnames(node_names)
 
-        if spec["spec"].get("rgw_frontend_ssl_certificate") == "create-cert":
-            subject = {
-                "common_name": spec["placement"]["hosts"][0],
-                "ip_address": self.cluster.get_node_by_hostname(
-                    spec["placement"]["hosts"][0]
-                ).ip_address,
-            }
-            key, cert, ca = generate_self_signed_certificate(subject=subject)
-            pem = key + cert + ca
-            cert_value = "|\n" + pem
-            spec["spec"]["rgw_frontend_ssl_certificate"] = "\n    ".join(
-                cert_value.split("\n")
-            )
-            LOG.debug(pem)
+        if spec.get("spec", False):
+            if spec["spec"].get("rgw_frontend_ssl_certificate", False):
+                subject = {
+                    "common_name": spec["placement"]["hosts"][0],
+                    "ip_address": self.cluster.get_node_by_hostname(
+                        spec["placement"]["hosts"][0]
+                    ).ip_address,
+                }
+                key, cert, ca = generate_self_signed_certificate(subject=subject)
+                pem = key + cert + ca
+                cert_value = "|\n" + pem
+                spec["spec"]["rgw_frontend_ssl_certificate"] = "\n    ".join(
+                    cert_value.split("\n")
+                )
+                LOG.debug(pem)
+
+        LOG.info(f"Generated rgw specification : {spec}")
 
         return template.render(spec=spec)
 

--- a/conf/squid/rgw/rgw_multisite_spec.yaml
+++ b/conf/squid/rgw/rgw_multisite_spec.yaml
@@ -1,0 +1,88 @@
+# System Under Test environment configuration for RGW multi site suites.
+globals:
+  - ceph-cluster:
+      name: ceph-pri
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+          - mon
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+          - rgw
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client
+
+  - ceph-cluster:
+      name: ceph-sec
+
+      node1:
+        role:
+          - _admin
+          - installer
+          - mgr
+          - mon
+
+      node2:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mgr
+          - osd
+          - mon
+
+      node3:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - mon
+          - osd
+
+      node4:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node5:
+        disk-size: 20
+        no-of-volumes: 4
+        role:
+          - osd
+          - rgw
+
+      node6:
+        role:
+          - client

--- a/suites/squid/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
+++ b/suites/squid/rgw/tier-2_rgw_io_ms_spec_to_disable_sync.yaml
@@ -1,0 +1,294 @@
+# This suites perform io on a cluster where rgw deplyed using a adavance rgw spec file updation to stop the RGW io sending multisite sync data
+# New feature of 8.0
+# test with conf file: conf/squid/rgw/rgw_multisite_spec.yaml
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply_spec
+                  service: orch
+                  specs:
+                    - service_type: rgw
+                      service_id: shared.pri.io
+                      spec:
+                        disable_multisite_sync_traffic: true
+                        rgw_realm: india
+                        rgw_zonegroup: shared
+                        rgw_zone: primary
+                      placement:
+                        nodes:
+                          - node4
+              - config:
+                  command: apply_spec
+                  service: orch
+                  specs:
+                    - service_type: rgw
+                      service_id: shared.pri.sync
+                      spec:
+                        rgw_realm: india
+                        rgw_zonegroup: shared
+                        rgw_zone: primary
+                      placement:
+                        nodes:
+                          - node5
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    skip-dashboard: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  command: apply_spec
+                  service: orch
+                  specs:
+                    - service_type: rgw
+                      service_id: shared.sec.io
+                      spec:
+                        disable_multisite_sync_traffic: true
+                        rgw_realm: india
+                        rgw_zonegroup: shared
+                        rgw_zone: secondary
+                      placement:
+                        nodes:
+                          - node4
+              - config:
+                  command: apply_spec
+                  service: orch
+                  specs:
+                    - service_type: rgw
+                      service_id: shared.sec.sync
+                      spec:
+                        rgw_realm: india
+                        rgw_zonegroup: shared
+                        rgw_zone: secondary
+                      placement:
+                        nodes:
+                          - node5
+      desc: Cluster deployment to stop the RGW io sending multisite sync data
+      polarion-id: CEPH-83591291
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster with advance fetaure in rgw spec file
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.2
+            node: node5
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.2
+            node: node5
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system in sync node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.3
+            node: node4
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.3
+            node: node4
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system in io node
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints http://{node_ip:node5}:80 --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph orch restart {service_name:shared.pri.io}"
+              - "ceph orch restart {service_name:shared.pri.sync}"
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url http://{node_ip:ceph-pri#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints http://{node_ip:node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph orch restart {service_name:shared.sec.io}"
+              - "ceph orch restart {service_name:shared.sec.sync}"
+              - "sleep 120"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-83591291
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "ceph config dump | grep rgw_run_sync_thread"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on primary
+      polarion-id: CEPH-83591291
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "ceph config dump | grep rgw_run_sync_thread"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      module: exec.py
+      name: get shared realm info on secondary
+      polarion-id: CEPH-83591291
+  # create user from primary
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+      desc: create non-tenanted user
+      polarion-id: CEPH-83575199
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -101,9 +101,11 @@ def run(**kw):
     cloud_type = config.get("cloud-type")
     primary_cluster = clusters.get("ceph-rgw1", clusters[list(clusters.keys())[0]])
     secondary_cluster = clusters.get("ceph-rgw2", clusters[list(clusters.keys())[1]])
-    primary_rgw_node = primary_cluster.get_ceph_object("rgw").node
+    primary_rgw_nodes = primary_cluster.get_ceph_objects("rgw")
+    primary_rgw_node = primary_rgw_nodes[0].node
     primary_client_node = primary_cluster.get_ceph_object("client").node
-    secondary_rgw_node = secondary_cluster.get_ceph_object("rgw").node
+    secondary_rgw_nodes = secondary_cluster.get_ceph_objects("rgw")
+    secondary_rgw_node = secondary_rgw_nodes[0].node
     secondary_client_node = secondary_cluster.get_ceph_object("client").node
     run_on_rgw = (
         True
@@ -166,6 +168,12 @@ def run(**kw):
         set_test_env(config, secondary_client_node)
         set_test_env(config, primary_rgw_node)
         set_test_env(config, secondary_rgw_node)
+        if len(primary_rgw_nodes) > 1:
+            for i in range(1, len(primary_rgw_nodes)):
+                set_test_env(config, primary_rgw_nodes[i].node)
+        if len(secondary_rgw_nodes) > 1:
+            for i in range(1, len(secondary_rgw_nodes)):
+                set_test_env(config, secondary_rgw_nodes[i].node)
         if archive_cluster_exists:
             set_test_env(config, archive_rgw_node)
             set_test_env(config, archive_client_node)


### PR DESCRIPTION
# Description
 This suites perform io on a cluster where rgw deplyed using a adavance rgw spec file updation to stop the RGW io sending multisite sync data
 New feature of 8.0
test with conf file: conf/squid/rgw/rgw_multisite_spec.yaml

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
