### PR TITLE
Add support for selected client upgrade, multiple client and reuse of existing mount after upgrade

### DIFF
--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_6x_to_8x.yaml
@@ -151,6 +151,7 @@ tests:
             abort-on-fail: false
             config:
               timeout: 30
+              client_upgrade: 1
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
             name: "creation of Prerequisites for Upgrade"

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_71_to_8x.yaml
@@ -148,6 +148,8 @@ tests:
             abort-on-fail: false
             config:
               timeout: 30
+              client_upgrade: 1
+              client_upgrade_node: 'node8'
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
             name: "creation of Prerequisites for Upgrade"

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_7x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_7x_to_8x.yaml
@@ -108,7 +108,10 @@ tests:
         id: client.1
         install_packages:
           - ceph-common
-        node: node8
+          - ceph-fuse
+        nodes:
+          - node8:
+              release: 7
       desc: "Configure the Cephfs client system 1"
       destroy-cluster: false
       module: test_client.py
@@ -121,7 +124,10 @@ tests:
         id: client.2
         install_packages:
           - ceph-common
-        node: node9
+          - ceph-fuse
+        nodes:
+          - node9:
+              release: 6
       desc: "Configure the Cephfs client system 1"
       destroy-cluster: false
       module: test_client.py

--- a/suites/squid/cephfs/tier-0_cephfs_upgrade_ibm_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_upgrade_ibm_6x_to_8x.yaml
@@ -149,6 +149,8 @@ tests:
             abort-on-fail: false
             config:
               timeout: 30
+              client_upgrade: 1
+              cleint_upgrade_node: 'node8'
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
             name: "creation of Prerequisites for Upgrade"

--- a/tests/cephfs/cephfs_upgrade/cephfs_io.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_io.py
@@ -90,7 +90,7 @@ def run(ceph_cluster, **kw):
                 client = [
                     i if upgrade_node in i.node.hostname else None for i in clients
                 ][0]
-                if client != None:
+                if client is not None:
                     cmd = "yum install -y --nogpgcheck ceph-common ceph-fuse"
                     client.exec_command(sudo=True, cmd=cmd)
 

--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -265,24 +265,18 @@ def snap_sched_test(snap_req_params):
             cmd=f"ceph fs subvolume getpath {vol_name} {sv} {sv_snap_tmp[sv]['svg']}",
         )
         subvol_path = subvol_path.strip()
-        try:
-            fs_util.fuse_mount(
-                [snap_client],
-                fuse_mounting_dir_1,
-                extra_params=f"-r {subvol_path} --client_fs {vol_name}",
-            )
-        except Exception as ex:
-            pass
-        try:
-            fs_util.kernel_mount(
-                [snap_client],
-                kernel_mounting_dir_1,
-                ",".join(mon_node_ips),
-                sub_dir=f"{subvol_path}",
-                extra_params=f",fs={vol_name}",
-            )
-        except Exception as ex:
-            pass
+        fs_util.fuse_mount(
+            [snap_client],
+            fuse_mounting_dir_1,
+            extra_params=f"-r {subvol_path} --client_fs {vol_name}",
+        )
+        fs_util.kernel_mount(
+            [snap_client],
+            kernel_mounting_dir_1,
+            ",".join(mon_node_ips),
+            sub_dir=f"{subvol_path}",
+            extra_params=f",fs={vol_name}",
+        )
         if sv in sv_snap:
             sv_snap[sv]["mnt_kernel"] = kernel_mounting_dir_1
             sv_snap[sv]["mnt_fuse"] = fuse_mounting_dir_1
@@ -660,7 +654,7 @@ def dir_pin_test(dir_pin_req_params):
             if int(mds["rank"]) == int(pin_vol["pin_rank"]):
                 mds_dirs_after = mds["dirs"]
                 break
-        if int(mds_dirs_after) > int(mds_dirs_before):
+        if int(mds_dirs_after) != int(mds_dirs_before):
             log.info(
                 f"IO from pinned dirs goes through MDS rank {pin_vol['pin_rank']} as expected"
             )
@@ -1130,9 +1124,7 @@ def run(ceph_cluster, **kw):
     try:
         fs_util = FsUtils(ceph_cluster)
         snap_util = SnapUtils(ceph_cluster)
-        config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
-        default_nfs_name = "cephfs-nfs"
         default_fs = "cephfs"
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
         cg_snap_util = CG_Snap_Utils(ceph_cluster)
@@ -1158,16 +1150,12 @@ def run(ceph_cluster, **kw):
             "fs_name": default_fs,
         }
         f.close()
-
         space_str = "\t\t\t\t\t\t\t\t\t"
-
-        """log.info(
+        log.info(
             f"\n\n {space_str} Test1 CEPH-83575098 : Post-upgrade NFS Validation\n"
         )
-        
         nfs_test(test_reqs)
-        log.info("NFS post upgrade validation succeeded \n")"""
-
+        log.info("NFS post upgrade validation succeeded \n")
         log.info(
             f"\n\n {space_str}Test2 : Post-upgrade Snapshot and Schedule Validation\n"
         )

--- a/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
+++ b/tests/cephfs/cephfs_upgrade/upgrade_pre_req.py
@@ -5,16 +5,13 @@ import time
 import traceback
 from distutils.version import LooseVersion
 
-import requests
-import yaml
-
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from tests.cephfs.snapshot_clone.cephfs_snap_utils import SnapUtils
 from utility.log import Log
 from utility.retry import retry
-from utility.utils import get_ceph_version_from_cluster, get_cephci_config
+from utility.utils import get_ceph_version_from_cluster
 
 log = Log(__name__)
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHCEPHQE-15781

Fix 1: Move client upgrade code to cephfs_io, as when cephfs_io is executed, repo for version being upgraded is added by ceph-ci upgrade framework and cephfs code needs to run just package upgrade cmds.
Support for all client upgrade retained, new option 'client_upgrade_node' with values as node8 or node9 can be used for single client upgraded, if not provided and 'client_upgrade' is set to 1, in config params, then all clients will be upgraded as before, otherwise only the specified client will be upgraded.
Logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GREIVD

Fix 2: Add support to use 2nd client for IO pre-upgrade and post-upgrade and also validate reuse of existing mountpoints after upgrade.
Logs: 
Pre-upgrade, upgrade automation logs with fixes: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-22MBYW
post upgrade logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-SSPUWW 

Fix 3: Add support for mixed version clients pre-upgrade and validate same config to be usable post ceph upgrade.
New Suite: suites/squid/cephfs/tier-0_cephfs_upgrade_7x_to_8x_mixed_client_version.yaml
Logs:
Pre-upgrade,upgrade:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GREIVD
Post-upgrade:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N1UPW2 

New config params for single client upgrade and integration of new mixed client version suite file will be done in jenkins cephfs metadata file.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
