### PR TITLE
Check mon connection scores post installation of cluster

### DIFF
--- a/ceph/rados/monitor_workflows.py
+++ b/ceph/rados/monitor_workflows.py
@@ -3,10 +3,12 @@ Module to perform Serviceability scenarios on mon daemons
 """
 
 import datetime
+import json
 import time
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonElectionStrategies
 from utility.log import Log
 
 log = Log(__name__)
@@ -43,6 +45,7 @@ class MonitorWorkflows:
         self.cluster = node.cluster
         self.config = node.config
         self.client = node.cluster.get_nodes(role="client")[0]
+        self.mon_election_obj = MonElectionStrategies(rados_obj=self.rados_obj)
 
     def get_host_labels(self, host) -> list:
         """
@@ -280,4 +283,160 @@ class MonitorWorkflows:
             )
             return False
         log.info("Successfully set the new tiebreaker mon on cluster")
+        return True
+
+    def connection_score_checks(self) -> bool:
+        """
+        Checks all mon daemons for correct number of monitors, correct number of peer monitors,
+        correct peer monitors exist for every monitor and valid connection scores for every
+        monitor ( connection scores in the range of 0 to 1 )
+
+        Example:
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Monitor connection score checks failed")
+        Args:
+            None
+        returns:
+            Pass -> True, Fail -> false
+        """
+        # Collect mon host and rank from ceph mon dump command
+        mon_quorum = self.mon_election_obj.get_mon_quorum()
+        hosts = self.cluster.get_nodes()
+        num_mons = len(mon_quorum)
+
+        for host in hosts:
+
+            if not self.rados_obj.check_daemon_exists_on_host(
+                host=host.hostname, daemon_type="mon"
+            ):
+                log.info(f"Host {host.hostname} has no mon daemon present")
+                log.info("but mon label present on host")
+                log.info("Continuing onto the next host for testing")
+                continue
+
+            mon_status, mon_status_desc = self.rados_obj.get_daemon_status(
+                daemon_type="mon", daemon_id=host.hostname
+            )
+
+            if mon_status != 1 or mon_status_desc != "running":
+                log.error(f"Mon daemon mon.{host.hostname} not in running state")
+                log.info("but mon label present on host")
+                log.info("Continuing onto the next host for testing")
+                continue
+
+            try:
+                cmd = f"cephadm shell ceph daemon mon.{host.hostname} connection scores dump"
+                out, err = host.exec_command(sudo=True, cmd=cmd)
+                mon_conn_score = json.loads(out)
+                log.info(
+                    f"Connectivity score of all daemons in the cluster: \n {mon_conn_score}"
+                )
+            except json.JSONDecodeError:
+                log.error(
+                    f"Connection scores are not populated for mon.{host.hostname}"
+                )
+                return False
+            except Exception as e:
+                log.error(f"Failed with exception: {e.__doc__}")
+                log.exception(e)
+                return False
+
+            reports = mon_conn_score["reports"]
+
+            # Compare count of mons from connection scores dump and
+            # ceph mon dump commands
+            if len(reports) != num_mons:
+                log.error(
+                    f"Incorrect count of mons in connection scores report for mon.{host.hostname}"
+                )
+                log.error(f"Count of mons in connection scores report {len(reports)}")
+                log.error(f"Actual count of mons in the cluster {num_mons}")
+                return False
+
+            log.info(
+                f"Count of mons in connection scores report verified for mon.{host.hostname}"
+            )
+
+            log.info(f"Proceeding to verify count of peers for mon.{host.hostname}")
+
+            for report in reports:
+                current_mon_rank = report["rank"]
+
+                # collect peer mon ranks from ceph mon dump command
+                peer_mons_rank = [
+                    peer_mon_rank
+                    for peer_mon_rank in mon_quorum.values()
+                    if peer_mon_rank != current_mon_rank
+                ]
+                peer_scores = report["peer_scores"]
+
+                log.info(
+                    f"mon host: {host.hostname} rank: {current_mon_rank} peer mons: {peer_mons_rank}"
+                )
+
+                # Compare number of peer monitors in connection scores dump and
+                # ceph mon dump command
+                if len(peer_scores) != len(peer_mons_rank):
+                    log.error(
+                        f"Incorrect count of peers for mon {current_mon_rank} in connection scores report"
+                    )
+                    log.error(
+                        f"Count of peers in connection scores report {len(peer_scores)}"
+                    )
+                    log.error(
+                        f"Actual count of peers in the cluster {len(peer_mons_rank)}"
+                    )
+                    return False
+
+                log.info(
+                    f"Count of peers verified for mon {current_mon_rank} on host {host.hostname}"
+                )
+                log.info("Proceeding to verify valid peers and connection scores ")
+                log.info(f"for mon {current_mon_rank} on host {host.hostname}")
+
+                # peer_score_detail example : {"peer_rank": 1,"peer_score": 0.9999606092626272,"peer_alive": true}
+                log.info(f"Peers for mon {current_mon_rank} are {peer_mons_rank}")
+                for peer_score_detail in peer_scores:
+                    log.info(
+                        f"Verifying peers are valid for mon {current_mon_rank} on host {host.hostname}"
+                    )
+                    log.info(f"Peer mon rank: {peer_score_detail['peer_rank']}")
+                    log.info(f"Peer mon score: {peer_score_detail['peer_score']}")
+
+                    if peer_score_detail["peer_rank"] not in peer_mons_rank:
+                        log.error(
+                            f"Additional mon {peer_score_detail['peer_rank']} added as peer for mon {current_mon_rank}"
+                        )
+                        log.error(
+                            f"Valid peers of mon {current_mon_rank} are {peer_mons_rank}"
+                        )
+                        return False
+
+                    # Connection scores for monitors are valid if they are in
+                    # the range of 0 to 1
+                    if (
+                        peer_score_detail["peer_score"] < 0
+                        or peer_score_detail["peer_score"] > 1
+                    ):
+                        log.error(
+                            f"Invalid connection score for peer mon {peer_score_detail['peer_rank']}"
+                        )
+                        log.error(
+                            f" in connection scores report for mon {current_mon_rank}"
+                        )
+                        log.error(
+                            "Valid connection score should be in the range of 0 to 1"
+                        )
+                        return False
+                log.info(
+                    f"Peer mon checks and connection score checks for mon.{host.hostname} completed successfully"
+                )
+
+            log.info(
+                f"All scenarios of mon connection score checks passed for host {host.hostname}"
+            )
+
+        log.info(
+            f"Verified connection scores of mon on hosts: {hosts}, and all scenarios passed"
+        )
         return True

