### PR TITLE
TFA RHCEPHQE-15959

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_archive_with_haproxy.yaml
@@ -537,6 +537,7 @@ tests:
       module: sanity_rgw_multisite.py
       name: test M buckets multipart uploads on haproxy node
       polarion-id: CEPH-83575433
+      comments: bug in 8.0, 2325018, not fixed
   - test:
       clusters:
         ceph-arc:

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -311,7 +311,7 @@ def run(**kw):
             )
             try:
                 for bucket in bucket_list_archive:
-                    if bucket.find("deleted"):
+                    if "deleted" in bucket:
                         log.info(f"Perform bucket stats on {bucket} at archive site")
                         output, _ = archive_client_node.exec_command(
                             cmd=f"sudo radosgw-admin bucket stats --bucket {bucket}"


### PR DESCRIPTION
# Description

This TFA addresses the issues seen 
- test LC transition on multisite, and bucket stats at archive and 
- test M buckets multipart uploads on haproxy node

logs 1. (http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-36CEDK/)
logs 2. http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.2.0-19/rgw/9/tier-2_rgw_ms_archive_with_haproxy/