### PR TITLE
CEPH-83575437: Test to verify rgw bilog trimming with down OSDs

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_rados_multisite_ecpool.yaml
+++ b/suites/reef/rgw/tier-2_rgw_rados_multisite_ecpool.yaml
@@ -1,7 +1,7 @@
 # Test suite for evaluating RGW multi-site deployment scenario.
 # the data bucket is configured to use EC
 
-# conf : conf/squid/rgw/ms-ec-profile-4+2-cluster.yaml
+# conf : conf/reef/rgw/ms-ec-profile-4+2-cluster.yaml
 ---
 
 tests:
@@ -252,12 +252,12 @@ tests:
 
   - test:
       clusters:
-        ceph-pri:
+        ceph-sec:
           config:
             config-file-name: test_Mbuckets_with_Nobjects.yaml
             script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: [ "ceph-sec" ]
-      desc: Execute M buckets with N objects on primary cluster
+            verify-io-on-site: [ "ceph-pri" ]
+      desc: Execute M buckets with N objects on secondary cluster
       polarion-id: CEPH-83575435
       module: sanity_rgw_multisite.py
       name: m buckets with n objects
@@ -276,9 +276,5 @@ tests:
   - test:
       name: scrub + bilog trimming with OSD down
       desc: test radosgw bilog trimming and deep-scrub with OSDs down
-      clusters:
-        ceph-pri:
-          config:
-            pool_name: rgw_bilog
       polarion-id: CEPH-83575437
       module: test_bilog_trim.py

--- a/tests/rados/test_bilog_trim.py
+++ b/tests/rados/test_bilog_trim.py
@@ -1,0 +1,160 @@
+"""
+Tier-2 test to ensure PG deep-scrub does not report inconsistent PGs
+when radosgw bilog trimming occurs on PGs where secondary OSD is down
+Customer Bug: 2056818 - [GSS][RADOS][RGW] Scrub errors (omap_digest_mismatch) on
+PGs of RGW metadata pools after upgrade to RHCS 5
+
+Test needs to run as part of rgw/tier-2_rgw_rados_multisite_ecpool.yaml
+as it needs a rgw multisite setup along with data present in RGW pools
+"""
+
+import datetime
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados import utils as rados_utils
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.stretch_cluster import wait_for_clean_pg_sets
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    # CEPH-83575437
+    # BZ-2056818
+    This test is to verify no issues are observed during deep-scrub when rgw bilog
+    trimming occurs with OSD down
+    Steps:
+    Ref:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2056818#c42
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2056818#c50
+    1. Deploy minimal RGW multisite setup
+    2. Add data to both the sites in S3 buckets and let the minimal client IO running
+    3. Keep running the deep-scrub for index pool PGs
+    4. Set noout flag
+    5. stop the secondary OSD on the primary site(site1)
+    6. run the following command
+       radosgw-admin bilog autotrim
+    7. Once the above command finishes, start the primary OSD that was stopped in step 4
+    8. Retrigger the deep-scrub for eight PGs in index pool
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    osd_nodes = ceph_cluster.get_nodes(role="osd")
+    rgw_node = ceph_cluster.get_nodes(role="rgw")[0]
+
+    try:
+        # to-do: Write a module to trigger background RGW IOs
+        """
+        # start background IOs using RGW
+        log.info("Starting background IOs with RGW client")
+        cfg_path = (
+            "/home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/"
+            + "s3_swift/multisite_configs/test_Mbuckets_with_Nobjects.yaml"
+        )
+
+        script_path = (
+            "/home/cephuser/rgw-ms-tests/ceph-qe-scripts/rgw/v2/tests/"
+            + "s3_swift/test_Mbuckets_with_Nobjects.py"
+        )
+
+        rgw_node_ip = rgw_node.ip_address
+
+        # modify object count to 1000
+        _cmd = f"sed -i 's/100/1000/g' {cfg_path}"
+        rados_obj.client.exec_command(cmd=_cmd, sudo=True)
+
+        run_cmd = f"sudo venv/bin/python {script_path} -c {cfg_path} --rgw-node {rgw_node_ip} &> /dev/null &"
+        rados_obj.client.exec_command(cmd=run_cmd, sudo=True, check_ec=False)
+        """
+
+        # set noout flag
+        if not rados_utils.configure_osd_flag(ceph_cluster, action="set", flag="noout"):
+            log.error("Could not set noout flag on the cluster")
+            raise Exception("Could not set noout flag on the cluster")
+
+        # get acting set for the rgw index pool
+        _pool_name = "primary.rgw.buckets.index"
+        acting_set = rados_obj.get_pg_acting_set(pool_name=_pool_name)
+        log.info(f"Acting set for pool {_pool_name}: {acting_set}")
+
+        # secondary osd of rgw index pool
+        second_osd = acting_set[1]
+
+        # trigger deep-scrub on the rgw index pool
+        rados_obj.run_deep_scrub(pool=_pool_name)
+
+        if not rados_obj.change_osd_state(action="stop", target=int(second_osd)):
+            log.error(f"Could not stop OSD.{second_osd}")
+            raise Exception(f"Could not stop OSD.{second_osd}")
+
+        # for a duration of 7 mins, trigger bi-log trimming along with deep-scrub
+        timeout_time = datetime.datetime.now() + datetime.timedelta(seconds=420)
+        while datetime.datetime.now() < timeout_time:
+            rados_obj.client.exec_command(cmd="radosgw-admin bilog autotrim", sudo=True)
+            rados_obj.run_deep_scrub(pool=_pool_name)
+            time.sleep(30)
+
+        # start the stopped OSDs
+        if not rados_obj.change_osd_state(action="start", target=int(second_osd)):
+            log.error(f"Could not start OSD.{second_osd}")
+            raise Exception(f"Could not start OSD.{second_osd}")
+
+        # triggering deep scrub on the rgw index pool now that OSDs have been started
+        rados_obj.run_deep_scrub(pool=_pool_name)
+        pg_id = rados_obj.get_pgid(pool_name=_pool_name)[0]
+        if not rados_obj.start_check_deep_scrub_complete(pg_id=pg_id):
+            log.error(f"PG {pg_id} could not be deep-scrubbed in time")
+            raise
+
+        # not warning should show up in cluster health
+        health_detail, _ = cephadm.shell(args=["ceph health detail"])
+        log.info(f"Cluster health: \n {health_detail}")
+        assert (
+            "inconsistent" not in health_detail
+        ), "'inconsistent' health warning unexpected"
+        assert (
+            "scrub errors" not in health_detail
+        ), "scrub errors reported in cluster health"
+        assert "data damage" not in health_detail, "cluster health reported data damage"
+
+        log.info(
+            "Verification completed, no issues observed during scrubbing and bi-log trimming "
+            "in a cluster with down OSDs"
+        )
+    except Exception as e:
+        log.error(f"Execution failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        log.info(
+            "\n \n ************** Execution of finally block begins here *************** \n \n"
+        )
+        # unset noout flag
+        if not rados_utils.configure_osd_flag(
+            ceph_cluster, action="unset", flag="noout"
+        ):
+            log.error("Could not unset noout flag on the cluster")
+            return 1
+
+        # start the stopped OSDs
+        if "second_osd" in locals() or "second_osd" in globals():
+            if not rados_obj.change_osd_state(action="start", target=int(second_osd)):
+                log.error(f"Could not start OSD.{second_osd}")
+                return 1
+
+        # wait for active+clean PGs
+        if not wait_for_clean_pg_sets(rados_obj, timeout=600):
+            log.error("Cluster cloud not reach active+clean state within 600 secs")
+
+        # log cluster health
+        rados_obj.log_cluster_health()
+        # check for crashes after test execution
+        if rados_obj.check_crash_status():
+            log.error("Test failed due to crash at the end of test")
+            return 1
+    return 0


