### PR TITLE
[TfaFix]Fix nfs deployment failures

### DIFF
--- a/suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml
+++ b/suites/quincy/cephadm/tier-1_os_tuning_profiles.yaml
@@ -170,25 +170,6 @@ tests:
                 - sleep
                 - "120"
   - test:
-      name: NFS Service deployment with spec
-      desc: Add NFS services using spec file
-      module: test_cephadm.py
-      polarion-id: CEPH-83574729
-      config:
-        steps:
-          - config:
-              command: apply_spec
-              service: orch
-              validate-spec-services: true
-              specs:
-                - service_type: nfs
-                  service_id: nfs-rgw-service
-                  placement:
-                    nodes:
-                      - node4
-                  spec:
-                    port: 2049
-  - test:
       name: RGW Service deployment with spec
       desc: Add RGW services using spec file
       module: test_cephadm.py

--- a/suites/reef/cephadm/tier1-os-tuning-profiles.yaml
+++ b/suites/reef/cephadm/tier1-os-tuning-profiles.yaml
@@ -170,25 +170,6 @@ tests:
                 - sleep
                 - "120"
   - test:
-      name: NFS Service deployment with spec
-      desc: Add NFS services using spec file
-      module: test_cephadm.py
-      polarion-id: CEPH-83574729
-      config:
-        steps:
-          - config:
-              command: apply_spec
-              service: orch
-              validate-spec-services: true
-              specs:
-                - service_type: nfs
-                  service_id: nfs-rgw-service
-                  placement:
-                    nodes:
-                      - node4
-                  spec:
-                    port: 2049
-  - test:
       name: RGW Service deployment with spec
       desc: Add RGW services using spec file
       module: test_cephadm.py

--- a/suites/squid/cephadm/tier1-os-tuning-profiles.yaml
+++ b/suites/squid/cephadm/tier1-os-tuning-profiles.yaml
@@ -170,25 +170,6 @@ tests:
                 - sleep
                 - "120"
   - test:
-      name: NFS Service deployment with spec
-      desc: Add NFS services using spec file
-      module: test_cephadm.py
-      polarion-id: CEPH-83574729
-      config:
-        steps:
-          - config:
-              command: apply_spec
-              service: orch
-              validate-spec-services: true
-              specs:
-                - service_type: nfs
-                  service_id: nfs-rgw-service
-                  placement:
-                    nodes:
-                      - node4
-                  spec:
-                    port: 2049
-  - test:
       name: RGW Service deployment with spec
       desc: Add RGW services using spec file
       module: test_cephadm.py


### PR DESCRIPTION
Issue:
The NFS Service deployment with spec test is failing in the regression suites.

Solution:
The test is removed from the suite as NFS deployments, including the one with spec are now handled separately in nfs specific suites. Thus removing this repetitive test

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
