### PR TITLE
[TFA-fix] Added long_running parameter for migration operations

### DIFF
--- a/tests/rbd/test_rbd_image_migration_qcow.py
+++ b/tests/rbd/test_rbd_image_migration_qcow.py
@@ -46,7 +46,8 @@ def test_qcow_image_migration(rbd_obj, client, **kw):
     }
 
     client.exec_command(
-        cmd="sudo curl -o /mnt/ubuntu-12.04.qcow2 http://download.ceph.com/qa/ubuntu-12.04.qcow2"
+        cmd="sudo curl -o /mnt/ubuntu-12.04.qcow2 http://download.ceph.com/qa/ubuntu-12.04.qcow2",
+        long_running=True,
     )
     out, err = client.exec_command(
         cmd="sudo du -h /mnt/ubuntu-12.04.qcow2", output=True
@@ -92,6 +93,7 @@ def test_qcow_image_migration(rbd_obj, client, **kw):
                 action="execute",
                 dest_spec=image_spec,
                 client_node=client,
+                long_running=True,
                 **kw,
             )
 
@@ -99,6 +101,7 @@ def test_qcow_image_migration(rbd_obj, client, **kw):
             if verify_migration_state(
                 action="execute",
                 image_spec=image_spec,
+                long_running=True,
                 **kw,
             ):
                 log.error("Failed to execute migration")
@@ -111,6 +114,7 @@ def test_qcow_image_migration(rbd_obj, client, **kw):
                 action="commit",
                 dest_spec=image_spec,
                 client_node=client,
+                long_running=True,
                 **kw,
             )
 
@@ -118,6 +122,7 @@ def test_qcow_image_migration(rbd_obj, client, **kw):
             if verify_migration_state(
                 action="commit",
                 image_spec=image_spec,
+                long_running=True,
                 **kw,
             ):
                 log.error("Failed to commit migration")


### PR DESCRIPTION
# Description

Added long_running parameter for migration operations as the default timeout is changed to 300sec for command execution   recently.

TFA failure log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-262/rbd/58/tier-3_rbd_migration/Test_image_migration_with_external_qcow_data_format_0.log

Success log after fix: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-QSG8IT/

Note: Raised this PR exclusively for this test fix. A previous PR having these changes reviewed along with other test fix was closed. (https://github.com/red-hat-storage/cephci/pull/4261)