### PR TITLE
NVMeOF 8.0 Greenfield scale 4 GW groups with 2GWs 1024 NS 128 Sub each

### DIFF
--- a/conf/squid/nvmeof/ceph_nvmeof_4-group_2-gws_scale.yaml
+++ b/conf/squid/nvmeof/ceph_nvmeof_4-group_2-gws_scale.yaml
@@ -1,0 +1,81 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      vm-size: ci.standard.xl
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - nvmeof-gw
+      node4:
+        role:
+          - nvmeof-gw
+      node5:
+        role:
+          - mds
+          - osd
+          - rgw
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - mon
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node7:
+        role:
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node8:
+        role:
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node9:
+        role:
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node10:
+        role:
+          - osd
+          - nvmeof-gw
+        no-of-volumes: 4
+        disk-size: 20
+      node11:
+        role:
+          - client
+      node12:
+        role:
+          - client
+      node13:
+        role:
+          - client
+      node14:
+        role:
+          - client
+      node15:
+        role:
+          - osd
+        no-of-volumes: 6
+        disk-size: 20
+      node16:
+        role:
+          - osd
+        no-of-volumes: 6
+        disk-size: 20

--- a/suites/squid/nvmeof/tier-3_4-group_2-gw_128-sub_1024-NS.yaml
+++ b/suites/squid/nvmeof/tier-3_4-group_2-gw_128-sub_1024-NS.yaml
@@ -1,0 +1,461 @@
+##############################################################################################
+# Test suite to scale to 4 GW groups with 2 GWs having 128 subsystems to 1024 namespaces
+# Tier-Level: 3
+# Cluster Configuration: conf/squid/nvmeof/ceph_nvmeof_4-group_2-gws_scale.yaml
+# Inventory: conf/inventory/rhel-9.4-server-x86_64-xlarge.yaml
+################################################################################################
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node11
+          - node12
+          - node13
+          - node14
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_pool
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node3
+                  - node4
+              pos_args:
+                - nvmeof_pool
+                - group1
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd1
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd1
+      desc: deploy NVMeoF service for GW group 1
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 1
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node3
+        rbd_pool: rbd1
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 128
+                max-namespaces: 1024
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 128
+                port: 4420
+                group: group1
+                nodes:
+                  - node3
+                  - node4
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 128
+                group: group1
+          - config:
+              service: namespace
+              command: add
+              args:
+                subsystems: 128
+                namespaces: 1024
+                group: group1
+                image_size: 1T
+                pool: rbd1
+        initiators:
+            listener_port: 4420
+            node: node11
+        run_io:
+          - node: node11
+            io_type: write
+      desc: Scale to 1024 namespaces with IO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 1024 namespaces with IO on 2GW and 128 subsystems
+      polarion-id: CEPH-83595512
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node5
+                  - node6
+              pos_args:
+                - nvmeof_pool
+                - group2
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd2
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd2
+      desc: deploy NVMeoF service for GW group 2
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 2
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node5
+        rbd_pool: rbd2
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 128
+                max-namespaces: 2048
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 128
+                port: 4420
+                group: group2
+                nodes:
+                  - node5
+                  - node6
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 128
+                group: group2
+          - config:
+              service: namespace
+              command: add
+              args:
+                subsystems: 128
+                namespaces: 1024
+                group: group2
+                image_size: 1T
+                pool: rbd2
+        initiators:
+            listener_port: 4420
+            node: node12
+        run_io:
+          - node: node12
+            io_type: write
+      desc: Scale to 1024 namespaces with IO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 1024 namespaces with IO on 2GW and 128 subsystems
+      polarion-id: CEPH-83595512
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node7
+                  - node8
+              pos_args:
+                - nvmeof_pool
+                - group3
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd3
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd3
+      desc: deploy NVMeoF service for GW group 3
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 3
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node7
+        rbd_pool: rbd3
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 128
+                max-namespaces: 2048
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 128
+                port: 4420
+                group: group3
+                nodes:
+                  - node7
+                  - node8
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 128
+                group: group3
+          - config:
+              service: namespace
+              command: add
+              args:
+                subsystems: 128
+                namespaces: 1024
+                group: group3
+                image_size: 1T
+                pool: rbd3
+        initiators:
+            listener_port: 4420
+            node: node13
+        run_io:
+          - node: node13
+            io_type: write
+      desc: Scale to 1024 namespaces with IO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 1024 namespaces with IO on 2GW and 128 subsystems
+      polarion-id: CEPH-83595512
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node9
+                  - node10
+              pos_args:
+                - nvmeof_pool
+                - group4
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd4
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd4
+      desc: deploy NVMeoF service for GW group 4
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 4
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node9
+        rbd_pool: rbd4
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 128
+                max-namespaces: 2048
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 128
+                port: 4420
+                group: group4
+                nodes:
+                  - node9
+                  - node10
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 128
+                group: group4
+          - config:
+              service: namespace
+              command: add
+              args:
+                subsystems: 128
+                namespaces: 1024
+                group: group4
+                image_size: 1T
+                pool: rbd4
+        initiators:
+            listener_port: 4420
+            node: node14
+        run_io:
+          - node: node14
+            io_type: write
+      desc: Scale to 1024 namespaces with IO
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Scale to 1024 namespaces with IO on 2GW and 128 subsystems
+      polarion-id: CEPH-83595512
+
+  - test:
+      abort-on-fail: false
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph orch rm nvmeof.nvmeof_pool.group1
+          - config:
+              command: shell
+              args:
+                - ceph orch rm nvmeof.nvmeof_pool.group2
+          - config:
+              command: shell
+              args:
+                - ceph orch rm nvmeof.nvmeof_pool.group3
+          - config:
+              command: shell
+              args:
+                - ceph orch rm nvmeof.nvmeof_pool.group4
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm nvmeof_pool nvmeof_pool --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd1 rbd1 --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd2 rbd2 --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd3 rbd3 --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd4 rbd4 --yes-i-really-really-mean-it
+      desc: Remove nvmeof service and all pools from ceph cluster
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: Remove nvmeof service on all GW nodes
+      polarion-id: CEPH-83595696


