### PR TITLE
RHCEPHQE-16740 - Move to concurrent.futures

### DIFF
--- a/ceph/parallel.py
+++ b/ceph/parallel.py
@@ -1,121 +1,122 @@
-import sys
+# -*- code: utf-8 -*-
+"""
+This module provides a context manager for running methods concurrently.
 
-import gevent.pool
-import gevent.queue
+For backward compatability, spawn method is leveraged however one can also
+choose to move submit. Likewise, thread pool executor is the default executor.
 
-from utility.log import Log
+Timeout is an inherited feature provided by concurrent futures. Additionally,
+one wait for all the threads/process to complete even when on thread or process
+encounters an exception. This is useful when multiple test modules are
+executing different test scenarios.
 
-log = Log(__name__)
+When a test module controls the threads then it can forcefully terminate all
+threads when an exception is encountered.
+
+Changelog:
+    Version 1.0 used gevent module for parallel method execution.
+    Version 2.0 uses concurrent.futures module instead of gevent.
+
+You add functions to be run with the spawn method::
+
+    with parallel() as p:
+        for foo in bar:
+            p.spawn(quux, foo, baz=True)
+
+You can iterate over the results (which are in arbitrary order)::
+
+    with parallel() as p:
+        for foo in bar:
+            p.spawn(quux, foo, baz=True)
+        for result in p:
+            print result
+
+In version 2, you can choose whether to use threads or processes by
+
+    with parallel(thread_pool=False, timeout=10) as p:
+        _r = [p.spawn(quux, x) for name in names]
+
+If one of the spawned functions throws an exception, it will be thrown
+when iterating over the results, or when the with block ends.
+
+At the end of the with block, the main thread waits until all
+spawned functions have completed, or, if one exited with an exception,
+kills the rest and raises the exception.
+"""
+import logging
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+
+logger = logging.getLogger(__name__)
 
 
-class ExceptionHolder(object):
-    def __init__(self, exc_info):
-        self.exc_info = exc_info
+class parallel:
+    """This class is a context manager for concurrent method execution."""
 
+    def __init__(
+        self,
+        thread_pool=True,
+        timeout=None,
+        shutdown_wait=True,
+        shutdown_cancel_pending=False,
+    ):
+        """Object initialization method.
 
-def capture_traceback(func, *args, **kwargs):
-    """
-    Utility function to capture tracebacks of any exception func
-    raises.
-    """
-    try:
-        return func(*args, **kwargs)
-    except Exception:
-        return ExceptionHolder(sys.exc_info())
+        Args:
+            thread_pool (bool)          Whether to use threads or processes.
+            timeout (int | float)       Maximum allowed time.
+            shutdown_wait (bool)        If disabled, it would not wait for executing
+                                        threads/process to complete.
+            shutdown_cancel_pending (bool) If enabled, it would cancel pending tasks.
+        """
+        self._executor = ThreadPoolExecutor() if thread_pool else ProcessPoolExecutor()
+        self._timeout = timeout
+        self._shutdown_wait = shutdown_wait
+        self._cancel_pending = shutdown_cancel_pending
+        self._futures = list()
+        self._results = list()
 
+    def spawn(self, fun, *args, **kwargs):
+        """Triggers the first class method.
 
-def resurrect_traceback(exc):
-    if isinstance(exc, ExceptionHolder):
-        exc_info = exc.exc_info
-    elif isinstance(exc, BaseException):
-        exc_info = (type(exc), exc, None)
-    else:
-        return
+        Args:
+            func:       Function to be executed.
+            args:       A list of variables to be passed to the function.
+            kwargs      A dictionary of named variables.
 
-    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
-
-
-class parallel(object):
-    """
-    This class is a context manager for running functions in parallel.
-
-    You add functions to be run with the spawn method::
-
-        with parallel() as p:
-            for foo in bar:
-                p.spawn(quux, foo, baz=True)
-
-    You can iterate over the results (which are in arbitrary order)::
-
-        with parallel() as p:
-            for foo in bar:
-                p.spawn(quux, foo, baz=True)
-            for result in p:
-                print result
-
-    If one of the spawned functions throws an exception, it will be thrown
-    when iterating over the results, or when the with block ends.
-
-    At the end of the with block, the main thread waits until all
-    spawned functions have completed, or, if one exited with an exception,
-    kills the rest and raises the exception.
-    """
-
-    def __init__(self):
-        self.group = gevent.pool.Group()
-        self.results = gevent.queue.Queue()
-        self.count = 0
-        self.any_spawned = False
-        self.iteration_stopped = False
-
-    def spawn(self, func, *args, **kwargs):
-        self.count += 1
-        self.any_spawned = True
-        greenlet = self.group.spawn(capture_traceback, func, *args, **kwargs)
-        greenlet.link(self._finish)
+        Returns:
+            None
+        """
+        _future = self._executor.submit(fun, *args, **kwargs)
+        self._futures.append(_future)
 
     def __enter__(self):
         return self
 
