### PR TITLE
Support for mtls in GWgroup

### DIFF
--- a/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/reef/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -848,3 +848,92 @@ tests:
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 4-GW HA 4-sub fail using node power on off
       polarion-id: CEPH-83589012
+
+# 4GW HA 4-subsystems node Failover and failback using maintanence_mode
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node8
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: maintanence_mode
+            nodes:
+              - node8
+          - tool: maintanence_mode
+            nodes:
+              - node7
+      desc: 4GW HA 4-subsystems Failover and failback using maintanence_mode
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub fail using node maintanence_mode
+      polarion-id: CEPH-83589020

--- a/suites/squid/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_cluster.yaml
+++ b/suites/squid/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_cluster.yaml
@@ -67,7 +67,7 @@ tests:
       polarion-id: CEPH-23573752
 
 
-# Non-mtls HA tests with GWgroup
+# Non-mtls HA tests with different NQNs in GWgroup
   - test:
       abort-on-fail: true
       config:
@@ -88,20 +88,22 @@ tests:
               - node7
             subsystems:                       # Configure subsystems with all sub-entities
               - nqn: nqn.2016-06.io.spdk:cnode1
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
                     lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode2
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
                     lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
@@ -118,20 +120,22 @@ tests:
               - node9
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode3
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
                     lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode4
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
                     lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
@@ -148,20 +152,22 @@ tests:
               - node11
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode5
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node10, node11]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
                     lb_group: node10
               - nqn: nqn.2016-06.io.spdk:cnode6
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node10, node11]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
                     lb_group: node11
             fault-injection-methods:                # Failure induction
               - tool: systemctl
@@ -178,12 +184,13 @@ tests:
               - node13
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode7
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node12, node13]
                 allow_host: "*"
                 bdevs:
                   - count: 2
-                    size: 5G
+                    size: 4G
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node12
@@ -193,8 +200,259 @@ tests:
               - nqn: connect-all
                 listener_port: 4420
                 node: node14
-      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback
+      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback with different NQN's in all GWgrps
       destroy-cluster: false
       module: test_nvmeof_gwgroup.py
-      name: Configure NVMeoF 4-GWgroups with 2 gateways HA failover-failback
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA failover-failback with different NQN's in all GWgrps
       polarion-id: CEPH-83595701
+
+# mtls HA tests with same NQNs in GWgroup
+  - test:
+      abort-on-fail: true
+      config:
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd1
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                             # Configure gatewayGroups
+          - gw_group: group1
+            mtls: true
+            gw_nodes:
+              - node6
+              - node7
+            subsystems:                       # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node6, node7]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node6
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node6, node7]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node7
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node6
+              - tool: daemon
+                nodes: node7
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+          - gw_group: group2
+            mtls: true
+            gw_nodes:
+              - node8
+              - node9
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node8, node9]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node8
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node8, node9]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node9
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node8
+              - tool: daemon
+                nodes: node9
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+          - gw_group: group3
+            mtls: true
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+          - gw_group: group4
+            mtls: true
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node12
+              - tool: daemon
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback with mtls and same NQN's in all GWgrps
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA failover-failback with mtls and same NQN's in all GWgrps
+      polarion-id: CEPH-83598264
+
+  - test:
+      abort-on-fail: true
+      config:
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd2
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd2
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                             # Configure gatewayGroups
+          - gw_group: group1
+            mtls: true
+            gw_nodes:
+              - node6
+              - node7
+            subsystems:                       # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node6, node7]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node6
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node6, node7]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node7
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node6
+              - tool: daemon
+                nodes: node7
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+          - gw_group: group2
+            mtls: true
+            gw_nodes:
+              - node8
+              - node9
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node8, node9]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node8
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node8, node9]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node9
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node8
+              - tool: daemon
+                nodes: node9
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+          - gw_group: group3
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+          - gw_group: group4
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node12
+              - tool: daemon
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node14
+      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback with and without mtls
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA failover-failback with and without mtls
+      polarion-id: CEPH-83598266

--- a/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
@@ -151,7 +151,7 @@ tests:
       name: Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail parallel
       polarion-id: CEPH-83595555
 
