### PR TITLE
Align fetch_build_artifacts with upstream recipe file structure

### DIFF
--- a/ceph/ceph_admin/__init__.py
+++ b/ceph/ceph_admin/__init__.py
@@ -215,6 +215,18 @@ class CephAdmin(BootstrapMixin, ShellMixin, RegistryLoginMixin):
                 check_ec=False,
             )
 
+            # public repo: needed to compensate for dependencies required during
+            # installation of ceph-common and other pkg RPMs
+            public_repo_url = (
+                f"https://dl.fedoraproject.org/pub/epel/"
+                f"{node.distro_info['VERSION_ID'][0]}/Everything/x86_64/"
+            )
+            node.exec_command(
+                sudo=True,
+                cmd=f"yum-config-manager --add-repo {public_repo_url}",
+                check_ec=False,
+            )
+
     def install(self, **kwargs: Dict) -> None:
         """Install the cephadm package in all node(s).
 

--- a/ceph/ceph_admin/bootstrap.py
+++ b/ceph/ceph_admin/bootstrap.py
@@ -226,12 +226,6 @@ class BootstrapMixin:
         self.cluster.rhcs_version = _rhcs_version or rhbuild
         if build_type == "upstream":
             self.setup_upstream_repository()
-            # Todo: This is temporary workaround of installing Red Hat Ceph
-            #       Storage tools repo to compensate ceph-common and other pkg RPMs
-            #       used in the CI test modules.
-            #       The `set_cdn_tool_repo` should be taken out, once
-            #       we have upstream build with all necessary pkg sources.
-            self.set_cdn_tool_repo(_rhcs_version)
         elif build_type == "released" or custom_repo.lower() == "cdn":
             custom_image = False
             self.set_cdn_tool_repo(_rhcs_version)


### PR DESCRIPTION
Previously we used to have a single recipe file for Upstream builds which had a structure as shown below:
```
main:
  ceph-version: 19.0.0-3459.gbf48674e
  composes:
    rhel-9: https://2.chacra.ceph.com/repos/ceph/main/bf48674e34560df11632dc37be59768041468a2d/centos/9/flavors/default/repo
  repository: quay.ceph.io/ceph-ci/ceph:bf48674e34560df11632dc37be59768041468a2d
  custom-configs:
    nvmeof_image: quay.io/ceph/nvmeof:1.1.0
    nvmeof_cli_image: quay.io/ceph/nvmeof-cli:1.1.0
reef:
  ceph-version: 18.2.2-1291.g9bc99b09
  composes:
    rhel-9: https://2.chacra.ceph.com/repos/ceph/reef/9bc99b09ffc49719013c96c7a9af4027a060bd4b/centos/9/flavors/default/repo
  repository: quay.ceph.io/ceph-ci/ceph:9bc99b09ffc49719013c96c7a9af4027a060bd4b
  custom-configs:
    nvmeof_image: quay.io/ceph/nvmeof:1.1.0
    nvmeof_cli_image: quay.io/ceph/nvmeof-cli:1.1.0
```

Later we wanted each upstream build detail to be segregated to individual recipe files to avoid failures during file updates if any one listener was not working correctly.

The module `fetch_build_artifacts` in `utility/utils.py` responsible for fetching the appropriate recipe file based on the user input to run.py was not updated to support the individual upstream recipe files.

This PR introduces necessary changes in `fetch_build_artifacts` to support the same.

```
hakumar@IBM-RHEL:$ python3.9 run.py --rhbuild 8.0 --global-conf conf/squid/rados/7-node-cluster.yaml --osp-cred /home/hakumar/osp-cred-ceph-systest.yaml --inventory conf/inventory/rhel-9-latest.yaml --suite ~/deploy-cluster.yaml --log-level INFO --platform rhel-9 --skip-sos-report --build upstream --store --upstream-build squid --instances-name up-squid

Note :
    1. Custom log directory will be disabled if '/ceph/cephci-jenkins' exists.
    2. If custom log directory not specified, then '/tmp' directory is considered .
    
log directory - /tmp/cephci-run-03ALQ4
2024-10-17 13:13:05,141 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.utility.log.py:221 - Test logfile: /tmp/cephci-run-03ALQ4/startup.log
2024-10-17 13:13:06,015 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.init_suite.py:306 - List of test suites provided: 
['/home/hakumar/deploy-cluster.yaml']
2024-10-17 13:13:06,016 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.init_suite.py:315 - Provided suite is a file
2024-10-17 13:13:06,058 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.run.py:502 - The CLI for the current run :
/usr/bin/python3.9 run.py --rhbuild 8.0 --global-conf conf/squid/rados/7-node-cluster.yaml --osp-cred /home/hakumar/osp-cred-ceph-systest.yaml --inventory conf/inventory/rhel-9-latest.yaml --suite /home/hakumar/deploy-cluster.yaml --log-level INFO --platform rhel-9 --skip-sos-report --build upstream --store --upstream-build squid --instances-name up-squid

2024-10-17 13:13:06,060 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.run.py:503 - RPM Compose source - https://2.chacra.ceph.com/repos/ceph/squid/057fc3e0953d1d792acd015e8d39e000d1301b13/centos/9/flavors/default/repo
2024-10-17 13:13:06,061 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.run.py:504 - Red Hat Ceph Image used - quay.ceph.io/ceph-ci/ceph:057fc3e0953d1d792acd015e8d39e000d1301b13
2024-10-17 13:13:06,072 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.run.py:567 - Compose id is: None
2024-10-17 13:13:06,073 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.run.py:568 - Testing Ceph Version: squid
2024-10-17 13:13:06,074 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.run.py:569 - Testing Ceph Ansible Version: 
2024-10-17 13:13:06,077 (cephci.utility.xunit) [INFO] - cephci.upstream-2024.cephci.utility.utils.py:2168 - Validate global configuration file
```
Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EZIE1U

Signed-off-by: Harsh Kumar <hakumar@redhat.com>