### PR TITLE
[TFA][Cephci]sanity suite execution needed to be within 120m

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
@@ -324,7 +324,7 @@ tests:
             config-file-name: test_versioning_objects_enable.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
       name: enabling bucket versioning and uploading objects on secondary
-      polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
+      polarion-id: CEPH-10652 # also applies to CEPH-14261 and CEPH-9222
       desc: test_versioning_objects_enable on secondary
       module: sanity_rgw_multisite.py
 

--- a/suites/squid/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/squid/rgw/tier-1_rgw_multisite.yaml
@@ -284,29 +284,6 @@ tests:
       name: create non-tenanted user
 
   - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_dynamic_resharding_greenfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec"]
-      desc: Test dynamic resharding brownfield scenario in greenfield
-      abort-on-fail: true
-      module: sanity_rgw_multisite.py
-      name: Dynamic Resharding tests on Primary cluster
-      polarion-id: CEPH-83574737
-  - test:
-      name: setting acls to versioned objects on secondary
-      desc: test_versioning_objects_acls on secondary
-      polarion-id: CEPH-9190
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_acls.yaml
-            verify-io-on-site: ["ceph-pri"]
-  - test:
       name: delete versioned objects on secondary
       desc: test_versioning_objects_delete on secondary
       polarion-id: CEPH-14262
@@ -316,17 +293,6 @@ tests:
           config:
             script-name: test_versioning_with_objects.py
             config-file-name: test_versioning_objects_delete.yaml
-  - test:
-      name: enabling bucket versioning and uploading objects on secondary
-      desc: test_versioning_objects_enable on secondary
-      polarion-id: CEPH-10652 # also applies to CEPH-14261 and CEPH-9222
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_enable.yaml
-            verify-io-on-site: ["ceph-pri"]
   - test:
       name: delete bucket policy on secondary
       desc: test_bucket_policy_delete.yaml on secondary
@@ -360,14 +326,3 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-  - test:
-      name: enable compression on secondary
-      desc: test_Mbuckets_with_Nobjects_compression on secondary
-      polarion-id: CEPH-11350
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
-            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml

--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -291,18 +291,6 @@ tests:
   # Baseline tests before upgrade
 
   - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            verify-io-on-site: ["ceph-sec"]
-      desc: test to create "M" buckets and "N" objects with multipart upload
-      module: sanity_rgw_multisite.py
-      name: multipart upload of M buckets with N objects
-      polarion-id: CEPH-9801
-
-  - test:
       name: Test LC Expiration on multisite
       desc: Test LC Expiration on multisite
       polarion-id: CEPH-10737
@@ -401,39 +389,3 @@ tests:
       module: sanity_rgw_multisite.py
       name: S3CMD tests, rgw log details post upgrade
       polarion-id: CEPH-83575470
-
-  - test:
-      name: Buckets and Objects test
-      desc: test_Mbuckets_with_Nobjects_download on secondary
-      polarion-id: CEPH-14237
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
-            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-
-  - test:
-      name: Test LC Expiration on multisite post upgrade
-      desc: Test LC Expiration on multisite post upgrade
-      polarion-id: CEPH-10737
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_rule_prefix_and_tag.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec"]
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_swift_basic_ops.py
-            config-file-name: test_swift_object_expire_op.yaml
-            verify-io-on-site: ["ceph-sec"]
-      desc: test object expiration with swift
-      module: sanity_rgw_multisite.py
-      name: swift object expiration post upgrade
-      polarion-id: CEPH-9718


### PR DESCRIPTION
# Description
TFA : https://issues.redhat.com/browse/RHCEPHQE-16417

request to reduce the execution time for the below suites to around 120 mins (2 hours) since they are running in the sanity.
tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest (~175 min)
tier-1_rgw_multisite (~150 min)

testcase removed from suites are part of other suites 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
