### PR TITLE
Merging suites with conf tier-2_cephfs_9-node-cluster

### DIFF
--- a/suites/quincy/cephfs/teir-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/quincy/cephfs/teir-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -1,0 +1,472 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: File and Dir Layout Lifecycle Operations
+      module: cephfs_file_and_dir_layout.file_dir_layout_lifecycle_ops.py
+      polarion-id: CEPH-11334
+      desc: File and Directory Layout Lifecycle Operations
+      abort-on-fail: false
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Create a subvolume in a non-existent subvolume group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: Create a subvolume in a non-existent subvolume group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: Test fs volume deletion when mon_allow_pool_delete is false
+      module: cephfs_vol_management.fs_del_allow_pool_false.py
+      polarion-id: CEPH-83574159
+      desc: Test fs volume deletion when mon_allow_pool_delete is false
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "test cephfs nfs export path"
+      module: cephfs_nfs.nfs_export_path.py
+      name: "cephfs nfs export path"
+      polarion-id: "CEPH-83574028"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs snapshot clone operations"
+      module: cephfs_nfs.nfs_snaphshot_clone.py
+      name: "cephfs nfs snapshot clone operations"
+      polarion-id: "CEPH-83574024"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs subvolume & subvolumegroup operations"
+      module: cephfs_nfs.nfs_subvolume_subvolumegroup.py
+      name: "cephfs nfs subvolume & subvolumegroup operations"
+      polarion-id: "CEPH-83574027"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs read only export"
+      module: cephfs_nfs.read_only_nfs_export.py
+      name: "cephfs nfs read only export"
+      polarion-id: "CEPH-83574003"
+  - test:
+      abort-on-fail: false
+      desc: "test recreation of cephfs nfs cluster with same name"
+      module: cephfs_nfs.recreate_same_name_nfs.py
+      name: "recreate same name nfs cluster"
+      polarion-id: "CEPH-83574015"
+  - test:
+      abort-on-fail: false
+      desc: "test creation of 2 node nfs cluster"
+      module: cephfs_nfs.2_node_nfs.py
+      name: "2 node nfs cluster"
+      polarion-id: "CEPH-83574022"
+  - test:
+      abort-on-fail: false
+      desc: "test zipping & unzipping files on nfs export continuously"
+      module: cephfs_nfs.zip_unzip_files_nfs.py
+      name: "zipping & unzipping files on nfs export"
+      polarion-id: "CEPH-83574026"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export for cephfs subvolume"
+      module: cephfs_nfs.subvolume_export.py
+      name: "cephfs nfs export for subvolume"
+      polarion-id: "CEPH-83573993"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on non-existing directory"
+      module: cephfs_nfs.nfs_non_exist_export_path.py
+      name: "Create cephfs nfs export on non-existing directory"
+      polarion-id: "CEPH-83573669"
+  - test:
+      abort-on-fail: false
+      desc: "Export and import data between NFS and CephFS"
+      module: cephfs_nfs.move_data_bw_nfs_and_cephfs_mounts.py
+      name: "Move Data bw nfs and cephfs exports"
+      polarion-id: "CEPH-11309"
+  - test:
+      abort-on-fail: false
+      desc: "Test data integrity between cephfs & nfs mounts"
+      module: cephfs_nfs.test_data_integrity_nfs_cephfs_mounts.py
+      name: "data integrity between cephfs & nfs mounts"
+      polarion-id: "CEPH-11312"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on existing path"
+      module: cephfs_nfs.existing_path_nfs_export.py
+      name: "existing path cephfs nfs export"
+      polarion-id: "CEPH-83573995"
+  - test:
+      abort-on-fail: false
+      desc: "Run IOs by mounting same subvolume with all the three mounts"
+      module: cephfs_nfs.nfs_fuse_kernel_same_subvolume.py
+      name: "Mount same volume on fuse,kernel and nfs and runIOs"
+      polarion-id: "CEPH-11310"
+  - test:
+      abort-on-fail: false
+      desc: "Backup and restore data using existing NFS backup tools"
+      module: cephfs_nfs.data_backup_restore_bw_nfs_and_local_mounts.py
+      name: "backup and restore data bw nfs exports and local dir"
+      polarion-id: "CEPH-11314"
+  - test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
+  - test:
+      abort-on-fail: false
+      desc: "Apply various number of hosts to nfs cluster and verify the changes"
+      module: cephfs_nfs.nfs_update_cluster_node_changes.py
+      name: "nfs cluster host changes and verification"
+      polarion-id: "CEPH-83574013"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs with io and network failures"
+      module: cephfs_nfs.nfs_io_network_failures.py
+      name: "cephfs nfs with io and network failures"
+      polarion-id: "CEPH-83574020"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs mount with fstab entry"
+      module: cephfs_nfs.nfs_mount_with_fstab.py
+      name: "cephfs nfs mount with fstab entry"
+      polarion-id: "CEPH-83574025"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_ro_rw_access.py
+      name: "cephfs nfs RO and RW export"
+      polarion-id: "CEPH-83574001"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_export_config.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83574008"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs config reset"
+      module: cephfs_nfs.nfs_config_reset.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83573999"
+  - test:
+      abort-on-fail: false
+      desc: "modifying_nfs_cluster_invalid_value"
+      module: cephfs_nfs.modifying_nfs_cluster_invalid_value.py
+      name: "modifying_nfs_cluster_invalid_value"
+      polarion-id: "CEPH-83574014"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_transfer_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+      name: "nfs_file_transfer_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575825"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_file_attributes_retention.py
+      name: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575937"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_multiple_export_using_single_conf"
+      module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
+      name: "nfs_multiple_export_using_single_conf"
+      polarion-id: "CEPH-83575082"

