### PR TITLE
[Squid][Automation][SMB]Add earmark support

### DIFF
--- a/cli/ceph/smb/share.py
+++ b/cli/ceph/smb/share.py
@@ -38,3 +38,16 @@ class Share(Cli):
         if isinstance(out, tuple):
             return out[0].strip()
         return out
+
+    def ls(self, cluster_id, **kw):
+        """List smb share
+
+        Args:
+            cluster_id (str): A short string uniquely identifying the cluster
+            format (str): the type to be formatted(json or yaml)
+        """
+        cmd = f"{self.base_cmd} ls {cluster_id} {build_cmd_from_args(**kw)}"
+        out = self.execute(sudo=True, cmd=cmd)
+        if isinstance(out, tuple):
+            return out[0].strip()
+        return out

--- a/suites/squid/smb/tier-1-smb.yaml
+++ b/suites/squid/smb/tier-1-smb.yaml
@@ -336,3 +336,92 @@ tests:
           user1: "batman"
           user2: "superman"
         file_name: "testfile"
+
+  - test:
+      name: Verify samba share creation with "nfs" earmark subvolume should failed
+      desc: Verify samba share creation with "nfs" earmark subvolume should failed
+      module: smb_deployment_earmark.py
+      polarion-id: CEPH-83599223
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: nfs
+        smb_subvolumes: [sv1]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1]
+        path: "/"
+        earmark: nfs
+
+  - test:
+      name: Verify samba multiple share creation with "nfs" earmark subvolume should failed
+      desc: Verify samba multiple share creation with "nfs" earmark subvolume should failed
+      module: smb_deployment_earmark.py
+      polarion-id: CEPH-83599224
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: nfs
+        smb_subvolumes: [sv1, sv2]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1, share2]
+        path: "/"
+        earmark: nfs
+
+  - test:
+      name: Verify samba share creation without any earmark subvolumes should pass
+      desc: Verify samba share creation without any earmark subvolumes should pass
+      module: smb_deployment_earmark.py
+      polarion-id: CEPH-83599225
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [sv1]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1]
+        path: "/"
+
+  - test:
+      name: Verify samba share creation with "smb" earmark subvolumes should pass
+      desc: Verify samba share creation with "smb" earmark subvolumes should pass
+      module: smb_deployment_earmark.py
+      polarion-id: CEPH-83599226
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [sv1]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1]
+        path: "/"
+        earmark: smb
+
+  - test:
+      name: Verify samba multiple share creation with "smb" earmark subvolumes should pass
+      desc: Verify samba multiple share creation with "smb" earmark subvolumes should pass
+      module: smb_deployment_earmark.py
+      polarion-id: CEPH-83599227
+      config:
+        cephfs_volume: cephfs
+        smb_subvolume_group: smb
+        smb_subvolumes: [sv1, sv2]
+        smb_subvolume_mode: '0777'
+        smb_cluster_id: smb1
+        auth_mode: user
+        smb_user_name: user1
+        smb_user_password: passwd
+        smb_shares: [share1, share2]
+        path: "/"
+        earmark: smb

--- a/tests/smb/smb_deployment_earmark.py
+++ b/tests/smb/smb_deployment_earmark.py
@@ -1,0 +1,130 @@
+from smb_operations import (
+    check_ctdb_health,
+    check_rados_clustermeta,
+    deploy_smb_service_imperative,
+    remove_sub_vol_group,
+    smb_cleanup,
+    smbclient_check_shares,
+)
+
+from ceph.ceph_admin import CephAdmin
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """Test samba service deployment with earmark
+    Args:
+        **kw: Key/value pairs of configuration information to be used in the test
+    """
+    # Get config
+    config = kw.get("config")
+
+    # Get cephadm obj
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+
+    # Get cephfs volume
+    cephfs_vol = config.get("cephfs_volume", "cephfs")
+
+    # Get smb subvloume group
+    smb_subvol_group = config.get("smb_subvolume_group", "smb")
+
+    # Get smb subvloumes
+    smb_subvols = config.get("smb_subvolumes", ["sv1", "sv2"])
+
+    # Get smb subvolume mode
+    smb_subvolume_mode = config.get("smb_subvolume_mode", "0777")
+
+    # Get smb cluster id
+    smb_cluster_id = config.get("smb_cluster_id", "smb1")
+
+    # Get auth_mode
+    auth_mode = config.get("auth_mode", "user")
+
+    # Get domain_realm
+    domain_realm = config.get("domain_realm", None)
+
+    # Get custom_dns
+    custom_dns = config.get("custom_dns", None)
+
+    # Get smb user name
+    smb_user_name = config.get("smb_user_name", "user1")
+
+    # Get smb user password
+    smb_user_password = config.get("smb_user_password", "passwd")
+
+    # Get smb shares
+    smb_shares = config.get("smb_shares", ["share1", "share2"])
+
+    # Get smb path
+    path = config.get("path", "/")
+
+    # Get installer node
+    installer = ceph_cluster.get_nodes(role="installer")[0]
+
+    # Get smb nodes
+    smb_nodes = ceph_cluster.get_nodes("smb")
+
+    # Get client node
+    client = ceph_cluster.get_nodes(role="client")[0]
+
+    # Check ctdb clustering
+    clustering = config.get("clustering", "default")
+
+    # Get subvolume earmaked
+    earmark = config.get("earmark", None)
+
+    try:
+        # deploy smb services
+        deploy_smb_service_imperative(
+            installer,
+            cephfs_vol,
+            smb_subvol_group,
+            smb_subvols,
+            smb_subvolume_mode,
+            smb_cluster_id,
+            auth_mode,
+            smb_user_name,
+            smb_user_password,
+            smb_shares,
+            path,
+            domain_realm,
+            custom_dns,
+            clustering,
+            earmark,
+        )
+
+        # Verify ctdb clustering
+        if clustering != "never":
+            # check samba clustermeta in rados
+            if not check_rados_clustermeta(cephadm, smb_cluster_id, smb_nodes):
+                log.error("rados clustermeta for samba not found")
+                return 1
+            # Verify CTDB health
+            if not check_ctdb_health(smb_nodes, smb_cluster_id):
+                log.error("ctdb health error")
+                return 1
+
+        # Check smb share using smbclient
+        smbclient_check_shares(
+            smb_nodes,
+            client,
+            smb_shares,
+            smb_user_name,
+            smb_user_password,
+            auth_mode,
+            domain_realm,
+        )
+    except Exception as e:
+        if earmark == "nfs":
+            log.info(
+                "As expected, Unable to create samba share with subvolume nfs earmark"
+            )
+        else:
+            log.error(f"Failed to deploy samba service : {e}")
+            return 1
+    finally:
+        smb_cleanup(installer, smb_shares, smb_cluster_id)
+        remove_sub_vol_group(installer, cephfs_vol, smb_subvol_group, smb_subvols)
+    return 0


### PR DESCRIPTION
Added below sceanrios automation
1. Verify samba share creation with "nfs" earmark subvolume should failed
2. Verify samba multiple share creation with "nfs" earmark subvolume should failed
3. Verify samba share creation without any earmark subvolumes should pass
4. Verify samba share creation with "smb" earmark subvolumes should pass
5. Verify samba multiple share creation with "smb" earmark subvolumes should pass

Last two sceanrios failing with know product issue