### PR TITLE
TFA fix for BZ2284364 and BZ2273569

### DIFF
--- a/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -162,6 +162,16 @@ tests:
   -
     test:
       abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+       ENABLE_LOGS : 1
+       daemon_list : ['mds','client']
+       daemon_dbg_level : {'mds':20,'client':20}
+  -
+    test:
+      abort-on-fail: false
       desc: "Verify quiesce suceeds with IO from nfs,fuse and kernel mounts"
       destroy-cluster: false
       module: snapshot_clone.cg_snap_test.py
@@ -210,3 +220,12 @@ tests:
       config:
        test_name: cg_snap_interop_workflow_1
       comments: product bug bz-2273569
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+       DISABLE_LOGS : 1
+       daemon_list : ['mds','client']

--- a/tests/cephfs/snapshot_clone/cg_snap_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_test.py
@@ -157,6 +157,10 @@ def run(ceph_cluster, **kw):
         if not fs_details:
             fs_util_v1.create_fs(client1, default_fs)
 
+        out, rc = client1.exec_command(
+            sudo=True, cmd="ceph config set mds debug_mds_quiesce 20"
+        )
+
         test_case_name = config.get("test_name", "all_tests")
         test_functional = [
             "cg_snap_func_workflow_1",
@@ -2861,6 +2865,7 @@ def wait_for_healthy_ceph(client1, fs_util, wait_time_secs):
                 f"Wait for sometime to check if Cluster health can be OK, current state : {ex}"
             )
             time.sleep(5)
+
     if ceph_healthy == 0:
         return 0
     return 1


### PR DESCRIPTION
# Description

Enabling debug logs for CG quiesce regression suite as required for both BZs, BZ2284364 and BZ2273569.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