--- a/suites/reef/cephfs/teir-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/reef/cephfs/teir-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -1,0 +1,472 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: File and Dir Layout Lifecycle Operations
+      module: cephfs_file_and_dir_layout.file_dir_layout_lifecycle_ops.py
+      polarion-id: CEPH-11334
+      desc: File and Directory Layout Lifecycle Operations
+      abort-on-fail: false
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Create a subvolume in a non-existent subvolume group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: Create a subvolume in a non-existent subvolume group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: Test fs volume deletion when mon_allow_pool_delete is false
+      module: cephfs_vol_management.fs_del_allow_pool_false.py
+      polarion-id: CEPH-83574159
+      desc: Test fs volume deletion when mon_allow_pool_delete is false
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "test cephfs nfs export path"
+      module: cephfs_nfs.nfs_export_path.py
+      name: "cephfs nfs export path"
+      polarion-id: "CEPH-83574028"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs snapshot clone operations"
+      module: cephfs_nfs.nfs_snaphshot_clone.py
+      name: "cephfs nfs snapshot clone operations"
+      polarion-id: "CEPH-83574024"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs subvolume & subvolumegroup operations"
+      module: cephfs_nfs.nfs_subvolume_subvolumegroup.py
+      name: "cephfs nfs subvolume & subvolumegroup operations"
+      polarion-id: "CEPH-83574027"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs read only export"
+      module: cephfs_nfs.read_only_nfs_export.py
+      name: "cephfs nfs read only export"
+      polarion-id: "CEPH-83574003"
+  - test:
+      abort-on-fail: false
+      desc: "test recreation of cephfs nfs cluster with same name"
+      module: cephfs_nfs.recreate_same_name_nfs.py
+      name: "recreate same name nfs cluster"
+      polarion-id: "CEPH-83574015"
+  - test:
+      abort-on-fail: false
+      desc: "test creation of 2 node nfs cluster"
+      module: cephfs_nfs.2_node_nfs.py
+      name: "2 node nfs cluster"
+      polarion-id: "CEPH-83574022"
+  - test:
+      abort-on-fail: false
+      desc: "test zipping & unzipping files on nfs export continuously"
+      module: cephfs_nfs.zip_unzip_files_nfs.py
+      name: "zipping & unzipping files on nfs export"
+      polarion-id: "CEPH-83574026"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export for cephfs subvolume"
+      module: cephfs_nfs.subvolume_export.py
+      name: "cephfs nfs export for subvolume"
+      polarion-id: "CEPH-83573993"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on non-existing directory"
+      module: cephfs_nfs.nfs_non_exist_export_path.py
+      name: "Create cephfs nfs export on non-existing directory"
+      polarion-id: "CEPH-83573669"
+  - test:
+      abort-on-fail: false
+      desc: "Export and import data between NFS and CephFS"
+      module: cephfs_nfs.move_data_bw_nfs_and_cephfs_mounts.py
+      name: "Move Data bw nfs and cephfs exports"
+      polarion-id: "CEPH-11309"
+  - test:
+      abort-on-fail: false
+      desc: "Test data integrity between cephfs & nfs mounts"
+      module: cephfs_nfs.test_data_integrity_nfs_cephfs_mounts.py
+      name: "data integrity between cephfs & nfs mounts"
+      polarion-id: "CEPH-11312"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on existing path"
+      module: cephfs_nfs.existing_path_nfs_export.py
+      name: "existing path cephfs nfs export"
+      polarion-id: "CEPH-83573995"
+  - test:
+      abort-on-fail: false
+      desc: "Run IOs by mounting same subvolume with all the three mounts"
+      module: cephfs_nfs.nfs_fuse_kernel_same_subvolume.py
+      name: "Mount same volume on fuse,kernel and nfs and runIOs"
+      polarion-id: "CEPH-11310"
+  - test:
+      abort-on-fail: false
+      desc: "Backup and restore data using existing NFS backup tools"
+      module: cephfs_nfs.data_backup_restore_bw_nfs_and_local_mounts.py
+      name: "backup and restore data bw nfs exports and local dir"
+      polarion-id: "CEPH-11314"
+  - test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
+  - test:
+      abort-on-fail: false
+      desc: "Apply various number of hosts to nfs cluster and verify the changes"
+      module: cephfs_nfs.nfs_update_cluster_node_changes.py
+      name: "nfs cluster host changes and verification"
+      polarion-id: "CEPH-83574013"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs with io and network failures"
+      module: cephfs_nfs.nfs_io_network_failures.py
+      name: "cephfs nfs with io and network failures"
+      polarion-id: "CEPH-83574020"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs mount with fstab entry"
+      module: cephfs_nfs.nfs_mount_with_fstab.py
+      name: "cephfs nfs mount with fstab entry"
+      polarion-id: "CEPH-83574025"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_ro_rw_access.py
+      name: "cephfs nfs RO and RW export"
+      polarion-id: "CEPH-83574001"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_export_config.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83574008"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs config reset"
+      module: cephfs_nfs.nfs_config_reset.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83573999"
+  - test:
+      abort-on-fail: false
+      desc: "modifying_nfs_cluster_invalid_value"
+      module: cephfs_nfs.modifying_nfs_cluster_invalid_value.py
+      name: "modifying_nfs_cluster_invalid_value"
+      polarion-id: "CEPH-83574014"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_transfer_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+      name: "nfs_file_transfer_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575825"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_file_attributes_retention.py
+      name: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575937"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_multiple_export_using_single_conf"
+      module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
+      name: "nfs_multiple_export_using_single_conf"
+      polarion-id: "CEPH-83575082"