-    def __exit__(self, type_, value, traceback):
-        self.group.join()
+    def __exit__(self, exc_type, exc_value, trackback):
+        _exceptions = []
+        exception_count = 0
 
-        if value is not None:
-            return False
+        for _f in as_completed(self._futures, timeout=self._timeout):
+            try:
+                self._results.append(_f.result())
+            except Exception as e:
+                logger.exception(e)
+                _exceptions.append(e)
+                exception_count += 1
 
-        try:
-            # raises if any greenlets exited with an exception
-            for result in self:
-                log.debug("result is %s", repr(result))
-                pass
-        except Exception:
-            # Emit message here because traceback gets stomped when we re-raise
-            log.exception("Exception in parallel execution")
-            raise
-        return True
+            if exception_count > 0 and not self._shutdown_wait:
+                # At this point we are ignoring results
+                self._executor.shutdown(wait=False, cancel_futures=self._cancel_pending)
+                raise _exceptions[0]
+
+        if len(_exceptions) > 0:
+            raise _exceptions[0]
+
+        return False if exception_count == 0 else True
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if not self.any_spawned or self.iteration_stopped:
-            raise StopIteration()
-        result = self.results.get()
-
-        try:
-            resurrect_traceback(result)
-        except StopIteration:
-            self.iteration_stopped = True
-            raise
-
-        return result
-
-    def _finish(self, greenlet):
-        if greenlet.successful():
-            self.results.put(greenlet.value)
-        else:
-            self.results.put(greenlet.exception)
-
-        self.count -= 1
-        if self.count <= 0:
-            self.results.put(StopIteration())
+        for r in self._results:
+            yield r

--- a/ceph/utils.py
+++ b/ceph/utils.py
@@ -5,11 +5,10 @@ import re
 import time
 import traceback
 from json import loads
-from time import mktime
+from time import mktime, sleep
 
 import requests
 import yaml
-from gevent import sleep
 from htmllistparse import fetch_listing
 from libcloud.common.exceptions import BaseHTTPError
 from libcloud.compute.providers import get_driver

--- a/run.py
+++ b/run.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-
-# Allow parallelized behavior of gevent. It has to be the first line.
-from gevent import monkey
-
-monkey.patch_all()
+#!/usr/bin/env python3
 
 import datetime
 import importlib

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setup(
         "apache-libcloud>=3.3.0",
         "cryptography",
         "docopt",
-        "gevent",
-        "greenlet",
         "htmllistparse",
         "ibm-cloud-sdk-core==3.15.0 ; python_version<'3.7'",
         "ibm-cloud-sdk-core ; python_version>='3.7'",

--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -35,8 +35,16 @@ log = Log(__name__)
 def run(**kwargs):
     results = {}
     parallel_tests = kwargs["parallel"]
+    max_time = kwargs.get("config", {}).get("max_time", None)
+    wait_till_complete = kwargs.get("config", {}).get("wait_till_complete", True)
+    cancel_pending = kwargs.get("config", {}).get("cancel_pending", False)
 
-    with parallel() as p:
+    with parallel(
+        thread_pool=False,
+        timeout=max_time,
+        shutdown_wait=wait_till_complete,
+        shutdown_cancel_pending=cancel_pending,
+    ) as p:
         for test in parallel_tests:
             p.spawn(execute, test, kwargs, results)
             sleep(1)

--- a/utility/psi_volume_cleanup.py
+++ b/utility/psi_volume_cleanup.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 """Utility to remove orphaned volumes."""
-from gevent import monkey, sleep
-
-monkey.patch_all()
 import sys
 from datetime import datetime, timedelta
+from time import sleep
 
 import yaml
 from docopt import docopt


### PR DESCRIPTION
# Description

In this PR, parallel is refactored to use concurrent.futures instead of gvent. This allows us to use threads or processes.

Along with the introduction of timeouts at the parallel phase. It also allows to avoid the dependency on gvent.

- [x] Review the automation design
- [x] Unit testing
- [ ] Pipeline testing

*Unit Testing*
RGW Tier - 1 execution results are [here](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MZ7EY5/)