### PR TITLE
integrating GetObjectAttributes tests into cephci

### DIFF
--- a/suites/squid/rgw/tier-1_rgw.yaml
+++ b/suites/squid/rgw/tier-1_rgw.yaml
@@ -170,3 +170,28 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+  - test:
+      name: Test GetObjectAttributes with normal objects
+      desc: Test GetObjectAttributes with normal objects
+      polarion-id: CEPH-83595849
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_get_object_attributes.yaml
+  - test:
+      name: Test GetObjectAttributes with checksum sha256
+      desc: Test GetObjectAttributes with checksum sha256
+      polarion-id: CEPH-83595849
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_get_object_attributes_checksum_sha256.yaml
+  - test:
+      name: Test GetObjectAttributes with multipart objects
+      desc: Test GetObjectAttributes with multipart objects
+      polarion-id: CEPH-83595849
+      module: sanity_rgw.py
+      comments: known issue (BZ2311872) targeted to 8.0
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml


### PR DESCRIPTION
this PR is to add support for testing s3api GetObjectAttributes
added basic support for checksum to test with GetObjectAttributes

depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/634

polarion: https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83595849

there is an existing issue with ObjectParts with multipart objects, failure in multipart log is because of that
bz: https://bugzilla.redhat.com/show_bug.cgi?id=2311872

pass logs for existing and new configs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_get_object_attributes/



# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