--- a/suites/squid/cephfs/teir-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/squid/cephfs/teir-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -1,0 +1,472 @@
+---
+tests:
+  -
+    test:
+      abort-on-fail: true
+      desc: "Setup phase to deploy the required pre-requisites for running the tests."
+      module: install_prereq.py
+      name: "setup install pre-requisistes"
+  -
+    test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-data-ec
+                - "64"
+                - erasure
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - create
+                - cephfs-metadata
+                - "64"
+          - config:
+              command: shell
+              args:
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs-data-ec
+                - allow_ec_overwrites
+                - "true"
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - fs
+                - new
+                - cephfs-ec
+                - cephfs-metadata
+                - cephfs-data-ec
+                - --force
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  label: mds
+          - config:
+              args:
+                - ceph
+                - fs
+                - set
+                - cephfs
+                - max_mds
+                - "2"
+              command: shell
+      destroy-cluster: false
+      abort-on-fail: true
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.1
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node8
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.2
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node9
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node10
+      desc: "Configure the Cephfs client system 3"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  -
+    test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+          - ceph-fuse
+        node: node11
+      desc: "Configure the Cephfs client system 4"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      name: File and Dir Layout Lifecycle Operations
+      module: cephfs_file_and_dir_layout.file_dir_layout_lifecycle_ops.py
+      polarion-id: CEPH-11334
+      desc: File and Directory Layout Lifecycle Operations
+      abort-on-fail: false
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Create a subvolume in a non-existent subvolume group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: Create a subvolume in a non-existent subvolume group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: Test fs volume deletion when mon_allow_pool_delete is false
+      module: cephfs_vol_management.fs_del_allow_pool_false.py
+      polarion-id: CEPH-83574159
+      desc: Test fs volume deletion when mon_allow_pool_delete is false
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false
+  - test:
+      abort-on-fail: true
+      desc: "test cephfs nfs export path"
+      module: cephfs_nfs.nfs_export_path.py
+      name: "cephfs nfs export path"
+      polarion-id: "CEPH-83574028"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs snapshot clone operations"
+      module: cephfs_nfs.nfs_snaphshot_clone.py
+      name: "cephfs nfs snapshot clone operations"
+      polarion-id: "CEPH-83574024"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs subvolume & subvolumegroup operations"
+      module: cephfs_nfs.nfs_subvolume_subvolumegroup.py
+      name: "cephfs nfs subvolume & subvolumegroup operations"
+      polarion-id: "CEPH-83574027"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs read only export"
+      module: cephfs_nfs.read_only_nfs_export.py
+      name: "cephfs nfs read only export"
+      polarion-id: "CEPH-83574003"
+  - test:
+      abort-on-fail: false
+      desc: "test recreation of cephfs nfs cluster with same name"
+      module: cephfs_nfs.recreate_same_name_nfs.py
+      name: "recreate same name nfs cluster"
+      polarion-id: "CEPH-83574015"
+  - test:
+      abort-on-fail: false
+      desc: "test creation of 2 node nfs cluster"
+      module: cephfs_nfs.2_node_nfs.py
+      name: "2 node nfs cluster"
+      polarion-id: "CEPH-83574022"
+  - test:
+      abort-on-fail: false
+      desc: "test zipping & unzipping files on nfs export continuously"
+      module: cephfs_nfs.zip_unzip_files_nfs.py
+      name: "zipping & unzipping files on nfs export"
+      polarion-id: "CEPH-83574026"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs export for cephfs subvolume"
+      module: cephfs_nfs.subvolume_export.py
+      name: "cephfs nfs export for subvolume"
+      polarion-id: "CEPH-83573993"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on non-existing directory"
+      module: cephfs_nfs.nfs_non_exist_export_path.py
+      name: "Create cephfs nfs export on non-existing directory"
+      polarion-id: "CEPH-83573669"
+  - test:
+      abort-on-fail: false
+      desc: "Export and import data between NFS and CephFS"
+      module: cephfs_nfs.move_data_bw_nfs_and_cephfs_mounts.py
+      name: "Move Data bw nfs and cephfs exports"
+      polarion-id: "CEPH-11309"
+  - test:
+      abort-on-fail: false
+      desc: "Test data integrity between cephfs & nfs mounts"
+      module: cephfs_nfs.test_data_integrity_nfs_cephfs_mounts.py
+      name: "data integrity between cephfs & nfs mounts"
+      polarion-id: "CEPH-11312"
+  - test:
+      abort-on-fail: false
+      desc: "Create cephfs nfs export on existing path"
+      module: cephfs_nfs.existing_path_nfs_export.py
+      name: "existing path cephfs nfs export"
+      polarion-id: "CEPH-83573995"
+  - test:
+      abort-on-fail: false
+      desc: "Run IOs by mounting same subvolume with all the three mounts"
+      module: cephfs_nfs.nfs_fuse_kernel_same_subvolume.py
+      name: "Mount same volume on fuse,kernel and nfs and runIOs"
+      polarion-id: "CEPH-11310"
+  - test:
+      abort-on-fail: false
+      desc: "Backup and restore data using existing NFS backup tools"
+      module: cephfs_nfs.data_backup_restore_bw_nfs_and_local_mounts.py
+      name: "backup and restore data bw nfs exports and local dir"
+      polarion-id: "CEPH-11314"
+  - test:
+      abort-on-fail: false
+      desc: "Verifying ceph nfs ls export with --detailed option and info with cluster_id"
+      module: cephfs_nfs.nfs_info_cluster_id_and_ls_export_detailed.py
+      name: "nfs ls export verification and info with cluster_id"
+      polarion-id: "CEPH-83573992"
+      comments: "No Clarity on the implementation"
+  - test:
+      abort-on-fail: false
+      desc: "Apply various number of hosts to nfs cluster and verify the changes"
+      module: cephfs_nfs.nfs_update_cluster_node_changes.py
+      name: "nfs cluster host changes and verification"
+      polarion-id: "CEPH-83574013"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs with io and network failures"
+      module: cephfs_nfs.nfs_io_network_failures.py
+      name: "cephfs nfs with io and network failures"
+      polarion-id: "CEPH-83574020"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs mount with fstab entry"
+      module: cephfs_nfs.nfs_mount_with_fstab.py
+      name: "cephfs nfs mount with fstab entry"
+      polarion-id: "CEPH-83574025"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_ro_rw_access.py
+      name: "cephfs nfs RO and RW export"
+      polarion-id: "CEPH-83574001"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs RO and RW export"
+      module: cephfs_nfs.nfs_export_config.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83574008"
+  - test:
+      abort-on-fail: false
+      desc: "test cephfs nfs config reset"
+      module: cephfs_nfs.nfs_config_reset.py
+      name: "cephfs nfs export creation using config file"
+      polarion-id: "CEPH-83573999"
+  - test:
+      abort-on-fail: false
+      desc: "modifying_nfs_cluster_invalid_value"
+      module: cephfs_nfs.modifying_nfs_cluster_invalid_value.py
+      name: "modifying_nfs_cluster_invalid_value"
+      polarion-id: "CEPH-83574014"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_transfer_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_transfer_file_bw_nfs_and_localfs.py
+      name: "nfs_file_transfer_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575825"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      module: cephfs_nfs.test_cephfs_nfs_file_attributes_retention.py
+      name: "nfs_file_attributes_retention_bw_nfs_and_localfs"
+      polarion-id: "CEPH-83575937"
+  - test:
+      abort-on-fail: false
+      desc: "nfs_multiple_export_using_single_conf"
+      module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
+      name: "nfs_multiple_export_using_single_conf"
+      polarion-id: "CEPH-83575082"

