### PR TITLE
TFA fix for CG quiesce tests

### DIFF
--- a/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -153,16 +153,6 @@ tests:
   -
     test:
       abort-on-fail: false
-      desc: "Verify quiesce lifecycle with and without --await"
-      destroy-cluster: false
-      module: snapshot_clone.cg_snap_test.py
-      name: "cg_snap_func_workflow_1"
-      polarion-id: CEPH-83581467
-      config:
-       test_name: cg_snap_func_workflow_1
-  -
-    test:
-      abort-on-fail: false
       desc: "Verify CG quiesce on pre-provisioned quiesce set"
       destroy-cluster: false
       module: snapshot_clone.cg_snap_test.py
@@ -170,6 +160,26 @@ tests:
       polarion-id: CEPH-83590253
       config:
        test_name: cg_snap_func_workflow_3
+  -
+    test:
+      abort-on-fail: false
+      desc: "Enable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-enable-logs
+      config:
+       ENABLE_LOGS : 1
+       daemon_list : ['mds','client']
+       daemon_dbg_level : {'mds':20,'client':20}
+  -
+    test:
+      abort-on-fail: false
+      desc: "Verify quiesce lifecycle with and without --await"
+      destroy-cluster: false
+      module: snapshot_clone.cg_snap_test.py
+      name: "cg_snap_func_workflow_1"
+      polarion-id: CEPH-83581467
+      config:
+       test_name: cg_snap_func_workflow_1
   -
     test:
       abort-on-fail: false
@@ -181,3 +191,12 @@ tests:
       config:
        test_name: cg_snap_interop_workflow_1
       comments: product bug bz-2273569
+  -
+    test:
+      abort-on-fail: false
+      desc: "Disable ceph debug logs"
+      module: cephfs_logs_util.py
+      name: cephfs-disable-logs
+      config:
+       DISABLE_LOGS : 1
+       daemon_list : ['mds','client']

--- a/tests/cephfs/snapshot_clone/cephfs_cg_io.py
+++ b/tests/cephfs/snapshot_clone/cephfs_cg_io.py
@@ -1331,7 +1331,18 @@ class CG_snap_IO(object):
             while retry_cnt > 0:
                 file_name = random.choice(files)
                 retry_cnt -= 1
-                if ("_copy" not in file_name) and ("dir" not in file_name):
+                cmd = f"ls {dir_path}/{file_name}"
+                file_exists = 0
+                try:
+                    out, _ = client.exec_command(sudo=True, cmd=cmd, timeout=15)
+                    file_exists = 1
+                except BaseException as ex:
+                    log.info(ex)
+                if (
+                    ("_copy" not in file_name)
+                    and ("dir" not in file_name)
+                    and file_exists
+                ):
                     retry_cnt = 0
             client_name = client.node.hostname
             client_name_1 = f"{client_name[0: -1]}"

--- a/tests/cephfs/snapshot_clone/cg_snap_system_test.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_system_test.py
@@ -676,7 +676,7 @@ def cg_stress(cg_test_params):
                 check_ec=False,
             )
             log.info(f"Reset the quiesce set - {qs_set}")
-            cg_snap_util.cg_quiesce_reset(client, qs_id_val, qs_set)
+            cg_snap_util.cg_quiesce_reset(client, qs_id_val, qs_set, cmd_timeout=600)
             client.exec_command(
                 sudo=True,
                 cmd="ceph config set mds log_to_file false",

--- a/tests/cephfs/snapshot_clone/cg_snap_utils.py
+++ b/tests/cephfs/snapshot_clone/cg_snap_utils.py
@@ -147,10 +147,8 @@ class CG_Snap_Utils(object):
             cmd += f"  --timeout {kw_args['timeout']}"
         if kw_args.get("expiration"):
             cmd += f"  --expiration {kw_args['expiration']}"
-        out, rc = client.exec_command(
-            sudo=True,
-            cmd=cmd,
-        )
+        cmd_timeout = kw_args.get("cmd_timeout", 300)
+        out, rc = client.exec_command(sudo=True, cmd=cmd, timeout=cmd_timeout)
         if kw_args.get("qs_id"):
             log.info(f"Quiesce cmd response for qs_id {kw_args['qs_id']} : {out}")
         else:
@@ -195,10 +193,8 @@ class CG_Snap_Utils(object):
             cmd += "  --await"
         if kw_args.get("if_version"):
             cmd += f"  --if_version {kw_args['if_version']}"
-        out, rc = client.exec_command(
-            sudo=True,
-            cmd=cmd,
-        )
+        cmd_timeout = kw_args.get("cmd_timeout", 300)
+        out, rc = client.exec_command(sudo=True, cmd=cmd, timeout=cmd_timeout)
         qs_output = json.loads(out)
         if kw_args.get("task_validate", True):
             for qs_id in qs_output["sets"]:
@@ -438,10 +434,8 @@ class CG_Snap_Utils(object):
         cmd = f"ceph fs quiesce {fs_name} --set-id {qs_id} --reset {qs_member_str} --format json"
         if if_await:
             cmd += "  --await"
-        out, rc = client.exec_command(
-            sudo=True,
-            cmd=cmd,
-        )
+        cmd_timeout = kw_args.get("cmd_timeout", 300)
+        out, rc = client.exec_command(sudo=True, cmd=cmd, timeout=cmd_timeout)
         qs_output = json.loads(out)
         if kw_args.get("task_validate", True):
             for qs_id in qs_output["sets"]:


### PR DESCRIPTION
# Description

JIRA: https://issues.redhat.com/browse/RHCEPHQE-17200

Fix Description:
Added debug log enablement to CG quiesce functional suite to debug failures in tests cg_snap_func_workflow_1 and cg_snap_interop_workflow_1.

Added cmd_timeout in cg_snap_utils and increased timeout to 600secs for cg_snap_system_test.

Added check in cg_io tool, to verify file exists before using it in linux cmds.

Logs: I had two runs to validate the fix, but once it failed as setup deployed was not healthy and second time due to storage space not enough to deploy nodes,
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-WQJHXR/cg_snap_system_test_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HXVKLJ/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
