### PR TITLE
Switch mergify to support main branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,7 @@ pull_request_rules:
     conditions:
       - label!=DNM
       - label!=work-in-progress
-      - base=master
+      - base=main
       - "approved-reviews-by=@red-hat-storage/cephci-top-level-reviewers"
       - "check-success=tox (3.9.18)"
       - check-success=WIP


### PR DESCRIPTION
# Description

The default branch is main hence modifying mergify to work with main instead of master branch.


- [x] Review the automation design
