### PR TITLE
Add wait time for FS_Degraded state to auto-resolve in 30secs

### DIFF
--- a/tests/cephfs/snapshot_clone/cephfs_cg_io.py
+++ b/tests/cephfs/snapshot_clone/cephfs_cg_io.py
@@ -580,29 +580,36 @@ class CG_snap_IO(object):
                             # Get time when state is achieved
                             time_before_state = float(curr_time) - float(age_ref)
                             ceph_health, _ = client.exec_command("ceph health detail")
+                            exp_str1 = "FS_DEGRADED"
+                            exp_str2 = "MDS_SLOW_REQUEST"
                             if "Slow OSD" in ceph_health:
                                 log.info(
                                     f"Ceph had {ceph_health} when {io_mod} {io_type} failed in {state}.Ignoring.."
                                 )
-                            elif "MDS_SLOW_REQUEST" in ceph_health:
+                            elif (exp_str1 in ceph_health) or (exp_str2 in ceph_health):
                                 log.info(
-                                    "Wait for 30secs to check if MDS Slowness issue resolves"
+                                    f"Wait for 30secs to check if {ceph_health} issue resolves"
                                 )
                                 retry_cnt = 0
                                 while retry_cnt < 31:
                                     ceph_health, _ = client.exec_command(
                                         "ceph health detail"
                                     )
-                                    if "MDS_SLOW_REQUEST" in ceph_health:
+                                    if (exp_str1 in ceph_health) or (
+                                        exp_str2 in ceph_health
+                                    ):
                                         time.sleep(5)
                                         retry_cnt += 5
                                     else:
                                         log.info(
-                                            f"MDS_SLOW_REQUEST issue is resolved in {retry_cnt}secs"
+                                            f"{ceph_health} issue is resolved in {retry_cnt}secs"
                                         )
                                         retry_cnt = 31
                                 cg_status = (
-                                    1 if ("MDS_SLOW_REQUEST" in ceph_health) else 0
+                                    1
+                                    if (exp_str1 in ceph_health)
+                                    or (exp_str2 in ceph_health)
+                                    else 0
                                 )
                             elif (float(end_time) - float(time_before_state)) < 10:
                                 log.info(
@@ -665,29 +672,36 @@ class CG_snap_IO(object):
                             log.info(f"age_ref:{age_ref},curr_time:{curr_time}")
                             ceph_health, _ = client.exec_command("ceph health detail")
                             log.info(ceph_health)
+                            exp_str1 = "FS_DEGRADED"
+                            exp_str2 = "MDS_SLOW_REQUEST"
                             if "Slow OSD" in ceph_health:
                                 log.info(
                                     f"Ceph had {ceph_health} when {io_mod} {io_type} failed in {state}.Ignoring.."
                                 )
-                            elif "MDS_SLOW_REQUEST" in ceph_health:
+                            elif (exp_str1 in ceph_health) or (exp_str2 in ceph_health):
                                 log.info(
-                                    "Wait for 30secs to check if MDS Slowness issue resolves"
+                                    f"Wait for 30secs to check if {ceph_health} issue resolves"
                                 )
                                 retry_cnt = 0
                                 while retry_cnt < 31:
                                     ceph_health, _ = client.exec_command(
                                         "ceph health detail"
                                     )
-                                    if "MDS_SLOW_REQUEST" in ceph_health:
+                                    if (exp_str1 in ceph_health) or (
+                                        exp_str2 in ceph_health
+                                    ):
                                         time.sleep(5)
                                         retry_cnt += 5
                                     else:
                                         log.info(
-                                            f"MDS_SLOW_REQUEST issue is resolved in {retry_cnt}secs"
+                                            f"{ceph_health} issue is resolved in {retry_cnt}secs"
                                         )
                                         retry_cnt = 31
                                 cg_status = (
-                                    1 if ("MDS_SLOW_REQUEST" in ceph_health) else 0
+                                    1
+                                    if (exp_str1 in ceph_health)
+                                    or (exp_str2 in ceph_health)
+                                    else 0
                                 )
 
                             elif float(time_before_state) > float(end_time):


### PR DESCRIPTION
# Description

IO can fail when FileSystem is in Degraded state. In one of CG quiesce test workflows back-2-back MDS failover is been performed and FS is gettign degraded causing IO failure. In later part of log noticed, ceph status is back healthy in ~30secs. So adding wait time of 30secs in IO Validation tool when such issue appears, if it persists even after 30secs, IO tool will report failure.

Failure logs: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.1-63/cephfs/27/tier-1_cephfs_cg_quiesce/cg_snap_interop_workflow_1_0.log 

Its a minor fix as the logic is already been validated and now just added additional string for validation.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
