### PR TITLE
[TFA]: Rearrange version id null testcase

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -346,17 +346,6 @@ tests:
             timeout: 5500
 
   - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_check_sharding_enabled.py
-            config-file-name: test_realm_rename.yaml
-      desc: Test realm rename in master
-      module: sanity_rgw_multisite.py
-      name: Perform realm rename in master
-      polarion-id: CEPH-10739
-
-  - test:
       name: Delete object version with id null
       desc: test_delete_object_version_id_null
       polarion-id: CEPH-83576431
@@ -366,3 +355,14 @@ tests:
           config:
             script-name: ../aws/test_delete_version_id_null.py
             config-file-name: ../../aws/configs/test_delete_version_id_null.yaml
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_check_sharding_enabled.py
+            config-file-name: test_realm_rename.yaml
+      desc: Test realm rename in master
+      module: sanity_rgw_multisite.py
+      name: Perform realm rename in master
+      polarion-id: CEPH-10739


### PR DESCRIPTION
# Description

TFA: [TFA][8.0] Delete_object_version_with_id_null : bucket creation
Fail log: 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.1.1-63/rgw/27/tier-2_rgw_ms_regression_test/Delete_object_version_with_id_null_0.log

executed testcase and no issue seen.
Pass log: 
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/tfa_versionid_null/test_delete_version_id_null.console.log


Renaming realm causes , rgw endpoint to go down for sometime which was the reason for failure with next testcase (i.e delete version id null).
to avoid this, rearranging testcase such that rename realm testcase comes at the end of the test suite.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
