### PR TITLE
NVMe upgrade test suite changes w.r.t 8.0 and 7.1z2

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
@@ -64,12 +64,6 @@ tests:
               service: osd
               args:
                 all-available-devices: true
-          # Remove this config step once below BZ is verified,
-          # https://bugzilla.redhat.com/show_bug.cgi?id=2305795
-          - config:
-              command: shell
-              args:
-                - ceph config set mgr mgr/cephadm/container_image_nvmeof cp.icr.io/cp/ibm-ceph/nvmeof-rhel9:1.2.16-8
       destroy-cluster: false
       abort-on-fail: true
 

--- a/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade.yaml
@@ -38,8 +38,6 @@ tests:
                 custom_image: false
                 rhcs-version: "7.1"
                 mon-ip: node1
-                orphan-initial-daemons: true
-                skip-monitoring-stack: true
                 log-to-file: true
           - config:
               command: add_hosts

--- a/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_7x-to-8x_upgrade_with_mtls.yaml
@@ -38,8 +38,6 @@ tests:
                 custom_image: false
                 rhcs-version: "7.1"
                 mon-ip: node1
-                orphan-initial-daemons: true
-                skip-monitoring-stack: true
                 log-to-file: true
           - config:
               command: add_hosts

--- a/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade.yaml
@@ -34,12 +34,10 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_repo: https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/IBM-CEPH-8.0-202409180241.ci.0/IBM-CEPH-8.0-202409180241.ci.0-rhel9.repo
-                custom_image: cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:8-30
+                custom_repo: "cdn"
+                custom_image: false
                 rhcs-version: "8.0"
                 mon-ip: node1
-                orphan-initial-daemons: true
-                skip-monitoring-stack: true
                 log-to-file: true
           - config:
               command: add_hosts

--- a/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof_b2b_upgrade_with_mtls.yaml
@@ -34,12 +34,10 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                custom_repo: https://public.dhe.ibm.com/ibmdl/export/pub/storage/ceph/testing/IBM-CEPH-8.0-202409180241.ci.0/IBM-CEPH-8.0-202409180241.ci.0-rhel9.repo
-                custom_image: cp.stg.icr.io/cp/ibm-ceph/ceph-8-rhel9:8-30
+                custom_repo: "cdn"
+                custom_image: false
                 rhcs-version: "8.0"
                 mon-ip: node1
-                orphan-initial-daemons: true
-                skip-monitoring-stack: true
                 log-to-file: true
           - config:
               command: add_hosts


### PR DESCRIPTION
# Description

- Revert or remove updation of container image, since 7.1z2 has right container image tag.
- Update 8.0 test suites to adopt CDN deployment.