### PR TITLE
[TFA] Fix the issue with HEALTH_WARNING post upgrade

### DIFF
--- a/conf/6-node-cluster-with-1-client.yaml
+++ b/conf/6-node-cluster-with-1-client.yaml
@@ -16,12 +16,14 @@ globals:
           - mon
           - mgr
           - osd
+          - rgw
         no-of-volumes: 4
         disk-size: 15
       node3:
         role:
           - osd
           - mon
+          - rgw
         no-of-volumes: 4
         disk-size: 15
       node4:

--- a/suites/reef/upgrades/tier1-upgrade-rhcs-5x-to-7x.yaml
+++ b/suites/reef/upgrades/tier1-upgrade-rhcs-5x-to-7x.yaml
@@ -2,7 +2,7 @@
 # Automation support for upgrade from RHCS5 to RHCS7 in RHEL9
 #
 #--------------------------------------------------------------------------------
-# Cluster Configuration: conf/reef/upgrades/upgrade_4-node-cluster.yaml
+# Cluster Configuration: conf/6-node-cluster-with-1-client.yaml
 #--------------------------------------------------------------------------------
 #
 # Test Steps:
@@ -82,9 +82,9 @@ tests:
               args:
                 placement:
                   nodes:
-                    - node2
+                    - node4
+                    - node5
                     - node6
-                  limit: 2            # no of daemons
                   sep: " "            # separator to be used for placements
           - config:
               args:


### PR DESCRIPTION
Issue - Suite was failing at test "Verify cephadm stray host warning post upgrade"

Failure logs - http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Upgrade/18.2.1-265/141/tier1-upgrade-rhcs-5x-to-7x/Verify_cephadm_stray_host_warning_post_upgrade_0.log 

Resolution -
Test was failing due to parameter "max_mds: 2", which requires 2 active and 1 standby MDS daemons.
So, after the upgrade is performed, even if there are no stray host daemons, there is a warning about the insufficient MDS daemons -

```
HEALTH_WARN
            insufficient standby MDS daemons available  services
```
To resolve this issue, we need MDS daemon running on 3 nodes of the cluster, so we need to run the suite against a bigger conf i.e. https://github.com/red-hat-storage/cephci/blob/master/conf/6-node-cluster-with-1-client.yaml which supports deploying 3 MDS daemons.

Since https://github.com/red-hat-storage/cephci/blob/master/conf/6-node-cluster-with-1-client.yaml did not have "rgw" label to any nodes, RGW service deployment was failing for the upgrade suite, hence added the same.

For more details, please check https://issues.redhat.com/browse/RHCEPHQE-16933 

