### PR TITLE
Revert recent change in ceph osd df test

### DIFF
--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -247,7 +247,8 @@ def run(ceph_cluster, **kw):
         )
         rados_obj.delete_pool(pool=pool_name)
         rados_obj.delete_pool(pool=bench_pool_name)
-        rados_obj.change_osd_state(action="start", target=osd_id)
+        if "osd_id" in locals() or "osd_id" in globals():
+            rados_obj.change_osd_state(action="start", target=osd_id)
         # log cluster health
         rados_obj.log_cluster_health()
         # check for crashes after test execution

--- a/tests/rados/test_osd_df.py
+++ b/tests/rados/test_osd_df.py
@@ -677,9 +677,14 @@ def verify_deviation(
                     f"TOTAL AVAIL: {pre_osd_df_stats['summary']['total_kb_avail']}"
                     f" ~= {post_osd_df_stats['summary']['total_kb_avail']}"
                 )
-                assert int(
-                    pre_osd_df_stats["summary"]["total_kb_avail"] / (1 < 30)
-                ) == int(post_osd_df_stats["summary"]["total_kb_avail"] / (1 < 30))
+                pre_avail_gb = int(
+                    pre_osd_df_stats["summary"]["total_kb_avail"] / 1048576
+                )
+                post_avail_gb = int(
+                    post_osd_df_stats["summary"]["total_kb_avail"] / 1048576
+                )
+                log.info(f"TOTAL AVAIL: {pre_avail_gb}G ~= {post_avail_gb}G")
+                assert pre_avail_gb == post_avail_gb, "Total avail value does not match"
                 log.info("Summary Stats verification post I/Os: PASSED")
             elif stage == "out":
                 log.info("Summary Stats verification after OSDs are OUT")


### PR DESCRIPTION
A recent change in `tests/rados/test_osd_df.py` introduced with PR #4117 broke the validation for total max available.

This PR reverts that change.

Logs:
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GJQ6G0

Signed-off-by: Harsh Kumar <hakumar@redhat.com>