### PR TITLE
Added the Test to verify RBD image with zero size to pacific

### DIFF
--- a/suites/pacific/rbd/tier-2_rbd_regression.yaml
+++ b/suites/pacific/rbd/tier-2_rbd_regression.yaml
@@ -213,3 +213,28 @@ tests:
       module: test_rbd_python_module.py
       polarion-id: CEPH-83574791
       name: Test image creation, write and read data using python rbd module
+
+  - test:
+      desc: Verify RBD image with zero size
+      config:
+        resize_to: 0
+        rep_pool_config:
+          num_pools: 1
+          num_images: 2
+          images:
+            image_1024:
+              size: 1024
+            image_zero:
+              size: 0
+        ec_pool_config:
+          num_pools: 1
+          num_images: 2
+          images_ec:
+            data_pool: rbd_ec_data_pool
+            image_1024:
+              size: 1024
+            image_zero:
+              size: 0
+      module: test_rbd_image_zero_size.py
+      name: Test to verify RBD image with zero size
+      polarion-id: CEPH-83597243


### PR DESCRIPTION
# Description
test backported to 5.3 added the test to the pacific test suite
refer: https://bugzilla.redhat.com/show_bug.cgi?id=2293936

Test results:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-U51UC4/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
