### PR TITLE
Automation of positive workflows for ceph-volume utility

### DIFF
--- a/ceph/rados/cephvolume_workflows.py
+++ b/ceph/rados/cephvolume_workflows.py
@@ -1,0 +1,250 @@
+"""
+Test Module to perform specific functionalities of ceph-volume.
+ - ceph-volume lvm list [OSD_ID | DEVICE_PATH | VOLUME_GROUP/LOGICAL_VOLUME]
+ - ceph-volume lvm zap [--destroy] [--osd-id OSD_ID | --osd-fsid OSD_FSID | DEVICE_PATH]
+ - ceph-volume --help
+ - ceph-volume lvm --help
+ - ceph-volume lvm prepare --bluestore [--block.db --block.wal] --data path
+ - ceph-volume lvm activate [--bluestore OSD_ID OSD_FSID] [--all]
+ - ceph-volume lvm deactivate OSD_ID
+ - ceph-volume lvm create --bluestore --data VOLUME_GROUP/LOGICAL_VOLUME
+ - ceph-volume lvm batch --bluestore PATH_TO_DEVICE [PATH_TO_DEVICE]
+ - ceph-volume lvm migrate --osd-id OSD_ID --osd-fsid OSD_UUID
+    --from [ data | db | wal ] --target VOLUME_GROUP_NAME/LOGICAL_VOLUME_NAME
+ - ceph-volume lvm new-db --osd-id OSD_ID --osd-fsid OSD_FSID --target VOLUME_GROUP_NAME/LOGICAL_VOLUME_NAME
+ - ceph-volume lvm new-wal --osd-id OSD_ID --osd-fsid OSD_FSID --target VOLUME_GROUP_NAME/LOGICAL_VOLUME_NAME
+"""
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.core_workflows import RadosOrchestrator
+from utility.log import Log
+
+log = Log(__name__)
+
+
+class CephVolumeWorkflows:
+    """
+    Contains various functions to verify ceph-volume commands
+    """
+
+    def __init__(self, node: CephAdmin):
+        """
+        initializes the env to run ceph-volume commands
+        Args:
+            node: CephAdmin object
+        """
+        self.rados_obj = RadosOrchestrator(node=node)
+        self.cluster = node.cluster
+        self.client = node.cluster.get_nodes(role="client")[0]
+
+    def run_cv_command(
+        self,
+        cmd: str,
+        host,
+        timeout: int = 300,
+    ) -> str:
+        """
+        Runs ceph-volume commands within cephadm shell
+        Args:
+            cmd: command that needs to be run
+            host: (ceph.utils.CephVMNode): CephVMNode
+            timeout: Maximum time allowed for execution.
+        Returns:
+            output of respective ceph-volume command in string format
+        """
+        _cmd = f"cephadm {cmd}"
+        try:
+            out, err = host.exec_command(sudo=True, cmd=_cmd, timeout=timeout)
+        except Exception as er:
+            log.error(f"Exception hit while command execution. {er}")
+            raise
+        return str(out)
+
+    def help(self, host):
+        """Module to run help command with ceph-volume to display usage
+         Args:
+            host: (ceph.utils.CephVMNode): CephVMNode
+        Returns:
+            Output of ceph-volume usage
+        """
+        _cmd = "ceph-volume --help"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_help(self, host):
+        """Module to run help command with ceph-volume lvm to display usage
+         Args:
+            host: (ceph.utils.CephVMNode): CephVMNode
+        Returns:
+            Output of ceph-volume lvm usage
+        """
+        _cmd = "ceph-volume --help"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_list(self, host, osd_id=None, device_path=None):
+        """Module to list logical volumes and devices
+        associated with a Ceph cluster
+
+        Args:
+            [optional] osd_id: ID of the OSD to list
+            [optional] device_path: path of the OSD device to list
+            host: (ceph.utils.CephVMNode): CephVMNode
+
+        Returns:
+            Returns the output of ceph-volume lvm list
+
+        Usage:
+            usage without any arguements:
+                cephvolume_obj.lvm_list(host=osd_host)
+            usage with osd_id:
+                cephvolume_obj.lvm_list(osd_id="6",host=osd_host)
+            usage with device:
+                cephvolume_obj.lvm_list(device_path="/dev/vdb", host=osd_host)
+        """
+        # Extracting the ceush map from the cluster
+        _cmd = "ceph-volume lvm list"
+        if osd_id:
+            _cmd = f"{_cmd} {osd_id}"
+        elif device_path:
+            _cmd = f"{_cmd} {device_path}"
+
+        _cmd = f"{_cmd} --format json"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_zap(self, host, destroy=None, osd_id=None, osd_fsid=None, device=None):
+        """Module to remove all data and file systems from a logical volume or partition.
+        Optionally, you can use the --destroy flag for complete removal of a logical volume,
+        partition, or the physical device.
+
+        Args:
+            [optional] destroy: If destroy is true --destory flag will be added to the command for
+            complete removal of logical volume, volume group and physical volume
+            [optional] osd_id: ID of the OSD to zap
+            [optional] osd_fsid: FSID of the OSD to zap
+            [optional] device: Device path of the OSD to zap
+
+        Returns:
+            Returns the output of ceph-volume lvm zap
+
+        Usage:
+            usage with device path:
+                cephvolume_obj.lvm_zap(device="/dev/vdb", destory=False, host=osd_host)
+            usage with osd-id:
+                cephvolume_obj.lvm_zap(osd_id="6", destroy=True, host=osd_host)
+            usage with osd-fsid:
+                cephvolume_obj.lvm_zap(osd_fsid="5cf86425-bd5b-4526-9961-a7d2286ab973", destroy=True, host=osd_host)
+        """
+        _cmd = "ceph-volume lvm zap"
+        if device:
+            _cmd = f"{_cmd} {device}"
+
+        if osd_id:
+            _cmd = f"{_cmd} --osd-id {osd_id}"
+
+        if osd_fsid:
+            _cmd = f"{_cmd} --osd-fsid {osd_fsid}"
+
+        if destroy:
+            _cmd = f"{_cmd} --destroy"
+
+        log.info(f"Proceeding to zap using command: {_cmd}")
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_prepare(self, device: str, host):
+        """Module to prepare volumes, partitions or physical devices.
+        The prepare subcommand prepares an OSD back-end object store
+        and consumes logical volumes (LV) for both the OSD data and journal.
+        Args:
+            destory
+        Returns:
+            Returns the output of ceph-volume lvm prepare
+        """
+        _cmd = f"ceph-volume lvm prepare --bluestore --data {device}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_activate(self, osd_id: int, osd_fsid: str, all: bool, host):
+        """Module to activate OSD. The activation process for a Ceph OSD enables
+        a systemd unit at boot time, which allows the correct OSD identifier and
+        its UUID to be enabled and mounted.
+        Args:
+            osd_id: ID of OSD to activate
+            osd_fsid: FSID of OSD to activate
+            all: activate all OSD that are prepared for activation by passing --all flag
+        Returns:
+            Returns the output of ceph-volume lvm activate
+        """
+        _cmd = "ceph-volume lvm activate"
+        if all:
+            _cmd = f"{_cmd} --all"
+        else:
+            _cmd = f"{_cmd} --bluestore {osd_id} {osd_fsid}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_deactivate(self, osd_id: int, host):
+        """Module to remove the volume groups and the logical volume
+        Args:
+            None
+        Returns:
+            Returns the output of ceph-volume lvm deactivate
+        """
+        _cmd = f"ceph-volume lvm deactivate {osd_id}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_batch(self, devices: list, host):
+        """Module to automate the creation of multiple OSDs
+        Args:
+            devices: list of devices for OSD creation
+        Returns:
+            Returns the output of ceph-volume lvm batch
+        """
+        _cmd = "ceph-volume lvm batch --bluestore"
+        for device in devices:
+            _cmd = f"{_cmd} {device}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_migrate(
+        self, osd_id: int, osd_fsid: str, host, from_flag_list: list, target: str
+    ):
+        """Module to migrate the BlueStore file system (BlueFS) data (RocksDB data)
+        from the source volume to the target volume.
+        Args:
+            from: arguement for --from flag. list can contain "data" "db" "wal"
+            osd_id: ID of the source OSD for data migration
+            osd_fsid: FSID of the source OSD for data migration
+            target: target device/logical volume for data migration
+        Returns:
+            Returns the output of ceph-volume lvm migrate
+        """
+        _cmd = f"ceph-volume lvm migrate --osd-id {osd_id} --osd-fsid {osd_fsid} --from"
+        for device in from_flag_list:
+            _cmd = f"{_cmd} {device}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_create(self, path: str, host):
+        """Module to call the prepare subcommand, and then calls the activate subcommand.
+        Args:
+            path: path can be device path (/dev/vdb) or logical volume (volume_group/logical_volume)
+        Returns:
+            Returns the output of ceph-volume lvm create
+        """
+        _cmd = f"ceph-volume lvm create --bluestore --data {path}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_new_db(self, path: str, host):
+        """Module to attache the given logical volume to the given OSD as a DB volume
+        Args:
+            path: path can be device path (/dev/vdb) or logical volume (volume_group/logical_volume)
+        Returns:
+            Returns the output of ceph-volume lvm new-db
+        """
+        _cmd = f"ceph-volume lvm create --bluestore --data {path}"
+        return self.run_cv_command(cmd=_cmd, host=host)
+
+    def lvm_new_wal(self, path: str, host):
+        """Module to attache the given logical volume to the given OSD as a WAL volume
+        Args:
+            path: path can be device path (/dev/vdb) or logical volume (volume_group/logical_volume)
+        Returns:
+            Returns the output of ceph-volume lvm new-wal
+        """
+        _cmd = f"ceph-volume lvm create --bluestore --data {path}"
+        return self.run_cv_command(cmd=_cmd, host=host)

