### PR TITLE
This PR adds data and metadata ops after upgrading secondary zone 

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
@@ -356,6 +356,20 @@ tests:
             service: upgrade
             verify_cluster_health: true
 
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+      comments: 2327402, known bug in 8.0
+
 #   # Basic swift based tests
 
   - test:
@@ -375,7 +389,7 @@ tests:
 
   - test:
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -375,20 +375,51 @@ tests:
       polarion-id: CEPH-83575470
 
 #   # Performing cluster upgrade
-
   - test:
       abort-on-fail: true
-      desc: Multisite upgrade
+      desc: Multisite upgrade, secondary first
       module: test_cephadm_upgrade.py
-      name: multisite ceph upgrade
+      name: multisite ceph upgrade, secondary first
       polarion-id: CEPH-83574647
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             command: start
             service: upgrade
             verify_cluster_health: true
+## create a user during mixed mode
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+      comments: 2327402, known bug in 8.0
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_download on secondary
+      polarion-id: CEPH-14237
+      module: sanity_rgw_multisite.py
+      clusters:
         ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+  - test:
+      abort-on-fail: true
+      desc: Multisite upgrade, next upgrade primary
+      module: test_cephadm_upgrade.py
+      name: multisite ceph upgrade, next upgrade primary
+      polarion-id: CEPH-83574647
+      clusters:
+        ceph-pri:
           config:
             command: start
             service: upgrade


### PR DESCRIPTION
This is to add data and metadata ops after upgrading the secondary zone first

bug [2327402](https://bugzilla.redhat.com/show_bug.cgi?id=2327402)

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BWPZ5K

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
