### PR TITLE
Fixing the Regression failures

### DIFF
--- a/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
+++ b/tests/cephfs/cephfs_nfs/nfs_info_cluster_id_and_ls_export_detailed.py
@@ -106,7 +106,8 @@ def run(ceph_cluster, **kw):
         if result["fsal"]["name"] != "CEPH":
             do_not_match.append("[fsal][name]")
 
-        elif result["fsal"]["user_id"] != user_id:
+        # In 8.0 the user_id is getting appended with 8 character sample : nfs.test-nfs_32igz.cephfs.540bf01f
+        elif not result["fsal"]["user_id"].startswith(user_id):
             do_not_match.append("[fsid][user_id]")
 
         elif result["fsal"]["fs_name"] != fs_name:

--- a/tests/cephfs/clients/client_caps_update_validation.py
+++ b/tests/cephfs/clients/client_caps_update_validation.py
@@ -128,6 +128,7 @@ def client_caps_quiesce_test(client, subvol_path, fs_name, qs_set, cg_snap_util)
     """
     out, _ = client.exec_command(sudo=True, cmd="ceph tell mds.0 client ls --f json")
     client_ls = json.loads(out)
+    client_id = ""
     for i in range(0, len(client_ls)):
         log.info(client_ls[i])
         if client_ls[i]["client_metadata"].get("root"):
@@ -135,7 +136,11 @@ def client_caps_quiesce_test(client, subvol_path, fs_name, qs_set, cg_snap_util)
             if sv_path in subvol_path and sv_path != "/":
                 caps_before_quiesce = client_ls[i]["num_caps"]
                 client_id = client_ls[i]["id"]
+                log.info(f"client_id is assigned with value {client_id}")
                 break
+    log.info(
+        f"client_id is assigned with value {client_id} After looping through clients"
+    )
     log.info(f"CG quiesce on members:{qs_set}")
     rand_str = "".join(random.choice(string.digits) for i in range(3))
     qs_id_val = f"caps_test_{rand_str}"

--- a/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
+++ b/tests/cephfs/snapshot_clone/cephfs_snap_utils.py
@@ -321,16 +321,28 @@ class SnapUtils(object):
         sched_verified = 0
         snap_count = 1
         for i in range(len(sched_snap_list)):
+            log.debug(
+                f"Comparing snapshot {sched_snap_list[i]} with subsequent snapshots."
+            )
             for j in range(i + 1, len(sched_snap_list)):
+                log.debug(
+                    f"Time difference between snapshot {sched_snap_list[i]} and {sched_snap_list[j]} minutes"
+                )
                 if sched_type == m_granularity:
-                    if int(sched_num) == abs(
-                        int(
-                            int(sched_snap_list[i].split("_")[1])
-                            - int(sched_snap_list[j].split("_")[1])
-                        )
-                    ):
+                    time_diff = abs(
+                        int(sched_snap_list[i].split("_")[1])
+                        - int(sched_snap_list[j].split("_")[1])
+                    )
+                    log.debug(
+                        f"Time difference between snapshot {sched_snap_list[i]} and "
+                        f"{sched_snap_list[j]}: {time_diff} minutes"
+                    )
+                    if int(sched_num) == time_diff:
                         sched_verified = 1
                         snap_count += 1
+                        log.info(
+                            f"Verified snapshot interval: {sched_num} {sched_type}. Verified count: {snap_count}"
+                        )
                 if sched_type == "h":
                     hour_val2 = sched_snap_list[j].split("-")[4].split("_")[0]
                     hour_val1 = sched_snap_list[i].split("-")[4].split("_")[0]
@@ -399,7 +411,7 @@ class SnapUtils(object):
         cmd = f"ceph fs snap-schedule status {kw_args.get('sched_path')} --fs {fs_name} -f json"
         if kw_args.get("subvol_name"):
             sv_name = kw_args["subvol_name"]
-            cmd = f"cceph fs snap-schedule status / --subvol {sv_name} --fs {fs_name} -f json"
+            cmd = f"ceph fs snap-schedule status / --subvol {sv_name} --fs {fs_name} -f json"
             if kw_args.get("group_name"):
                 cmd += f" --group {kw_args['group_name']}"
         out, rc = client.exec_command(sudo=True, cmd=cmd)


### PR DESCRIPTION
# Description
Fixing the Regression failures

Failed Log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-53/cephfs/48/teir-2_file-dir-lay_vol-mgmt_nfs/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-53/cephfs/48/tier-2_fs_mutlifs_quota_snaphost/snap_schedule_retention_vol_subvol_0.log

We have added extra debug logs for other failures 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
