### PR TITLE
[TFA-Fix] Removed dependency of .env file in rest/common/utils/rest.py

### DIFF
--- a/rest/common/utils/rest.py
+++ b/rest/common/utils/rest.py
@@ -6,26 +6,32 @@ import json
 import time
 
 import requests
-from dotenv import dotenv_values
 
 from rest.common.config.config import Config
 from rest.common.utils.exceptions import CommandExecutionError, HTTPError
 from utility.log import Log
 
+# from dotenv import dotenv_values
+
+
 log = Log(__name__)
 
 
-def rest():
+def rest(**kw):
     """
     REST method to be used by any test method
     # config = {"IP": "10.12.34.23", "USERNAME": "admin", "PASSWORD":"passwd", "PORT":"3211"}
     """
-    config = dotenv_values(".env")
-    username = config["USERNAME"]
-    password = config["PASSWORD"]
-    port = config["PORT"]
-    ip = config["IP"]
-    rest = REST(ip=ip, username=username, password=password, port=port)
+    # config = dotenv_values(".env")
+    # username = config["USERNAME"]
+    # password = config["PASSWORD"]
+    # port = config["PORT"]
+    # ip = config["IP"]
+    # rest = REST(ip=ip, username=username, password=password, port=port)
+    ceph_cluster = kw["ceph_cluster"]
+    nodes = ceph_cluster.node_list
+    ip = nodes[0].ip_address
+    rest = REST(ip=ip)
     return rest
 
 

--- a/suites/reef/rbd/tier-2_rbd_rest.yaml
+++ b/suites/reef/rbd/tier-2_rbd_rest.yaml
@@ -8,7 +8,7 @@
 #    Node 4 must to be a client node
 tests:
 
-  # Setup the cluster
+  #Setup the cluster
   - test:
       abort-on-fail: true
       module: install_prereq.py
@@ -26,6 +26,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password : "admin123"
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host

--- a/suites/squid/rbd/tier-2_rbd_rest.yaml
+++ b/suites/squid/rbd/tier-2_rbd_rest.yaml
@@ -26,6 +26,8 @@ tests:
                 mon-ip: node1
                 orphan-initial-daemons: true
                 skip-monitoring-stack: true
+                initial-dashboard-password : "admin123"
+                dashboard-password-noupdate: true
           - config:
               command: add_hosts
               service: host

--- a/tests/rbd/rest/test_rbd_rest_pool_image_creation.py
+++ b/tests/rbd/rest/test_rbd_rest_pool_image_creation.py
@@ -17,7 +17,7 @@ def test_rest_image_creation_in_pool(client, **kw):
         client: rbd client obj
         **kw: test data
     """
-    _rest = rest()
+    _rest = rest(**kw)
     config = {}
     rep_pool_config = kw["config"].get("rep_pool_config", None)
     if rep_pool_config:


### PR DESCRIPTION
# Description
Removed dependency of .env file in rest/common/utils/rest.py
Passed the arguments from the test file to rest.py to fetch the cluster object and obtain IP.
Added parameters 'initial-dashboard-password' and 'dashboard-password-noupdate' to the suites file to utilize the default credentials that exists in rest.py.

TFA Failure log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.2.0-52/rbd/12/tier-2_rbd_rest/Run_rest_API_tests_to_create_pool_and_image_0.log

Success log after fix: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-MWZ6EX/

Note: Raised this PR exclusively for this test fix. A previous PR having these changes reviewed along with other test fix was closed. (https://github.com/red-hat-storage/cephci/pull/4261)
