### PR TITLE
CEPH-83602685: Tier-2 test to verify deletion of object and pool snaps

### DIFF
--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -363,9 +363,9 @@ class PoolFunctions:
 
         """
         # Checking if snapshots can be created on the supplied pool
-        cmd = "ceph osd dump"
-        pool_status = self.rados_obj.run_ceph_command(cmd=cmd, timeout=800)
-        for detail in pool_status["pools"]:
+        cmd = "ceph osd pool ls detail"
+        pool_detail = self.rados_obj.run_ceph_command(cmd=cmd, timeout=800)
+        for detail in pool_detail:
             if detail["pool_name"] != pool_name:
                 continue
             if "selfmanaged_snaps" in detail["flags_names"]:
@@ -408,9 +408,9 @@ class PoolFunctions:
 
         Returns: list of the snaps created
         """
-        cmd = "ceph osd dump"
-        pool_status = self.rados_obj.run_ceph_command(cmd=cmd, timeout=800)
-        for detail in pool_status["pools"]:
+        cmd = "ceph osd pool ls detail"
+        pool_detail = self.rados_obj.run_ceph_command(cmd=cmd, timeout=800)
+        for detail in pool_detail:
             if detail["pool_name"] == pool_name:
                 snap_list = [snap["name"] for snap in detail["pool_snaps"]]
                 log.debug(f"snapshots on pool : {snap_list}")
