### PR TITLE
CEPH-83595780: Tier-2 test to verify max_avail value updation upon OSD size change

### DIFF
--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -21,6 +21,7 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
+                orphan-initial-daemons: true
 
   - test:
       name: Add host
@@ -183,6 +184,15 @@ tests:
           pool_name: test-max-avail
           obj_nums: 5
           delete_pool: true
+
+  - test:
+      name: Verify MAX_AVAIL variance with OSD size change
+      desc: MAX_AVAIL value update correctly when OSD size changes
+      module: test_cephdf.py
+      polarion-id: CEPH-83595780
+      config:
+        cephdf_max_avail_osd_expand: true
+
   - test:
       name: Compression algorithms - modes
       module: rados_prep.py

--- a/suites/squid/rados/tier-4_rados_tests.yaml
+++ b/suites/squid/rados/tier-4_rados_tests.yaml
@@ -21,6 +21,7 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
+                orphan-initial-daemons: true
 
   - test:
       name: Add host
@@ -183,6 +184,15 @@ tests:
           pool_name: test-max-avail
           obj_nums: 5
           delete_pool: true
+
+  - test:
+      name: Verify MAX_AVAIL variance with OSD size change
+      desc: MAX_AVAIL value update correctly when OSD size changes
+      module: test_cephdf.py
+      polarion-id: CEPH-83595780
+      config:
+        cephdf_max_avail_osd_expand: true
+
   - test:
       name: Compression algorithms - modes
       module: rados_prep.py

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -10,8 +10,12 @@ import time
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados import utils
+from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.pool_workflows import PoolFunctions
+from ceph.rados.serviceability_workflows import ServiceabilityMethods
+from ceph.utils import get_node_by_id
+from tests.misc_env.lvm_deployer import create_lvms
 from tests.rados.rados_test_util import get_device_path, wait_for_device_rados
 from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
