### PR TITLE
RHCEPHQE-16103: exec_command hangs when there is no read/write

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1632,8 +1632,21 @@ class CephNode(object):
             self.rssh_transport().set_keepalive(15)
 
         cmd = kw["cmd"]
-        _out, _err, _exit, _ = self.long_running(**kw)
+        _out, _err, _exit, _time = self.long_running(**kw)
         self.exit_status = _exit
+
+        if kw.get("pretty_print"):
+            msg = f"\nCommand:    {cmd}"
+            msg += f"\nDuration:   {_time} seconds"
+            msg += f"\nExit Code:  {_exit}"
+
+            if _out:
+                msg += f"\nStdout:     {_out}"
+
+            if _err:
+                msg += f"\nStderr:      {_err}"
+
+            logger.info(msg)
 
         # Historically, we are only providing command exit code for long
         # running commands.

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -12,7 +12,6 @@ from time import sleep, time
 import paramiko
 import requests
 import yaml
-from paramiko.ssh_exception import SSHException
 
 from ceph.parallel import parallel
 from cli.ceph.ceph import Ceph as CephCli
@@ -1157,6 +1156,36 @@ def check_timeout(end_time, timeout):
         raise TimeoutException("Command exceed the allocated execution time.")
 
 
+def read_stream(channel, end_time, stderr=False):
+    """Reads the data from the given channel.
+
+    Args:
+      channel: the paramiko.Channel object to be used for reading.
+      end_time: maximum allocated time for reading from the channel.
+      stderr: read from the stderr stream. Default is False.
+
+    Returns:
+      a string with the data read from the channel.
+
+    Raises:
+      TimeoutException: if reading from the channel exceeds the allocated time.
+    """
+    _output = ""
+    _stream = channel.recv_stderr if stderr else channel.recv
+    _data = _stream(2048)
+
+    while _data:
+        _output += _data.decode("utf-8")
+        for _ln in _data.splitlines():
+            _log = logger.error if stderr else logger.debug
+            _log(_ln.decode("utf-8"))
+
+        check_timeout(end_time, timeout=True)
+        _data = _stream(2048)
+
+    return _output
+
+
 class RolesContainer(object):
     """
     Container for single or multiple node roles.
@@ -1525,17 +1554,12 @@ class CephNode(object):
         timeout = None if kw.get("timeout") == "notimeout" else kw.get("timeout", 3600)
         _end_time = None
 
-        logger.info(
-            f"long running command on {self.ip_address} -- {cmd} with {timeout} seconds"
-        )
-
         try:
-            channel = ssh().get_transport().open_session()
+            channel = ssh().get_transport().open_session(timeout=timeout)
             channel.settimeout(timeout)
 
-            # A mismatch between stdout and stderr streams have been observed hence
-            # combining the streams and logging is set to debug level.
-            channel.set_combine_stderr(True)
+            logger.info(f"Execute {cmd} on {self.ip_address}")
+            _exec_start_time = datetime.datetime.now()
             channel.exec_command(cmd)
 
             if timeout:
@@ -1543,23 +1567,33 @@ class CephNode(object):
                     seconds=timeout
                 )
 
+            _out = ""
+            _err = ""
             while not channel.exit_status_ready():
                 # Prevent high resource consumption
                 sleep(1)
                 if channel.recv_ready():
-                    data = channel.recv(1024)
-                    while data:
-                        for line in data.splitlines():
-                            logger.debug(line)
+                    _out += read_stream(channel, _end_time)
 
-                        check_timeout(_end_time, timeout)
-                        data = channel.recv(1024)
+                if channel.recv_stderr_ready():
+                    _err += read_stream(channel, _end_time, stderr=True)
 
                 check_timeout(_end_time, timeout)
 
-            logger.info(f"Command completed on {datetime.datetime.now()}")
-            return channel.recv_exit_status()
+            _time = (datetime.datetime.now() - _exec_start_time).total_seconds()
+            logger.info(
+                f"Execution of {cmd} on {self.ip_address} took {_time} seconds."
+            )
 
+            # Check for data residues in the channel streams. This is required for the following reasons
+            #   - exit_ready and first line is blank causing data to be None
+            #   - race condition between data read and exit ready
+            _new_timeout = datetime.datetime.now() + datetime.timedelta(seconds=10)
+            _out += read_stream(channel, _new_timeout)
+            _err += read_stream(channel, _new_timeout, stderr=True)
+
+            _exit = channel.recv_exit_status()
+            return _out, _err, _exit, _time
         except socket.timeout as terr:
             logger.error(f"Command failed to execute within {timeout} seconds.")
             raise SocketTimeoutException(terr)
@@ -1572,70 +1606,47 @@ class CephNode(object):
             raise CommandFailed(be)
 
     def exec_command(self, **kw):
-        """execute a command.
+        """Execute the given command on the remote host.
 
-        Attributes:
-            kw (Dict): execute command configuration
-            check_ec: False will run the command and not wait for exit code
+        Args:
+          cmd: The command that needs to be executed on the remote host.
+          long_running: Bool flag to indicate if the command is long running.
+          check_ec: Bool flag to indicate if the command should check for error code.
+          timeout: Max time to wait for command to complete. Default is 600 seconds.
 
-        Example::
+        Returns:
+          Exit code when long_running is used
+          Tuple having stdout, stderr data output when long_running is not used
 
-            eg: self.exec_cmd(cmd='uptime')
-            or
+        Raises:
+          CommandFailed: when the exit code is non-zero and check_ec is enabled.
+          TimeoutError: when the command times out.
+
+        Examples:
+            self.exec_cmd(cmd='uptime')
+          or
             self.exec_cmd(cmd='background_cmd', check_ec=False)
-
-            kw:
-                check_ec: False will run the command and not wait for exit code
         """
