### PR TITLE
Handle last read call to streams in long_running

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1604,14 +1604,21 @@ class CephNode(object):
             # Check for data residues in the channel streams. This is required for the following reasons
             #   - exit_ready and first line is blank causing data to be None
             #   - race condition between data read and exit ready
-            _new_timeout = datetime.datetime.now() + datetime.timedelta(seconds=10)
-            _out += read_stream(channel, _new_timeout, timeout=True)
-            _err += read_stream(channel, _new_timeout, timeout=True, stderr=True)
+            try:
+                _new_timeout = datetime.datetime.now() + datetime.timedelta(seconds=10)
+                _out += read_stream(channel, _new_timeout, timeout=True)
+                _err += read_stream(channel, _new_timeout, timeout=True, stderr=True)
+            except CommandFailed:
+                logger.debug("Encountered a timeout during read post execution.")
+            except BaseException as be:
+                logger.debug(
+                    f"Encountered an unknown exception during last read.\n {be}"
+                )
 
             _exit = channel.recv_exit_status()
             return _out, _err, _exit, _time
         except socket.timeout as terr:
-            logger.error(f"Command failed to execute within {timeout} seconds.")
+            logger.error(f"{cmd} failed to execute within {timeout} seconds.")
             raise SocketTimeoutException(terr)
         except TimeoutException as tex:
             channel.close()


### PR DESCRIPTION
# Description

The last read call being made to session / channel is resulting in multiple unknowns. Hence, this commit we handle and ignore any exceptions that are being thrown.

The timeout is ignored whereas we would print the traceback if there is an unknown exception.

*Checklist*

- [x] Review the automation design
- [x] Unit testing