--- a/tests/cephfs/cephfs_nfs/nfs_export_path.py
+++ b/tests/cephfs/cephfs_nfs/nfs_export_path.py
@@ -7,6 +7,7 @@ from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.cephfs_volume_management import wait_for_process
 from utility.log import Log
+from utility.retry import retry
 
 log = Log(__name__)
 
@@ -69,9 +70,9 @@ def run(ceph_cluster, **kw):
         export_path = "/"
         fs_name = "cephfs" if not erasure else "cephfs-ec"
         fs_details = fs_util.get_fs_info(client1, fs_name)
-
+        retry_fs_create = retry(CommandFailed, tries=3, delay=60)(fs_util.create_fs)
         if not fs_details:
-            fs_util.create_fs(client1, fs_name)
+            retry_fs_create(client1, fs_name)
         if "5.0" in rhbuild:
             client1.exec_command(
                 sudo=True,


### PR DESCRIPTION
# Description
Merging suites with conf tier-2_cephfs_9-node-cluster
In total we have 4 suites using tier-2_cephfs_9-node-cluster

1. `tier-2_cephfs_test_file_and_dir_layout.yaml`
2. `tier-2_cephfs_test-volume-management.yaml`
3. `tier-2_cephfs_test-nfs.yaml`
4. `tier-2_cephfs_test-clients.yaml`

In this PR we have merged first 3 and the clients have not merged as the suite is not stabilised. 

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ORFSZ8/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
