### PR TITLE
RADOS: TFA fix for slow_osd_heartbeat & CBT/COT Library improvements

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -4482,12 +4482,12 @@ EOF"""
         """
         osd_dict = {"up": [], "down": [], "in": [], "out": [], "destroyed": []}
         # prepare separate OSD lists
-        osd_tree = self.run_ceph_command(cmd="ceph osd tree")
-        if osd_tree["nodes"]:
-            for entry in osd_tree["nodes"]:
-                if entry["type"] == "osd":
-                    osd_dict[entry["status"]].append(entry["id"])
         for key in osd_dict:
+            osd_tree = self.run_ceph_command(cmd=f"ceph osd tree {key}")
+            if osd_tree["nodes"]:
+                for entry in osd_tree["nodes"]:
+                    if entry["type"] == "osd":
+                        osd_dict[key].append(entry["id"])
             log.info(f"List of {key} OSDs: {osd_dict[key]}")
 
         return osd_dict[status]

--- a/ceph/rados/crushtool_workflows.py
+++ b/ceph/rados/crushtool_workflows.py
@@ -681,7 +681,7 @@ class CrushToolWorkflows:
             False -> device class removal failed
         """
         device_rm_cmd = "ceph osd crush rm-device-class "
-        _cmd = device_rm_cmd + " ".join(osd_list)
+        _cmd = device_rm_cmd + " ".join(str(oid) for oid in osd_list)
         out, err = self.client.exec_command(cmd=_cmd, sudo=True)
         log.info(err)
         if "done removing class of osd" in err or "belongs to no class" in err:

--- a/tests/rados/stretch_cluster.py
+++ b/tests/rados/stretch_cluster.py
@@ -675,8 +675,7 @@ def setup_crush_rule_with_no_affinity(node, rule_name: str) -> bool:
     rule = rule_name
     rules = """id 11
 type replicated
-min_size 1
-max_size 10
+step take default
 step choose firstn 0 type datacenter
 step chooseleaf firstn 2 type host
 step emit"""

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -171,9 +171,9 @@ def run(ceph_cluster, **kw):
                 )
 
             # fetch list of OSD hosts
-            osd_hosts = rados_obj.get_osd_hosts()
+            osd_hosts = ceph_cluster.get_nodes(role="osd")
             rand_host = random.choice(osd_hosts)
-            log.info(f"Chosen OSD host to add network delay: {rand_host}")
+            log.info(f"Chosen OSD host to add network delay: {rand_host.hostname}")
 
             osd_list = rados_obj.collect_osd_daemon_ids(osd_node=rand_host)
             log.info(f"List of OSDs on the host: {osd_list}")


### PR DESCRIPTION
# Description

[RHCEPHQE-17076](https://issues.redhat.com/browse/RHCEPHQE-17076) - TFA fix for issue introduced by PR #4241

[RHCEPHQE-16924](https://issues.redhat.com/browse/RHCEPHQE-16924) - Improve ceph-bluestore-tool and ceph-objectstore-tool libraries to control OSD start and stop

Update the crush rule for stretch cluster to remove unsupported entries

Signed-off-by: Harsh Kumar <hakumar@redhat.com>


<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
