### PR TITLE
Enhance method to fetch OSD list & Enable faster recovery during PG merge

### DIFF
--- a/tests/rados/test_add_new_osd.py
+++ b/tests/rados/test_add_new_osd.py
@@ -25,8 +25,7 @@ def run(ceph_cluster, **kw):
     log.info("Running test case to verify addition of new OSD on existing OSD disk")
 
     try:
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
+        osd_list = rados_obj.get_osd_list(status="up")
         osd_id = random.choice(osd_list)
         osd_metadata = ceph_cluster.get_osd_metadata(osd_id=int(osd_id), client=client)
         log.debug(osd_metadata)

--- a/tests/rados/test_bluestore_superblock.py
+++ b/tests/rados/test_bluestore_superblock.py
@@ -65,7 +65,7 @@ def run(ceph_cluster, **kw):
 
         # determine the number of replicas that would ideally exist on an OSD
         # pick an OSD at random from list of active OSDs
-        osd_list = rados_obj.get_active_osd_list()
+        osd_list = rados_obj.get_osd_list(status="up")
         osd_id = random.choice(osd_list)
 
         # determine the OSD size is GB

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -56,7 +56,7 @@ def run(ceph_cluster, **kw):
     service_obj = ServiceabilityMethods(cluster=ceph_cluster, **config)
 
     try:
-        osd_list = rados_obj.get_active_osd_list()
+        osd_list = rados_obj.get_osd_list(status="up")
         log.info(f"List of OSDs: \n{osd_list}")
 
         if config.get("non-collocated"):

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -175,8 +175,7 @@ def run(ceph_cluster, **kw):
             rand_host = random.choice(osd_hosts)
             log.info(f"Chosen OSD host to add network delay: {rand_host}")
 
-            _cmd = f"ceph osd ls-tree {rand_host}"
-            osd_list = rados_obj.run_ceph_command(cmd=_cmd, client_exec=True)
+            osd_list = rados_obj.collect_osd_daemon_ids(osd_node=rand_host)
             log.info(f"List of OSDs on the host: {osd_list}")
 
             assert rados_obj.add_network_delay_on_host(
@@ -346,7 +345,7 @@ def run(ceph_cluster, **kw):
             _pool_name = "test-bluefs-shared"
 
             # get the list of OSDs on the cluster
-            osd_list = rados_obj.run_ceph_command(cmd="ceph osd ls")
+            osd_list = rados_obj.get_osd_list(status="up")
             log.debug(f"List of active OSDs: \n{osd_list}")
 
             # check the current value of 'bluestore_min_alloc_size'

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -200,7 +200,7 @@ def run(ceph_cluster, **kw):
             initial_pool_stat = rados_obj.get_cephdf_stats()["pools"]
 
             # obtain the last osd id
-            osd_list = rados_obj.get_active_osd_list()
+            osd_list = rados_obj.get_osd_list(status="up")
             osd_id = osd_list.pop(-1)
 
             osd_df_stats = rados_obj.get_osd_df_stats(
@@ -373,7 +373,7 @@ def run(ceph_cluster, **kw):
                     f"List of LVMs created on {node_obj.hostname}: {lvm_list[node]}"
                 )
 
-            init_osd_list = rados_obj.get_active_osd_list()
+            init_osd_list = rados_obj.get_osd_list(status="up")
             log.info(f"Active OSD list before OSD addition: {init_osd_list}")
             init_osd_count = len(init_osd_list)
             # deploy single OSD on lvm devices created
@@ -391,7 +391,7 @@ def run(ceph_cluster, **kw):
                     raise Exception(f"OSD addition on {node_obj.hostname} failed")
 
             time.sleep(30)
-            post_osd_list = rados_obj.get_active_osd_list()
+            post_osd_list = rados_obj.get_osd_list(status="up")
             log.info(f"Active OSD list after OSD addition: {post_osd_list}")
             post_osd_count = len(post_osd_list)
             if post_osd_count - init_osd_count < 2:

--- a/tests/rados/test_crash_daemon.py
+++ b/tests/rados/test_crash_daemon.py
@@ -33,8 +33,7 @@ def run(ceph_cluster, **kw):
 
     try:
         # 1. Crash an OSD daemon and inject crash manually
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
+        osd_list = rados_obj.get_osd_list(status="up")
         log.debug(f"List of OSDs: {osd_list}")
         osd_id = random.choice(osd_list)
         log.debug(f"Chosen OSD to crash: OSD.{osd_id}")

--- a/tests/rados/test_libcephsqlite.py
+++ b/tests/rados/test_libcephsqlite.py
@@ -73,8 +73,7 @@ def run(ceph_cluster, **kw):
         )
 
         # Fetch list of OSDs in the cluster
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
+        osd_list = rados_obj.get_osd_list(status="up")
         log.debug(f"List of OSDs: \n{osd_list}")
 
         # Choose an OSD at random

