### PR TITLE
Rados TFA fixes - Online reads balancer fixes with require_min_compat_client param

### DIFF
--- a/suites/squid/rados/tier-2_rados_test-clay-ecpool.yaml
+++ b/suites/squid/rados/tier-2_rados_test-clay-ecpool.yaml
@@ -143,6 +143,7 @@ tests:
                   byte_size: 100KB
       desc: Perform tests on EC pools having a RBD Image
 
+# Pool scale down tests commented until fix for 2302230
   - test:
       name: Test Online Reads Balancer Read
       module: test_online_reads_balancer.py
@@ -150,6 +151,9 @@ tests:
       polarion-id: CEPH-83590731
       config:
         balancer_mode: read
+        negative_scenarios: true
+        scale_up: true
+        scale_down: false
         create_pools:
           - create_pool:
               pool_name: rpool_1

--- a/suites/squid/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/squid/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -375,6 +375,7 @@ tests:
         Verify_osd_in_out_behaviour: true
       desc: Verify OSD behaviour when it is marked in and out of cluster
 
+# Pool scale down tests commented until fix for 2302230
   - test:
       name: Test Online Reads Balancer Upmap-read
       module: test_online_reads_balancer.py
@@ -382,6 +383,9 @@ tests:
       polarion-id: CEPH-83590731
       config:
         balancer_mode: upmap-read
+        negative_scenarios: true
+        scale_up: true
+        scale_down: false
         create_pools:
           - create_pool:
               pool_name: rpool_1


### PR DESCRIPTION
Fixed the automation TFA issues. 

There were new features introduced and behaviour was modified post bugs. With the new changes, require_min_compat_client was enforced and no Pg_upmap_primary or MSR rules could be created if the  min_compat_client was not reef & squid resp.

1. Updated the workflow of Online commands and offline commands test scenario for reads balancer.
2. Updated the workflow for Balancer module based read balancing.
3. Updated workflow for MSR EC pool tests.