### PR TITLE
RHCEPHQE-15796: TFA fix to make osd_memory_target config update relative to cluster

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3917,12 +3917,12 @@ class RadosOrchestrator:
             metadata (Dict) -> If daemon_id is provided
             None if metadata is not found
         """
-        log.debug(f"Passed daemon type : {daemon_type}, Deamon ID : {daemon_id}")
+        log.debug(f"Passed daemon type : {daemon_type}, Daemon ID : {daemon_id}")
         base_cmd = f"ceph {daemon_type} metadata"
-        if not daemon_id:
+        if daemon_id is None:
             return self.run_ceph_command(cmd=base_cmd, client_exec=True)
 
-        if daemon_type == "osd" and daemon_id:
+        if daemon_type == "osd" and daemon_id is not None:
             return self.run_ceph_command(
                 cmd=f"{base_cmd} {daemon_type}.{daemon_id}", client_exec=True
             )

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -24,6 +24,7 @@ def set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged):
         osd_id: OSD id
         unmanaged: true/false
     """
+    out = err = None
     config = {
         "command": "apply",
         "service": "osd",
@@ -53,8 +54,9 @@ def set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged):
     )
 
     # return if no services found
-    if "No services reported" in out + err:
-        log.warning(out)
+    if "No services reported" in out or "No services reported" in err:
+        log.debug(out)
+        log.debug(err)
         return
     svc = loads(out)[0]
 
@@ -145,11 +147,14 @@ def set_osd_out(ceph_cluster, osd_id):
     Returns:
         Pass->true, Fail->false
     """
+    out = err = None
     config = {"command": "out", "service": "osd", "pos_args": [osd_id]}
     log.info(f"Executing OSD {config.pop('command')} service")
     osd = OSD(cluster=ceph_cluster, **config)
     out, err = osd.out(config)
-    if f"marked out osd.{osd_id}" in err:
+    log.debug(out)
+    log.debug(err)
+    if f"marked out osd.{osd_id}" in err or f"marked out osd.{osd_id}" in out:
         return True
     return False
 

--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -90,6 +90,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
       desc: Verification of osd_memory_target parameter set at OSD level

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -91,6 +91,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
       desc: Verification of osd_memory_target parameter set at OSD level

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -91,6 +91,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
       desc: Verification of osd_memory_target parameter set at OSD level

--- a/suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -91,6 +91,13 @@ tests:
           mgr: "allow *"
 
   - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
       desc: Verification of osd_memory_target parameter set at OSD level

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -463,7 +463,7 @@ def run(ceph_cluster, **kw):
             log.info(out)
             assert "success" in out
 
-            if rhbuild.split(".")[0] >= "6":
+            if rhbuild.split(".")[0] != "8":
                 # Execute ceph-bluestore-tool qfsck --path <osd_path>
                 osd_id = random.choice(osd_list)
                 log.info(
@@ -672,21 +672,19 @@ def run(ceph_cluster, **kw):
             )
             out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
             log.info(out)
-            if rhbuild.split(".")[0] >= "7":
-                for pattern in [
-                    "device size",
-                    "DEV/LEV",
-                    "LOG",
-                    "WAL",
-                    "DB",
-                    "SLOW",
-                    "MAXIMUMS",
-                    "TOTAL",
-                ]:
-                    assert pattern in out
-            else:
-                for pattern in ["device size", "wal_total", "db_total", "slow_total"]:
-                    assert pattern in out
+            for pattern in [
+                "device size",
+                "DEV/LEV",
+                "LOG",
+                "WAL",
+                "DB",
+                "SLOW",
+                "MAXIMUMS",
+                "TOTAL",
+            ]:
+                assert (
+                    pattern in out
+                ), f"{pattern} not found in bluefs stats output for build {rhbuild}"
 
             # restart OSD services
             osd_services = rados_obj.list_orch_services(service_type="osd")

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -324,11 +324,6 @@ def run(ceph_cluster, **kw):
             return round(val / (1 << 30), 1)
 
         try:
-            # pass without execution for Squid
-            if not rhbuild.startswith("7"):
-                log.info("Test is currently valid only for RHCS 7.x")
-                return 0
-
             # create default pool with given name
             rados_obj.create_pool(pool_name=pool_name)
 
@@ -355,7 +350,7 @@ def run(ceph_cluster, **kw):
                 )
                 if len(empty_devices) < 1:
                     log.error(
-                        f"Need at least 1 spare disks available on host {node_obj.hostname}"
+                        f"Need at least 1 spare disk available on host {node_obj.hostname}"
                     )
                     raise Exception(
                         f"One spare disk not available on host {node_obj.hostname}"

--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -77,7 +77,10 @@ def run(ceph_cluster, **kw):
         # getting list of omap objects present in the pool
         out, _ = cephadm.shell([f"rados ls -p {pool_name} | grep 'omap_obj'"])
         omap_obj_list = out.split()
-        log.info(f"List of Objects having large omaps in {pool_name}: {omap_obj_list}")
+        log.info(
+            f"List of Objects having large omaps in {pool_name},"
+            f"listing first 100: {omap_obj_list[:100]}"
+        )
 
         # performing various operations on large omap objects
         # 1. List omap key entries for an object

--- a/tests/rados/test_osd_df.py
+++ b/tests/rados/test_osd_df.py
@@ -322,9 +322,8 @@ def verify_deviation(
         status: status of host/node or osd | new or old or ignored
     Returns: True -> pass | False - fail
     """
