### PR TITLE
Switch to install EPEL 9 repo

### DIFF
--- a/pipeline/vars/node_bootstrap.bash
+++ b/pipeline/vars/node_bootstrap.bash
@@ -16,7 +16,7 @@ echo "Initialize Node"
 sudo sysctl -w net.ipv6.conf.eth0.disable_ipv6=1
 
 sudo yum install -y git-core zip unzip
-sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 sudo yum install -y p7zip
 
 # Mount reesi for storing logs


### PR DESCRIPTION
# Description

By default, the jenkins nodes are RHEL 9 systems and this commit switches to installing EPEL 9 repo instead of 8.

Fixes: #3966

- [x] Review the automation design
- [x] Unit testing 
