### PR TITLE
RHCEPHQE-16216: Include error message in Command failed exception.

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1678,7 +1678,9 @@ class CephNode(object):
             return _exit
 
         if kw.get("check_ec", True) and _exit != 0:
-            raise CommandFailed(f"{cmd} returned {_exit} on {self.ip_address}")
+            raise CommandFailed(
+                f"{cmd} returned {_err} and code {_exit} on {self.ip_address}"
+            )
 
         return _out, _err
 


### PR DESCRIPTION
We are missing the error message as part of command failed exception. This commit adds the error message as part of it

# Description

We are missing the error message as part of command failed exception. This commit adds the error message as part of it

- [x] Review the automation design
- [x] Unit testing

