### PR TITLE
Fix failures observed due to exec_command changes

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1674,14 +1674,8 @@ class CephNode(object):
         if kw.get("long_running", False):
             return _exit
 
-        if kw.get("check_ec", True):
-            if _exit != 0:
-                raise CommandFailed(f"{cmd} returned {_exit} on {self.ip_address}")
-
-            # Fixme: cephadm when enabled for verbose logging writes the
-            #        verbose output to stderr. This behavior causes issues in
-            #        the new method of gathering stderr. Hence, err is made
-            return _out, None
+        if kw.get("check_ec", True) and _exit != 0:
+            raise CommandFailed(f"{cmd} returned {_exit} on {self.ip_address}")
 
         return _out, _err
 


### PR DESCRIPTION
# Description

The following changes are being done to fix test failures observed with the recent change.

- Default timeout of 300 seconds is set
- Timeout is to 3600 as a default value if `long_running=true`
- Fixes `TypeError` execption when `timeout=None`
- Fixes `TypeError` can only concatenate str

*Checklist*

- [x] Review the automation design
- [x] Unit test
- [x] [Run 1](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HLVC3W)
- [x] Unit test of `timeout=None` logs are [here](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VBDID0)
- [x] Unit test of `concatenate error` logs are [here](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-B2B66L)   