### PR TITLE
[TFA] Including set-env for the testcase post setting multisite

### DIFF
--- a/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/reef/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -265,6 +265,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
             run-on-haproxy: true

--- a/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -265,6 +265,7 @@ tests:
       clusters:
         ceph-pri:
           config:
+            set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_multipart_archive_colocated.yaml
             run-on-haproxy: true


### PR DESCRIPTION
# Description
adding missing set-env for the testcase post setting multisite

log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-A8IE3M/

issue : https://issues.redhat.com/browse/RHCEPHQE-17081
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-55/rgw/51/tier-3_archive_zone_colocate_data_zone/Perform_IOs_and_test_bucket_versioned_at_the_colocated_archive_zone_0.log

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
