### PR TITLE
Installing ceph-common on cluster nodes

### DIFF
--- a/run.py
+++ b/run.py
@@ -50,6 +50,7 @@ from utility.utils import (  # ReportPortal,
     fetch_build_artifacts,
     generate_unique_id,
     magna_url,
+    setup_cluster_access,
     validate_conf,
     validate_image,
 )
@@ -1012,8 +1013,12 @@ def run(args):
             "\n\nGenerating sosreports for all the nodes due to failures in testcase"
         )
         for cluster in ceph_cluster_dict.keys():
+            log.info(f"Installing Ceph-common on {cluster} nodes to gather Sos report")
+            for node in ceph_cluster_dict[cluster].get_nodes():
+                setup_cluster_access(ceph_cluster_dict[cluster], node)
             installer = ceph_cluster_dict[cluster].get_nodes(role="installer")[0]
             sosreport.run(installer.ip_address, "cephuser", "cephuser", run_dir)
+            # This can be Removed as sos report will have this details as well
             get_ceph_var_logs(ceph_cluster_dict[cluster], run_dir)
         log.info(f"Generated sosreports location : {url_base}/sosreports\n")
 

--- a/utility/sosreport.py
+++ b/utility/sosreport.py
@@ -54,7 +54,7 @@ def generate_sosreport_in_node(
         ssh_d.connect(nodeip, username=uname, password=pword)
         ssh_d.exec_command("sudo yum -y install sos")
         stdin, stdout, stderr = ssh_d.exec_command(
-            "sudo sosreport -a --all-logs -e ceph --batch"
+            "sudo sos report -a --all-logs --batch"
         )
         rc = stdout.channel.recv_exit_status()
         sosreport = re.search(r"sosreport-.*.tar.xz", stdout.read().decode())


### PR DESCRIPTION
# Description
Installing ceph-common on cluster nodes

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OVD6KQ/

Changes were made to sosreport.py as the collection was failing with the below error 
```
[root@ceph-amk-common-1pwnfc-node7 ~]# sosreport -a --all-logs -e ceph --batch
WARNING: the 'sosreport' command has been deprecated in favor of the new 'sos' command, E.G. 'sos report', and will be removed in the upcoming sos-4.9 release.
Redirecting to 'sos report -a --all-logs -e ceph --batch'

sos report (version 4.8.0)

a non-existing plugin (ceph) was specified in the command line.
```
sos report 4.8.0 does not support ceph plugin but it still collects the ceph logs by default. In latest 4.8.1 it supports this plugin 
Ref : https://github.com/sosreport/sos/releases 


sos report output : 
```
[root@ceph-amk-common-ovd6kq-node1-installer sosreport-ceph-amk-common-ovd6kq-node1-installer-2024-10-28-mdqjvwg]# cd sos_commands/ceph_common/
[root@ceph-amk-common-ovd6kq-node1-installer ceph_common]# car ceph_-v 
-bash: car: command not found
[root@ceph-amk-common-ovd6kq-node1-installer ceph_common]# cat ceph_-v 
ceph version 19.2.0-46.el9cp (a4cb203339716cc1aa131a8c545e534241c22b51) squid (stable)
[root@ceph-amk-common-ovd6kq-node1-installer ceph_common]# 
[root@ceph-amk-common-ovd6kq-node1-installer ceph_common]# ls -lrt
total 4
-rw-r--r--. 1 root root 87 Oct 28 02:05 ceph_-v
[root@ceph-amk-common-ovd6kq-node1-installer ceph_common]# cd ..
[root@ceph-amk-common-ovd6kq-node1-installer sos_commands]# ls -lrt | grep ceph
drwx------. 2 root root   21 Oct 28 02:05 ceph_common
drwx------. 3 root root 4096 Oct 28 02:05 ceph_mgr
drwx------. 3 root root 4096 Oct 28 02:05 ceph_mon
[root@ceph-amk-common-ovd6kq-node1-installer sos_commands]# cd ceph_mgr
[root@ceph-amk-common-ovd6kq-node1-installer ceph_mgr]# ls -lrt
total 616
-rw-r--r--. 1 root root    333 Oct 28 02:05 ceph_balancer_status
-rw-r--r--. 1 root root    158 Oct 28 02:05 ceph_healthcheck_history_ls
-rw-r--r--. 1 root root   4460 Oct 28 02:05 ceph_log_last_cephadm
-rw-r--r--. 1 root root 494604 Oct 28 02:05 ceph_mgr_dump
-rw-r--r--. 1 root root   2097 Oct 28 02:05 ceph_mgr_metadata
-rw-r--r--. 1 root root   1332 Oct 28 02:05 ceph_mgr_module_ls
-rw-r--r--. 1 root root    133 Oct 28 02:05 ceph_mgr_stat
-rw-r--r--. 1 root root    100 Oct 28 02:05 ceph_mgr_versions
-rw-r--r--. 1 root root    635 Oct 28 02:05 ceph_orch_host_ls
-rw-r--r--. 1 root root   3439 Oct 28 02:05 ceph_orch_device_ls
-rw-r--r--. 1 root root    355 Oct 28 02:05 ceph_orch_ls
-rw-r--r--. 1 root root    422 Oct 28 02:05 ceph_orch_ls_--export
-rw-r--r--. 1 root root   4158 Oct 28 02:05 ceph_orch_ps
-rw-r--r--. 1 root root     64 Oct 28 02:05 ceph_orch_status_--detail
-rw-r--r--. 1 root root    175 Oct 28 02:05 ceph_orch_upgrade_status
drwx------. 2 root root   4096 Oct 28 02:05 json_output
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_config_diff
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_config_show
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_counter_dump
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_counter_schema
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_dump_cache
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_dump_mempools
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_dump_osd_network
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_mds_requests
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_mds_sessions
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_objecter_requests
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_perf_dump
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_perf_histogram_dump
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_perf_histogram_schema
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_perf_schema
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_status
-rw-r--r--. 1 root root     76 Oct 28 02:05 ceph_daemon_.var.run.ceph.5c47a3da-9480-11ef-8ed7-fa163ef1b6a8.ceph-mgr.ceph-amk-common-ovd6kq-node1-installer.gphemm.asok_version
[root@ceph-amk-common-ovd6kq-node1-installer ceph_mgr]# cat ceph_orch_ls
NAME                       PORTS  RUNNING  REFRESHED  AGE  PLACEMENT  
mds.cephfs                            3/3  3m ago     9h   label:mds  
mgr                                   2/2  3m ago     9h   label:mgr  
mon                                   3/3  3m ago     9h   label:mon  
osd.all-available-devices              12  3m ago     9h   *          
```

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
