### PR TITLE
Fixing Stretch mode netsplit test & replaced arbiter -> tiebreaker

### DIFF
--- a/ceph/rados/crushtool_workflows.py
+++ b/ceph/rados/crushtool_workflows.py
@@ -202,7 +202,7 @@ class CrushToolWorkflows:
             status, file_loc = obj.add_new_bucket_into_bin(
                 source_loc="/tmp/crush.map.bin",
                 target_loc="/tmp/crush_modified.map.bin",
-                bucket_name="arbiter",
+                bucket_name="tiebreaker",
                 bucket_type="datacenter",
             )
 
@@ -251,7 +251,7 @@ class CrushToolWorkflows:
         Examples::
             status, file_loc = obj.verify_add_new_bucket_into_bin(
                 loc="/tmp/crush_modified.map.bin",
-                bucket_name="arbiter",
+                bucket_name="tiebreaker",
                 bucket_type="datacenter",
             )
 
@@ -354,7 +354,7 @@ class CrushToolWorkflows:
         Examples::
             status = obj.verify_add_new_bucket_into_bin(
                 loc="/tmp/crush_modified.map.bin",
-                bucket_name="arbiter",
+                bucket_name="tiebreaker",
                 reweight_val="0.020"
             )
         Returns::

--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -11,7 +11,7 @@ globals:
           - _admin
           - installer
           - mon
-# Keeping the mgr daemon in the arbiter node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+# Keeping the mgr daemon in the tiebreaker node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
           - mgr
           - alertmanager
           - grafana

--- a/conf/reef/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/reef/rados/stretch-mode-host-location-attrs.yaml
@@ -12,7 +12,7 @@ globals:
           - _admin
           - installer
           - mon
-# Keeping the mgr daemon in the arbiter node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+# Keeping the mgr daemon in the tiebreaker node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
           - mgr
           - alertmanager
           - grafana

--- a/conf/squid/rados/7node-1client-stretch-mode-rhos-d.yaml
+++ b/conf/squid/rados/7node-1client-stretch-mode-rhos-d.yaml
@@ -8,25 +8,32 @@ globals:
   - ceph-cluster:
       name: ceph
       node1:
+        networks:
+          - provider_net_cci_16
         role:
           - _admin
           - installer
           - mon
-# Keeping the mgr daemon in the tiebreaker node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
-          - mgr
           - alertmanager
           - grafana
           - prometheus
       node2:
+        networks:
+          - provider_net_cci_15
         role:
           - mon
           - mgr
           - _admin
           - osd
           - osd-bak
+          - alertmanager
+          - grafana
+          - prometheus
         no-of-volumes: 4
         disk-size: 25
       node3:
+        networks:
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -36,6 +43,8 @@ globals:
         no-of-volumes: 4
         disk-size: 25
       node4:
+        networks:
+          - provider_net_cci_15
         role:
           - rgw
           - osd
@@ -44,15 +53,22 @@ globals:
         no-of-volumes: 4
         disk-size: 25
       node5:
+        networks:
+          - provider_net_cci_13
         role:
           - mon
           - _admin
           - mgr
           - osd
           - osd-bak
+          - alertmanager
+          - grafana
+          - prometheus
         no-of-volumes: 4
         disk-size: 25
       node6:
+        networks:
+          - provider_net_cci_13
         role:
           - mon
           - mgr
@@ -62,6 +78,8 @@ globals:
         no-of-volumes: 4
         disk-size: 25
       node7:
+        networks:
+          - provider_net_cci_13
         role:
           - osd
           - rgw

--- a/conf/squid/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/squid/rados/stretch-mode-host-location-attrs.yaml
@@ -12,7 +12,7 @@ globals:
           - _admin
           - installer
           - mon
-# Keeping the mgr daemon in the arbiter node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
+# Keeping the mgr daemon in the tiebreaker node until bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2249962
           - mgr
           - alertmanager
           - grafana

--- a/suites/pacific/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/pacific/rados/deploy-stretch-cluster-mode.yaml
@@ -22,8 +22,8 @@
 #              name: "DC2"                           # Name of the datacenter-2 to be added in crush map
 #              hosts: ["<host3-shortname>", ... ]    # List of hostnames present in datacenter-2
 #       - site3:
-#              name: "DC3"                           # Name of the Arbiter location to be added in crush map
-#              hosts: ["<host5-shortname>"]          # List of hostname present in Arbiter
+#              name: "DC3"                           # Name of the tiebreaker location to be added in crush map
+#              hosts: ["<host5-shortname>"]          # List of hostname present in tiebreaker
 
 tests:
   - test:
