### PR TITLE
[RADOS] Enable Bluestore Superblock Redundnacy test | Fix test_bluefs_space test case

### DIFF
--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -716,7 +716,7 @@ class PoolFunctions:
             return
 
         log.info(f"Executing command: {_cmd}")
-        return self.node.shell([_cmd])
+        return self.rados_obj.client.exec_command(cmd=_cmd, sudo=True)
 
     def fetch_pool_stats(self, pool: str) -> dict:
         """

--- a/suites/squid/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/squid/rados/tier-2_rados_test_bluestore.yaml
@@ -134,12 +134,11 @@ tests:
         bluestore_cache: true
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
-# commented until the fix has been merged in Squid
-#  - test:
-#      name: BlueStore Superblock redundancy
-#      module: test_bluestore_superblock.py
-#      polarion-id: CEPH-83590892
-#      desc: Verify OSD recovery when Bluestore superblock is corrupted
+  - test:
+      name: BlueStore Superblock redundancy
+      module: test_bluestore_superblock.py
+      polarion-id: CEPH-83590892
+      desc: Verify OSD recovery when Bluestore superblock is corrupted
 
   - test:
       name: OSD Superblock redundancy

--- a/suites/squid/rados/tier-2_rados_test_omap.yaml
+++ b/suites/squid/rados/tier-2_rados_test_omap.yaml
@@ -202,3 +202,20 @@ tests:
             normal_objs: 400
             num_keys_obj: 200001
       desc: Large number of omap creation on objects and OSD resiliency
+
+  - test:
+      name: Verification of dump scrub parameters
+      desc: Verification of forced and scheduled time flags
+      module: test_scrub_parameters.py
+      polarion-id: CEPH-83593830
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_rp_pool
+          pg_num: 1
+        ec_pool:
+          pool_name: scrub_ec_pool
+          k: 2
+          m: 2
+          pg_num: 1
+          plugin: jerasure

--- a/tests/rados/monitor_configurations.py
+++ b/tests/rados/monitor_configurations.py
@@ -238,7 +238,7 @@ class MonConfigMethods:
         cmd = f"ceph config get {section} {param}"
         if daemon_name:
             cmd = f"ceph config get {daemon_name}"
-        return self.rados_obj.node.shell([cmd])[0]
+        return str(self.rados_obj.node.shell([cmd])[0]).strip()
 
     def remove_config(self, **kwargs):
         """

--- a/tests/rados/test_bluefs_space.py
+++ b/tests/rados/test_bluefs_space.py
@@ -80,20 +80,23 @@ def run(ceph_cluster, **kw):
             f"Log ceph df detail: \n {rados_obj.get_cephdf_stats(pool_name=pool_name, detail=True)}"
         )
 
-        # Write 1500 large OMAP objects on the pool, 150 at a time to
+        # Write about 1500 large OMAP objects on the pool, 150 at a time to
         # not overwhelm VM cluster
-        for _ in range(10):
-            cmd_options = f"--pool {pool_name} --start 0 --end 150 --key-count 200001"
-            cmd = f"python3 generate_omap_entries.py {cmd_options} &> /dev/null &"
-            rados_obj.client.exec_command(
-                sudo=True, cmd=cmd, timeout=600, check_ec=False
-            )
-            time.sleep(10)
+        for _ in range(2):
+            for _ in range(5):
+                cmd_options = (
+                    f"--pool {pool_name} --start 0 --end 150 --key-count 200001"
+                )
+                cmd = f"python3 generate_omap_entries.py {cmd_options} &> /dev/null &"
+                rados_obj.client.exec_command(
+                    sudo=True, cmd=cmd, timeout=600, check_ec=False
+                )
+                time.sleep(10)
 
-        cmd_options = f"--pool {pool_name} --start 0 --end 150 --key-count 200001"
-        cmd = f"python3 generate_omap_entries.py {cmd_options}"
-        rados_obj.client.exec_command(sudo=True, cmd=cmd, timeout=900)
-        time.sleep(10)
+            cmd_options = f"--pool {pool_name} --start 0 --end 150 --key-count 200001"
+            cmd = f"python3 generate_omap_entries.py {cmd_options}"
+            rados_obj.client.exec_command(sudo=True, cmd=cmd, timeout=900)
+            time.sleep(10)
 
         log.info(
             f"Log ceph df detail: \n {rados_obj.get_cephdf_stats(pool_name=pool_name, detail=True)}"


### PR DESCRIPTION
This PR addresses the following changes:

1. Enables Bluestore Superblock Redundancy test case(CEPH-83590892) which was previously commented as the feature has been merged in Squid and works as expected in greenfield deployments
2. Included missing test case CEPH-83593830 in `suites/squid/rados/tier-2_rados_test_omap.yaml`
3. Fixes newly introduced test case `tests/rados/test_bluefs_space.py` by limiting the number of parallel OMAP ops executed in the background to 5.

Log: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-NJWUJI

Signed-off-by: Harsh Kumar <hakumar@redhat.com>