--- a/suites/squid/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/squid/rados/tier-2_rados_test_bluestore.yaml
@@ -160,3 +160,20 @@ tests:
           obj_end: 15
           normal_objs: 400
           num_keys_obj: 200001
+
+  - test:
+      name: Ceph Volume utility zap test with destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id:
+      desc: verify ceph-volume lvm zap functionality with destroy flag
+      config:
+        zap_with_destroy_flag: true
+  
+  - test:
+      name: Ceph Volume utility zap test without destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id:
+      desc: verify ceph-volume lvm zap functionality without destroy flag
+      config:
+        zap_without_destroy_flag: true
+        

--- a/tests/rados/test_cephvolume_workflows.py
+++ b/tests/rados/test_cephvolume_workflows.py
@@ -1,0 +1,455 @@
+"""
+Test Module to perform specific functionalities of ceph-volume.
+ - ceph-volume lvm list [OSD_ID | DEVICE_PATH | VOLUME_GROUP/LOGICAL_VOLUME]
+ - ceph-volume lvm zap [--destroy] [--osd-id OSD_ID | --osd-fsid OSD_FSID | DEVICE_PATH ]
+ - ceph-volume --help
+"""
+
+import itertools
+import json
+import random
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados import utils
+from ceph.rados.cephvolume_workflows import CephVolumeWorkflows
+from ceph.rados.core_workflows import RadosOrchestrator
+from cli.utilities.operations import wait_for_osd_daemon_state
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Test to perform +ve workflows for the ceph-volume utility
+    Returns:
+        1 -> Fail, 0 -> Pass
+
+    Zap Steps:
+    1.  Deploy a Ceph cluster
+    2.  Fetch all active OSDs and select random OSD from the list to zap
+    3.  Set OSD service to unmanaged
+    4.  Remove selected OSD from cluster without passing --zap flag to
+         test ceph-volume utility
+    5.  Zap using ceph-volume utility with/without --destroy flag
+    6.  Validate OSD details are removed from ceph-volume lvm list
+    7.  If --destroy flag is not passed, Validate file system is wiped from OSD device
+    8.  If --destroy flag is passed, Validate LVs, VGs and PVs are
+        removed from the host
+    9.  If --destroy flag is not passed, Validate LVs, VGs and PVs are
+        not removed from the host
+    10. Set OSD service back to managed
+    11. If --destroy flag is not passed, Execute zap with --destroy flag
+        to clear LVs, VGs and PVs related to OSD device
+    12. Wait until removed OSD is added back, since OSD service is set to managed
+    13. Perform steps#2 through steps#12 for different options of zap command
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    volumeobject_obj = CephVolumeWorkflows(node=cephadm)
+
+    try:
+
+        if config.get("zap_with_destroy_flag") or config.get(
+            "zap_without_destroy_flag"
+        ):
+
+            options = ["device", "osd_id", "osd_fsid"]
+            options_list = list()
+
+            # Retrieve combination of options for zapping.
+            # [ ['device'], ['osd_id'], ['fsid'],['device','osd_id]... ]
+            for L in range(1, len(options) + 1):
+                for subset in itertools.combinations(options, L):
+                    subset_list = list(subset)
+
+                    if config.get("zap_with_destroy_flag"):
+                        subset_list.append("--destroy")
+
+                    options_list.append(subset_list)
+
+            for option in options_list:
+
+                if (
+                    config.get("zap_without_destroy_flag")
+                    and len(option) == 1
+                    and option[0] == "device"
+                ):
+                    log.debug(
+                        "Issue with `ceph-volume lvm zap device` execution\n"
+                        "BZ 2329904\n"
+                        "continuing with next option"
+                    )
+                    continue
+
+                log.info(
+                    f"\n -------------------------------------------"
+                    f"\n Option selected: {option}"
+                    f"\n -------------------------------------------"
+                )
+
+                log.info(
+                    "fetching active OSDs and selecting random OSD for 'ceph-volume lvm zap' test\n"
+                )
+
+                osd_list = rados_obj.get_osd_list(status="up")
+                osd_id = random.choice(osd_list)
+
+                log.info(
+                    f"Active OSDs in the cluster: {osd_list}\n"
+                    f"OSD {osd_id} selected at random for zap test\n"
+                    f"Proceeding to fetch Host, osd_fsid and device path for OSD {osd_id}\n"
+                )
+
+                osd_host = rados_obj.fetch_host_node(
+                    daemon_type="osd", daemon_id=osd_id
+                )
+                osd_fsid = rados_obj.get_osd_uuid(osd_id)
+                lvm_list = volumeobject_obj.lvm_list(host=osd_host, osd_id=osd_id)
+                try:
+                    lvm_list = json.loads(lvm_list)
+                except json.JSONDecodeError as e:
+                    log.error(f"Error decoding ceph-volume lvm list command {e}")
+                    raise Exception(
+                        "Error Deserialising output of `ceph-volume lvm list` into python object"
+                    )
+
+                dev_path = lvm_list[str(osd_id)][0]["devices"][0]
+                osd_lv_name = lvm_list[str(osd_id)][0]["lv_name"]
+                osd_vg_name = lvm_list[str(osd_id)][0]["vg_name"]
+
+                log.info(
+                    f"Successfully fetched Host, osd fsid and device path for OSD {osd_id}\n"
+                    f"Host: {osd_host.hostname}\n"
+                    f"OSD fsid: {osd_fsid}\n"
+                    f"device path: {dev_path}\n"
+                    f"OSD LV name: {osd_lv_name}\n"
+                    f"OSD VG name: {osd_vg_name}\n"
+                )
+
+                # Execute ceph-volume --help
+                log.info(
+                    "\n ---------------------------------"
+                    "\n Running help for Ceph Volume"
+                    "\n ---------------------------------"
+                )
+                out = volumeobject_obj.help(osd_host)
+                log.info(out)
+
+                # ceph-volume lvm zap [ --destroy | device path | --osd-id osd id | --osd-fsid osd fsid ]
+                log.info(
+                    f"\n -------------------------------------------"
+                    f"\n Zapping device on host {osd_host.hostname} with command: "
+                    f"ceph-volume lvm zap {' '.join(option)}\n"
+                    f"\n -------------------------------------------"
+                )
+
+                log.info("Setting OSD service to unmanaged")
+                utils.set_osd_devices_unmanaged(
+                    ceph_cluster=ceph_cluster, osd_id=osd_id, unmanaged=True
+                )
+
+                log.info(
+                    "Successfully set OSD service to unmanaged\n"
+                    f"proceeding to remove OSD [id:{osd_id}, fsid:{osd_fsid}"
+                    f"device path:{dev_path}] on host {osd_host.hostname}"
+                )
+
+                utils.osd_remove(ceph_cluster, osd_id=osd_id)
+
+                log.info(
+                    f"Removed OSD {osd_id} on host {osd_host}"
+                    f"Proceeding to zap volume on host {osd_host}"
+                )
+
+                _ = volumeobject_obj.lvm_zap(
+                    device=dev_path if "device" in option else None,
+                    destroy=True if "--destroy" in option else False,
+                    osd_id=osd_id if "osd_id" in option else None,
+                    osd_fsid=osd_fsid if "osd_fsid" in option else None,
+                    host=osd_host,
+                )
+
+                log.info(
+                    f"Zapped device {dev_path} using `ceph-volume lvm zap`\n"
+                    f"Proceeding to check OSD {osd_id} removed from `ceph-volume lvm list`"
+                )
+
+                if check_osd_id_or_device_exists_in_lvm_list(
+                    volumeobject_obj,
+                    osd_host=osd_host,
+                    osd_id=osd_id,
+                    device_path=dev_path,
+                ):
+                    log.error(
+                        f"zapping OSD device failed [ device_path: {dev_path} OSD ID: {osd_id} OSD FSID: {osd_fsid} ]\n"
+                        f"`ceph-volume lvm list` output still contains OSD ID {osd_id} and device path {dev_path}\n"
+                    )
+                    raise Exception(
+                        f"`ceph-volume lvm list` output still contains OSD ID {osd_id} and device path {dev_path}\n"
+                    )
+
+                log.info(
+                    f"OSD {osd_id} removed from `ceph-volume lvm list` on host {osd_host.hostname}\n"
+                )
+
+                if config.get("zap_without_destroy_flag"):
+                    log.info(
+                        f"Proceeding to check if file systems are removed from OSD {osd_id}"
+                    )
+                    try:
+                        out, _ = osd_host.exec_command(
+                            sudo=True,
+                            cmd=f"lsblk --fs /dev/{osd_vg_name}/{osd_lv_name} --json",
+                        )
+                        out = json.loads(out)
+                        file_system = out["blockdevices"][0]["fstype"]
+                    except json.JSONDecodeError as e:
+                        log.error(f"Error decoding `lsblk --fs` {e}")
+                        raise Exception(
+                            "Error Deserialising output of `lsblk --fs "
+                            f"/dev/{osd_vg_name}/{osd_lv_name} --json` into python object"
+                        )
+
+                    log.info(f"Filesystem for OSD {dev_path}: {file_system}")
+
+                    if file_system:
+                        log.error(
+                            f"zapping device {dev_path} failed\n"
+                            f"`ceph-volume lvm zap` did not wipe filesystem on device {dev_path}\n"
+                            f"Filesystem on device {dev_path} on host {osd_host.hostname}: {file_system}"
+                        )
+                        raise
+
+                    log.info(
+                        f"File system successfully wiped from OSD {osd_id} device {dev_path}\n"
+                    )
+
+                log.info(
+                    f"Proceeding to check if LVs/VGs/PVs for OSD {osd_id} on host {osd_host.hostname}"
+                )
+
+                try:
+                    out, _ = osd_host.exec_command(
+                        sudo=True, cmd="lvs -o lv_name --reportformat json"
+                    )
+                    out = json.loads(out)
+                    lv_names = [
+                        lv_detail["lv_name"] for lv_detail in out["report"][0]["lv"]
+                    ]
+                    log.info(f"lvs on host {osd_host.hostname} are {lv_names}")
+                except json.JSONDecodeError as e:
+                    log.error(f"Error decoding lvs output {e}")
+                    raise Exception(
+                        "Error Deserialising output of `lvs -o lv_name --reportformat json` into python object"
+                    )
+
+                log.info(
+                    f"Retrieved logical volumes from OSD {osd_id} device {dev_path} : {lv_names}\n"
+                    f"Proceeding to retrieve volume groups of OSD {osd_id} on host {osd_host.hostname}"
+                )
+
+                try:
+                    out, _ = osd_host.exec_command(
+                        sudo=True, cmd="vgs -o vg_name --reportformat json"
+                    )
+                    out = json.loads(out)
+                    vg_names = [
+                        vg_detail["vg_name"] for vg_detail in out["report"][0]["vg"]
+                    ]
+                    log.info(f"vgs on host {osd_host.hostname} are {vg_names}")
+                except json.JSONDecodeError as e:
+                    log.error(f"Error decoding vgs output {e}")
+                    raise Exception(
+                        "Error Deserialising output of `vgs -o vg_name --reportformat json` into python object"
+                    )
+
+                log.info(
+                    f"Retrieved volume groups from OSD {osd_id} device {dev_path} : {vg_names}\n"
+                    f"Proceeding to retrieve physical volumes of OSD {osd_id} on host {osd_host.hostname}"
+                )
+
+                try:
+                    out, _ = osd_host.exec_command(
+                        sudo=True, cmd="pvs -o pv_name --reportformat json"
+                    )
+                    out = json.loads(out)
+                    pv_names = [
+                        pv_detail["pv_name"] for pv_detail in out["report"][0]["pv"]
+                    ]
+                    log.info(f"pvs on host {osd_host.hostname} are {pv_names}")
+                except json.JSONDecodeError as e:
+                    log.error(f"Error decoding pvs output {e}")
+                    raise Exception(
+                        "Error Deserialising output of `pvs -o pv_name --reportformat json` into python object"
+                    )
+
+                log.info(
+                    f"Retrieved physical volumes from OSD {osd_id} device {dev_path} : {vg_names}\n"
+                    f"Proceeding with LV/VG/PV validation of OSD {osd_id} on host {osd_host.hostname}"
+                )
+
+                if config.get("zap_with_destroy_flag"):
+                    log.info(
+                        "Destroy flag (--destroy) passed during test execution\n"
+                        f"Proceeding to check if LVs/VGs/PVs are removed for OSD {osd_id}"
+                        f" ( OSD device path {dev_path} ) on host {osd_host.hostname}"
+                    )
+
+                    if (
+                        (dev_path in pv_names)
+                        or (osd_lv_name in lv_names)
+                        or (osd_vg_name in vg_names)
+                    ):
+                        log.error(
+                            f"LVs/VGs/PVs not cleared for OSD {osd_id} {osd_fsid} {dev_path}\n"
+                            f"PVs on host {osd_host.hostname} are {pv_names}"
+                            f"VGs on host {osd_host.hostname} are {vg_names}"
+                            f"LVs on host {osd_host.hostname} are {lv_names}"
+                        )
+                        raise
+
+                    log.info(
+                        f"LVs/VGs/PVs are cleared for OSD {osd_id} on host {osd_host.hostname}\n"
+                    )
+
+                if config.get("zap_without_destroy_flag"):
+                    # If --destroy flag is not passed with ceph-volume lvm zap command
+                    # logical volumes, volume groups and physical volumes should not be wiped.
+                    log.info(
+                        f"Destroy flag (--destroy) not passed during test execution\n"
+                        f"Proceeding to check LVs/VGs/PVs are intact for"
+                        f" OSD {osd_id} ( OSD device path {dev_path} ) on host {osd_host.hostname}"
+                    )
+                    if (
+                        (dev_path not in pv_names)
+                        or (osd_lv_name not in lv_names)
+                        or (osd_vg_name not in vg_names)
+                    ):
+                        log.error(
+                            f"LVs/VGs/PVs are wiped without --destory flag for OSD {osd_id} {osd_fsid} {dev_path}\n"
+                            f"PVs on host {osd_host.hostname} are {pv_names}\n"
+                            f"VGs on host {osd_host.hostname} are {vg_names}\n"
+                            f"LVs on host {osd_host.hostname} are {lv_names}\n"
+                        )
+                        raise
+                    log.info(
+                        f"LVs/VGs/PVs are intact for OSD {osd_id} on host {osd_host.hostname}\n"
+                    )
+
+                log.info(
+                    f"Successfully zapped device {dev_path} with path:{dev_path}"
+                    f" OSD_ID:{osd_id} OSD_FSID:{osd_fsid} on host:{osd_host.hostname}"
+                    f"\nAdding back zapped OSD {osd_id}\n"
+                    f"Retriving list of active OSDs"
+                )
+
+                cluster_osds = rados_obj.get_osd_list(status="up")
+
+                log.info("Setting OSD service to managed")
+                if len(cluster_osds):
+                    utils.set_osd_devices_unmanaged(
+                        ceph_cluster, cluster_osds[0], unmanaged=False
+                    )
+
+                log.info(
+                    "Successfully set osd service to managed\n"
+                    f"Waiting until removed osd {osd_id} on host {osd_host.hostname} is added back"
+                )
+
+                if config.get("zap_without_destroy_flag"):
+                    log.info("Zapping device with --destroy flag to wipe LVs/VGs/PVs")
+                    _ = volumeobject_obj.lvm_zap(
+                        device=dev_path,
+                        destroy=True,
+                        osd_id=None,
+                        osd_fsid=None,
+                        host=osd_host,
+                    )
+
+                wait_for_osd_daemon_state(osd_host, osd_id, "up")
+
+                log.info(
+                    f"Successfully added back osd {osd_id} to cluster\n"
+                    f"Successfully removed osd {osd_id}, zapped device {dev_path}"
+                    f" associated with osd [osd_id: {osd_id}, osd_fsid: {osd_fsid}]"
+                    f" and added back the removed OSD"
+                )
+
+    except Exception as e:
+        log.error(f"Failed with exception: {e.__doc__}")
+        log.exception(e)
+        return 1
+    finally:
+        log.info(
+            "\n \n ************** Execution of finally block begins here *************** \n \n"
+        )
+
+        # log cluster health
+        rados_obj.log_cluster_health()
+
+        # check for crashes after test execution
+        if rados_obj.check_crash_status():
+            log.error("Test failed due to crash at the end of test")
+            return 1
+
+    log.info("Completed verification of ceph-volume utility commands.")
+    return 0
+
+
+def check_osd_id_or_device_exists_in_lvm_list(
+    volumeobject, osd_host, osd_id, device_path
+) -> bool:
+    """
+    Method to check if OSD ID or device path entry exists in `ceph-volume lvm list` command output
+
+    Args:
+        volumeobject: CephVolumeWorkflows object
+        osd_host: Host to perform check
+        osd_id: OSD ID, example: 0
+        device_path: device path, example: /dev/vdb
+    Usage:
+        check_osd_id_or_device_exists_in_lvm_list(volumeobject, osd_host, osd_id="0", device_path="/dev/vdb")
+    Returns:
+        Fail -> False
+        Pass -> True
+    """
+
+    out = volumeobject.lvm_list(host=osd_host)
+
+    try:
+        ceph_volume_lvm_list = json.loads(out)
+    except json.JSONDecodeError as e:
+        log.error(f"Error decoding ceph-volume lvm list command {e}")
+        raise Exception(
+            "Error Deserialising output of `ceph-volume lvm list` into python object"
+        )
+
+    cephvolume_lvm_list_osd_ids = [osd_id for osd_id in ceph_volume_lvm_list]
+    cephvolume_lvm_list_devices = [
+        ceph_volume_lvm_list[osd_id][0]["devices"][0] for osd_id in ceph_volume_lvm_list
+    ]
+
+    log.info(
+        f"OSD ID's in `ceph-volume lvm list` output: {cephvolume_lvm_list_osd_ids}\n"
+        f"Devices in `ceph-volume lvm list` output: {cephvolume_lvm_list_devices}"
+    )
+
+    if (
+        osd_id in cephvolume_lvm_list_osd_ids
+        or device_path in cephvolume_lvm_list_devices
+    ):
+        log.info(
+            f"`ceph-volume lvm list` output contains device path: {device_path}\n"
+            f"`ceph-volume lvm list` output contains OSD ID: {ceph_volume_lvm_list}"
+        )
+        return True
+
+    log.info(
+        f"`ceph-volume lvm list` output does not contains device path: {device_path}\n"
+        f"`ceph-volume lvm list` output does not contains OSD ID: {ceph_volume_lvm_list}"
+    )
+    return False


### PR DESCRIPTION
Polarion : [CEPH-83603694](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83603694)

Zap steps: 
    1.  Deploy a Ceph cluster
    2.  Fetch all active OSDs and select random OSD from the list to zap
    3.  Set OSD service to unmanaged
    4.  Remove selected OSD from cluster without passing --zap flag to
         test ceph-volume utility
    5.  Zap using ceph-volume utility with/without --destroy flag
    6.  Validate OSD details are removed from ceph-volume lvm list
    7.  If --destroy flag is not passed, Validate file system is wiped from OSD device
    8.  If --destroy flag is passed, Validate LVs, VGs and PVs are
        removed from the host
    9.  If --destroy flag is not passed, Validate LVs, VGs and PVs are
        not removed from the host
    10. Set OSD service back to managed
    11. If --destroy flag is not passed, Execute zap with --destroy flag
        to clear LVs, VGs and PVs related to OSD device
    12. Wait until removed OSD is added back, since OSD service is set to managed
    13. Perform steps#2 through steps#12 for different options of zap command
    
   Pass logs with --destroy flag: http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_ceph_volume_with_destory/ 
   Pass logs without --destroy flag: http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_ceph_volume_without_destroy/ 
   Working on logs with entire suite. 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