@@ -167,5 +167,5 @@ tests:
         site3:
           name: "DC3"
           hosts: ["<host5-shortname>"]
-      desc: Enables connectivity mode, deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode, deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -161,8 +161,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
 

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode.yaml
@@ -158,8 +158,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -159,9 +159,9 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: False
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       comments: -ve scenarios bug - 2293147
       abort-on-fail: true
 
@@ -220,7 +220,7 @@ tests:
       config:
         pool_name: test_stretch_pool6
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving
       abort-on-fail: true
@@ -232,34 +232,34 @@ tests:
       config:
         pool_name: test_stretch_pool9
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
         add_network_delay: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster site down - Arbiter site
+      name: test stretch Cluster site down - tiebreaker site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974
       config:
         pool_name: test_stretch_pool5
-        shutdown_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        shutdown_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is shut down
+      desc: Test the cluster when the tiebreaker site is shut down
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -269,20 +269,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -291,21 +291,21 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
   - test:
-      name: Mon replacement on Arbiter site
+      name: Mon replacement on tiebreaker site
       module: test_stretch_mon_replacements.py
       polarion-id: CEPH-83574971
       config:
         pool_name: test_stretch_pool6
-        replacement_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        replacement_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster mon replacement - Arbiter site
+      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -317,7 +317,7 @@ tests:
       config:
         pool_name: test_stretch_pool8
         netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
 
@@ -328,20 +328,20 @@ tests:
       config:
         pool_name: test_stretch_pool7
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: test stretch Cluster maintenance mode - data site
@@ -350,7 +350,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
 
@@ -360,5 +360,5 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode

--- a/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/pacific/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -201,7 +201,7 @@ tests:
         add_buckets:
           DC1: datacenter
           DC2: datacenter
-          Arbiter: datacenter
+          tiebreaker: datacenter
           test-host-1: host
           test-host-2: host
         bin_tests:

--- a/suites/quincy/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/quincy/rados/deploy-stretch-cluster-mode.yaml
@@ -22,8 +22,8 @@
 #              name: "DC2"                           # Name of the datacenter-2 to be added in crush map
 #              hosts: ["<host3-shortname>", ... ]    # List of hostnames present in datacenter-2
 #       - site3:
-#              name: "DC3"                           # Name of the Arbiter location to be added in crush map
-#              hosts: ["<host5-shortname>"]          # List of hostname present in Arbiter
+#              name: "DC3"                           # Name of the tiebreaker location to be added in crush map
+#              hosts: ["<host5-shortname>"]          # List of hostname present in tiebreaker
 
 tests:
   - test:
@@ -167,5 +167,5 @@ tests:
         site3:
           name: "DC3"
           hosts: ["<host5-shortname>"]
-      desc: Enables connectivity mode, deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode, deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -58,7 +58,7 @@ tests:
               spec:
                 crush_locations:
                   node1:
-                    - datacenter=arbiter
+                    - datacenter=tiebreaker
                   node2:
                     - datacenter=DC1
                   node3:
@@ -176,8 +176,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
 

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
@@ -52,7 +52,7 @@ tests:
               spec:
                 crush_locations:
                   node1:
-                    - datacenter=arbiter
+                    - datacenter=tiebreaker
                   node2:
                     - datacenter=DC1
                   node3:
@@ -170,8 +170,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -159,10 +159,10 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: False
       comments: -ve scenarios bug - 2293147
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
 
@@ -220,7 +220,7 @@ tests:
       config:
         pool_name: test_stretch_pool6
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving
       abort-on-fail: true
@@ -232,34 +232,34 @@ tests:
       config:
         pool_name: test_stretch_pool9
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
         add_network_delay: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster site down - Arbiter site
+      name: test stretch Cluster site down - tiebreaker site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974
       config:
         pool_name: test_stretch_pool5
-        shutdown_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        shutdown_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is shut down
+      desc: Test the cluster when the tiebreaker site is shut down
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -269,20 +269,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -291,21 +291,21 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
   - test:
-      name: Mon replacement on Arbiter site
+      name: Mon replacement on tiebreaker site
       module: test_stretch_mon_replacements.py
       polarion-id: CEPH-83574971
       config:
         pool_name: test_stretch_pool6
-        replacement_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        replacement_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster mon replacement - Arbiter site
+      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -317,7 +317,7 @@ tests:
       config:
         pool_name: test_stretch_pool8
         netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
 
@@ -328,20 +328,20 @@ tests:
       config:
         pool_name: test_stretch_pool7
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: test stretch Cluster maintenance mode - data site
@@ -350,7 +350,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
 
