### PR TITLE
Fixing set-require-min-compat-client with --yes-i-really-mean-it

### DIFF
--- a/tests/rados/test_online_reads_balancer.py
+++ b/tests/rados/test_online_reads_balancer.py
@@ -88,7 +88,7 @@ def run(ceph_cluster, **kw):
             log.debug("Starting with -ve scenario in online reads balancer tests")
             failed = False
             try:
-                config_cmd = "ceph osd set-require-min-compat-client quincy"
+                config_cmd = "ceph osd set-require-min-compat-client quincy --yes-i-really-mean-it"
                 rados_obj.client.exec_command(cmd=config_cmd, sudo=True)
                 # Verify the updated min compat client version
                 new_version = rados_obj.run_ceph_command(cmd="ceph osd dump")[
@@ -160,7 +160,9 @@ def run(ceph_cluster, **kw):
             log.debug(
                 "Setting config to allow clients to perform read balancing on the clusters."
             )
-            config_cmd = "ceph osd set-require-min-compat-client reef"
+            config_cmd = (
+                "ceph osd set-require-min-compat-client reef --yes-i-really-mean-it"
+            )
             rados_obj.client.exec_command(cmd=config_cmd, sudo=True)
             time.sleep(5)
 

--- a/tests/rados/test_reads_balancer.py
+++ b/tests/rados/test_reads_balancer.py
@@ -82,7 +82,7 @@ def run(ceph_cluster, **kw):
                 "Trying to change the primary without setting the set-require-min-compat-client to reef. -ve test"
             )
             try:
-                config_cmd = "ceph osd set-require-min-compat-client quincy"
+                config_cmd = "ceph osd set-require-min-compat-client quincy --yes-i-really-mean-it"
                 rados_obj.client.exec_command(cmd=config_cmd, sudo=True)
                 time.sleep(10)
                 test_pool = random.choice(existing_pools)


### PR DESCRIPTION
Added --yes-i-really-mean-it flag while updating the min-compat-client during balancer tests

