### PR TITLE
adding kernel log when it ends

### DIFF
--- a/tests/cephfs/xfs_test.py
+++ b/tests/cephfs/xfs_test.py
@@ -2,6 +2,7 @@ import random
 import string
 import traceback
 
+from ceph.ceph import SocketTimeoutException
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
 
@@ -124,13 +125,20 @@ def run(ceph_cluster, **kw):
             cmd="cd /root/xfstests-dev && ./check -d -T -g quick -e ceph.exclude",
             check_ec=False,
             long_running=True,
-            timeout=1800,
+            timeout=7200,
         )
         log.info("XFS tests completed successfully")
         return 0
     except Exception as e:
+        dmesg, _ = clients[0].exec_command(sudo=True, cmd="dmesg")
+        log.error(dmesg)
         log.error(e)
         log.error(traceback.format_exc())
+        return 1
+    except SocketTimeoutException as ste:
+        dmesg, _ = clients[0].exec_command(sudo=True, cmd="dmesg")
+        log.error(dmesg)
+        log.error(ste)
         return 1
     finally:
         uninstall_commands = [


### PR DESCRIPTION
# Description

https://ocs3xstage-jenkins-csb-rhgsocs3x.apps.ocp-c1.prod.psi.redhat.com/view/Executor/job/qe-pacific-test-executor-openstack/137/consoleText

it goes to the right exception and show dmesg log correctly when socket time out.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