@@ -360,5 +360,5 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode

--- a/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -143,9 +143,9 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: false
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:
@@ -417,7 +417,7 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool6
 #        shutdown_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #      desc: Test the cluster when we have only 1 of 2 DC's surviving
 #      abort-on-fail: true
@@ -429,34 +429,34 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool9
 #        shutdown_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #        add_network_delay: true
 #      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
 #      abort-on-fail: true
 #
 #  - test:
-#      name: test stretch Cluster site down - Arbiter site
+#      name: test stretch Cluster site down - tiebreaker site
 #      module: test_stretch_site_down.py
 #      polarion-id: CEPH-83574974
 #      config:
 #        pool_name: test_stretch_pool5
-#        shutdown_site: arbiter
-#        tiebreaker_mon_site_name: arbiter
+#        shutdown_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
-#      desc: Test the cluster when the arbiter site is shut down
+#      desc: Test the cluster when the tiebreaker site is shut down
 #      abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -466,20 +466,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -488,22 +488,22 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
 # No free host without any mon daemon on the cluster.
-# Arbiter site Mon replacement test commented as of now
+# tiebreaker site Mon replacement test commented as of now
 #  - test:
-#      name: Mon replacement on Arbiter site
+#      name: Mon replacement on tiebreaker site
 #      module: test_stretch_mon_replacements.py
 #      polarion-id: CEPH-83574971
 #      config:
 #        pool_name: test_stretch_pool6
-#        replacement_site: arbiter
-#        tiebreaker_mon_site_name: arbiter
+#        replacement_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
-#      desc: Test stretch Cluster mon replacement - Arbiter site
+#      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -514,7 +514,7 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool8
 #        netsplit_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #      desc: Test stretch Cluster netsplit scenario between data sites
 #
@@ -527,21 +527,21 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool7
 #        stretch_bucket: datacenter
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #        add_network_delay: true
 #      desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: Negative scenarios - post-deployment
@@ -549,7 +549,7 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode
 
   - test:
@@ -559,7 +559,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
       abort-on-fail: true

--- a/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -201,7 +201,7 @@ tests:
         add_buckets:
           DC1: datacenter
           DC2: datacenter
-          Arbiter: datacenter
+          tiebreaker: datacenter
           test-host-1: host
           test-host-2: host
         bin_tests:

--- a/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
@@ -158,8 +158,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
 

--- a/suites/reef/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/reef/rados/deploy-stretch-cluster-mode.yaml
@@ -22,8 +22,8 @@
 #              name: "DC2"                           # Name of the datacenter-2 to be added in crush map
 #              hosts: ["<host3-shortname>", ... ]    # List of hostnames present in datacenter-2
 #       - site3:
-#              name: "DC3"                           # Name of the Arbiter location to be added in crush map
-#              hosts: ["<host5-shortname>"]          # List of hostname present in Arbiter
+#              name: "DC3"                           # Name of the tiebreaker location to be added in crush map
+#              hosts: ["<host5-shortname>"]          # List of hostname present in tiebreaker
 # Added to BM pipeline
 
 tests:
@@ -192,5 +192,5 @@ tests:
         site3:
           name: "DC3"
           hosts: ["mero017", "mero018", "mero014", "mero019", "mero020"]
-      desc: Enables connectivity mode, deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode, deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true

--- a/suites/reef/rados/test_rados_all_generic_features.yaml
+++ b/suites/reef/rados/test_rados_all_generic_features.yaml
@@ -1586,7 +1586,7 @@ tests:
         add_buckets:
           DC1: datacenter
           DC2: datacenter
-          Arbiter: datacenter
+          tiebreaker: datacenter
           test-host-1: host
           test-host-2: host
         bin_tests:

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -62,7 +62,7 @@ tests:
               spec:
                 crush_locations:
                   node1:
-                    - datacenter=arbiter
+                    - datacenter=tiebreaker
                   node2:
                     - datacenter=DC1
                   node3:
@@ -180,8 +180,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode.yaml
@@ -53,7 +53,7 @@ tests:
               spec:
                 crush_locations:
                   node1:
-                    - datacenter=arbiter
+                    - datacenter=tiebreaker
                   node2:
                     - datacenter=DC1
                   node3:
@@ -171,8 +171,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -162,10 +162,10 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: False
       comments: -ve scenarios bug - 2293147
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
 
@@ -223,7 +223,7 @@ tests:
       config:
         pool_name: test_stretch_pool6
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving
       abort-on-fail: true
