### PR TITLE
uncomment the fuse-mount code that was commented unknowingly in previ…

### DIFF
--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -222,11 +222,11 @@ def snap_sched_test(snap_req_params):
     log.info("Fuse-Mount cephfs volume")
     fuse_mounting_dir = f"/mnt/{vol_name}_post_upgrade_fuse"
     cephfs_client = random.choice(clients)
-    """fs_util.fuse_mount(
+    fs_util.fuse_mount(
         [cephfs_client],
         fuse_mounting_dir,
         extra_params=f"-r / --client_fs {vol_name}",
-    )"""
+    )
 
     log.info(
         "Using existing mountpoint,verify existing snapshots are accessible, perform readwrite IO."


### PR DESCRIPTION
…ous fixes

# Description
In previous client upgrade fixes to post upgrade script, fuse-mount section was left as commented which will cause snap schedule validation to fail.
As part of this fix, i have uncommented it.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