### PR DESCRIPTION
Test suite to scale to 4 GW groups with 2 GWs having 128 subsystems to 1024 namespaces
Tier-Level: 3
Cluster Configuration: conf/squid/nvmeof/ceph_nvmeof_4-group_2-gws_scale.yaml
Inventory: conf/inventory/rhel-9.4-server-x86_64-xlarge.yaml

Developed with combination of CEPH-83595696 and CEPH-83595512
test run - http://magna002.ceph.redhat.com/cephci-jenkins/harika/cephci-run-6AWTZF/

- This also handles new subsystem NQN - "NQN.group_name"

Test run 
```
  - test:
      abort-on-fail: false
      config:
        node: node3
        rbd_pool: rbd1
        do_not_create_image: true
        rep-pool-only: true
        steps:
          - config:
              service: subsystem
              command: add
              args:
                subsystems: 2
                max-namespaces: 1024
          - config:
              service: listener
              command: add
              args:
                subsystems: 2
                port: 4420
                group: group1
                nodes:
                  - node3
                  - node4
          - config:
              service: host
              command: add
              args:
                subsystems: 2
                group: group1
          - config:
              service: namespace
              command: add
              args:
                subsystems: 2
                namespaces: 10
                group: group1
                image_size: 1T
                pool: rbd1
        initiators:
            listener_port: 4420
            node: node11
        run_io:
          - node: node11
            io_type: write
      desc: Scale to 1024 namespaces with IO
      destroy-cluster: false
      module: test_ceph_nvmeof_gateway_sub_scale.py
      name: Scale to 1024 namespaces with IO on 2GW and 128 subsystems
      polarion-id: CEPH-83583005

  - test:
      abort-on-fail: false
      config:
        node: node5
        rbd_pool: rbd2
        do_not_create_image: true
        rep-pool-only: true
        steps:
          - config:
              service: subsystem
              command: add
              args:
                subsystems: 2
                max-namespaces: 2048
                no-group-append: True
          - config:
              service: listener
              command: add
              args:
                subsystems: 2
                port: 4420
                nodes:
                  - node5
                  - node6
          - config:
              service: host
              command: add
              args:
                subsystems: 2
          - config:
              service: namespace
              command: add
              args:
                subsystems: 2
                namespaces: 10
                image_size: 1T
                pool: rbd2
        initiators:
            listener_port: 4420
            node: node12
        run_io:
          - node: node12
            io_type: write
      desc: Scale to 1024 namespaces with IO
      destroy-cluster: false
      module: test_ceph_nvmeof_gateway_sub_scale.py
      name: Scale to 1024 namespaces with IO on 2GW and 128 subsystems
      polarion-id: CEPH-83583005
```
[Scale_to_1024_namespaces_with_IO_on_2GW_and_128_subsystems_0.log](https://github.com/user-attachments/files/17057438/Scale_to_1024_namespaces_with_IO_on_2GW_and_128_subsystems_0.log)
[Scale_to_1024_namespaces_with_IO_on_2GW_and_128_subsystems_1.log](https://github.com/user-attachments/files/17057439/Scale_to_1024_namespaces_with_IO_on_2GW_and_128_subsystems_1.log)
[Scale_to_1024_namespaces_with_IO_on_2GW_and_128_subsystems_2.log](https://github.com/user-attachments/files/17057440/Scale_to_1024_namespaces_with_IO_on_2GW_and_128_subsystems_2.log)