@@ -235,34 +235,34 @@ tests:
       config:
         pool_name: test_stretch_pool9
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
         add_network_delay: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster site down - Arbiter site
+      name: test stretch Cluster site down - tiebreaker site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974
       config:
         pool_name: test_stretch_pool5
-        shutdown_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        shutdown_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is shut down
+      desc: Test the cluster when the tiebreaker site is shut down
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -272,20 +272,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -294,21 +294,21 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
   - test:
-      name: Mon replacement on Arbiter site
+      name: Mon replacement on tiebreaker site
       module: test_stretch_mon_replacements.py
       polarion-id: CEPH-83574971
       config:
         pool_name: test_stretch_pool6
-        replacement_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        replacement_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster mon replacement - Arbiter site
+      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -319,7 +319,7 @@ tests:
       config:
         pool_name: test_stretch_pool8
         netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
       comments: Active bug - 2249962
@@ -331,20 +331,20 @@ tests:
       config:
         pool_name: test_stretch_pool7
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: test stretch Cluster maintenance mode - data site
@@ -353,7 +353,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
 
@@ -363,5 +363,5 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode

--- a/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -143,9 +143,9 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: false
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:
@@ -407,7 +407,7 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool6
 #        shutdown_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #      desc: Test the cluster when we have only 1 of 2 DC's surviving
 #      abort-on-fail: true
@@ -419,34 +419,34 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool9
 #        shutdown_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #        add_network_delay: true
 #      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
 #      abort-on-fail: true
 #
 #  - test:
-#      name: test stretch Cluster site down - Arbiter site
+#      name: test stretch Cluster site down - tiebreaker site
 #      module: test_stretch_site_down.py
 #      polarion-id: CEPH-83574974
 #      config:
 #        pool_name: test_stretch_pool5
-#        shutdown_site: arbiter
-#        tiebreaker_mon_site_name: arbiter
+#        shutdown_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
-#      desc: Test the cluster when the arbiter site is shut down
+#      desc: Test the cluster when the tiebreaker site is shut down
 #      abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -456,20 +456,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -478,22 +478,22 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
 # No free host without any mon daemon on the cluster.
-# Arbiter site Mon replacement test commented as of now
+# tiebreaker site Mon replacement test commented as of now
 #  - test:
-#      name: Mon replacement on Arbiter site
+#      name: Mon replacement on tiebreaker site
 #      module: test_stretch_mon_replacements.py
 #      polarion-id: CEPH-83574971
 #      config:
 #        pool_name: test_stretch_pool6
-#        replacement_site: arbiter
-#        tiebreaker_mon_site_name: arbiter
+#        replacement_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
-#      desc: Test stretch Cluster mon replacement - Arbiter site
+#      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -504,7 +504,7 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool8
 #        netsplit_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #      desc: Test stretch Cluster netsplit scenario between data sites
 #
@@ -517,21 +517,21 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool7
 #        stretch_bucket: datacenter
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #        add_network_delay: true
 #      desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: Negative scenarios - post-deployment
@@ -539,7 +539,7 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode
 
   - test:
@@ -549,7 +549,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
       abort-on-fail: true

--- a/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -201,7 +201,7 @@ tests:
         add_buckets:
           DC1: datacenter
           DC2: datacenter
-          Arbiter: datacenter
+          tiebreaker: datacenter
           test-host-1: host
           test-host-2: host
         bin_tests:

--- a/suites/squid/rados/deploy-stretch-cluster-mode.yaml
+++ b/suites/squid/rados/deploy-stretch-cluster-mode.yaml
@@ -22,8 +22,8 @@
 #              name: "DC2"                           # Name of the datacenter-2 to be added in crush map
 #              hosts: ["<host3-shortname>", ... ]    # List of hostnames present in datacenter-2
 #       - site3:
-#              name: "DC3"                           # Name of the Arbiter location to be added in crush map
-#              hosts: ["<host5-shortname>"]          # List of hostname present in Arbiter
+#              name: "DC3"                           # Name of the tiebreaker location to be added in crush map
+#              hosts: ["<host5-shortname>"]          # List of hostname present in tiebreaker
 # Added to BM pipeline
 
 tests:
@@ -192,5 +192,5 @@ tests:
         site3:
           name: "DC3"
           hosts: ["mero017", "mero018", "mero014", "mero019", "mero020"]
-      desc: Enables connectivity mode, deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode, deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -61,7 +61,7 @@ tests:
               spec:
                 crush_locations:
                   node1:
-                    - datacenter=arbiter
+                    - datacenter=tiebreaker
                   node2:
                     - datacenter=DC1
                   node3:
@@ -177,8 +177,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode.yaml
@@ -53,7 +53,7 @@ tests:
               spec:
                 crush_locations:
                   node1:
-                    - datacenter=arbiter
+                    - datacenter=tiebreaker
                   node2:
                     - datacenter=DC1
                   node3:
@@ -169,8 +169,8 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:

--- a/suites/squid/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/squid/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -158,4 +158,4 @@ tests:
         netsplit_site_1: DC1
         netsplit_site_2: DC3
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -160,10 +160,10 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: False
       comments: -ve scenarios bug - 2293147
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
 
@@ -221,7 +221,7 @@ tests:
       config:
         pool_name: test_stretch_pool6
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving
       abort-on-fail: true
@@ -233,34 +233,34 @@ tests:
       config:
         pool_name: test_stretch_pool9
         shutdown_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
         add_network_delay: true
       desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster site down - Arbiter site
+      name: test stretch Cluster site down - tiebreaker site
       module: test_stretch_site_down.py
       polarion-id: CEPH-83574974
       config:
         pool_name: test_stretch_pool5
-        shutdown_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        shutdown_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is shut down
+      desc: Test the cluster when the tiebreaker site is shut down
       abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -270,20 +270,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -292,21 +292,21 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         add_mon_without_location: true
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
   - test:
-      name: Mon replacement on Arbiter site
+      name: Mon replacement on tiebreaker site
       module: test_stretch_mon_replacements.py
       polarion-id: CEPH-83574971
       config:
         pool_name: test_stretch_pool6
-        replacement_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        replacement_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster mon replacement - Arbiter site
+      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -317,7 +317,7 @@ tests:
       config:
         pool_name: test_stretch_pool8
         netsplit_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
       comments: Active bug - 2249962
@@ -329,20 +329,20 @@ tests:
       config:
         pool_name: test_stretch_pool7
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: test stretch Cluster maintenance mode - data site
@@ -351,7 +351,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
 
@@ -361,5 +361,5 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode

--- a/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -143,9 +143,9 @@ tests:
       config:
         no_affinity: false
         stretch_rule_name: stretch_rule
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         negative_scenarios: false
-      desc: Enables connectivity mode and deploys cluster with Stretch rule with arbiter node
+      desc: Enables connectivity mode and deploys cluster with Stretch rule with tiebreaker node
       abort-on-fail: true
 
   - test:
@@ -407,7 +407,7 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool6
 #        shutdown_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #      desc: Test the cluster when we have only 1 of 2 DC's surviving
 #      abort-on-fail: true
@@ -419,34 +419,34 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool9
 #        shutdown_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #        add_network_delay: true
 #      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
 #      abort-on-fail: true
 #
 #  - test:
-#      name: test stretch Cluster site down - Arbiter site
+#      name: test stretch Cluster site down - tiebreaker site
 #      module: test_stretch_site_down.py
 #      polarion-id: CEPH-83574974
 #      config:
 #        pool_name: test_stretch_pool5
-#        shutdown_site: arbiter
-#        tiebreaker_mon_site_name: arbiter
+#        shutdown_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
-#      desc: Test the cluster when the arbiter site is shut down
+#      desc: Test the cluster when the tiebreaker site is shut down
 #      abort-on-fail: true
 
   - test:
-      name: test stretch Cluster maintenance mode - arbiter site
+      name: test stretch Cluster maintenance mode - tiebreaker site
       module: test_stretch_site_maintenance_modes.py
       polarion-id: CEPH-83574976
       config:
         pool_name: test_stretch_pool2
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is moved to maintenance mode
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
       abort-on-fail: true
 
   - test:
@@ -456,20 +456,20 @@ tests:
       config:
         pool_name: test_stretch_pool3
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the data site is rebooted
 
   - test:
-      name: test stretch Cluster site reboot - Arbiter site
+      name: test stretch Cluster site reboot - tiebreaker site
       module: test_stretch_site_reboot.py
       polarion-id: CEPH-83574977
       config:
         pool_name: test_stretch_pool4
-        affected_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test the cluster when the arbiter site is rebooted
+      desc: Test the cluster when the tiebreaker site is rebooted
 
   - test:
       name: Mon replacement on Data site
@@ -478,22 +478,22 @@ tests:
       config:
         pool_name: test_stretch_pool5
         replacement_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Data site
 
 # No free host without any mon daemon on the cluster.
-# Arbiter site Mon replacement test commented as of now
+# tiebreaker site Mon replacement test commented as of now
 #  - test:
-#      name: Mon replacement on Arbiter site
+#      name: Mon replacement on tiebreaker site
 #      module: test_stretch_mon_replacements.py
 #      polarion-id: CEPH-83574971
 #      config:
 #        pool_name: test_stretch_pool6
-#        replacement_site: arbiter
-#        tiebreaker_mon_site_name: arbiter
+#        replacement_site: tiebreaker
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
-#      desc: Test stretch Cluster mon replacement - Arbiter site
+#      desc: Test stretch Cluster mon replacement - tiebreaker site
 
 # Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
 # New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
@@ -504,7 +504,7 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool8
 #        netsplit_site: DC1
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #      desc: Test stretch Cluster netsplit scenario between data sites
 #
@@ -517,21 +517,21 @@ tests:
 #      config:
 #        pool_name: test_stretch_pool7
 #        stretch_bucket: datacenter
-#        tiebreaker_mon_site_name: arbiter
+#        tiebreaker_mon_site_name: tiebreaker
 #        delete_pool: true
 #        add_network_delay: true
 #      desc: Test stretch Cluster osd and Host replacement
 
   - test:
-      name: Netsplit Scenarios data-arbiter sites
+      name: Netsplit Scenarios data-tiebreaker sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
       config:
         pool_name: test_stretch_pool7
-        netsplit_site: arbiter
-        tiebreaker_mon_site_name: arbiter
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
-      desc: Test stretch Cluster netsplit scenario between data site and arbiter site
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
 
   - test:
       name: Negative scenarios - post-deployment
@@ -539,7 +539,7 @@ tests:
       polarion-id: CEPH-83584499
       config:
         stretch_bucket: datacenter
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
       desc: Perform post-deployment negative tests on stretch mode
 
   - test:
@@ -549,7 +549,7 @@ tests:
       config:
         pool_name: test_stretch_pool1
         affected_site: DC1
-        tiebreaker_mon_site_name: arbiter
+        tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
       desc: Test the cluster when the Data site is moved to maintenance mode
       abort-on-fail: true

--- a/suites/squid/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/squid/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -201,7 +201,7 @@ tests:
         add_buckets:
           DC1: datacenter
           DC2: datacenter
-          Arbiter: datacenter
+          tiebreaker: datacenter
           test-host-1: host
           test-host-2: host
         bin_tests:

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -27,7 +27,7 @@ log = Log(__name__)
 
 def run(ceph_cluster, **kw):
     """
-    enables connectivity mode and deploys stretch cluster with arbiter mon node
+    enables connectivity mode and deploys stretch cluster with tiebreaker mon node
     Actions Performed:
     1. Disables the automatic crush map update
     2. Collects the OSD daemons in the cluster and split them into 2 sites.
@@ -44,7 +44,7 @@ def run(ceph_cluster, **kw):
     Args:
         ceph_cluster (ceph.ceph.Ceph): ceph cluster
     """
-    log.info("Deploying stretch cluster with arbiter mon node")
+    log.info("Deploying stretch cluster with tiebreaker mon node")
     log.info(run.__doc__)
     config = kw.get("config")
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
@@ -301,7 +301,7 @@ def run(ceph_cluster, **kw):
         )
         return 1
     log.info(f"Acting set : {acting_set} Consists of 4 OSDs per PG")
-    log.info("Stretch rule with arbiter monitor node set up successfully")
+    log.info("Stretch rule with tiebreaker monitor node set up successfully")
     return 0
 
 
@@ -607,10 +607,10 @@ def get_mon_details(node: CephAdmin) -> dict:
 
 def set_mon_sites(node: CephAdmin, tiebreaker_node, site1: str, site2: str) -> bool:
     """
-    Adds the mon daemons into the two sites with arbiter node at site 3 as a tie breaker
+    Adds the mon daemons into the two sites with tiebreaker node at site 3 as a tie breaker
     Args:
         node: Cephadm node where the commands need to be executed
-        tiebreaker_node: name of the monitor to be added as tie breaker( site 3 )
+        tiebreaker_node: name of the monitor to be added as tiebreaker( site 3 )
         site1: Name the 1st site
         site2: Name of the 2nd site
     Returns: True -> pass, False -> fail
@@ -620,7 +620,7 @@ def set_mon_sites(node: CephAdmin, tiebreaker_node, site1: str, site2: str) -> b
     monitors = list(mon_state["monitors"])
     monitors.remove(tiebreaker_node.hostname)
     commands = [
-        f"/bin/ceph mon set_location {tiebreaker_node.hostname} datacenter=arbiter",
+        f"/bin/ceph mon set_location {tiebreaker_node.hostname} datacenter=tiebreaker",
         f"/bin/ceph mon set_location {monitors[0]} datacenter={site1}",
         f"/bin/ceph mon set_location {monitors[1]} datacenter={site1}",
         f"/bin/ceph mon set_location {monitors[2]} datacenter={site2}",

--- a/tests/rados/test_deploy_stretch_cluster_baremetal.py
+++ b/tests/rados/test_deploy_stretch_cluster_baremetal.py
@@ -20,8 +20,8 @@ Example::
               name: "DC2"                           # Name of the datacenter-2 to be added in crush map
               hosts: ["<host3-shortname>", ... ]    # List of hostnames present in datacenter-2
             site3:
-              name: "DC3"                           # Name of the Arbiter location to be added in crush map
-              hosts: ["<host5-shortname>"]          # List of hostname present in Arbiter
+              name: "DC3"                           # Name of the tiebreaker location to be added in crush map
+              hosts: ["<host5-shortname>"]          # List of hostname present in tiebreaker
 """
 
 import re