@@ -27,9 +31,12 @@ def run(ceph_cluster, **kw):
     """
     log.info(run.__doc__)
     config = kw["config"]
+    rhbuild = config.get("rhbuild")
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_obj = RadosOrchestrator(node=cephadm)
     pool_obj = PoolFunctions(node=cephadm)
+    bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+    service_obj = ServiceabilityMethods(cluster=ceph_cluster, **config)
     client = ceph_cluster.get_nodes(role="client")[0]
 
     if config.get("verify_cephdf_stats"):
@@ -285,4 +292,238 @@ def run(ceph_cluster, **kw):
                 return 1
 
         log.info("ceph df MAX AVAIL stats verification completed")
+        return 0
+
+    if config.get("cephdf_max_avail_osd_expand"):
+        desc = (
+            "\n#CEPH-83595780"
+            "\nReef: BZ-2296248"
+            "\nSquid: BZ-2296247"
+            "\nThis test is to verify that ceph df MAX AVAIL is displayed correctly for all the pools"
+            " when OSD size is increased"
+            "\nSteps- \n"
+            "1. Creating a pool with default config\n"
+            "2. Log pool stats and verify max_avail \n"
+            "3. Create LVMs on backup nodes \n"
+            "4. Add backup hosts to the cluster and deploy OSDs on them \n"
+            "5. Log pool stats and verify max_avail \n"
+            "6. Expand OSD size on one backup host \n"
+            "7. Log pool stats and verify max_avail \n"
+            "8. Write data to a pool to fill the cluster \n"
+            "9. Log pool stats and verify max_avail \n"
+            "10. Expand OSD size on other backup host \n"
+            "11. Log pool stats and verify max_avail"
+        )
+
+        log.info(desc)
+        df_config = config.get("cephdf_max_avail_osd_expand")
+        pool_name = "test-osd-expand"
+        lvm_list = {"node12": [], "node13": []}
+
+        def bytes_to_gb(val):
+            return round(val / (1 << 30), 1)
+
+        try:
+            # pass without execution for Squid
+            if not rhbuild.startswith("7"):
+                log.info("Test is currently valid only for RHCS 7.x")
+                return 0
+
+            # create default pool with given name
+            rados_obj.create_pool(pool_name=pool_name)
+
+            initial_pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+            log.info(f"{pool_name} pool stat: {initial_pool_stat}")
+
+            # execute max_avail check across the cluster
+            if not rados_obj.verify_max_avail(variance=0.25):
+                log.error("MAX_AVAIL deviates on the cluster more than expected")
+                raise Exception("MAX_AVAIL deviates on the cluster more than expected")
+            log.info("MAX_AVAIL on the cluster are as per expectation")
+
+            # add backup hosts to the cluster
+            service_obj.add_new_hosts(add_nodes=["node12", "node13"], deploy_osd=False)
+            node12_obj = get_node_by_id(ceph_cluster, "node12")
+            node13_obj = get_node_by_id(ceph_cluster, "node13")
+            time.sleep(15)
+
+            for node in ["node12", "node13"]:
+                # create 10G LVMs on backup nodes
+                node_obj = node12_obj if node == "node12" else node13_obj
+                empty_devices = rados_obj.get_available_devices(
+                    node_name=node_obj.hostname, device_type="hdd"
+                )
+                if len(empty_devices) < 1:
+                    log.error(
+                        f"Need at least 1 spare disks available on host {node_obj.hostname}"
+                    )
+                    raise Exception(
+                        f"One spare disk not available on host {node_obj.hostname}"
+                    )
+
+                # for dev in empty_devices:
+                lvm_list[node] = create_lvms(
+                    node=node_obj, count=1, size="10G", devices=[empty_devices[0]]
+                )
+                log.info(
+                    f"List of LVMs created on {node_obj.hostname}: {lvm_list[node]}"
+                )
+
+            init_osd_list = rados_obj.get_active_osd_list()
+            log.info(f"Active OSD list before OSD addition: {init_osd_list}")
+            init_osd_count = len(init_osd_list)
+            # deploy single OSD on lvm devices created
+            for node in ["node12", "node13"]:
+                node_obj = node12_obj if node == "node12" else node13_obj
+                log.info(f"Proceeding to deploy OSDs on {node_obj.hostname}")
+                add_cmd = f"ceph orch daemon add osd {node_obj.hostname}:data_devices={lvm_list[node][0]}"
+                out, err = cephadm.shell(args=[add_cmd])
+
+                if not (
+                    "Created osd" in out and f"on host '{node_obj.hostname}" in out
+                ):
+                    log.error(f"OSD addition on {node_obj.hostname} failed")
+                    log.error(err)
+                    raise Exception(f"OSD addition on {node_obj.hostname} failed")
+
+            post_osd_list = rados_obj.get_active_osd_list()
+            log.info(f"Active OSD list after OSD addition: {post_osd_list}")
+            post_osd_count = len(post_osd_list)
+            if post_osd_count - init_osd_count < 2:
+                log.error(
+                    f"Expected 2 OSD to get deployed. New osd count {post_osd_count} | Old osd count {init_osd_count}"
+                )
+                raise Exception("Required no of OSDs not added to the cluster")
+
+            _pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+            log.info(f"{pool_name} pool stat: {_pool_stat}")
+
+            rados_obj.change_recovery_threads(config=config, action="set")
+            if not wait_for_clean_pg_sets(rados_obj, timeout=900):
+                log.error("Cluster cloud not reach active+clean state within 900 secs")
+                raise Exception("Cluster cloud not reach active+clean state")
+
+            # execute max_avail check across the cluster
+            if not rados_obj.verify_max_avail():
+                log.error("MAX_AVAIL deviates on the cluster more than expected")
+                raise Exception("MAX_AVAIL deviates on the cluster more than expected")
+            log.info("MAX_AVAIL on the cluster are as per expectation")
+
+            # expand the OSD LVMs on backup node12
+            for lvm in lvm_list["node12"]:
+                _cmd = f"lvextend -L 15G {lvm}"
+                node12_obj.exec_command(cmd=_cmd, sudo=True)
+
+            log.info("LVM size on node12 increased from 10G to 15G")
+            node12_osds = rados_obj.collect_osd_daemon_ids(osd_node=node12_obj)
+
+            # for each OSD on node 12, execute bluefs-bdev-expand
+            for osd_id in node12_osds:
+                out = bluestore_obj.block_device_expand(osd_id=osd_id)
+                log.info(out)
+                assert "device size" in out and "Expanding" in out
+            log.info(f"OSDs {node12_osds} should now be 15G each")
+
+            osd_node12_meta = rados_obj.get_daemon_metadata(
+                daemon_type="osd", daemon_id=node12_osds[0]
+            )
+            bdev_size = bytes_to_gb(int(osd_node12_meta["bluestore_bdev_size"]))
+            if not bdev_size == 15:
+                log.error(
+                    f"{node12_obj.hostname}'s OSD size post expansion does not match expected value of 15"
+                )
+                log.error(
+                    f"Actual OSD {node12_osds[0]} size: {bdev_size} | Expected 15"
+                )
+                raise Exception(f"OSD.{node12_osds[0]} size post expansion incorrect")
+
+            _pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+            log.info(f"{pool_name} pool stat: {_pool_stat}")
+
+            time.sleep(30)
+            # execute max_avail check across the cluster
+            if not rados_obj.verify_max_avail():
+                log.error("MAX_AVAIL deviates on the cluster more than expected")
+                raise Exception("MAX_AVAIL deviates on the cluster more than expected")
+            log.info("MAX_AVAIL on the cluster are as per expectation")
+
+            # write data to the pool and expand OSD LVMs on backup node13
+            assert rados_obj.bench_write(pool_name=pool_name, rados_write_duration=300)
+
+            _pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+            log.info(f"{pool_name} pool stat: {_pool_stat}")
+
+            time.sleep(30)
+            # execute max_avail check across the cluster
+            if not rados_obj.verify_max_avail():
+                log.error("MAX_AVAIL deviates on the cluster more than expected")
+                raise Exception("MAX_AVAIL deviates on the cluster more than expected")
+            log.info("MAX_AVAIL on the cluster are as per expectation")
+
+            # expand the OSD LVMs on backup node13
+            for lvm in lvm_list["node13"]:
+                _cmd = f"lvextend -L 13G {lvm}"
+                node13_obj.exec_command(cmd=_cmd, sudo=True)
+
+            log.info("LVM size on node13 increased from 10G to 13G")
+            node13_osds = rados_obj.collect_osd_daemon_ids(osd_node=node13_obj)
+
+            # for each OSD on node 12, execute bluefs-bdev-expand
+            for osd_id in node13_osds:
+                out = bluestore_obj.block_device_expand(osd_id=osd_id)
+                log.info(out)
+                assert "device size" in out and "Expanding" in out
+
+            log.info(f"OSDs {node13_osds} should now be 13G each")
+            osd_node13_meta = rados_obj.get_daemon_metadata(
+                daemon_type="osd", daemon_id=node13_osds[0]
+            )
+            bdev_size = bytes_to_gb(int(osd_node13_meta["bluestore_bdev_size"]))
+            if not bdev_size == 13:
+                log.error(
+                    f"{node13_obj.hostname}'s OSD size post expansion does not match expected value of 13"
+                )
+                log.error(
+                    f"Actual OSD {node13_osds[0]} size: {bdev_size} | Expected 13"
+                )
+                raise Exception(f"OSD.{node13_osds[0]} size post expansion incorrect")
+
+            _pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
+            log.info(f"{pool_name} pool stat: {_pool_stat}")
+
+            time.sleep(30)
+            # execute max_avail check across the cluster
+            if not rados_obj.verify_max_avail():
+                log.error("MAX_AVAIL deviates on the cluster more than expected")
+                raise Exception("MAX_AVAIL deviates on the cluster more than expected")
+            log.info("MAX_AVAIL on the cluster are as per expectation")
+
+        except AssertionError as AE:
+            log.error(f"Failed with exception: {AE.__doc__}")
+            log.exception(AE)
+            return 1
+        finally:
+            log.info("\n ************* Executing finally block **********\n")
+            rados_obj.delete_pool(pool=pool_name)
+            # remove backup hosts
+            if "node12_obj" in locals() or "node12_obj" in globals():
+                service_obj.remove_custom_host(host_node_name=node12_obj.hostname)
+            if "node13_obj" in locals() or "node13_obj" in globals():
+                service_obj.remove_custom_host(host_node_name=node13_obj.hostname)
+            if not wait_for_clean_pg_sets(rados_obj, timeout=900):
+                log.error("Cluster cloud not reach active+clean state")
+                return 1
+            rados_obj.change_recovery_threads(config=config, action="rm")
+
+            # log cluster health
+            rados_obj.log_cluster_health()
+            # check for crashes after test execution
+            if rados_obj.check_crash_status():
+                log.error("Test failed due to crash at the end of test")
+                return 1
+
+        log.info(
+            "ceph df MAX AVAIL stats verification upon expansion of OSD size"
+            "completed successfully"
+        )
         return 0


### PR DESCRIPTION
[CEPH-83595780](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83595780): Tier-2 test to verify if MAX_AVAIL value at individual pool level gets updated correctly when OSD size changes in the cluster
Verify that when OSD disk is resized , and OSD is expanded via "bluefs-bdev-expand" command via CBT tool, the storage capacity increase is correctly displayed in Ceph

Jira tracker: [RHCEPHQE-15770](https://issues.redhat.com/browse/RHCEPHQE-15770)
Bugzilla tracker:
Reef - [2296248](https://bugzilla.redhat.com/show_bug.cgi?id=2296248)
Squid - [2296247](https://bugzilla.redhat.com/show_bug.cgi?id=2296247)

Test modules modified:
-  `verify_max_avail` in `ceph/rados/core_workflows.py`
- `tests/rados/test_cephdf.py`

Test suites modified:
- `suites/reef/rados/tier-4_rados_tests.yaml`
- `suites/squid/rados/tier-4_rados_tests.yaml`

Steps:
1. Create a pool with default config
2. Log pool stats and verify max_avail
3. Create LVMs on backup nodes
4. Add backup hosts to the cluster and deploy OSDs on them
5. Log pool stats and verify max_avail
6. Expand OSD size on one backup host
7. Log pool stats and verify max_avail
8. Write data to a pool to fill the cluster
9. Log pool stats and verify max_avail
10. Expand OSD size on other backup host
11. Log pool stats and verify max_avail

Logs:
Reef - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AJLC51
Squid - NA

Signed-off-by: Harsh Kumar <hakumar@redhat.com>