--- a/tests/rados/test_mon_system_operations.py
+++ b/tests/rados/test_mon_system_operations.py
@@ -136,8 +136,7 @@ def run(ceph_cluster, **kw):
         )
 
         # fetching all the OSDs on the cluster and selecting 1 OSD at random to be shut down.
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
+        osd_list = rados_obj.get_osd_list(status="up")
 
         osd_id = int(random.choice(osd_list))
         log.debug(f"Selected OSD : {osd_id} to be shut down")
@@ -202,8 +201,7 @@ def run(ceph_cluster, **kw):
         )
 
         # fetching all the OSDs on the cluster and selecting 1 OSD at random to be shut down.
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
+        osd_list = rados_obj.get_osd_list(status="up")
 
         osd_id = int(random.choice(osd_list))
         log.debug(f"Selected OSD : {osd_id} to be shut down")

--- a/tests/rados/test_node_drain_customer_bug.py
+++ b/tests/rados/test_node_drain_customer_bug.py
@@ -45,7 +45,7 @@ def run(ceph_cluster, **kw):
 
     replicated_config = config.get("replicated_pool")
     pool_name = replicated_config["pool_name"]
-    active_osd_list = rados_obj.get_active_osd_list()
+    active_osd_list = rados_obj.get_osd_list(status="up")
     log.info(f"The active OSDs list before starting the test-{active_osd_list}")
     if not rados_obj.create_pool(pool_name=pool_name):
         log.error("Failed to create the  Pool")
@@ -194,7 +194,7 @@ def run(ceph_cluster, **kw):
             return 1
 
         if bug_exists:
-            active_osd_list = rados_obj.get_active_osd_list()
+            active_osd_list = rados_obj.get_osd_list(status="up")
             log.info(
                 f"The active OSDs list after reproducing the issue is-{active_osd_list}"
             )

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -91,7 +91,7 @@ def run(ceph_cluster, **kw):
     ]
     operations = config.get("operations", all_ops)
     try:
-        osd_list = rados_obj.get_active_osd_list()
+        osd_list = rados_obj.get_osd_list(status="up")
         log.info(f"List of OSDs: \n{osd_list}")
 
         log.info("Create a data pool with default config")

--- a/tests/rados/test_osd_async_recovery.py
+++ b/tests/rados/test_osd_async_recovery.py
@@ -50,8 +50,7 @@ def run(ceph_cluster, **kw):
                 pool_name=pool_name, rados_write_duration=900, background=True
             )
 
-            out, _ = cephadm.shell(args=["ceph osd ls"])
-            osd_list = out.strip().split("\n")
+            osd_list = rados_object.get_osd_list(status="up")
             log.debug(f"List of OSDs: \n{osd_list}")
             log.info(f"The number of OSDs in the cluster are-{len(osd_list)}")
 

--- a/tests/rados/test_osd_inprogress_rebalance.py
+++ b/tests/rados/test_osd_inprogress_rebalance.py
@@ -93,8 +93,7 @@ def run(ceph_cluster, **kw):
         log.info(
             "\n \n ************** Execution of finally block begins here *************** \n \n"
         )
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        active_osd_list = out.strip().split("\n")
+        active_osd_list = rados_obj.get_osd_list(status="up")
         log.info(f"List of active OSDs: \n{active_osd_list}")
         if osd_id not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)