@@ -38,12 +38,12 @@ log = Log(__name__)
 
 def run(ceph_cluster, **kw):
     """
-    enables connectivity mode and deploys stretch cluster with arbiter mon node
+    enables connectivity mode and deploys stretch cluster with tiebreaker mon node
     Args:
         ceph_cluster (ceph.ceph.Ceph): ceph cluster
     """
 
-    log.info("Deploying stretch cluster with arbiter mon node")
+    log.info("Deploying stretch cluster with tiebreaker mon node")
     log.info(run.__doc__)
     config = kw.get("config")
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
@@ -175,7 +175,7 @@ def run(ceph_cluster, **kw):
         )
         return 1
     log.info(f"Acting set : {acting_set} Consists of 4 OSD's per PG")
-    log.info("Stretch rule with arbiter monitor node set up successfully")
+    log.info("Stretch rule with tiebreaker monitor node set up successfully")
     return 0
 
 

--- a/tests/rados/test_stretch_negative_scenarios.py
+++ b/tests/rados/test_stretch_negative_scenarios.py
@@ -43,7 +43,7 @@ def run(ceph_cluster, **kw):
     pool_name = config.get("pool_name", "test_stretch_io")
     mon_obj = MonitorWorkflows(node=cephadm)
     stretch_bucket = config.get("stretch_bucket", "datacenter")
-    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "arbiter")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
 
     try:
         if not stretch_enabled_checks(rados_obj=rados_obj):

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -49,7 +49,7 @@ def run(ceph_cluster, **kw):
     rhbuild = config.get("rhbuild")
     pool_name = config.get("pool_name", "test_stretch_io")
     stretch_bucket = config.get("stretch_bucket", "datacenter")
-    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "arbiter")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
     add_network_delay = config.get("add_network_delay", False)
 
     def check_stretch_health_warning():

--- a/tests/rados/test_stretch_site_down.py
+++ b/tests/rados/test_stretch_site_down.py
@@ -1,9 +1,9 @@
 """
 This test module is used to test site down scenarios with recovery in the stretch environment
 includes:
-CEPH-83574976 - Data Site and Arbiter site Nodes enter maintenance mode.
+CEPH-83574976 - Data Site and tiebreaker site Nodes enter maintenance mode.
 1. Data Sites are shut down
-2. Arbiter Site hosts are shut down
+2. tiebreaker Site hosts are shut down
 
 """
 
@@ -38,7 +38,7 @@ def run(ceph_cluster, **kw):
     pool_name = config.get("pool_name", "test_stretch_io")
     osp_cred = config.get("osp_cred")
     shutdown_site = config.get("shutdown_site", "DC1")
-    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "arbiter")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
     add_network_delay = config.get("add_network_delay", False)
 
     try:
@@ -106,7 +106,7 @@ def run(ceph_cluster, **kw):
         pool_stat = rados_obj.get_cephdf_stats(pool_name=pool_name)
         init_objects = pool_stat["stats"]["objects"]
 
-        # Checking which DC to be turned off, It would be either data site or Arbiter site
+        # Checking which DC to be turned off, It would be either data site or tiebreaker site
         # Proceeding to Shut down either one of the Data DCs if crush name sent is either DC1 or DC2.
         if shutdown_site in [dc_1_name, dc_2_name]:
             log.debug(f"Proceeding to shutdown one of the data site {dc_1_name}")
@@ -161,7 +161,7 @@ def run(ceph_cluster, **kw):
             )
 
         else:
-            log.info("Shutting down arbiter mon site")
+            log.info("Shutting down tiebreaker mon site")
             for host in tiebreaker_hosts:
                 log.debug(f"Proceeding to shutdown host {host}")
                 if not host_shutdown(gyaml=osp_cred, name=host):
@@ -226,7 +226,7 @@ def run(ceph_cluster, **kw):
             )
 
         else:
-            log.info("Restarting arbiter mon site")
+            log.info("Restarting tiebreaker mon site")
             for host in tiebreaker_hosts:
                 log.debug(f"Proceeding to Restart host {host}")
                 if not host_restart(gyaml=osp_cred, name=host):

--- a/tests/rados/test_stretch_site_maintenance_modes.py
+++ b/tests/rados/test_stretch_site_maintenance_modes.py
@@ -1,9 +1,9 @@
 """
 This test module is used to test site maintenance mode scenarios with recovery in the stretch environment.
 includes:
-CEPH-83574976 - Data Site and Arbiter site Nodes enter maintenance mode.
+CEPH-83574976 - Data Site and tiebreaker site Nodes enter maintenance mode.
 1. Data Sites enter maintenance mode
-2. Arbiter Site hosts enter maintenance mode
+2. tiebreaker Site hosts enter maintenance mode
 """
 
 import time
@@ -36,7 +36,7 @@ def run(ceph_cluster, **kw):
     client_node = ceph_cluster.get_nodes(role="client")[0]
     pool_name = config.get("pool_name", "test_stretch_io")
     affected_site = config.get("affected_site", "DC1")
-    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "arbiter")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
 
     try:
         if not stretch_enabled_checks(rados_obj=rados_obj):
@@ -93,7 +93,7 @@ def run(ceph_cluster, **kw):
         init_objects = pool_stat["stats"]["objects"]
         log.debug(f"pool stats before site down : {pool_stat}")
 
-        # Checking which DC to be added to maintenance mode is It data site or Arbiter site
+        # Checking which DC to be added to maintenance mode is It data site or tiebreaker site
         if affected_site in [dc_1_name, dc_2_name]:
             log.debug(
                 f"Proceeding to add hosts of the data site {dc_2_name} into maintenance mode"
@@ -175,7 +175,7 @@ def run(ceph_cluster, **kw):
             )
 
         else:
-            log.info("Moving host of arbiter mon site into maintenance mode")
+            log.info("Moving host of tiebreaker mon site into maintenance mode")
             for host in tiebreaker_hosts:
                 mgr_dump = "ceph mgr dump"
                 active_mgr = rados_obj.run_ceph_command(cmd=mgr_dump, client_exec=True)
@@ -259,7 +259,7 @@ def run(ceph_cluster, **kw):
             )
 
         else:
-            log.info("removing arbiter mon site host from maintenance mode")
+            log.info("removing tiebreaker mon site host from maintenance mode")
             for host in tiebreaker_hosts:
                 if not rados_obj.host_maintenance_exit(hostname=host, retry=15):
                     log.error(f"Failed to remove host : {host} from maintenance mode")

--- a/tests/rados/test_stretch_site_reboot.py
+++ b/tests/rados/test_stretch_site_reboot.py
@@ -3,7 +3,7 @@ This test module is used to test site reboot scenarios with recovery in the stre
 includes:
 CEPH-83574977 - Reboot all the nodes of Site.
 1. Perform Data Site reboots
-2. Perform Arbiter Site hosts reboots
+2. Perform tiebreaker Site hosts reboots
 """
 
 import re
@@ -37,7 +37,7 @@ def run(ceph_cluster, **kw):
     client_node = ceph_cluster.get_nodes(role="client")[0]
     pool_name = config.get("pool_name", "test_stretch_io")
     affected_site = config.get("affected_site", "DC1")
-    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "arbiter")
+    tiebreaker_mon_site_name = config.get("tiebreaker_mon_site_name", "tiebreaker")
 
     try:
         if not stretch_enabled_checks(rados_obj=rados_obj):
@@ -135,7 +135,7 @@ def run(ceph_cluster, **kw):
             log.info("Proceeding to try writes into cluster post reboots")
 
         else:
-            log.info("Rebooting host of arbiter mon site")
+            log.info("Rebooting host of tiebreaker mon site")
             for host in tiebreaker_hosts:
                 log.debug(f"Proceeding to reboot host : {host}")
                 host_obj = get_host_obj_from_hostname(


### PR DESCRIPTION
1. Added host reboot after flushing the IP tables in netsplit tests.
2. Replaced "arbiter" with "tiebreaker" in all the Stretch mode tests and suites


