### PR TITLE
Correcting inventory file - rhel-9.5-server-x86_64-xlarge.yaml

### DIFF
--- a/conf/inventory/rhel-9.5-server-x86_64-xlarge.yaml
+++ b/conf/inventory/rhel-9.5-server-x86_64-xlarge.yaml
@@ -4,7 +4,7 @@ id: rhel
 instance:
   create:
     image-name: RHEL-9.5.0-x86_64-ga-latest
-    vm-size: ci.standard.x1
+    vm-size: ci.standard.xl
 
   setup: |
     #cloud-config


### PR DESCRIPTION
# Description

Correcting inventory file - rhel-9.5-server-x86_64-xlarge.yaml

File "/home/jenkins/ceph-builds/openstack/IBM/8.0/rhel-9/Regression/19.2.0-53/nvmeotcp/20/cephci/compute/openstack.py", line 333, in _get_vm_size
    raise ResourceNotFound(f"Failed to retrieve vm size with name: {name}")
compute.exceptions.ResourceNotFound: Failed to retrieve vm size with name: ci.standard.x1