### PR TITLE
Enable debug logs in CG quiesce functional for reef

### DIFF
--- a/suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -122,16 +122,6 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Verify quiesce release with if-version, repeat with exclude and include prior to release"
-      destroy-cluster: false
-      module: snapshot_clone.cg_snap_test.py
-      name: "cg_snap_func_workflow_2"
-      polarion-id: CEPH-83581470
-      config:
-       test_name: cg_snap_func_workflow_2
-  -
-    test:
-      abort-on-fail: false
       desc: "Verify restore suceeds from snapshot taken when subvolume was quiesced"
       destroy-cluster: false
       module: snapshot_clone.cg_snap_test.py
@@ -169,6 +159,26 @@ tests:
       polarion-id: CEPH-83591508
       config:
        test_name: cg_snap_interop_workflow_2
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+       ENABLE_LOGS : 1
+       daemon_list : ['mds','client']
+       daemon_dbg_level : {'mds':20,'client':20}
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce release with if-version, repeat with exclude and include prior to release"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_2"
+      polarion-id: CEPH-83581470
+      config:
+       test_name: cg_snap_func_workflow_2
   -
     test:
       abort-on-fail: false
@@ -210,3 +220,12 @@ tests:
       config:
        test_name: cg_snap_interop_workflow_1
       comments: product bug bz-2273569
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+       DISABLE_LOGS : 1
+       daemon_list : ['mds','client']


### PR DESCRIPTION
# Description
Enable debug logs to report issue on write timeout after >10secs of release state and ceph health OK.
Jira: https://issues.redhat.com/browse/RHCEPHQE-16029

Suite: suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