-        if kw.get("long_running"):
-            return self.long_running(**kw)
-
-        timeout = kw["timeout"] if kw.get("timeout") else 600
-        ssh = self.rssh() if kw.get("sudo") else self.ssh()
-
-        logger.info(
-            f"Running command {kw['cmd']} on {self.ip_address} timeout {timeout}"
-        )
-
         if self.run_once:
             self.ssh_transport().set_keepalive(15)
             self.rssh_transport().set_keepalive(15)
 
-        stdout = str()
-        stderr = str()
-        _stdout = None
-        _stderr = None
-        try:
-            _, _stdout, _stderr = ssh.exec_command(kw["cmd"], timeout=timeout)
-            for line in _stdout:
-                if line:
-                    stdout += line
-            for line in _stderr:
-                if line:
-                    stderr += line
-        except socket.timeout as sock_err:
-            logger.error("socket.timeout doesn't give an error message")
-            ssh.close()
-            raise SocketTimeoutException(sock_err)
-        except SSHException as e:
-            logger.error("SSHException during cmd: %s", str(e))
+        cmd = kw["cmd"]
+        _out, _err, _exit, _ = self.long_running(**kw)
+        self.exit_status = _exit
 
-        exit_status = None
-        if _stdout is not None:
-            exit_status = _stdout.channel.recv_exit_status()
+        # Historically, we are only providing command exit code for long
+        # running commands.
+        # Fixme: Ensure the method returns a tuple of
+        #        (stdout, stderr, exit_code, time_taken)
+        if kw.get("long_running", False):
+            return _exit
 
-        self.exit_status = exit_status
         if kw.get("check_ec", True):
-            if exit_status == 0:
-                logger.info("Command completed successfully")
-            else:
-                logger.error(f"Error {exit_status} during cmd, timeout {timeout}")
-                logger.error(stderr)
-                raise CommandFailed(
-                    f"{kw['cmd']} Error:  {str(stderr)} {str(self.ip_address)}"
-                )
+            if _exit != 0:
+                raise CommandFailed(f"{cmd} returned {_exit} on {self.ip_address}")
 
-        return stdout, stderr
+        return _out, _err
 
     def remote_file(self, **kw):
         """Return contents of the remote file."""

--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1646,6 +1646,11 @@ class CephNode(object):
             if _exit != 0:
                 raise CommandFailed(f"{cmd} returned {_exit} on {self.ip_address}")
 
+            # Fixme: cephadm when enabled for verbose logging writes the
+            #        verbose output to stderr. This behavior causes issues in
+            #        the new method of gathering stderr. Hence, err is made
+            return _out, None
+
         return _out, _err
 
     def remote_file(self, **kw):

--- a/ceph/ceph_admin/helper.py
+++ b/ceph/ceph_admin/helper.py
@@ -861,9 +861,7 @@ def get_cluster_state(cls, commands=None):
     __CLUSTER_STATE_COMMANDS.extend(commands)
 
     for cmd in __CLUSTER_STATE_COMMANDS:
-        out, err = cls.shell(args=[cmd])
-        LOG.info("STDOUT:\n %s" % out)
-        LOG.error("STDERR:\n %s" % err)
+        cls.shell(args=[cmd], pretty_print=True)
 
 
 def get_host_osd_map(cls):

--- a/ceph/ceph_admin/shell.py
+++ b/ceph/ceph_admin/shell.py
@@ -9,7 +9,7 @@ from .common import config_dict_to_string
 from .typing_ import CephAdmProtocol
 
 LOG = Log(__name__)
-BASE_CMD = ["cephadm", "-v", "shell"]
+BASE_CMD = ["cephadm", "shell"]
 
 
 class ShellMixin:
@@ -23,6 +23,7 @@ class ShellMixin:
         timeout: int = 600,
         long_running: bool = False,
         print_output: bool = True,
+        pretty_print: bool = False,
     ):
         """
         Ceph orchestrator shell interface to run ceph commands.
@@ -33,7 +34,8 @@ class ShellMixin:
             check_status (Bool): check command status
             timeout (Int): Maximum time allowed for execution.
             long_running (Bool): Long running command (default: False)
-            print_output ( Bool): Flag to decide whether the output should be printed in log or not
+            print_output (Bool): Flag to decide whether the output should be printed in log or not
+            pretty_print (Bool): When enabled, output/error will be pretty printed. Default false.
 
         Returns:
             out (Str), err (Str) stdout and stderr response
@@ -54,6 +56,7 @@ class ShellMixin:
             timeout=timeout,
             check_ec=check_status,
             long_running=long_running,
+            pretty_print=pretty_print,
         )
 
         if isinstance(out, tuple):

--- a/tests/ceph_installer/test_cephadm.py
+++ b/tests/ceph_installer/test_cephadm.py
@@ -187,8 +187,8 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
     except BaseException as be:  # noqa
         LOG.error(be, exc_info=True)
-        return 1
-    finally:
         LOG.debug("Gathering cluster state after running test_cephadm")
         get_cluster_state(cephadm)
+        return 1
+
     return 0


### PR DESCRIPTION
# Description

Timeout is not honoured when there is no read or write occurring on the established channel. This leads to an hang.

In this commit, exec_command will always call long_running method as it manages the execution time.

*Checklist*

- [x] Review the automation design
- [x] Unit test and attach results 
- [x] [logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-943UET/) 
