### PR TITLE
TFA fix in cg_snap_neg_1 to include fs_name during cg_quiesce

### DIFF
--- a/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -56,35 +56,6 @@ tests:
                 all-available-devices: true
               command: apply
               service: osd
-          -
-            config:
-              args:
-                - ceph
-                - fs
-                - volume
-                - create
-                - cephfs
-              command: shell
-          -
-            config:
-              args:
-                placement:
-                  label: mds
-              base_cmd_args:
-                verbose: true
-              command: apply
-              pos_args:
-                - cephfs
-              service: mds
-          - config:
-              args:
-                - ceph
-                - fs
-                - set
-                - cephfs
-                - max_mds
-                - "2"
-              command: shell
         verify_cluster_health: true
       desc: "Execute the cluster deployment workflow."
       destroy-cluster: false
@@ -162,16 +133,6 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Enable ceph debug logs"
-      module: cephfs_logs_util.py
-      name: cephfs-enable-logs
-      config:
-       ENABLE_LOGS : 1
-       daemon_list : ['mds','client']
-       daemon_dbg_level : {'mds':20,'client':20}
-  -
-    test:
-      abort-on-fail: false
       desc: "Verify quiesce suceeds with IO from nfs,fuse and kernel mounts"
       destroy-cluster: false
       module: snapshot_clone.cg_snap_test.py
@@ -220,12 +181,3 @@ tests:
       config:
        test_name: cg_snap_interop_workflow_1
       comments: product bug bz-2273569
-  -
-    test:
-      abort-on-fail: false
-      desc: "Disable ceph debug logs"
-      module: cephfs_logs_util.py
-      name: cephfs-disable-logs
-      config:
-       DISABLE_LOGS : 1
-       daemon_list : ['mds','client']

--- a/tests/cephfs/snapshot_clone/cg_snap_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_test.py
@@ -2773,6 +2773,7 @@ def cg_snap_neg_1(cg_test_params):
                     "timeout": 300,
                     "expiration": 300,
                     "if_await": "False",
+                    "fs_name": fs_name,
                 }
                 try:
                     quiesce_proc = Thread(
@@ -3005,7 +3006,8 @@ def cg_mds_failover(fs_util, client, fs_name, repeat_cnt=1):
         standby_mds = [
             mds["name"] for mds in output["mdsmap"] if mds["state"] == "standby"
         ]
-        mds_to_fail = random.sample(mds_ls, len(standby_mds))
+        sample_cnt = min(3, len(standby_mds))
+        mds_to_fail = random.sample(mds_ls, sample_cnt)
         for mds in mds_to_fail:
             out, rc = client.exec_command(cmd=f"ceph mds fail {mds}", client_exec=True)
             log.info(out)


### PR DESCRIPTION
# Description
Jira: https://issues.redhat.com/browse/RHCEPHQE-16777

Failure:
cg_snap_neg_workflow_1
Log - http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-53/cephfs/48/tier-1_cephfs_cg_quiesce/cg_snap_neg_workflow_1_0.log 
Error as quiesce set id does not exist after creating 5 parallel quiesce sets
Fix: fs_name as cephfs-ec was not passed to cg_quiesce module hence the issue, fixed it
cg_snap_neg_workflow_1 fix passed logs: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PTCDKY/cg_snap_neg_workflow_1_0.log

[cg_snap_interop_workflow_1](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83581472) : test was executed on FS volume cephfs-ec, but there existed another volume on cluster cephfs created during ceph deploy as per cg quiesce suite.
With too many mds instances some from cephfs volume and some from cephfs-ec volume, sampling error happens during selection of standby_mds count worth of MDS'es for Rolling MDS failures, as we expected 3 but there are more than 3 standby MDSes during 2 FS volumes.
Removed cephfs volume creation during ceph deploy as we are creating within cg_snap_test setup.
Also added limit for sampling as min(3,standby_mds_cnt)
Passed logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FPUKFF

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
