### PR TITLE
Updated RBD squid test suites for upgrade tests

### DIFF
--- a/suites/squid/rbd/tier-2_rbd_upgrade_6x_to_8x.yaml
+++ b/suites/squid/rbd/tier-2_rbd_upgrade_6x_to_8x.yaml
@@ -1,6 +1,6 @@
 #===============================================================================================
-# Tier-level: 3
-# Test-Suite: tier-3_rbd_mirror_upgrade_scale.yaml
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_upgrade_6x_to_8x.yaml
 #
 # Cluster Configuration:
 #    cephci/conf/squid/rbd/5-node-2-clusters.yaml
@@ -25,12 +25,11 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 5.3
+                    rhcs-version: 6.1
                     release: "rc"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -62,12 +61,11 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 5.3
+                    rhcs-version: 6.1
                     release: "rc"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -105,8 +103,6 @@ tests:
             node: node2
             install_packages:
               - ceph-common
-              - rbd-nbd
-              - fio
             copy_admin_keyring: true
         ceph-rbd2:
           config:
@@ -115,8 +111,6 @@ tests:
             node: node2
             install_packages:
                 - ceph-common
-                - rbd-nbd
-                - fio
             copy_admin_keyring: true
       desc: Configure the client system 1
       destroy-cluster: false
@@ -134,7 +128,9 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      label: rbd-mirror
+                      nodes:
+                        - node5
+                        - node4
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -144,76 +140,116 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      label: rbd-mirror
+                      nodes:
+                        - node5
+                        - node4
       desc: RBD Mirror daemon deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
       name: deploy rbd-mirror daemon
 
   - test:
-      abort-on-fail: True
-      desc: Verify snapshot mirroring with upgrade
-      name: Test upgrade on snapshot mirrored clusters
-      module: test_rbd_snapshot_mirroring_with_upgrade.py
-      polarion-id: CEPH-83574895
+      abort-on-fail: true
+      desc: Multicluster upgrade to latest 8.x ceph version with rbd mirror daemon
+      module: test_cephadm_upgrade.py
+      name: multi-cluster ceph upgrade to latest 8.x ceph
       clusters:
         ceph-rbd1:
           config:
-            installed_version: "5.3"
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
         ceph-rbd2:
           config:
-            installed_version: "5.3"
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
+
+  - test:
+      name: Test daemon failure in dual rbd-mirror daemon clusters
+      clusters:
+        ceph-rbd1:
+          dummy: true
+      desc: Verification of mirorring with failures of mirror daemons
+      module: test_rbd_mirror_multi_daemon.py
+      polarion-id: CEPH-83574962
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: Reduce mirroring daemons to 1
+      module: test_cephadm.py
+      name: Reduce mirroring daemons
+
+  - test:
+      name: test rbd mirror daemon restartwith resync
+      module: test_rbd_mirror_daemon_restart_imagesync.py
+      clusters:
+        ceph-rbd1:
+          config:
+            dummy: true
+      polarion-id: CEPH-10468
+      desc: Verification of image sync continuation after multiple rbd mirror daemon restarts
+
+  - test:
+      name: Test delayed replication - Secondary
+      clusters:
+        ceph-rbd1:
+          config:
+            delay_at_secondary: true
+      desc: Testing Delayed replication for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11492
+
+  - test:
+      name: Test delayed replication - primary
+      clusters:
+        ceph-rbd1:
+          config:
+            skip_initial_config: true
+            delay_at_primary: true
+      desc: Testing Delayed replication with delay set in primary per image
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11494
+
+  - test:
+      name: Test delayed replication - Failover
+      clusters:
+        ceph-rbd1:
+          config:
+            direct_failover_with_delay: true
+            skip_initial_config: true
+      desc: Testing Delayed replication with failover for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11490
+
+  - test:
+      name: Test delayed replication - Failback
+      clusters:
+        ceph-rbd1:
+          config:
+            direct_failback_scenario: true
+            skip_initial_config: true
+      desc: Testing Delayed replication with failback for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11493

--- a/suites/squid/rbd/tier-2_rbd_upgrade_7x_to_8x.yaml
+++ b/suites/squid/rbd/tier-2_rbd_upgrade_7x_to_8x.yaml
@@ -1,6 +1,6 @@
 #===============================================================================================
-# Tier-level: 3
-# Test-Suite: tier-3_rbd_mirror_upgrade_scale.yaml
+# Tier-level: 2
+# Test-Suite: tier-2_rbd_upgrade_7x_to_8x.yaml
 #
 # Cluster Configuration:
 #    cephci/conf/squid/rbd/5-node-2-clusters.yaml
@@ -25,12 +25,11 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 6.1
+                    rhcs-version: 7.1
                     release: "rc"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -62,12 +61,11 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 6.1
