### PR TITLE
Remove known issue BZ2269490

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -928,7 +928,7 @@ tests:
   #     desc: Test LC transition with rule by lc process
   #     polarion-id: CEPH-83574044
   #     module: sanity_rgw.py
-  #     comments: known issue (BZ-2269490) targeted to 8.0
+  #     comments: known issue (BZ-2315885) targeted to 7.1z3
   #     config:
   #       script-name: test_bucket_lifecycle_object_expiration_transition.py
   #       config-file-name: test_lc_transition_with_lc_process.yaml

--- a/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression_extended.yaml
@@ -195,7 +195,7 @@ tests:
   #     desc: Test LC transition with rule by lc process
   #     polarion-id: CEPH-83574044
   #     module: sanity_rgw.py
-  #     comments: known issue (BZ-2269490) targeted to 8.0
+  #     comments: known issue (BZ-2315885) targeted to 7.1z3
   #     config:
   #       script-name: test_bucket_lifecycle_object_expiration_transition.py
   #       config-file-name: test_lc_transition_with_lc_process.yaml

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -210,15 +210,15 @@ tests:
         config-file-name: ../../aws/configs/test_ldap_auth.yaml
         run-on-rgw: true
 
-  # - test:
-  #     name: Test LC transition with rule by lc process
-  #     desc: Test LC transition with rule by lc process
-  #     polarion-id: CEPH-83574044
-  #     module: sanity_rgw.py
-  #     comments: known issue (BZ-2269490) targeted to 8.0
-  #     config:
-  #       script-name: test_bucket_lifecycle_object_expiration_transition.py
-  #       config-file-name: test_lc_transition_with_lc_process.yaml
+  - test:
+      name: Test LC transition with rule by lc process
+      desc: Test LC transition with rule by lc process
+      polarion-id: CEPH-83574044
+      module: sanity_rgw.py
+      comments: known issue (BZ-2315885) targeted to 7.1z3
+      config:
+        script-name: test_bucket_lifecycle_object_expiration_transition.py
+        config-file-name: test_lc_transition_with_lc_process.yaml
 
   - test:
       name: Test LC transition without rule by lc process

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -215,7 +215,6 @@ tests:
       desc: Test LC transition with rule by lc process
       polarion-id: CEPH-83574044
       module: sanity_rgw.py
-      comments: known issue (BZ-2269490) targeted to 8.0
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_with_lc_process.yaml


### PR DESCRIPTION
This PR includes below changes:
1. Remove BZ-2269490 from known issue since BZ has been fixed and verified in 8.0
2. Instead add known issue BZ-2315885 which is the clone bz targeted to 7.1z3
3. Latest release where this issue is not fixed is in reef, hence uncommented test-case in reef suite




Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
