### PR TITLE
Remove default tier-0 build type

### DIFF
--- a/pipeline/rhcs_deploy.groovy
+++ b/pipeline/rhcs_deploy.groovy
@@ -73,7 +73,7 @@ node ("rhel-9-medium || ceph-qe-ci") {
 
         majorVersion = ciMap.rhbuild.substring(0,1)
         clusterName = ciMap["cluster_name"]
-        def buildType = "${ciMap.build}" ?: "tier-0"
+        def buildType = "${ciMap.build}" ?: "latest"
 
         // Prepare the CLI arguments
         cliArgs += "--rhbuild ${ciMap.rhbuild}"
@@ -121,8 +121,8 @@ node ("rhel-9-medium || ceph-qe-ci") {
                 "email": "cephci@redhat.com",
             ],
             "system": [
-                "os": "centos-7",
-                "label": "centos-7",
+                "os": "rhel-9",
+                "label": "rhel-9-medium",
                 "provider": "openstack",
             ],
             "pipeline": [


### PR DESCRIPTION
# Description

We no longer have tier-0 as a build type hence using the default value as latest. This would be an untested version and would be required only when we need to have testing against a new relase.

Also, correctly the details of the system on which the execution was carried out.

*Checklist*

- [x] Review the automation design
- [x] Unit testing completed. 