+                    rhcs-version: 7.1
                     release: "rc"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
-                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -105,8 +103,6 @@ tests:
             node: node2
             install_packages:
               - ceph-common
-              - rbd-nbd
-              - fio
             copy_admin_keyring: true
         ceph-rbd2:
           config:
@@ -115,8 +111,6 @@ tests:
             node: node2
             install_packages:
                 - ceph-common
-                - rbd-nbd
-                - fio
             copy_admin_keyring: true
       desc: Configure the client system 1
       destroy-cluster: false
@@ -134,7 +128,9 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      label: rbd-mirror
+                      nodes:
+                        - node5
+                        - node4
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -144,76 +140,117 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      label: rbd-mirror
+                      nodes:
+                        - node5
+                        - node4
       desc: RBD Mirror daemon deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
       name: deploy rbd-mirror daemon
 
   - test:
-      abort-on-fail: True
-      desc: Verify snapshot mirroring with upgrade
-      name: Test upgrade on snapshot mirrored clusters
-      module: test_rbd_snapshot_mirroring_with_upgrade.py
-      polarion-id: CEPH-83574895
+      abort-on-fail: true
+      desc: Multicluster upgrade to latest 8.x ceph version with rbd mirror daemon
+      module: test_cephadm_upgrade.py
+      name: Multi-cluster ceph upgrade to latest 8.x ceph
+      polarion-id: CEPH-83574829
       clusters:
         ceph-rbd1:
           config:
-            installed_version: "6.1"
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
         ceph-rbd2:
           config:
-            installed_version: "6.1"
-            rep_pool_config:
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
-            ec_pool_config:
-              ec-pool-k-m: "2,1"
-              ec_profile: "ec_profile"
-              num_pools: 1
-              num_images: 1
-              size: 1G
-              mode: image # compulsory argument if mirroring needs to be setup
-              mirrormode: snapshot
-              snap_schedule_levels:
-                - image
-              snap_schedule_intervals: #one value for each level specified above
-                - 1m
-              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
+
+  - test:
+      name: Test daemon failure in dual rbd-mirror daemon clusters
+      clusters:
+        ceph-rbd1:
+          dummy: true
+      desc: Verification of mirorring with failures of mirror daemons
+      module: test_rbd_mirror_multi_daemon.py
+      polarion-id: CEPH-83574962
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-rbd1:
+          config:
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+        ceph-rbd2:
+          config:
+            steps:
+              - config:
+                  command: apply
+                  service: rbd-mirror
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+      desc: Reduce mirroring daemons to 1
+      module: test_cephadm.py
+      name: Reduce mirroring daemons
+
+  - test:
+      name: test rbd mirror daemon restartwith resync
+      module: test_rbd_mirror_daemon_restart_imagesync.py
+      clusters:
+        ceph-rbd1:
+          config:
+            dummy: true
+      polarion-id: CEPH-10468
+      desc: Verification of image sync continuation after multiple rbd mirror daemon restarts
+
+  - test:
+      name: Test delayed replication - Secondary
+      clusters:
+        ceph-rbd1:
+          config:
+            delay_at_secondary: true
+      desc: Testing Delayed replication for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11492
+
+  - test:
+      name: Test delayed replication - primary
+      clusters:
+        ceph-rbd1:
+          config:
+            skip_initial_config: true
+            delay_at_primary: true
+      desc: Testing Delayed replication with delay set in primary per image
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11494
+
+  - test:
+      name: Test delayed replication - Failover
+      clusters:
+        ceph-rbd1:
+          config:
+            direct_failover_with_delay: true
+            skip_initial_config: true
+      desc: Testing Delayed replication with failover for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11490
+
+  - test:
+      name: Test delayed replication - Failback
+      clusters:
+        ceph-rbd1:
+          config:
+            direct_failback_scenario: true
+            skip_initial_config: true
+      desc: Testing Delayed replication with failback for journal mirroring
+      module: test_delayed_replication_handler.py
+      polarion-id: CEPH-11493

--- a/suites/squid/rbd/tier-3_rbd_mirror_upgrade_6x_to_8x_scale.yaml
+++ b/suites/squid/rbd/tier-3_rbd_mirror_upgrade_6x_to_8x_scale.yaml
@@ -1,6 +1,6 @@
 #===============================================================================================
-# Tier-level: 2
-# Test-Suite: tier-2_rbd_upgrade_6x_to_7x.yaml
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_mirror_upgrade_6x_to_8x_scale.yaml
 #
 # Cluster Configuration:
 #    cephci/conf/squid/rbd/5-node-2-clusters.yaml
@@ -30,6 +30,7 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -66,6 +67,7 @@ tests:
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -103,6 +105,8 @@ tests:
             node: node2
             install_packages:
               - ceph-common