--- a/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
@@ -14,6 +14,11 @@
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
+#     10.https://bugzilla.redhat.com/show_bug.cgi?id=1892173
+#     11.https://bugzilla.redhat.com/show_bug.cgi?id=2174954
+#     12.https://bugzilla.redhat.com/show_bug.cgi?id=2151501
+#     13.https://bugzilla.redhat.com/show_bug.cgi?id=2315595
+#     14.https://bugzilla.redhat.com/show_bug.cgi?id=2326179
 #===============================================================================================
 tests:
   - test:
@@ -190,3 +195,12 @@ tests:
       module: test_v1client.py
       polarion-id: CEPH-83594645
       desc: Ensure client connection over v1 port does not crash
+
+  # Below test is currently failing, BZ raised #2327571
+  # will be un-commented once fix is available
+  # - test:
+  #     name: Mon connection scores testing
+  #     desc: Verification of mon connection scores in different scenarios
+  #     module: test_mon_connection_scores.py
+  #     polarion-id: CEPH-83602911
+  #     comments: Active bug 2151501

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -14,6 +14,11 @@
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
+#     10.https://bugzilla.redhat.com/show_bug.cgi?id=1892173
+#     11.https://bugzilla.redhat.com/show_bug.cgi?id=2174954
+#     12.https://bugzilla.redhat.com/show_bug.cgi?id=2151501
+#     13.https://bugzilla.redhat.com/show_bug.cgi?id=2315595
+#     14.https://bugzilla.redhat.com/show_bug.cgi?id=2326179
 #===============================================================================================
 tests:
   - test:
@@ -205,3 +210,12 @@ tests:
       module: test_v1client.py
       polarion-id: CEPH-83594645
       desc: Ensure client connection over v1 port does not crash
+
+  # Below test is currently failing, BZ raised #2315596
+  # will be un-commented once fix is available
+  # - test:
+  #     name: Mon connection scores testing
+  #     desc: Verification of mon connection scores in different scenarios
+  #     module: test_mon_connection_scores.py
+  #     polarion-id: CEPH-83602911
+  #     comments: Active bug 2151501

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -14,6 +14,11 @@
 #     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
 #     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
 #     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
+#     10.https://bugzilla.redhat.com/show_bug.cgi?id=1892173
+#     11.https://bugzilla.redhat.com/show_bug.cgi?id=2174954
+#     12.https://bugzilla.redhat.com/show_bug.cgi?id=2151501
+#     13.https://bugzilla.redhat.com/show_bug.cgi?id=2315595
+#     14.https://bugzilla.redhat.com/show_bug.cgi?id=2326179
 #===============================================================================================
 tests:
   - test:
@@ -204,3 +209,10 @@ tests:
       module: test_v1client.py
       polarion-id: CEPH-83594645
       desc: Ensure client connection over v1 port does not crash
