### PR TITLE
Enhance crash module to archive existing crashes & max avail added for OSD out

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -4204,5 +4204,15 @@ class RadosOrchestrator:
         crash_list = self.do_crash_ls()
         if crash_list:
             log.error("!!!ERROR: Crash exists in the cluster \n\n:" f"{crash_list}")
+            log.info("Logging crash info for each crash")
+            for crash_id in crash_list:
+                crash_info, _ = self.run_ceph_command(
+                    f"ceph crash info {crash_id}", client_exec=True
+                )
+                log.info(crash_info)
+
+            log.info("Archiving all the existing crashes on the cluster")
+            out, _ = self.node.shell(["ceph crash archive-all"])
+            log.info(out)
             return True
         return False

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -106,6 +106,11 @@ def run(ceph_cluster, **kw):
         method_should_succeed(
             wait_for_clean_pg_sets, rados_obj, timeout=timeout, test_pool=pool_name
         )
+        # ensure ceph df max avail has updated correctly after OSDs are out
+        if not rados_obj.verify_max_avail():
+            log.error("ceph df max avail is not accurate")
+            raise Exception("ceph df max avail is not accurate")
+
         utils.osd_remove(ceph_cluster, osd_id)
         if cr_pool.get("rados_put", False):
             do_rados_get(client_node, pool["pool_name"], 1)


### PR DESCRIPTION
With recent changes in PR #4037 we introduced a crash module intended to run at the execution of each test workflow logging and checking crashes present in the cluster.
The current PR is an enhancement to the same where we are archiving any existing crashes on the cluster after they are reported. This ensures only one test case fails with a unique crash on the cluster and a series of tests do not fail due to the same common crash which are not even related to or caused the running workflow.

ceph-ci pipeline runs for recent Squid build saw [numerous false failures](http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.1.1-19/rados/6/tier-4_rados_tests) which prompted this necessary change.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>