@@ -426,7 +426,7 @@ class PoolFunctions:
 
         """
         if snap_name:
-            delete_list = list(snap_name)
+            delete_list = snap_name.split()
         else:
             delete_list = self.get_snap_names(pool_name=pool_name)
 

--- a/suites/pacific/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-brownfield.yaml
@@ -23,7 +23,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 5.3
-                release: z5
+                release: z5     # deploying old build to verify obj snap deletion
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
@@ -146,11 +146,27 @@ tests:
       abort-on-fail: false
 
   - test:
+      name: "issue repro: obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
       name: Upgrade ceph cluster
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
       abort-on-fail: true
+
+  - test:
+      name: "verify fix: obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
 
   # Running basic rbd and rgw tests after upgrade
   - test:

--- a/suites/quincy/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-brownfield.yaml
@@ -23,7 +23,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 5.3
-                release: rc
+                release: z6     # deploying old build to verify obj snap deletion
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
@@ -146,11 +146,27 @@ tests:
       abort-on-fail: false
 
   - test:
+      name: "issue repro: obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
       name: Upgrade ceph cluster
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
       abort-on-fail: true
+
+  - test:
+      name: "verify fix: obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
 
   # Running basic rbd and rgw tests after upgrade
   - test:

--- a/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_bluestore.yaml
@@ -135,6 +135,7 @@ tests:
       desc: Verify tuning of BlueStore cache size for HDDs and SSDs
 
 # commented until CBT bluefs-stats o/p is not verbose
+# RFE: https://bugzilla.redhat.com/show_bug.cgi?id=2326891
 #  - test:
 #      name: Bluefs DB utilization
 #      desc: DB utilization is under check - bluefs files are not inflated

--- a/suites/reef/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/reef/rados/tier-2_rados_test-brownfield.yaml
@@ -23,7 +23,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 6.1
-                release: rc
+                release: z6     # deploying old build to verify obj snap deletion
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
@@ -146,6 +146,14 @@ tests:
       abort-on-fail: false
 
   - test:
+      name: "issue repro-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+      polarion-id: CEPH-83602685
+      config:
+        issue_reproduction: true
+
+  - test:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
@@ -158,6 +166,14 @@ tests:
         verify_cluster_health: true
       destroy-cluster: false
       abort-on-fail: true
+
+  - test:
+      name: "verify fix-obj snap and pool snap deletion"
+      module: test_pool_snap.py
+      desc: obj snap deletion when pool snapshot is deleted on fixed build
+      polarion-id: CEPH-83602685
+      config:
+        verify_fix: true
 
   # Running basic rbd and rgw tests after upgrade
   - test:

--- a/suites/squid/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/squid/rados/tier-2_rados_test-brownfield.yaml
@@ -23,7 +23,7 @@ tests:
                 verbose: true
               args:
                 rhcs-version: 7.1
-                release: rc
+                release: z1     # deploying old build to verify obj snap deletion
                 mon-ip: node1
                 orphan-initial-daemons: true
                 registry-url: registry.redhat.io
@@ -145,6 +145,15 @@ tests:
       polarion-id: CEPH-83574439
       abort-on-fail: false
 
+# commented until fix merged in Squid: #2326892
+#  - test:
+#      name: "issue repro-obj snap and pool snap deletion"
+#      module: test_pool_snap.py
+#      desc: obj snap deletion when pool snapshot is deleted on unfixed build
+#      polarion-id: CEPH-83602685
+#      config:
+#        issue_reproduction: true
+
   - test:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
@@ -158,6 +167,15 @@ tests:
         verify_cluster_health: true
       destroy-cluster: false
       abort-on-fail: true
+
+# commented until fix merged in Squid: #2326892
+#  - test:
+#      name: "verify fix-obj snap and pool snap deletion"
+#      module: test_pool_snap.py
+#      desc: obj snap deletion when pool snapshot is deleted on fixed build
+#      polarion-id: CEPH-83602685
+#      config:
+#        verify_fix: true
 
   # Running basic rbd and rgw tests after upgrade
   - test:

--- a/tests/rados/test_pool_snap.py
+++ b/tests/rados/test_pool_snap.py
@@ -1,0 +1,258 @@
+"""
+Method to create object snaps using pool snapshot and ensure object snaps are deleted
+when pool snapshot is removed.
+"""
+
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.pool_workflows import PoolFunctions
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83602685
+    Covers:
+        - Pacific: BZ-2272361
+        - Quincy: BZ-2272362
+        - Reef: BZ-2263169
+    Test to verify object snap deletion when parent pool snapshot is deleted.
+    1. Create a replicated pool with default config
+    2. Use rados put to write a single object to the pool
+    3. Create a pool snapshot
+    4. Write another object on the pool using rados put
+    5. Create another pool snapshot
+    6. Log rados df, rados lssnap, and rados listsnaps outputs
+    7. Remove pool snapshot 1 using ceph osd rmsnap cmd
+    8. Validate that object snap for obj1 could not be deleted
+    9. Upgrade the cluster to fixed version.
+    10. Run the force-snap-removal cmd and log rados df, rados lssnap, and rados listsnaps outputs
+    11. Remove all RADOS pools from the cluster
+    12. Re-run steps 1-7 on the fixed version
+    13. Validate that object snap for obj1 was removed alongside pool snapshot
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    pool_obj = PoolFunctions(node=cephadm)
+    client = ceph_cluster.get_nodes(role="client")[0]
+    _pool_name = "test-obj-snap"
+    snap_1 = ""
+    log.info("Running test case to verify deletion of object snap with pool snap")
+
+    def verify_radosdf_out(num_obj, num_obj_clone, num_obj_cop, timeout):
+        """
+        Module to implement smart wait and verify the o/p of rados df
+        Args:
+            num_obj: total number of objects in the pool
+            num_obj_clone: number of object clones
+            num_obj_cop: number of object copies
+            timeout: timeout for smart wait
+        Return:
+            True -> all expected values match rados df o/p
+            False -> all expected values do not match rados df o/p
+        """
+        timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+        while datetime.datetime.now() < timeout_time:
+            try:
+                df_out, _ = rados_obj.client.exec_command(cmd="rados df", sudo=True)
+                log.info(f"rados df o/p after object clone creation: \n{df_out}")
+                rados_df = rados_obj.get_rados_df(pool_name=_pool_name)
+                assert (
+                    int(rados_df["num_objects"]) == num_obj
+                ), f"obj count for {_pool_name} is not {num_obj}"
+                assert (
+                    int(rados_df["num_object_clones"]) == num_obj_clone
+                ), f"obj clones for {_pool_name} is not {num_obj_clone}"
+                assert (
+                    int(rados_df["num_object_copies"])
+                ) == num_obj_cop, f"obj copies for {_pool_name} is not {num_obj_clone}"
+                break
+            except AssertionError as AE:
+                log.exception(AE)
+                log.error(
+                    "rados df o/p is not as expected, sleeping for 30 secs and trying again"
+                )
+                time.sleep(30)
+        else:
+            log.error("rados df o/p is incorrect even after 100 secs")
+            return False
+        return True
+
+    def common_workflow():
+        """
+        Module to execute common test workflow:
+        1. Create a replicated pool
+        2. Write single object to the pool
+        3. Create a pool snapshot
+        4. Write another object to the pool
+        5. Log o/p of rados df
+        6. Create another pool snapshot
+        7. Create obj clones
+        8. Check if rados df o/p reports the correct number of clones
+        9. List snapshots at pool, and object level
+        10 Delete first pool snapshot
+        """
+
+        log.info(common_workflow.__doc__)
+        # create pool with given config
+        log.info("Creating a replicated pool with default config")
+        assert rados_obj.create_pool(pool_name=_pool_name), "pool creation failed"
+
+        # write single object to the pool
+        pool_obj.do_rados_put(client=client, pool=_pool_name, obj_name="obj1")
+
+        # log rados df o/p
+        time.sleep(10)
+        df_out, _ = rados_obj.client.exec_command(cmd="rados df", sudo=True)
+        log.info(f"rados df o/p after object addition to the pool: \n {df_out}")
+
+        # create a pool snapshot
+        log.info(f"Creating pool snapshot of pool {_pool_name}")
+        snap_1 = pool_obj.create_pool_snap(pool_name=_pool_name)
+        log.info(f"First Pool snapshot created successfully: {snap_1}")
+
+        # write another single object to the pool
+        pool_obj.do_rados_put(client=client, pool=_pool_name, obj_name="obj2")
+
+        # log rados df o/p
+        time.sleep(10)
+        df_out, _ = rados_obj.client.exec_command(cmd="rados df", sudo=True)
+        log.info(
+            f"rados df o/p after another object was added to the pool: \n {df_out}"
+        )
+
+        # create another pool snapshot
+        log.info(f"Creating pool snapshot of pool {_pool_name}")
+        snap_2 = pool_obj.create_pool_snap(pool_name=_pool_name)
+        log.info(f"Second Pool snapshot created successfully: {snap_2}")
+
+        # create object clones for obj1 and obj2
+        for obj in ["obj1", "obj2"]:
+            pool_obj.do_rados_put(client=client, pool=_pool_name, obj_name=obj)
+
+        # log rados df o/p and ensure number of reported clones is 2
+        if not verify_radosdf_out(
+            num_obj=4, num_obj_clone=2, num_obj_cop=12, timeout=100
+        ):
+            log.error("rados df o/p check failed")
+            raise Exception("rados df o/p is incorrect even after 100 secs")
+
+        # list snaps for each obj
+        log.info("Listing snaps for objects obj1 and obj2")
+        for obj in ["obj1", "obj2"]:
+            out = rados_obj.list_obj_snaps(pool_name=_pool_name, obj_name=obj)
+            log.info(f"Object snapshot for {obj}: {out}")
+
+        # list pool level snapshots
+        out = rados_obj.list_pool_snaps(pool_name=_pool_name)
+        log.info(f"Listing pool level snapshots: \n{out}")
+
+        # delete pool snapshots
+        for snap in [snap_1, snap_2]:
+            if not pool_obj.delete_pool_snap(pool_name=_pool_name, snap_name=snap):
+                log.error(f"Pool snapshot deletion failed for snap {snap}")
+                raise Exception(f"Pool snapshot deletion failed for {snap}")
+
+    try:
+        if config.get("issue_reproduction"):
+            common_workflow()
+
+            # object snap should linger even after pool snapshot deletion
+            if not verify_radosdf_out(
+                num_obj=4, num_obj_clone=2, num_obj_cop=12, timeout=100
+            ):
+                log.error("rados df o/p check failed")
+                raise Exception("rados df o/p is incorrect even after 100 secs")
+
+            # list snaps for obj1
+            log.info(f"Listing snaps for objects obj1 after {snap_1} deletion")
+            out = rados_obj.list_obj_snaps(pool_name=_pool_name, obj_name="obj1")
+            log.info(f"Object snaps for obj1 after pool snap deletion: {out}")
+            assert (
+                len(out["clones"][0]["snapshots"]) == 2
+            ), "obj1 clone snaps should have been 2"
+
+            log.info(
+                "Completed reproducing issue with unfixed build, test will resume after upgrade"
+            )
+        if config.get("verify_fix"):
+            # check if test pool exists on the cluster
+            if rados_obj.get_pool_details(pool=_pool_name):
+                log.info(
+                    f"Pool {_pool_name} exists, proceeding with force removal of snaps"
+                )
+                log.info("Force remove the undeleted lingering object snaps for obj1")
+                _cmd = f"ceph osd pool force-remove-snap {_pool_name}"
+                out, err = rados_obj.client.exec_command(cmd=_cmd, sudo=True)
+                log.info(f"Force removal o/p: \n {out+err}")
+                assert (
+                    "removed snapids" in out + err
+                ), "force-remove-snap o/p not as expected"
+
+                time.sleep(10)
+                # list snaps for obj1 after force removal
+                log.info("Listing snaps for objects obj1 after deletion")
+                out = rados_obj.list_obj_snaps(pool_name=_pool_name, obj_name="obj1")
+                log.info(f"Object snaps for obj1 after pool snap deletion: {out}")
+                assert (
+                    len(out["clones"][0]["snapshots"]) == 0
+                ), "obj1 clone snaps should have been 0"
+
+                # list pool snapshot after force removal
+                out = rados_obj.list_pool_snaps(pool_name=_pool_name)
+                log.info(f"Pool snaphots for {_pool_name} after force removal:\n {out}")
+                assert (
+                    "0 snaps" in out
+                ), f"pool snapshots for {_pool_name} should have been 0"
+
+                # remove all rados pools and perform the test steps again
+                rados_obj.rados_pool_cleanup()
+
+            log.info(
+                "\n\n -----------------------------------------"
+                "Testing the same workflow again with fixed version"
+                "---------------------------------------------\n\n"
+            )
+            common_workflow()
+
+            # object snap should NOT linger after pool snapshot deletion
+            if not verify_radosdf_out(
+                num_obj=2, num_obj_clone=0, num_obj_cop=6, timeout=120
+            ):
+                log.error("rados df o/p check failed")
+                raise Exception("rados df o/p is incorrect even after 120 secs")
+
+            # list snaps for obj1
+            log.info("Listing snaps for objects obj1 after pool snap deletion")
+            out = rados_obj.list_obj_snaps(pool_name=_pool_name, obj_name="obj1")
+            log.info(f"Object snaps for obj1 after pool snap deletion: {out}")
+            assert (
+                len(out["clones"][0]["snapshots"]) == 0
+            ), "obj1 clone snaps should have been 0"
+
+            log.info(
+                "Test verification completed for object snapshot and pool snapshot removal"
+            )
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        log.info("*********** Execution of finally block starts ***********")
+        if not config.get("issue_reproduction"):
+            # delete the created osd pool
+            rados_obj.delete_pool(pool=_pool_name)
+        # log cluster health
+        rados_obj.log_cluster_health()
+        # check for crashes after test execution
+        if rados_obj.check_crash_status():
+            log.error("Test failed due to crash at the end of test")
+            return 1
+    return 0


### PR DESCRIPTION
[CEPH-83602685](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83602685): Tier-2 test to verify object snap does not leak and remain behind when parent pool snapshot is deleted.

Jira tracker: [RHCEPHQE-16470](https://issues.redhat.com/browse/RHCEPHQE-16470)

Bugs covered-
Pacific: https://bugzilla.redhat.com/show_bug.cgi?id=2272361
Quincy: https://bugzilla.redhat.com/show_bug.cgi?id=2272362
Reef: https://bugzilla.redhat.com/show_bug.cgi?id=2263169

The issue existed in the `ceph osd rmsnap` command which cause the object snap to linger behind even after removing the pool snap

> Previously, the `osd pool rmsnap` command was faulty and as a result removing snaps using this command would leave clone objects behind. 
With this fix, the `osd pool rmsnap` command is corrected and a new command `force-remove-snap` is introduced to remove the leaked clone objects if the faulty command was used.

Test modules modified:
- `create_pool_snap` in `ceph/rados/pool_workflows.py`

Test modules added:
- `list_obj_snaps` in `ceph/rados/core_workflows.py`
- `list_pool_snaps` in `ceph/rados/core_workflows.py`
- `tests/rados/test_pool_snap.py`

Test suites modified:
- suites/pacific/rados/tier-2_rados_test-brownfield.yaml
- suites/quincy/rados/tier-2_rados_test-brownfield.yaml
- suites/reef/rados/tier-2_rados_test-brownfield.yaml

Steps:
1. Create a replicated pool with default config
2. Use rados put to write a single object to the pool
3. Create a pool snapshot
4. Write another object on the pool using rados put
5. Create another pool snapshot
6. Log rados df, rados lssnap, and rados listsnaps outputs
7. Remove pool snapshot 1 using ceph osd rmsnap cmd
8. Validate that object snap for obj1 could not be deleted
9. Upgrade the cluster to fixed version.
10. Run the force-snap-removal cmd and log rados df, rados lssnap, and rados listsnaps outputs
11. Remove all RADOS pools from the cluster
12. Re-run steps 1-7 on the fixed version
13. Validate that object snap for obj1 was removed alongside pool snapshot


Logs-
Quincy: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-L7GE3P
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ZLEGWK
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RYTH74/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>