### PR TITLE
Switch rados bench long_running to timeouts | Fix CBT bluefs-stats validation for Pacific

### DIFF
--- a/ceph/rados/rados_bench.py
+++ b/ceph/rados/rados_bench.py
@@ -158,6 +158,7 @@ class RadosBench:
         """
         base_cmd = ["rados", "bench"]
         seconds = str(config.pop("seconds"))
+        _timeout = config.get("timeout", int(seconds) + 100)
         base_cmd.extend(["-p", pool_name, seconds, "write"])
 
         run_name = config.pop("run-name", False)
@@ -168,7 +169,7 @@ class RadosBench:
         base_cmd.append(config_dict_to_string(config))
         base_cmd = " ".join(base_cmd)
 
-        client.exec_command(cmd=base_cmd, sudo=True, long_running=True)
+        client.exec_command(cmd=base_cmd, sudo=True, timeout=_timeout)
         return run_name if run_name else None
 
     @staticmethod

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -672,7 +672,8 @@ def run(ceph_cluster, **kw):
             )
             out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
             log.info(out)
-            for pattern in [
+
+            pattern_list = [
                 "device size",
                 "DEV/LEV",
                 "LOG",
@@ -681,7 +682,10 @@ def run(ceph_cluster, **kw):
                 "SLOW",
                 "MAXIMUMS",
                 "TOTAL",
-            ]:
+            ]
+            if rhbuild.split(".")[0] < "6":
+                pattern_list = ["device size", "wal_total", "db_total", "slow_total"]
+            for pattern in pattern_list:
                 assert (
                     pattern in out
                 ), f"{pattern} not found in bluefs stats output for build {rhbuild}"


### PR DESCRIPTION
Part - 1
===========================================================================================
During TFA analysis of RADOS test test_slow_op_requests.py
Basically the timeout of 3600 secs for a long_running execution is not getting considered because the code is but in an else block and the if block checks for existence of variable timeout which is always defined by default in the parent module called shell in ceph/ceph_admin/shell.py which calls exec_command

Failure log - http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-251/rados/52/tier-2_rados_test-slow-op-requests/Limit_slow_request_details_to_cluster_log_0.log

As shell.py is setting default timeout to 600, it was advised that rados bench executions be moved to client node instead of installer node or switch from `long_running` to setting longer `timeout` explicitly.

This PR sets `timeout` explicitly in every rados bench call, making it relative to the `rados_bench_duration`

Part - 2
===============================================================================================
The output of ceph-bluestore-tool bluefs-stats for Pacific is still different than others, this PR re-introduces conditional check for Pacific executions.

Logs:
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-E55H2B

Signed-off-by: Harsh Kumar <hakumar@redhat.com>