--- a/tests/rados/test_osd_memory_target.py
+++ b/tests/rados/test_osd_memory_target.py
@@ -55,8 +55,7 @@ def run(ceph_cluster, **kw):
         """
         log.info(doc)
         try:
-            out, _ = cephadm.shell(args=["ceph osd ls"])
-            osd_list = out.strip().split("\n")
+            osd_list = rados_obj.get_osd_list(status="up")
             log.debug(f"List of OSDs: {osd_list}")
 
             """ inorder to verify the precedence between osd_memory_target set at

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -140,8 +140,7 @@ def run(ceph_cluster, **kw):
         log.info(
             "\n \n ************** Execution of finally block begins here *************** \n \n"
         )
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        active_osd_list = out.strip().split("\n")
+        active_osd_list = rados_obj.get_osd_list(status="up")
         log.debug(f"List of active OSDs: \n{active_osd_list}")
         if osd_id not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)

--- a/tests/rados/test_osd_rebalance_snap.py
+++ b/tests/rados/test_osd_rebalance_snap.py
@@ -121,8 +121,7 @@ def run(ceph_cluster, **kw):
         log.info(
             "\n \n ************** Execution of finally block begins here *************** \n \n"
         )
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        active_osd_list = out.strip().split("\n")
+        active_osd_list = rados_obj.get_osd_list(status="up")
         log.debug(f"List of active OSDs: \n{active_osd_list}")
         if osd_id not in active_osd_list:
             utils.set_osd_devices_unmanaged(ceph_cluster, osd_id, unmanaged=True)

--- a/tests/rados/test_osd_replacement.py
+++ b/tests/rados/test_osd_replacement.py
@@ -33,8 +33,7 @@ def run(ceph_cluster, **kw):
     log.info("Running test case to verify addition of new OSD on existing OSD disk")
 
     try:
-        out, _ = cephadm.shell(args=["ceph osd ls"])
-        osd_list = out.strip().split("\n")
+        osd_list = rados_obj.get_osd_list(status="up")
         log.debug(f"List of OSDs: {osd_list}")
         osd_id = int(random.choice(osd_list))
         osd_list.pop(osd_id)

--- a/tests/rados/test_osd_superblock.py
+++ b/tests/rados/test_osd_superblock.py
@@ -53,7 +53,7 @@ def run(ceph_cluster, **kw):
 
     try:
         # choosing an OSD at random
-        osd_list = rados_obj.get_active_osd_list()
+        osd_list = rados_obj.get_osd_list(status="up")
         log.info(f"List of active OSDs on the cluster: {osd_list}")
         osd_id = random.choice(osd_list)
         log.info(f"Random OSD chosen for the test: {osd_id}")

--- a/tests/rados/test_pg_split.py
+++ b/tests/rados/test_pg_split.py
@@ -305,7 +305,7 @@ def run(ceph_cluster, **kw):
         log.info("*********** Execution of finally block starts ***********")
 
         if "target_osd" in locals() or "target_osd" in globals():
-            active_osd_list = rados_obj.run_ceph_command(cmd="ceph osd ls")
+            active_osd_list = rados_obj.get_osd_list(status="up")
             log.debug(f"List of active OSDs: \n{active_osd_list}")
             if target_osd not in active_osd_list:
                 utils.set_osd_devices_unmanaged(

--- a/tests/rados/test_replica1.py
+++ b/tests/rados/test_replica1.py
@@ -64,8 +64,7 @@ def run(ceph_cluster, **kw):
             log.info("Running test case to verify replica-1 non-resilient pool")
 
             # Fetch all the OSDs on the cluster
-            out, _ = cephadm.shell(args=["ceph osd ls"])
-            osd_list = out.strip().split("\n")
+            osd_list = rados_obj.get_osd_list(status="up")
             log.debug(f"List of OSDs: {osd_list}")
 
             # remove the device class for all the OSDs


### PR DESCRIPTION
PR addresses the following two changes:

- Enhances existing method to fetch active OSDs to be able to provide list of OSD depending on the status argument provided by the user.
- TFA fix for no-recover flag test case: Recently it was observed that test would timeout just as soon as desired number of PGs were reached, to enable faster recovery and PG split and merge, recovery flags are being modified and timeout has been slightly increased.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>