### PR TITLE
TFA fix for read op exit and snap cmd errors

### DIFF
--- a/tests/cephfs/snapshot_clone/cephfs_cg_io.py
+++ b/tests/cephfs/snapshot_clone/cephfs_cg_io.py
@@ -1211,6 +1211,7 @@ class CG_snap_IO(object):
                     log.info(f"linux_cmds {io_type} cmd op : {out}")
                     out = out.strip()
                     files = out.split()
+                    file_name = random.choice(files)
                     cmd_pass = 1
                 except BaseException as ex:
                     log.info(ex)

--- a/tests/cephfs/snapshot_clone/cg_snap_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_test.py
@@ -497,10 +497,22 @@ def cg_snap_func_1(cg_test_params):
                             "subvol_name": subvol_name,
                         }
                     )
-                fs_util.create_snapshot(client, **snapshot)
-                log.info(f"Created snapshot {snap_name} on {subvol_name}")
-                snap_list.append(snap_name)
-                snap_qs_dict.update({subvol_name: snap_list})
+                snap_create = 0
+                retry_cnt = 0
+                while (retry_cnt < 10) and (snap_create == 0):
+                    try:
+                        fs_util.create_snapshot(client, **snapshot)
+                        snap_create = 1
+                    except BaseException as ex:
+                        log.info(ex)
+                        time.sleep(3)
+                        retry_cnt += 1
+                if snap_create == 0:
+                    test_fail += 1
+                else:
+                    log.info(f"Created snapshot {snap_name} on {subvol_name}")
+                    snap_list.append(snap_name)
+                    snap_qs_dict.update({subvol_name: snap_list})
             log.info(f"Release quiesce set {qs_id_val}")
             cg_snap_util.cg_quiesce_release(client, qs_id_val, if_await=True)
             i += 1
@@ -684,11 +696,22 @@ def cg_snap_func_1(cg_test_params):
                             "subvol_name": subvol_name,
                         }
                     )
-
-                fs_util.create_snapshot(client, **snapshot)
-                log.info(f"Created snapshot cg_snap_{rand_str} on {subvol_name}")
-                snap_list.append(snap_name)
-                snap_qs_dict.update({subvol_name: snap_list})
+                snap_create = 0
+                retry_cnt = 0
+                while (retry_cnt < 10) and (snap_create == 0):
+                    try:
+                        fs_util.create_snapshot(client, **snapshot)
+                        snap_create = 1
+                    except BaseException as ex:
+                        log.info(ex)
+                        time.sleep(3)
+                        retry_cnt += 1
+                if snap_create == 0:
+                    test_fail += 1
+                else:
+                    log.info(f"Created snapshot cg_snap_{rand_str} on {subvol_name}")
+                    snap_list.append(snap_name)
+                    snap_qs_dict.update({subvol_name: snap_list})
 
             log.info(f"Release quiesce set {qs_id_val}")
             qs_output = cg_snap_util.cg_quiesce_release(
@@ -1238,10 +1261,22 @@ def cg_snap_func_3(cg_test_params):
                             "subvol_name": subvol_name,
                         }
                     )
-                fs_util.create_snapshot(client, **snapshot)
-                log.info(f"Created snapshot {snap_name} on {subvol_name}")
-                snap_list.append(snap_name)
-                snap_qs_dict.update({subvol_name: snap_list})
+                snap_create = 0
+                retry_cnt = 0
+                while (retry_cnt < 10) and (snap_create == 0):
+                    try:
+                        fs_util.create_snapshot(client, **snapshot)
+                        snap_create = 1
+                    except BaseException as ex:
+                        log.info(ex)
+                        time.sleep(3)
+                        retry_cnt += 1
+                if snap_create == 0:
+                    test_fail += 1
+                else:
+                    log.info(f"Created snapshot {snap_name} on {subvol_name}")
+                    snap_list.append(snap_name)
+                    snap_qs_dict.update({subvol_name: snap_list})
 
             log.info(f"Release the subset {qs_subset}")
             out = cg_snap_util.cg_quiesce_release(client, qs_id_val_sub, if_await=True)
@@ -2629,10 +2664,22 @@ def cg_snap_neg_1(cg_test_params):
                             "subvol_name": subvol_name,
                         }
                     )
-                fs_util.create_snapshot(client, **snapshot)
-                log.info(f"Created snapshot {snap_name} on {subvol_name}")
-                snap_list.append(snap_name)
-                snap_qs_dict.update({subvol_name: snap_list})
+                snap_create = 0
+                retry_cnt = 0
+                while (retry_cnt < 10) and (snap_create == 0):
+                    try:
+                        fs_util.create_snapshot(client, **snapshot)
+                        snap_create = 1
+                    except BaseException as ex:
+                        log.info(ex)
+                        time.sleep(3)
+                        retry_cnt += 1
+                if snap_create == 0:
+                    test_fail += 1
+                else:
+                    log.info(f"Created snapshot {snap_name} on {subvol_name}")
+                    snap_list.append(snap_name)
+                    snap_qs_dict.update({subvol_name: snap_list})
 
             for qs_id in qs_id_list:
                 log.info(f"Release the qs_set with id {qs_id}")


### PR DESCRIPTION
# Description

JIRA: https://issues.redhat.com/browse/RHCEPHQE-16029

Fix1: Read op doesn't find file created by write op in wait time of 15secs, added fix to check for atleast one file in additional time.
Fix2: Snap cmd doesn't suceed when run in parallel to IO and when subvolumes are quiesced, added retries with timeout of 30secs.
Logs:
Failed logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-R3Q2TG/
Corresponding Passed logs with fix - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Y2YKVU/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
