### PR TITLE
Moving radosbench shell executions to long running

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -164,7 +164,7 @@ class RadosOrchestrator:
             if client_exec:
                 out, err = self.client.exec_command(cmd=cmd, sudo=True, timeout=timeout)
             else:
-                out, err = self.node.shell([cmd], timeout=timeout, print_output=False)
+                out, err = self.node.shell([cmd], timeout=timeout)
         except Exception as er:
             log.error(f"Exception hit while command execution. {er}")
             return None
@@ -440,7 +440,7 @@ class RadosOrchestrator:
         log.info(f"check_ec: {check_ec}")
 
         try:
-            self.node.shell([cmd], check_status=check_ec)
+            self.node.shell([cmd], check_status=check_ec, long_running=True)
             if max_objs and verify_stats:
                 time.sleep(90)
                 new_objs = self.get_cephdf_stats(pool_name=pool_name)["stats"][

--- a/ceph/rados/rados_bench.py
+++ b/ceph/rados/rados_bench.py
@@ -168,7 +168,7 @@ class RadosBench:
         base_cmd.append(config_dict_to_string(config))
         base_cmd = " ".join(base_cmd)
 
-        client.exec_command(cmd=base_cmd, sudo=True)
+        client.exec_command(cmd=base_cmd, sudo=True, long_running=True)
         return run_name if run_name else None
 
     @staticmethod

--- a/suites/squid/rados/tier-2_rados_test-clay-ecpool.yaml
+++ b/suites/squid/rados/tier-2_rados_test-clay-ecpool.yaml
@@ -144,9 +144,9 @@ tests:
       desc: Perform tests on EC pools having a RBD Image
 
   - test:
-      name: Test Online Reads Balancer
+      name: Test Online Reads Balancer Read
       module: test_online_reads_balancer.py
-      desc: Testing Online reads balancer tool via balancer module
+      desc: Testing Online reads balancer tool via balancer module | read
       polarion-id: CEPH-83590731
       config:
         balancer_mode: read

--- a/suites/squid/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/squid/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -376,9 +376,9 @@ tests:
       desc: Verify OSD behaviour when it is marked in and out of cluster
 
   - test:
-      name: Test Online Reads Balancer
+      name: Test Online Reads Balancer Upmap-read
       module: test_online_reads_balancer.py
-      desc: Testing Online reads balancer tool via balancer module
+      desc: Testing Online reads balancer tool via balancer module | upmap-read
       polarion-id: CEPH-83590731
       config:
         balancer_mode: upmap-read

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -229,7 +229,7 @@ def run(ceph_cluster, **kw):
             )
 
             # addition of small device as wal/db fails with CBT
-            # BZ -
+            # BZ - https://bugzilla.redhat.com/show_bug.cgi?id=2309610
             if False:
                 osd_id = random.choice(osd_list)
 

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -386,6 +386,7 @@ def run(ceph_cluster, **kw):
                     log.error(err)
                     raise Exception(f"OSD addition on {node_obj.hostname} failed")
 
+            time.sleep(30)
             post_osd_list = rados_obj.get_active_osd_list()
             log.info(f"Active OSD list after OSD addition: {post_osd_list}")
             post_osd_count = len(post_osd_list)
@@ -448,7 +449,7 @@ def run(ceph_cluster, **kw):
             log.info("MAX_AVAIL on the cluster are as per expectation")
 
             # write data to the pool and expand OSD LVMs on backup node13
-            assert rados_obj.bench_write(pool_name=pool_name, rados_write_duration=300)
+            assert rados_obj.bench_write(pool_name=pool_name, rados_write_duration=60)
 
             _pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
             log.info(f"{pool_name} pool stat: {_pool_stat}")


### PR DESCRIPTION
Currently if a radosbench command is stuck due to not being able to write data to the cluster, it remains in that state indefinitely.

Expectation is that the default timeout of 600 secs should come into picture and automation should not get stuck with radosbench.

Recent failure from ceph-ci:
Testrun - https://ocs3xstage-jenkins-csb-rhgsocs3x.apps.ocp-c1.prod.psi.redhat.com/job/qe-squid-rados-regression-openstack/20
Testsuite - https://ocs3xstage-jenkins-csb-rhgsocs3x.apps.ocp-c1.prod.psi.redhat.com/job/qe-squid-rados-regression-openstack/20/execution/node/74/log

From Pragadeeswaran Sathyanarayanan:

> A new channel is opened everytime exec_command is executed and a default timeout of 600 seconds is set to make it a blocking call. This is done to ensure the Channel (paramiko) to raise a socket.timeout exception when it exceeds the allocated time.
> However, an exception is only raised when there is pending read/write operation.
> A workaround for now would be set the parameter long_running=true when calling exec_command. Here, we are not dependant on the Channel to timeout instead is handled internally (i.e. control is not yielded to paramiko).

Following the suggested workaround, all radosbench shell calls have been changed to use `long_running=True`

Logs - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HKZRI2

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
