### PR TITLE
Changing the test suite for transition tests to 3 way ms in reef as well

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -552,3 +552,35 @@ tests:
             run-on-haproxy: true
             monitor-consistency-bucket-stats: true
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
+      desc: test LC cloud transition to IBM cos with retain false
+      polarion-id: CEPH-83581973 #CEPH-83581975
+      module: sanity_rgw_multisite.py
+      name: test LC cloud transition to IBM cos with retain false
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sts_using_boto.py
+            config-file-name: test_sts_multisite.yaml
+      desc: test assume role at secondary, with s3 ops
+      polarion-id: CEPH-83575592
+      module: sanity_rgw_multisite.py
+      name: test assume role at secondary, with s3 ops
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
+      desc: test LC cloud transition to IBM cos with retain true
+      polarion-id: CEPH-83581972 #CEPH-83575498
+      module: sanity_rgw_multisite.py
+      name: test LC cloud transition to IBM cos with retain true

--- a/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/reef/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -512,36 +512,6 @@ tests:
           config:
             script-name: test_bucket_request_payer.py
             config-file-name: test_bucket_request_payer.yaml
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_false.yaml
-      desc: test LC cloud transition to IBM cos with retain false
-      polarion-id: CEPH-83581973 #CEPH-83581975
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain false
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sts_using_boto.py
-            config-file-name: test_sts_multisite.yaml
-      desc: test assume role at secondary, with s3 ops
-      polarion-id: CEPH-83575592
-      module: sanity_rgw_multisite.py
-      name: test assume role at secondary, with s3 ops
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_lifecycle_object_expiration_transition.py
-            config-file-name: test_lc_cloud_transition_ibm_retain_true.yaml
-      desc: test LC cloud transition to IBM cos with retain true
-      polarion-id: CEPH-83581972 #CEPH-83575498
-      module: sanity_rgw_multisite.py
-      name: test LC cloud transition to IBM cos with retain true
 
   # please include test cases before below rename testcase as the process is disruptive currently
   # - test:


### PR DESCRIPTION
# Description
Changing the test suite for transition tests to 3 way ms in reef as well

TFA https://issues.redhat.com/browse/RHCEPHQE-16710

with tests chenged to the 3 way suite as it is in squid, we do not see the error 

passed logs on 7.1 http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-M0KMAW
