### PR TITLE
Updating default timeout of long-running command.

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -170,7 +170,7 @@ def install_prereq(
         if repo:
             setup_addition_repo(ceph, repo)
 
-        ceph.exec_command(cmd="sudo yum -y upgrade", check_ec=False)
+        ceph.exec_command(cmd="sudo yum -y upgrade", timeout=600, check_ec=False)
 
         rpm_all_packages = " ".join(rpm_packages.get("all"))
         if distro_ver.startswith("7"):


### PR DESCRIPTION
# Description

Updating default timeout of long-running command.

Install pre-requisites test failed in DMFG baremetal pipeline due to timeout issues.
Increased the default timeout to 600seconds.

https://ocs3xstage-jenkins-csb-rhgsocs3x.apps.ocp-c1.prod.psi.redhat.com/view/Baremetal/job/qe-squid-dmfg-baremetal/6/console

