### PR TITLE
Fixing change in behavior for nfs export user_id

### DIFF
--- a/conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
+++ b/conf/pacific/cephfs/tier-2_cephfs_9-node-cluster.yaml
@@ -38,6 +38,9 @@ globals:
         role:
           - mds
           - nfs
+          - osd
+        no-of-volumes: 4
+        disk-size: 15
       node8:
         role:
           - client

--- a/tests/cephfs/cephfs_nfs/nfs_export_config.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_config.py
@@ -2,12 +2,14 @@ import json
 import secrets
 import string
 import traceback
+from distutils.version import LooseVersion
 from json import JSONDecodeError
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from utility.log import Log
+from utility.utils import get_ceph_version_from_cluster
 
 log = Log(__name__)
 
@@ -52,6 +54,7 @@ def run(ceph_cluster, **kw):
         )
         clients = ceph_cluster.get_ceph_objects("client")
         client1 = clients[0]
+        ceph_version = get_ceph_version_from_cluster(clients[0])
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
         nfs_servers = ceph_cluster.get_ceph_objects("nfs")
@@ -89,21 +92,39 @@ def run(ceph_cluster, **kw):
             cmd=f"ceph auth get-key client.{clients[0].node.hostname}", sudo=True
         )
         log.info("Output : %s" % out)
-        export_fstr = f"""EXPORT {{
-          Export_Id = {export_id};
-          Transports = TCP;
-          Path = /;
-          Pseudo = {nfs_export_name};
-          Protocols = 4;
-          Access_Type = RW;
-          Attr_Expiration_Time = 0;
-          Squash = None;
-          FSAL {{
-            Name = CEPH;
-            Filesystem = {fs_name};
-            User_Id = nfs.cephfs-nfs.{export_id};
-          }}
-        }}"""
+        export_fstr = (
+            f"""EXPORT {{
+                  Export_Id = {export_id};
+                  Transports = TCP;
+                  Path = /;
+                  Pseudo = {nfs_export_name};
+                  Protocols = 4;
+                  Access_Type = RW;
+                  Attr_Expiration_Time = 0;
+                  Squash = None;
+                  FSAL {{
+                    Name = CEPH;
+                    Filesystem = {fs_name};
+                    User_Id = nfs.cephfs-nfs.{export_id};
+                  }}
+                }}"""
+            if LooseVersion(ceph_version) <= LooseVersion("19.1.1")
+            else f"""EXPORT {{
+                  Export_Id = {export_id};
+                  Transports = TCP;
+                  Path = /;
+                  Pseudo = {nfs_export_name};
+                  Protocols = 4;
+                  Access_Type = RW;
+                  Attr_Expiration_Time = 0;
+                  Squash = None;
+                  FSAL {{
+                    Name = CEPH;
+                    Filesystem = {fs_name};
+                    #User_Id = nfs.cephfs-nfs.{export_id};
+                  }}
+                }}"""
+        )
 
         # Push the export_fstr to a file
         filename = "export_file.conf"


### PR DESCRIPTION
# Description
Fixing change in behavior for nfs export user_id

Failed Log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-36/cephfs/40/tier-2_cephfs_test-nfs/ 
Passed Log : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PWB23A/ 

BZ Raised : https://bugzilla.redhat.com/show_bug.cgi?id=2301751 and we got confirmation that only 8.0 will have this changes

We have added 2 other fixes in same PR : 
1. Adding extra OSD in conf file for pacific


Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OPKB0Z/ 
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
