### PR TITLE
Remove the known issue for test_policy_torrent

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -341,7 +341,6 @@ tests:
       config:
         script-name: test_policy_torrent.py
         config-file-name: test_policy_torrent.yaml
-      comments: known issue BZ 2299815
 
   # Bucket Lifecycle Tests
   - test:

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -332,7 +332,6 @@ tests:
       config:
         script-name: test_policy_torrent.py
         config-file-name: test_policy_torrent.yaml
-      comments: known issue BZ 2299815
 
   # Bucket Lifecycle Tests
   - test:


### PR DESCRIPTION
Polarion TC : CEPH-11209

BZ https://bugzilla.redhat.com/show_bug.cgi?id=2299815 is resolved , we just needed a config option to be set for object torrents to be generated.

Remove the known issue marked for this TC in the suite file.
