### PR TITLE
Adding allow-overwrite flag to suite file

### DIFF
--- a/suites/reef/integrations/ocs_rgw_ssl_vsphere.yaml
+++ b/suites/reef/integrations/ocs_rgw_ssl_vsphere.yaml
@@ -18,6 +18,7 @@ tests:
         args:
           mon-ip: node1
           allow-fqdn-hostname: true
+          allow-overwrite: true
         command: bootstrap
         service: cephadm
       desc: "Bootstrap the cluster with minimal configuration."


### PR DESCRIPTION
# Description

Adding this fix to avoid errors like ERROR: /etc/ceph/ceph.conf already exists; delete or pass --allow-overwrite to overwrite
example error http://magna002.ceph.redhat.com/ocsci-jenkins/standalone-ceph/j-033vu1csms33-t1-external/ceph-ci-logs/Test_cluster_deployment_using_cephadm_0.log

test run: https://ocs4-jenkins-csb-odf-qe.apps.ocp-c1.prod.psi.redhat.com/job/qe-standalone-ceph-deployment/110/