### PR TITLE
cephci integration of support to add placement and storageclass durin…

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -231,6 +231,15 @@ tests:
         config-file-name: test_lc_process_without_applying_rule.yaml
 
   - test:
+      name: Test user creation with placement and storage class cold
+      desc: Test user creation with placement and storage class cold
+      polarion-id: CEPH-83575880
+      module: sanity_rgw.py
+      config:
+        script-name: user_create.py
+        config-file-name: test_user_with_placement_id_storage_class_cold.yaml
+
+  - test:
       abort-on-fail: false
       config:
         branch: ceph-reef

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -231,6 +231,25 @@ tests:
         config-file-name: test_lc_process_without_applying_rule.yaml
 
   - test:
+      name: Test user creation with placement and storage class cold
+      desc: Test user creation with placement and storage class cold
+      polarion-id: CEPH-83575880
+      module: sanity_rgw.py
+      config:
+        script-name: user_create.py
+        config-file-name: test_user_with_placement_id_storage_class_cold.yaml
+
+  - test:
+      name: Test user creation with placement and storage class
+      desc: Test user creation with placement and storage class
+      polarion-id: CEPH-83575880
+      comments: known issue (BZ-2311474)
+      module: sanity_rgw.py
+      config:
+        script-name: user_create.py
+        config-file-name: test_user_with_placement_id_storage_class.yaml
+
+  - test:
       abort-on-fail: false
       config:
         branch: ceph-squid


### PR DESCRIPTION
…g user creation

cephci integration of support to add placement and storageclass during user creation
depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/633

log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-ZK7OTS/Test_user_creation_with_placement_and_storage_class_0.log

http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-ZK7OTS/Test_user_creation_with_placement_and_storage_class_0.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