-# 8GW HA 4-subsystems multinode(7/8) Failover and failback parallely using power_onoff and maintanence_mode
+# 8GW HA 4-subsystems multinode(7/8) Failover and failback parallely using power off|on and maintanence_mode
   - test:
       abort-on-fail: true
       config:

--- a/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
@@ -150,3 +150,89 @@ tests:
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail parallel
       polarion-id: CEPH-83595555
+
+# 8GW HA 4-subsystems multinode(7/8) Failover and failback parallely using power_onoff and maintanence_mode
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd2
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd2
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+          - node10
+          - node11
+          - node12
+          - node13
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node14
+        fault-injection-methods:                # Failure induction
+          - tool: maintanence_mode
+            nodes:
+              - node6
+              - node7
+              - node8
+              - node9
+              - node10
+              - node11
+              - node12
+          - tool: power_on_off
+            nodes:
+              - node6
+              - node7
+              - node8
+              - node9
+              - node10
+              - node11
+              - node12
+      desc: 8GW 1GWgroup HA 4-subsystems multinode 7/8 Failover and failback using poweronoff
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail parallel using poweronoff
+      polarion-id: CEPH-83595555

--- a/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -858,3 +858,93 @@ tests:
       module: test_ceph_nvmeof_high_availability.py
       name: Test NVMeoF 4-GW HA 4-sub fail using node power on off
       polarion-id: CEPH-83589012
+
+# 4GW HA 4-subsystems node Failover and failback using maintanence_mode
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node6
+          - node7
+          - node8
+          - node9
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node6
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node7
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node8
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node9
+            listener_port: 4420
+            listeners:
+              - node6
+              - node7
+              - node8
+              - node9
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node10
+        fault-injection-methods:                # Failure induction
+          - tool: maintanence_mode
+            nodes:
+              - node8
+          - tool: maintanence_mode
+            nodes:
+              - node7
+      desc: 4GW HA 4-subsystems Failover and failback using node maintanence_mode
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub fail using node maintanence_mode
+      polarion-id: CEPH-83589020

--- a/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
+++ b/tests/nvmeof/test_ceph_nvmeof_data_integrity.py
@@ -24,7 +24,11 @@ def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
                 **sub_args,
                 **{
                     "max-namespaces": config.get("max_ns", 32),
-                    "no-group-append": config.get("no-group-append", True),
+                    **(
+                        {"no-group-append": config.get("no-group-append", True)}
+                        if ceph_cluster.rhcs_version >= "8.0"
+                        else {}
+                    ),
                 },
             }
         }

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -29,7 +29,11 @@ def configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, config):
                 **sub_args,
                 **{
                     "max-namespaces": config.get("max_ns", 32),
-                    "no-group-append": config.get("no-group-append", True),
+                    **(
+                        {"no-group-append": config.get("no-group-append", True)}
+                        if ceph_cluster.rhcs_version >= "8.0"
+                        else {}
+                    ),
                 },
             }
         }

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -59,7 +59,11 @@ def configure_subsystems(pool, ha, config):
                 **{
                     "max-namespaces": config.get("max_ns", 32),
                     "enable-ha": config.get("enable_ha", False),
-                    "no-group-append": config.get("no-group-append", True),
+                    **(
+                        {"no-group-append": config.get("no-group-append", True)}
+                        if ceph_cluster.rhcs_version >= "8.0"
+                        else {}
+                    ),
                 },
             }
         }


### PR DESCRIPTION
# Description

Support for GWgroup with mtls

Code adjustments provided for new ceph nvme show command output which came from 1.3.2-1 NVMe build version.
Testcases for mtls support within GW groups.
Testcases added with subsystems having same NQN across gatewaygroups followed by HA.
Support added for maintanence mode failure injection method for HA.
Testcases added for power_on_off failure method having n-1 node failures.
logs:
http://magna002.ceph.redhat.com/cephci-jenkins/harika/cephci-run-3X1P7J/
http://magna002.ceph.redhat.com/cephci-jenkins/harika/cephci-run-Q8A4QE/

<summary>click to expand checklist</summary>

- [x] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [x] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [x] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
