### PR TITLE
RHCEPHQE-16694:[RADOS] TFA fix for crash module, max avail check, PG ID listing

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -2216,13 +2216,13 @@ class RadosOrchestrator:
         cmd = "ceph pg "
         if pool_name:
             cmd += f"ls-by-pool {pool_name}"
-        elif osd:
+        elif osd is not None:
             cmd += f"ls-by-osd {osd}"
             cmd = f"{cmd} {pool_id}" if pool_id else cmd
-        elif osd_primary:
+        elif osd_primary is not None:
             cmd += f"ls-by-primary {osd_primary}"
             cmd = f"{cmd} {pool_id}" if pool_id else cmd
-        elif pool_id:
+        elif pool_id is not None:
             cmd += f"ls {pool_id}"
         else:
             log.info("No argument was provided.")
@@ -4566,9 +4566,10 @@ EOF"""
         if crash_list:
             log.error("!!!ERROR: Crash exists in the cluster \n\n:" f"{crash_list}")
             log.info("Logging crash info for each crash")
-            for crash_id in crash_list:
-                crash_info, _ = self.run_ceph_command(
-                    f"ceph crash info {crash_id}", client_exec=True
+            for entry in crash_list:
+                log.info(f"crash ID: {entry['crash_id']}")
+                crash_info = self.run_ceph_command(
+                    f"ceph crash info {entry['crash_id']}", client_exec=True
                 )
                 log.info(crash_info)
 

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -45,6 +45,7 @@ def set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged):
             break
 
     if not service_name:
+        log.error(f"No orch service found for osd: {osd_id}")
         return
     log.info(f"Setting OSD service {service_name} to unmanaged={unmanaged}")
 
@@ -56,7 +57,7 @@ def set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged):
     # return if no services found
     if "No services reported" in out or "No services reported" in err:
         log.debug(out)
-        log.debug(err)
+        log.error(err)
         return
     svc = loads(out)[0]
 

--- a/suites/pacific/rados/tier-2_rados_test_omap.yaml
+++ b/suites/pacific/rados/tier-2_rados_test_omap.yaml
@@ -105,13 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/suites/pacific/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/pacific/rados/tier-2_rados_trim_tests.yaml
@@ -105,13 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
       name: Automatic trimming of osdmaps
       desc: check for periodic trimming of osdmaps
       module: test_osdmap_trim.py

--- a/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/pacific/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -307,13 +307,11 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
-# New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
   - test:
       name: Netsplit Scenarios data-data sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
-      comments: Active bug - 2249962
+      comments: Active bug - 2318975
       config:
         pool_name: test_stretch_pool8
         netsplit_site: DC1

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -134,17 +134,18 @@ tests:
         bluestore_cache: true
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
-  - test:
-      name: Bluefs DB utilization
-      desc: DB utilization is under check - bluefs files are not inflated
-      module: test_bluefs_space.py
-      polarion-id: CEPH-83600867
-      config:
-        omap_config:
-          pool_name: re_pool_bluefs_db
-          pg_num: 1
-          pg_num_max: 1
-          obj_start: 0
-          obj_end: 15
-          normal_objs: 400
-          num_keys_obj: 200001
+# commented until CBT bluefs-stats o/p is not verbose
+#  - test:
+#      name: Bluefs DB utilization
+#      desc: DB utilization is under check - bluefs files are not inflated
+#      module: test_bluefs_space.py
+#      polarion-id: CEPH-83600867
+#      config:
+#        omap_config:
+#          pool_name: re_pool_bluefs_db
+#          pg_num: 1
+#          pg_num_max: 1
+#          obj_start: 0
+#          obj_end: 15
+#          normal_objs: 400
+#          num_keys_obj: 200001

--- a/suites/quincy/rados/tier-2_rados_test_omap.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_omap.yaml
@@ -105,13 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/suites/quincy/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/quincy/rados/tier-2_rados_trim_tests.yaml
@@ -105,13 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
       name: Automatic trimming of osdmaps
       desc: check for periodic trimming of osdmaps
       module: test_osdmap_trim.py

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -307,13 +307,11 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
-# New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
   - test:
       name: Netsplit Scenarios data-data sites
       module: test_stretch_netsplit_scenarios.py
       polarion-id: CEPH-83574979
-      comments: Active bug - 2249962
+      comments: Active bug - 2318975
       config:
         pool_name: test_stretch_pool8
         netsplit_site: DC1

--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -105,14 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-
-  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/suites/reef/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/reef/rados/tier-2_rados_trim_tests.yaml
@@ -105,13 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
       name: Automatic trimming of osdmaps
       desc: check for periodic trimming of osdmaps
       module: test_osdmap_trim.py

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -310,8 +310,6 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
-# New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
   - test:
       name: Netsplit Scenarios data-data sites
       module: test_stretch_netsplit_scenarios.py
@@ -322,7 +320,7 @@ tests:
         tiebreaker_mon_site_name: arbiter
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
-      comments: Active bug - 2249962
+      comments: Active bug - 2318975
 
   - test:
       name: OSD and host replacement

--- a/suites/squid/rados/tier-2_rados_test_omap.yaml
+++ b/suites/squid/rados/tier-2_rados_test_omap.yaml
@@ -105,14 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-
-  - test:
       name: OMAP feature
       desc: Testing omap features
       module: test_scrub_omap.py

--- a/suites/squid/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/squid/rados/tier-2_rados_trim_tests.yaml
@@ -105,13 +105,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Enable logging to file
-      module: rados_prep.py
-      config:
-        log_to_file: true
-      desc: Change config options to enable logging to file
-
-  - test:
       name: Automatic trimming of osdmaps
       desc: check for periodic trimming of osdmaps
       module: test_osdmap_trim.py

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -308,8 +308,6 @@ tests:
         delete_pool: true
       desc: Test stretch Cluster mon replacement - Arbiter site
 
-# Commenting test until fix for bug : https://bugzilla.redhat.com/show_bug.cgi?id=2249962
-# New Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2265116
   - test:
       name: Netsplit Scenarios data-data sites
       module: test_stretch_netsplit_scenarios.py
@@ -320,7 +318,7 @@ tests:
         tiebreaker_mon_site_name: arbiter
         delete_pool: true
       desc: Test stretch Cluster netsplit scenario between data sites
-      comments: Active bug - 2249962
+      comments: Active bug - 2318975
 
   - test:
       name: OSD and host replacement

--- a/suites/squid/rados/tier-4_rados_tests.yaml
+++ b/suites/squid/rados/tier-4_rados_tests.yaml
@@ -185,13 +185,14 @@ tests:
           obj_nums: 5
           delete_pool: true
 
-  - test:
-      name: Verify MAX_AVAIL variance with OSD size change
-      desc: MAX_AVAIL value update correctly when OSD size changes
-      module: test_cephdf.py
-      polarion-id: CEPH-83595780
-      config:
-        cephdf_max_avail_osd_expand: true
+# commented due to active bug: https://bugzilla.redhat.com/show_bug.cgi?id=2316351
+#  - test:
+#      name: Verify MAX_AVAIL variance with OSD size change
+#      desc: MAX_AVAIL value update correctly when OSD size changes
+#      module: test_cephdf.py
+#      polarion-id: CEPH-83595780
+#      config:
+#        cephdf_max_avail_osd_expand: true
 
   - test:
       name: Compression algorithms - modes

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -463,28 +463,27 @@ def run(ceph_cluster, **kw):
             log.info(out)
             assert "success" in out
 
-            if rhbuild.split(".")[0] != "8":
-                # Execute ceph-bluestore-tool qfsck --path <osd_path>
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n --------------------"
-                    f"\n Running quick consistency check for OSD {osd_id}"
-                    f"\n --------------------"
-                )
-                out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
-                log.info(out)
-                assert "success" in out
+            # Execute ceph-bluestore-tool qfsck --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Running quick consistency check for OSD {osd_id}"
+                f"\n --------------------"
+            )
+            out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+            log.info(out)
+            assert "success" in out
 
-                # Execute ceph-bluestore-tool allocmap --path <osd_path>
-                osd_id = random.choice(osd_list)
-                log.info(
-                    f"\n --------------------"
-                    f"\n Fetching allocmap for OSD {osd_id}"
-                    f"\n ---------------------"
-                )
-                out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
-                log.info(out)
-                assert "success" in out
+            # Execute ceph-bluestore-tool allocmap --path <osd_path>
+            osd_id = random.choice(osd_list)
+            log.info(
+                f"\n --------------------"
+                f"\n Fetching allocmap for OSD {osd_id}"
+                f"\n ---------------------"
+            )
+            out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+            log.info(out)
+            assert "success" in out
 
             # Execute ceph-bluestore-tool repair --path <osd_path>
             osd_id = random.choice(osd_list)

--- a/tests/rados/test_osd_onode_trimming.py
+++ b/tests/rados/test_osd_onode_trimming.py
@@ -202,8 +202,7 @@ def verify_osd_log(
     log.debug(f"Journalctl logs : {log_lines}")
     for line in lines:
         if line in log_lines:
-            log.error(f" The {line} found on the OSD : {osd}")
-            log.error(f"Journalctl logs lines: {log_lines}")
+            log.error(f"The line {line} found in OSD.{osd} logs")
             return False
-    log.info(f"Not found the log lines on OSD : {osd}")
+    log.info(f"{lines} not found in OSD.{osd} logs | Expected")
     return True


### PR DESCRIPTION
This PR addresses the following TFA fixes:

- PG ID listing method would fail when the OSD is was 0 and it was considered as False.
This fixes intermittent failure in test `tests/rados/test_objectstoretool_workflows.py`

- `test_bluefs_space.py` has been commented out for Quincy as the output of ceph-bluestore-tool bluefs-stats does not provide verbose output needed for validation of the test.
To-do: Raise RFE asking for output bluefs-stats in Quincy to be aligned with later releases.

- Setting OSD service as unmanaged to prevent deployment of OSDs on newly added hosts before creation of required LVMs
This fixes continuous false failure in `tests/rados/test_cephdf.py` | Verify MAX_AVAIL variance with OSD size change

- Addition of finally block in `tests/rados/test_pool_osd_recovery.py` at individual test level

- Method to detect and log crashes in the cluster was not fetching the `crash_id` correctly resulting in `crash info` command failing

Log:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QRQCH5

Signed-off-by: Harsh Kumar <hakumar@redhat.com>