+              - rbd-nbd
+              - fio
             copy_admin_keyring: true
         ceph-rbd2:
           config:
@@ -111,6 +115,8 @@ tests:
             node: node2
             install_packages:
                 - ceph-common
+                - rbd-nbd
+                - fio
             copy_admin_keyring: true
       desc: Configure the client system 1
       destroy-cluster: false
@@ -128,9 +134,7 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      nodes:
-                        - node5
-                        - node4
+                      label: rbd-mirror
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -140,117 +144,76 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      nodes:
-                        - node5
-                        - node4
+                      label: rbd-mirror
       desc: RBD Mirror daemon deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
       name: deploy rbd-mirror daemon
 
   - test:
-      abort-on-fail: true
-      desc: Multicluster upgrade with rbd mirror daemon
-      module: test_cephadm_upgrade.py
-      name: multi-cluster ceph upgrade
-      polarion-id: CEPH-83574829
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with upgrade from 6.1 to 8.x
+      name: Test upgrade on snapshot mirrored clusters 6.1 to 8.x
+      module: test_rbd_snapshot_mirroring_with_upgrade.py
+      polarion-id: CEPH-83574895
       clusters:
         ceph-rbd1:
           config:
+            installed_version: "6.1"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
         ceph-rbd2:
           config:
+            installed_version: "6.1"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
-
-  - test:
-      name: Test daemon failure in dual rbd-mirror daemon clusters
-      clusters:
-        ceph-rbd1:
-          dummy: true
-      desc: Verification of mirorring with failures of mirror daemons
-      module: test_rbd_mirror_multi_daemon.py
-      polarion-id: CEPH-83574962
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-rbd1:
-          config:
-            steps:
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
-        ceph-rbd2:
-          config:
-            steps:
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
-      desc: Reduce mirroring daemons to 1
-      module: test_cephadm.py
-      name: Reduce mirroring daemons
-
-  - test:
-      name: test rbd mirror daemon restartwith resync
-      module: test_rbd_mirror_daemon_restart_imagesync.py
-      clusters:
-        ceph-rbd1:
-          config:
-            dummy: true
-      polarion-id: CEPH-10468
-      desc: Verification of image sync continuation after multiple rbd mirror daemon restarts
-
-  - test:
-      name: Test delayed replication - Secondary
-      clusters:
-        ceph-rbd1:
-          config:
-            delay_at_secondary: true
-      desc: Testing Delayed replication for journal mirroring
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11492
-
-  - test:
-      name: Test delayed replication - primary
-      clusters:
-        ceph-rbd1:
-          config:
-            skip_initial_config: true
-            delay_at_primary: true
-      desc: Testing Delayed replication with delay set in primary per image
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11494
-
-  - test:
-      name: Test delayed replication - Failover
-      clusters:
-        ceph-rbd1:
-          config:
-            direct_failover_with_delay: true
-            skip_initial_config: true
-      desc: Testing Delayed replication with failover for journal mirroring
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11490
-
-  - test:
-      name: Test delayed replication - Failback
-      clusters:
-        ceph-rbd1:
-          config:
-            direct_failback_scenario: true
-            skip_initial_config: true
-      desc: Testing Delayed replication with failback for journal mirroring
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11493

--- a/suites/squid/rbd/tier-3_rbd_mirror_upgrade_7x_to_8x_scale.yaml
+++ b/suites/squid/rbd/tier-3_rbd_mirror_upgrade_7x_to_8x_scale.yaml
@@ -1,6 +1,6 @@
 #===============================================================================================
-# Tier-level: 2
-# Test-Suite: tier-2_rbd_upgrade_6x_to_7x.yaml
+# Tier-level: 3
+# Test-Suite: tier-3_rbd_mirror_upgrade_7x_to_8x_scale.yaml
 #
 # Cluster Configuration:
 #    cephci/conf/squid/rbd/5-node-2-clusters.yaml
@@ -25,11 +25,12 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 5.3
+                    rhcs-version: 7.1
                     release: "rc"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -61,11 +62,12 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 5.3
+                    rhcs-version: 7.1
                     release: "rc"
                     registry-url: registry.redhat.io
                     mon-ip: node1
                     orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -103,6 +105,8 @@ tests:
             node: node2
             install_packages:
               - ceph-common
+              - rbd-nbd
+              - fio
             copy_admin_keyring: true
         ceph-rbd2:
           config:
@@ -111,6 +115,8 @@ tests:
             node: node2
             install_packages:
                 - ceph-common
+                - rbd-nbd
+                - fio
             copy_admin_keyring: true
       desc: Configure the client system 1
       destroy-cluster: false
