### PR TITLE
TFA: Comment the Ratelimit test at global scope

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -164,14 +164,14 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
 
-  - test:
-      name: Test Ratelimit at global scope
-      desc: Test Ratelimit at global scope
-      polarion-id: CEPH-83574915 # also CEPH-83574916 and CEPH-83574919
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_ratelimit_global.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
+  # - test:
+  #    name: Test Ratelimit at global scope
+  #    desc: Test Ratelimit at global scope
+  #    polarion-id: CEPH-83574915 # also CEPH-83574916 and CEPH-83574919
+  #    module: sanity_rgw.py
+  #    config:
+  #      script-name: ../s3cmd/test_ratelimit_global.py
+  #      config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
 
   - test:
       name: Test Ratelimit for versioned buckets

--- a/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -264,15 +264,15 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multipart_upload_with_failed_parts_using_s3cmd_and_boto3.yaml
 
-  - test:
-      name: Test Ratelimit at global scope
-      desc: Test Ratelimit at global scope
-      polarion-id: CEPH-83574915 # also CEPH-83574916 and CEPH-83574919
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_ratelimit_global.py
-        config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
-      comments: known issue BZ 2301986
+  # - test:
+  #    name: Test Ratelimit at global scope
+  #    desc: Test Ratelimit at global scope
+  #    polarion-id: CEPH-83574915 # also CEPH-83574916 and CEPH-83574919
+  #    module: sanity_rgw.py
+  #    config:
+  #      script-name: ../s3cmd/test_ratelimit_global.py
+  #      config-file-name: ../../s3cmd/configs/test_ratelimit_global.yaml
+  #    comments: known issue BZ 2301986
 
   - test:
       name: Test Ratelimit for versioned buckets


### PR DESCRIPTION
Ratelimit test at global scope is causing failures in the bare metal suite, because the step to disable the global ratelmit is not executed due to a known failure.
Commenting this test until the known issue is resolved.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2301986