-    acting_total_size = acting_total_raw_use = acting_total_data = (
-        acting_total_avail
-    ) = 0
+    acting_total_size = 0
+    acting_total_raw_use = acting_total_data = acting_total_avail = 0
     stored_data_kb = config["WI"] * 4 * 1024
     pre_osd_df_stats = config["pre_osd_df_stats"]
     post_osd_df_stats = config["post_osd_df_stats"]
@@ -679,8 +678,8 @@ def verify_deviation(
                     f" ~= {post_osd_df_stats['summary']['total_kb_avail']}"
                 )
                 assert int(
-                    pre_osd_df_stats["summary"]["total_kb_avail"] / 1048576
-                ) == int(post_osd_df_stats["summary"]["total_kb_avail"] / 1048576)
+                    pre_osd_df_stats["summary"]["total_kb_avail"] / (1 < 30)
+                ) == int(post_osd_df_stats["summary"]["total_kb_avail"] / (1 < 30))
                 log.info("Summary Stats verification post I/Os: PASSED")
             elif stage == "out":
                 log.info("Summary Stats verification after OSDs are OUT")

--- a/tests/rados/test_osd_ecpool_inconsistency_scenario.py
+++ b/tests/rados/test_osd_ecpool_inconsistency_scenario.py
@@ -50,6 +50,8 @@ def run(ceph_cluster, **kw):
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
     client_node = ceph_cluster.get_nodes(role="client")[0]
     try:
+        # set global autoscaler to off
+        rados_obj.configure_pg_autoscaler(**{"default_mode": "off"})
         # Creating ec pool
         ec_config = config.get("ec_pool")
         pool_name = ec_config["pool_name"]
@@ -210,6 +212,7 @@ def run(ceph_cluster, **kw):
         log.info(
             "\n\n================ Execution of finally block =======================\n\n"
         )
+        rados_obj.configure_pg_autoscaler(**{"default_mode": "on"})
         if config.get("delete_pool"):
             method_should_succeed(rados_obj.delete_pool, pool_name)
             log.info("deleted the pool successfully")
@@ -325,4 +328,5 @@ def set_default_param_value(mon_obj):
     mon_obj.remove_config(section="osd", name="osd_scrub_max_interval")
     mon_obj.remove_config(section="osd", name="osd_deep_scrub_interval")
     mon_obj.remove_config(section="osd", name="debug_osd")
+    mon_obj.remove_config(section="global", name="osd_pool_default_pg_autoscale_mode")
     time.sleep(10)


### PR DESCRIPTION
Currently the test tests/rados/test_osd_memory_target.py contains hard-coded values which are being as osd_memory_target at OSD, and OSD host level.

Now although these values are compatible with RHOS-D pipeline executions, it was found that they result in false failures when the cluster is a baremetal setup with higher memory or a VM in IBM cloud.

To tackle this problem, the `osd_memory_target` value set at different instances is now relative to the optimal `osd_memory_target` fetched from the cluster 

Test modules modified:
- tests/rados/test_osd_memory_target.py

Logs:
Pacific:
Quincy:
Reef:
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IVP58V

Signed-off-by: Harsh Kumar <hakumar@redhat.com>