### PR TITLE
Moving the test to weekly suites to adhere to new CI

### DIFF
--- a/suites/quincy/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/quincy/cephfs/tier-2_cephfs_test-clients.yaml
@@ -35,7 +35,6 @@
 #   CEPH-83581592: Verify Client eviction is deferred if OSD was laggy.
 #   CEPH-83581613: Verify Client is blocklisted if session metadata is bloated.
 #   CEPH-83591419: Validate Root Sqaush operations on Cephfs
-#   CEPH-83595737: Validate selinux relabel on kernel client
 #
 # Bugs :
 # https://bugzilla.redhat.com/show_bug.cgi?id=2309363
@@ -405,13 +404,6 @@ tests:
       name: Validate Root Sqaush operations on Cephfs
       comments: "BZ-2293943"
       polarion-id: "CEPH-83591419"
-  - test:
-      abort-on-fail: false
-      desc: "Validate selinux relabel on kernel client"
-      module: clients.test_selinux_relabel.py
-      name: Validate selinux relabels
-      comments: "BZ-2309363"
-      polarion-id: "CEPH-83595737"
   - test:
       abort-on-fail: false
       desc: "Client Caps Validation during quiesce,mds failover and evict"

--- a/suites/quincy/cephfs/tier-2_cephfs_test_mds_pinning.yaml
+++ b/suites/quincy/cephfs/tier-2_cephfs_test_mds_pinning.yaml
@@ -219,3 +219,10 @@ tests:
       polarion-id: CEPH-83574329
       desc: map and unmap directory trees to a mds rank
       abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Validate selinux relabel on kernel client"
+      module: clients.test_selinux_relabel.py
+      name: Validate selinux relabels
+      comments: "BZ-2309363"
+      polarion-id: "CEPH-83595737"

--- a/suites/reef/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test-clients.yaml
@@ -35,7 +35,6 @@
 #   CEPH-83581592: Verify Client eviction is deferred if OSD was laggy.
 #   CEPH-83581613: Verify Client is blocklisted if session metadata is bloated.
 #   CEPH-83591419: Validate Root Sqaush operations on Cephfs
-#   CEPH-83595737: Validate selinux relabel on kernel client
 #
 # Bugs :
 # https://bugzilla.redhat.com/show_bug.cgi?id=2309363
@@ -414,13 +413,6 @@ tests:
       name: Validate Root Sqaush operations on Cephfs
       comments: "BZ-2293943"
       polarion-id: "CEPH-83591419"
-  - test:
-      abort-on-fail: false
-      desc: "Validate selinux relabel on kernel client"
-      module: clients.test_selinux_relabel.py
-      name: Validate selinux relabels
-      comments: "BZ-2309363"
-      polarion-id: "CEPH-83595737"
   - test:
       abort-on-fail: false
       desc: "Client Caps Validation during quiesce,mds failover and evict"

--- a/suites/reef/cephfs/tier-2_cephfs_test_mds_pinning.yaml
+++ b/suites/reef/cephfs/tier-2_cephfs_test_mds_pinning.yaml
@@ -206,3 +206,10 @@ tests:
       polarion-id: CEPH-83574329
       desc: map and unmap directory trees to a mds rank
       abort-on-fail: false
+  - test:
+      abort-on-fail: false
+      desc: "Validate selinux relabel on kernel client"
+      module: clients.test_selinux_relabel.py
+      name: Validate selinux relabels
+      comments: "BZ-2309363"
+      polarion-id: "CEPH-83595737"

--- a/suites/squid/cephfs/tier-2_cephfs_test-clients.yaml
+++ b/suites/squid/cephfs/tier-2_cephfs_test-clients.yaml
@@ -35,7 +35,6 @@
 #   CEPH-83581592: Verify Client eviction is deferred if OSD was laggy.
 #   CEPH-83581613: Verify Client is blocklisted if session metadata is bloated.
 #   CEPH-83591419: Validate Root Sqaush operations on Cephfs
-#   CEPH-83595737: Validate selinux relabel on kernel client
 #
 # Bugs :
 # https://bugzilla.redhat.com/show_bug.cgi?id=2309363
@@ -425,4 +424,3 @@ tests:
       module: clients.client_root_squash_non_root_user.py
       name: client_root_squash_non_root_user
       polarion-id: "CEPH-83602912"
-


### PR DESCRIPTION
# Description
Moving the test to weekly suites to adhere to new CI

Client suite is taking more than 6 hours because of the below test 83595737 and suites are getting aborted
So moving this to Weekly suites


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