@@ -128,9 +134,7 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      nodes:
-                        - node5
-                        - node4
+                      label: rbd-mirror
         ceph-rbd2:
           config:
             verify_cluster_health: true
@@ -140,116 +144,76 @@ tests:
                   service: rbd-mirror
                   args:
                     placement:
-                      nodes:
-                        - node5
-                        - node4
+                      label: rbd-mirror
       desc: RBD Mirror daemon deployment using cephadm
       destroy-clster: false
       module: test_cephadm.py
       name: deploy rbd-mirror daemon
 
   - test:
-      abort-on-fail: true
-      desc: Multicluster upgrade with rbd mirror daemon
-      module: test_cephadm_upgrade.py
-      name: multi-cluster ceph upgrade
+      abort-on-fail: True
+      desc: Verify snapshot mirroring with upgrade from 7.1 to 8.x
+      name: Test upgrade on snapshot mirrored clusters 7.1 to 8.x
+      module: test_rbd_snapshot_mirroring_with_upgrade.py
+      polarion-id: CEPH-83574895
       clusters:
         ceph-rbd1:
           config:
+            installed_version: "7.1"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
         ceph-rbd2:
           config:
+            installed_version: "7.1"
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
+            ec_pool_config:
+              ec-pool-k-m: "2,1"
+              ec_profile: "ec_profile"
+              num_pools: 1
+              num_images: 1
+              size: 1G
+              mode: image # compulsory argument if mirroring needs to be setup
+              mirrormode: snapshot
+              snap_schedule_levels:
+                - image
+              snap_schedule_intervals: #one value for each level specified above
+                - 1m
+              io_size: 200M
             command: start
             service: upgrade
             verify_cluster_health: true
-
-  - test:
-      name: Test daemon failure in dual rbd-mirror daemon clusters
-      clusters:
-        ceph-rbd1:
-          dummy: true
-      desc: Verification of mirorring with failures of mirror daemons
-      module: test_rbd_mirror_multi_daemon.py
-      polarion-id: CEPH-83574962
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-rbd1:
-          config:
-            steps:
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
-        ceph-rbd2:
-          config:
-            steps:
-              - config:
-                  command: apply
-                  service: rbd-mirror
-                  args:
-                    placement:
-                      nodes:
-                        - node5
-      desc: Reduce mirroring daemons to 1
-      module: test_cephadm.py
-      name: Reduce mirroring daemons
-
-  - test:
-      name: test rbd mirror daemon restartwith resync
-      module: test_rbd_mirror_daemon_restart_imagesync.py
-      clusters:
-        ceph-rbd1:
-          config:
-            dummy: true
-      polarion-id: CEPH-10468
-      desc: Verification of image sync continuation after multiple rbd mirror daemon restarts
-
-  - test:
-      name: Test delayed replication - Secondary
-      clusters:
-        ceph-rbd1:
-          config:
-            delay_at_secondary: true
-      desc: Testing Delayed replication for journal mirroring
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11492
-
-  - test:
-      name: Test delayed replication - primary
-      clusters:
-        ceph-rbd1:
-          config:
-            skip_initial_config: true
-            delay_at_primary: true
-      desc: Testing Delayed replication with delay set in primary per image
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11494
-
-  - test:
-      name: Test delayed replication - Failover
-      clusters:
-        ceph-rbd1:
-          config:
-            direct_failover_with_delay: true
-            skip_initial_config: true
-      desc: Testing Delayed replication with failover for journal mirroring
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11490
-
-  - test:
-      name: Test delayed replication - Failback
-      clusters:
-        ceph-rbd1:
-          config:
-            direct_failback_scenario: true
-            skip_initial_config: true
-      desc: Testing Delayed replication with failback for journal mirroring
-      module: test_delayed_replication_handler.py
-      polarion-id: CEPH-11493


### PR DESCRIPTION
# Description
Updated squid upgrade test suites for **6.x to 8.x** and **7.x to 8.x**

`renamed:    suites/squid/rbd/tier-2_rbd_upgrade_6x_to_7x.yaml -> suites/squid/rbd/tier-2_rbd_upgrade_6x_to_8x.yaml`
`renamed:    suites/squid/rbd/tier-2_rbd_upgrade_5x_to_7x.yaml -> suites/squid/rbd/tier-2_rbd_upgrade_7x_to_8x.yaml`
`renamed:    suites/squid/rbd/tier-3_rbd_mirror_upgrade_6xto7x_scale.yaml -> suites/squid/rbd/tier-3_rbd_mirror_upgrade_6x_to_8x_scale.yaml`
`renamed:    suites/squid/rbd/tier-3_rbd_mirror_upgrade_5xto7x_scale.yaml -> suites/squid/rbd/tier-3_rbd_mirror_upgrade_7x_to_8x_scale.yaml`


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
