### PR TITLE
Fix the condition evaluating the default timeout

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1561,7 +1561,7 @@ class CephNode(object):
             timeout = None if kw["timeout"] == "notimeout" else kw["timeout"]
         else:
             # Set defaults if long_running then 1h else 5m
-            timeout = 3600 if kw.get("long_running", False) in kw else 300
+            timeout = 3600 if kw.get("long_running", False) else 300
 
         try:
             channel = ssh().get_transport().open_session(timeout=timeout)


### PR DESCRIPTION
# Description

This commit fixes the condition that evaluates the default timeout for long_running command execution.

Earlier we where attempting to check for True in the list of arguments instead of evaluating if it is long_running or not. This caused the default value to be 5 minutes always.

<summary>click to expand checklist</summary>

- [x] Review the automation design
- [x] Unit testing