### PR DESCRIPTION
# Description
[CEPH-83575437](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575437): Tier-3 test to verify scrub errors on PGs of RGW metadata pools after osds are rebooted

> Before the fix, partial recovery did not set `clean_omap` to `false` for `CEPH_OSD_OP_OMAPRMKEYRANGE` operations. This caused replicated pools with inconsistent PGs due to incomplete omap recovery.

Jira tracker: [RHCEPHQE-15945](https://issues.redhat.com/browse/RHCEPHQE-15945)
Customer Bug: [2056818](https://bugzilla.redhat.com/show_bug.cgi?id=2056818)

Test suites modified:
- `suites/squid/rgw/tier-2_rgw_rados_multisite_ecpool.yaml`

Test suites added:
- `suites/reef/rgw/tier-2_rgw_rados_multisite_ecpool.yaml`

Test cases added:
- `tests/rados/test_bilog_trim.py`

Steps:
Refer:
    - https://bugzilla.redhat.com/show_bug.cgi?id=2056818#c42
    - https://bugzilla.redhat.com/show_bug.cgi?id=2056818#c50
    1. Deploy minimal RGW multisite setup
    2. Add data to both the sites in S3 buckets and let the minimal client IO running
    3. Keep running the deep-scrub for index pool PGs
    4. Set noout flag
    5. stop the secondary OSD on the primary site(site1)
    6. run the following command
       radosgw-admin bilog autotrim
    7. Once the above command finishes, start the primary OSD that was stopped in step 4
    8. Re-trigger the deep-scrub for eight PGs in index pool

Logs-
Reef:
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5T9F91
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BA3HNP

Signed-off-by: Harsh Kumar <hakumar@redhat.com>


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
