### PR TITLE
fix reef gateway operations test suite

### DIFF
--- a/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_functional_Regression.yaml
@@ -65,7 +65,7 @@ tests:
 
 #  Perform Data Integrity tests
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         cleanup:
           - subsystems
@@ -99,7 +99,7 @@ tests:
 
 #  Run IO on NVMe Targets
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd
@@ -134,7 +134,7 @@ tests:
 
 # Perform QoS while IO is running between Targets
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd
@@ -175,7 +175,7 @@ tests:
 
 #  GW deployment collocation with Mon_MGR nodes
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node2
         rbd_pool: rbd
@@ -210,7 +210,7 @@ tests:
 
 # Run IOs using multiple-initiators against multi-subsystems based NVMe-OF targets using fio tool
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd
@@ -255,7 +255,7 @@ tests:
 
 #  Multiple gateways deployment in the cluster
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6                       # Deploying multiple gateways on the cluster
         rbd_pool: rbd
@@ -289,7 +289,7 @@ tests:
       polarion-id: CEPH-83576112
 
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd
@@ -306,7 +306,7 @@ tests:
       polarion-id: CEPH-83575812
 
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd
@@ -340,7 +340,7 @@ tests:
       polarion-id: CEPH-83575813
 
   - test:
-      abort-on-fail: true
+      abort-on-fail: false
       config:
         gw_node: node6
         rbd_pool: rbd

--- a/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -185,7 +185,7 @@ tests:
               command: add              # add Host access
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
-                host: "*"
+                host: '"*"'
           - config:
               service: host
               command: list             # List access hosts
@@ -196,7 +196,7 @@ tests:
               command: delete           # access host del
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
-                host: "*"
+                host: '"*"'
           - config:
               service: namespace
               command: add              # Namespace add
@@ -301,10 +301,25 @@ tests:
                 subsystem: nqn.2016-06.io.spdk:cnode1
                 nsid: 2
           - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 3
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                nsid: 4
+          - config:
               service: subsystem
               command: delete           # subsystem delete
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1
+          - config:
+              service: gateway          # https://bugzilla.redhat.com/show_bug.cgi?id=2308160
+              command: info             # gateway info
           - config:
               service: version          # CLI Version
               command: version

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -15,7 +15,7 @@ from utility.utils import generate_unique_id
 LOG = Log(__name__)
 
 
-def configure_subsystems(rbd, pool, nvmegwcli, config):
+def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
     """Configure Ceph-NVMEoF Subsystems."""
     sub_args = {"subsystem": config["nqn"]}
     nvmegwcli.subsystem.add(
@@ -28,7 +28,19 @@ def configure_subsystems(rbd, pool, nvmegwcli, config):
         "trsvcid": config["listener_port"],
     }
     nvmegwcli.listener.add(**{"args": {**listener_cfg, **sub_args}})
-    nvmegwcli.host.add(**{"args": {**sub_args, **{"host": config["allow_host"]}}})
+
+    # All host to subsystem
+    if config.get("allow_host"):
+        nvmegwcli.host.add(
+            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
+        )
+
+    if config.get("hosts"):
+        for host in config["hosts"]:
+            initiator_node = get_node_by_id(ceph_cluster, host)
+            initiator = Initiator(initiator_node)
+            host_nqn = initiator.nqn()
+            nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
 
     if config.get("bdevs"):
         name = generate_unique_id(length=4)
@@ -203,7 +215,12 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
             with parallel() as p:
                 for subsys_args in config["subsystems"]:
                     p.spawn(
-                        configure_subsystems, rbd_obj, rbd_pool, nvmegwcli, subsys_args
+                        configure_subsystems,
+                        ceph_cluster,
+                        rbd_obj,
+                        rbd_pool,
+                        nvmegwcli,
+                        subsys_args,
                     )
 
         if config.get("initiators"):


### PR DESCRIPTION
# Description
- fix reef gateway operations test suite

**Gateway operations**
```
All test logs located here: /Users/sunilkumarn/logs/7-1z1-GW-ops-03

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
deploy nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:02:20.390699                   Pass
Manage nvmeof gateway entities   Manage NVMeoF Subsystem entities                               0:01:01.099003                   Pass
Delete nvmeof gateway            NVMeoF Gateway deployment using cephadm                        0:00:25.920730                   Pass
Delete nvmeof gateway pre-reqs   NVMeoF Gateway deployment using cephadm                        0:00:25.853262                   Pass
```

Logs are stored under magna2, `/ceph-qe-logs/Sunil-Kumar/7-1z1-GW-ops-03/`

**Functional Regression**

```
Test <module 'test_ceph_nvmeof_neg_tests' from '/Users/sunilkumarn/workspace/cephci/tests/nvmeof/test_ceph_nvmeof_neg_tests.py'> passed
2024-09-18 02:22:03,323 (cephci.test_ceph_nvmeof_neg_tests) [INFO] - cephci.run.py:956 -
All test logs located here: /Users/sunilkumarn/logs/7-1z2-func-regression-01

All test logs located here: /Users/sunilkumarn/logs/7-1z2-func-regression-01

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Test to perform Data Integrity   Perform Data integrity test over NVMEoF targets                0:05:39.579651                   Pass
Basic E2E-Test Ceph NVMEoF GW    E2E-Test NVMEoF Gateway collocated with OSD node and Run IOs   0:17:16.303056                   Pass
Perform QoS while IO is runnin   Perform QoS while IO is running between Targets                0:16:36.414641                   Pass
Basic E2E-Test Ceph NVMEoF GW    E2E-Test NVMEoF Gateway collocated with MON-MGR node and Run   0:18:48.564401                   Pass
Test to run IOs using multiple   Perform IOs on multi-subsystems with Multiple-Initiators       0:27:42.734737                   Pass
Test to Deploy multiple NVMEoF   Deploy multiple NVMEoF Gateway on the cluster                  0:15:57.057289                   Pass
Remove-image ops on NVMe Names   Test remove RBD image used as NVMe namespace                   0:04:23.809019                   Pass
Perform restart of NVMeOF gate   Perform restart and validate the gateway entities              0:04:00.400437                   Pass
RBD operations shrink and expa   Perform RBD operations shrink and expand on images.            0:16:20.163928                   Pass
Validate Host accessibility to   Validate Host accessibility via nvme-cli commands.             0:04:15.517927                   Pass
```

Logs are stored under magna2, `/ceph-qe-logs/Sunil-Kumar/7-1z2-func-regression-01`