+
+  - test:
+      name: Mon connection scores testing
+      desc: Verification of mon connection scores in different scenarios
+      module: test_mon_connection_scores.py
+      polarion-id: CEPH-83602911
+      comments: Active bug 2151501

--- a/tests/rados/test_mon_connection_scores.py
+++ b/tests/rados/test_mon_connection_scores.py
@@ -1,0 +1,232 @@
+"""
+Module to verify connection scores of monitor dameons are valid
+at different scenarios
+"""
+
+import random
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from ceph.rados.monitor_workflows import MonitorWorkflows
+from tests.rados.monitor_configurations import MonElectionStrategies
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83602911
+    Covers:
+        - BZ-1892173
+        - BZ-2174954
+        - BZ-2151501
+        - BZ-2315595
+        - BZ-2326179
+    Module to verify connection scores of monitor
+    dameons are valid at different scenarios
+    Returns:
+        1 -> Fail, 0 -> Pass
+    #steps
+    1. Deploy a Ceph cluster
+    2. Validate correct number of mons in connection score,
+       correct number of peers for each mon, each mon present in quorum
+       and valid connection score ( score between 0 - 1 )
+    3. Change election strategy to disallow mode and perform
+       validations mentioned in step(2)
+    4. Change election strategy to connectivity mode and perform
+       validations mentioned in step(2)
+    5. Add new host as mon and perform validations
+       mentioned in step(2)
+    6. Remove mon added in step(5) in the cluster
+       and perform validation mentioned in step(2)
+    7. Restart monitor service using systemctl
+       and perform validations mentioned in step(2)
+    8. Stop monitor service using systemctl
+       and perform validations mentioned in step(2)
+    9. Start monitor service using systemctl
+       and validations mentioned in step(2)
+    """
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_election_obj = MonElectionStrategies(rados_obj=rados_obj)
+    mon_workflow_obj = MonitorWorkflows(node=cephadm)
+
+    try:
+        # Collect mon details such as name, rank and number of mons
+        mon_nodes = ceph_cluster.get_nodes(role="mon")
+        osd_nodes = ceph_cluster.get_nodes(role="osd")
+
+        for mon_election_strategy in ["classic", "disallow", "connectivity"]:
+            log.debug(f"Setting mon election strategy to {mon_election_strategy} mode")
+            log.debug(
+                f"Proceeding to test all scenarios with mon election strategy {mon_election_strategy}"
+            )
+
+            # Changing mon election strategy
+            # and perform connection score validation
+            if not mon_election_obj.set_election_strategy(mode=mon_election_strategy):
+                log.error(
+                    f"could not set election strategy to {mon_election_strategy} mode"
+                )
+                raise Exception("Changing election strategy failed")
+
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Connection score checks failed")
+
+            log.debug(
+                f"mon connection scores verified after changing election strategy to {mon_election_strategy} mode"
+            )
+
+            # Adding new host as mon and perform connection
+            # score validation
+            new_mon_host = random.choice(osd_nodes)
+
+            log.debug(
+                f"Picked random osd host {new_mon_host.hostname} to be added as mon host"
+            )
+            log.debug(f"Proceeding to add {new_mon_host.hostname} as mon service")
+
+            if not mon_workflow_obj.set_mon_service_managed_type(unmanaged=True):
+                log.error("Could not set the mon service to unmanaged")
+                raise Exception("mon service not unmanaged error")
+
+            log.debug("Successfully set mon service as unmanaged")
+
+            if not mon_workflow_obj.add_mon_service(host=new_mon_host):
+                log.error(f"Could not add mon service on host {new_mon_host.hostname}")
+                raise Exception("mon service not added error")
+
+            log.debug(
+                f"Successfully added new mon.{new_mon_host.hostname} as mon service"
+            )
+            log.debug("Proceeding to check mon connection scores after adding new mon")
+
+            if not mon_workflow_obj.connection_score_checks():
+                log.debug(
+                    "mon connection score checks skipped after adding mon service - active bug BZ-2151501"
+                )
+                # Adding mon service to cluster causes test case failure - active bug BZ-2151501
+                # raise Exception("Connection score checks failed")
+
+            log.debug(
+                f"Mon connection scores verified after adding new mon host {new_mon_host.hostname}"
+            )
+            log.debug(f"Proceeding to remove newly added mon {new_mon_host.hostname}")
+
+            # Remove added mon service
+            # and perform connection score validation
+            if not mon_workflow_obj.remove_mon_service(host=new_mon_host.hostname):
+                log.error(f"Could not remove mon on host {new_mon_host.hostname}")
+                raise Exception("mon service not removed error")
+
+            log.debug(f"Successfully removed mon.{new_mon_host.hostname} service")
+            log.debug(
+                "Proceeding to check mon connection scores after removing newly added mon"
+            )
+
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Connection score checks failed")
+
+            log.debug(
+                f"Mon connection scores verified after removing mon host {new_mon_host.hostname}"
+            )
+
+            # Restart monitor service and perform connection
+            # score validation
+            mon_host = random.choice(mon_nodes)
+
+            log.debug(
+                f"Picked random mon host {mon_host.hostname} to restart, stop and start mon service"
+            )
+            log.debug(f"Proceeding to restart mon service {mon_host.hostname}")
+
+            if not rados_obj.change_daemon_systemctl_state(
+                action="restart", daemon_type="mon", daemon_id=mon_host.hostname
+            ):
+                log.error(f"Failed to restart mon daemon on host {mon_host.hostname}")
+                raise Exception("Mon restart failure error")
+
+            log.debug(f"Successfully restarted mon.{mon_host.hostname} service")
+            log.debug(
+                "Proceeding to check mon connection scores after restarting mon service"
+            )
+
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Connection score checks failed")
+
+            log.debug(
+                f"Mon connection scores verified after restarting mon service on host {mon_host.hostname}"
+            )
+            log.debug(f"Proceeding to stop mon service on host {mon_host.hostname}")
+
+            # Stop monitor service and perform connection score validation
+            if not rados_obj.change_daemon_systemctl_state(
+                action="stop", daemon_type="mon", daemon_id=mon_host.hostname
+            ):
+                log.error(f"Failed to stop mon daemon on host {mon_host.hostname}")
+                raise Exception("Mon stop failure error")
+
+            log.debug(f"Successfully stopped mon.{mon_host.hostname} service")
+            log.debug(
+                "Proceeding to check mon connection scores after stopping mon service"
+            )
+
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Connection score checks failed")
+
+            log.debug(
+                f"Mon connection scores verified after stopping mon service on host {mon_host.hostname}"
+            )
+            log.debug(f"Proceeding to start mon service on host {mon_host.hostname}")
+
+            # Start stopped monitor service and perform connection score validation
+            if not rados_obj.change_daemon_systemctl_state(
+                action="start", daemon_type="mon", daemon_id=mon_host.hostname
+            ):
+                log.error(f"Failed to start mon daemon on host {mon_host.hostname}")
+                raise Exception("Mon start failure error")
+
+            log.debug(f"Successfully started mon.{mon_host.hostname} service")
+            log.debug(
+                "Proceeding to check mon connection scores after starting mon service"
+            )
+
+            if not mon_workflow_obj.connection_score_checks():
+                raise Exception("Connection score checks failed")
+
+            log.debug(
+                f"Mon connection scores verified after starting mon service on host {mon_host.hostname}"
+            )
+            log.debug(
+                f"Successfully verified mon connection scores with mon election strategy set as {mon_election_strategy}"
+            )
+
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+
+    finally:
+        log.info(
+            "\n \n ************** Execution of finally block begins here *************** \n \n"
+        )
+        # Setting the mon service as managed by cephadm
+        if not mon_workflow_obj.set_mon_service_managed_type(unmanaged=False):
+            log.error("Could not set the mon service to managed")
+            return 1
+
+        # log cluster health
+        rados_obj.log_cluster_health()
+
+        # check for crashes after test execution
+        if rados_obj.check_crash_status():
+            log.error("Test failed due to crash at the end of test")
+            return 1
+
+    log.info(
+        "Successfully verified connection scores at different scenarios\
+        later reverted cluster to original state"
+    )
+    return 0


### PR DESCRIPTION
Automation of the issues - BZ-1892173, BZ-2174954, BZ-2151501, BZ-2315595

The steps are updated at - CEPH-83602911

Automation steps:-

1. Deploy a Ceph cluster
2. Validate correct number of mons in connection score, correct number of peers for each mon, each mon present in quorum and valid connection score ( score between 0 - 1 ) 
3. Change election strategy to disallow mode and perform validations mentioned in step(2)
4. Change election strategy to connectivity mode and perform validations mentioned in step(2)
5. Add new host as mon and perform validations mentioned in step(2)
6. Remove mon added in step(5) in the cluster and perform validation mentioned in step(2)
7. Restart monitor service using systemctl and perform validations mentioned in step(2)
8. Stop monitor service using systemctland perform validations mentioned in step(2)
9. Start monitor service using systemctl and validations mentioned in step(2)

Pass log for test case :- http://magna002.ceph.redhat.com/ceph/ceph-qe-logs/vips/logs-vipin-mon-conn-score-18-nov-4-39-pm/

Pass log along with entire suite yet to be updated.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
