### PR TITLE
[TFA] updating indentation for testcase of parallel run

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -352,15 +352,15 @@ tests:
             name: multisite ceph upgrade
             polarion-id: CEPH-83574647
         - test:
-          clusters:
-            ceph-pri:
-              config:
-                script-name: test_Mbuckets_with_Nobjects.py
-                config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-          desc: test to create "M" no of buckets and "N" no of objects with download
-          module: sanity_rgw_multisite.py
-          name: download objects post upgrade
-          polarion-id: CEPH-14237
+            clusters:
+              ceph-pri:
+                config:
+                  script-name: test_Mbuckets_with_Nobjects.py
+                  config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            desc: test to create "M" no of buckets and "N" no of objects with download
+            module: sanity_rgw_multisite.py
+            name: download objects post upgrade
+            polarion-id: CEPH-14237
 
   - test:
       name: Retrieve the versions of the cluster parallelly

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -101,13 +101,13 @@ tests:
       module: test_parallel.py
       parallel:
         - test:
-          name: S3CMD small and multipart object download
-          desc: S3CMD small and multipart object download or GET
-          polarion-id: CEPH-83575477
-          module: sanity_rgw.py
-          config:
-            script-name: ../s3cmd/test_s3cmd.py
-            config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+            name: S3CMD small and multipart object download
+            desc: S3CMD small and multipart object download or GET
+            polarion-id: CEPH-83575477
+            module: sanity_rgw.py
+            config:
+              script-name: ../s3cmd/test_s3cmd.py
+              config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
         - test:
             name: Upgrade cluster to latest 8.x ceph version
             desc: Upgrade cluster to latest version


### PR DESCRIPTION
# Description
 updating indentation for test case of parallel run
 issue:
 http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Sanity/19.1.1-39/103/  
tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest :
tier-2_rgw_upgrade_8xsanity_to_8xlatest : indentation

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
