### PR TITLE
Fix long_running timeout not taking effect

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1557,11 +1557,12 @@ class CephNode(object):
         _verbose = kw.get("verbose", False)
         ssh = self.rssh if kw.get("sudo") else self.ssh
         long_running = kw.get("long_running", False)
+        timeout = 300
         if "timeout" in kw:
             timeout = None if kw["timeout"] == "notimeout" else kw["timeout"]
-        else:
-            # Set defaults if long_running then 1h else 5m
-            timeout = 3600 if kw.get("long_running", False) in kw else 300
+        if long_running:
+            # Set timeout to 1h if long_running is enabled
+            timeout = 3600
 
         try:
             channel = ssh().get_transport().open_session(timeout=timeout)


### PR DESCRIPTION
Found during TFA analysis of RADOS test `test_slow_op_requests.py`

Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-251/rados/52/tier-2_rados_test-slow-op-requests/Limit_slow_request_details_to_cluster_log_0.log

Basically the timeout of 3600 secs for a long_running execution is not getting considered because the code is but in an else block and the if block checks for existence of variable `timeout` which is always defined by default in the parent module called `shell` in `ceph/ceph_admin/shell.py` which calls `exec_command`

So in short, the arguments being sent to `long_running` method in `ceph/ceph.py` would always contain `timeout=600` and therefore the `long_running` timeout of 3600 secs would never get assigned due to being present in `else` block.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>