### PR TITLE
Include change-load-balancing-group test

### DIFF
--- a/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -91,7 +91,9 @@ tests:
               service: nvmeof
               args:
                 placement:
-                  label: nvmeof-gw
+                  nodes:
+                    - node5
+                    - node6
               pos_args:
                 - rbd
       desc: NVMeoF Gateway deployment using cephadm
@@ -215,6 +217,28 @@ tests:
                 size: 10G
           - config:
               service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                rbd-image: image3
+                rbd-pool: rbd
+                nsid: 3
+                load-balancing-group: 1
+                rbd-create-image: true
+                size: 1G
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                rbd-image: image4
+                rbd-pool: rbd
+                nsid: 4
+                load-balancing-group: 2
+                rbd-create-image: true
+                size: 1G
+          - config:
+              service: namespace
               command: list             # namespace list
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
@@ -244,6 +268,20 @@ tests:
               command: list             # namespace list
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 3
+                load-balancing-group: 2
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 4
+                load-balancing-group: 1
           - config:
               service: namespace
               command: get_io_stats             # namespace get_io_stats

--- a/suites/squid/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -91,7 +91,9 @@ tests:
               service: nvmeof
               args:
                 placement:
-                  label: nvmeof-gw
+                  nodes:
+                    - node5
+                    - node6
               pos_args:
                 - rbd
                 - gw_group1
@@ -216,6 +218,28 @@ tests:
                 size: 10G
           - config:
               service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                rbd-image: image3
+                rbd-pool: rbd
+                nsid: 3
+                load-balancing-group: 1
+                rbd-create-image: true
+                size: 1G
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                rbd-image: image4
+                rbd-pool: rbd
+                nsid: 4
+                load-balancing-group: 2
+                rbd-create-image: true
+                size: 1G
+          - config:
+              service: namespace
               command: list             # namespace list
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
@@ -240,6 +264,20 @@ tests:
                 subsystem: nqn.2016-06.io.spdk:cnode1
                 nsid: 2
                 size: 15G
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 3
+                load-balancing-group: 2
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 4
+                load-balancing-group: 1
           - config:
               service: namespace
               command: list             # namespace list


### PR DESCRIPTION
# Description
Include change-load-balancing-group test


```
All test logs located here: /Users/sunilkumarn/logs/8-0-gw-ops-02

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
install ceph pre-requisites      None                                                           0:07:54.599491                   Pass
deploy cluster                   RHCS cluster deployment using cephadm                          0:13:26.735930                   Pass
configure Ceph client for NVMe   Setup client on NVMEoF gateway                                 0:00:50.838689                   Pass
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:02:48.680140                   Pass
Manage nvmeof gateway entities   Manage NVMeoF Subsystem entities                               0:01:09.488411                   Failed
Delete nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:35.781696                   Pass
Delete nvmeof gateway pre-reqs   NVMeoF Gateway deployment using cephadm                        0:00:29.314883                   Pass
```

```2024-09-11 14:44:44,686 (cephci.test_nvme_cli) [INFO] - cephci.ceph.nvmegw_cli.execute.py:33 - NVMe CLI command : namespace change_load_balancing_group
2024-09-11 14:44:44,687 (cephci.test_nvme_cli) [INFO] - cephci.ceph.ceph.py:1596 - Running command podman run --quiet --rm  cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.3.1-1  --server-address 10.0.67.228 --server-port 5500 namespace change_load_balancing_group  --subsystem nqn.2016-06.io.spdk:cnode1 --nsid 3 --load-balancing-group 2 on 10.0.67.228 timeout 600
2024-09-11 14:44:46,487 (cephci.test_nvme_cli) [ERROR] - cephci.ceph.ceph.py:1632 - Error 22 during cmd, timeout 600
2024-09-11 14:44:46,489 (cephci.test_nvme_cli) [ERROR] - cephci.ceph.ceph.py:1633 - Failure changing load balancing group for namespace with NSID 3 in nqn.2016-06.io.spdk:cnode1:
module 'spdk.rpc.nvmf' has no attribute 'nvmf_subsystem_set_ns_ana_group'

2024-09-11 14:44:46,490 (cephci.test_nvme_cli) [ERROR] - cephci.tests.nvmeof.test_nvme_cli.py:83 - podman run --quiet --rm  cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.3.1-1  --server-address 10.0.67.228 --server-port 5500 namespace change_load_balancing_group  --subsystem nqn.2016-06.io.spdk:cnode1 --nsid 3 --load-balancing-group 2 Error:  Failure changing load balancing group for namespace with NSID 3 in nqn.2016-06.io.spdk:cnode1:
module 'spdk.rpc.nvmf' has no attribute 'nvmf_subsystem_set_ns_ana_group'
 10.0.67.228
Traceback (most recent call last):
  File "/Users/sunilkumarn/workspace/cephci/tests/nvmeof/test_nvme_cli.py", line 81, in run
    func(**cfg)
  File "/Users/sunilkumarn/workspace/cephci/ceph/nvmegw_cli/namespace.py", line 41, in change_load_balancing_group
    return self.run_nvme_cli("change_load_balancing_group", **kwargs)
  File "/Users/sunilkumarn/workspace/cephci/ceph/nvmegw_cli/execute.py", line 56, in run_nvme_cli
    err, out = self.node.exec_command(cmd=command, sudo=True)
  File "/Users/sunilkumarn/workspace/cephci/ceph/ceph.py", line 1634, in exec_command
    raise CommandFailed(
ceph.ceph.CommandFailed: podman run --quiet --rm  cp.stg.icr.io/cp/ibm-ceph/nvmeof-cli-rhel9:1.3.1-1  --server-address 10.0.67.228 --server-port 5500 namespace change_load_balancing_group  --subsystem nqn.2016-06.io.spdk:cnode1 --nsid 3 --load-balancing-group 2 Error:  Failure changing load balancing group for namespace with NSID 3 in nqn.2016-06.io.spdk:cnode1:
module 'spdk.rpc.nvmf' has no attribute 'nvmf_subsystem_set_ns_ana_group'
 10.0.67.228```
