### PR TITLE
[TFA-Fix]- Reducing the execution time of scheduled scrub test suite

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-scrubbing.yaml
@@ -102,6 +102,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "default"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 
@@ -116,6 +117,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "begin_end_time_equal"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -129,6 +131,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "beginTime gt endTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -142,6 +145,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "beginTime gt endTime lt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -155,6 +159,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "beginTime and endTime gt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -168,6 +173,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "decreaseTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -181,5 +187,6 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "unsetScrub"
+        debug_enable: False
       delete_pools:
         - scrub_pool

--- a/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
@@ -102,6 +102,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "default"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 
@@ -116,6 +117,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "begin_end_time_equal"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 
@@ -130,6 +132,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "beginTime gt endTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 
@@ -144,6 +147,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "beginTime gt endTime lt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 
@@ -158,9 +162,9 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "beginTime and endTime gt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
-      comments: Active Bug#2312538
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371
@@ -172,6 +176,7 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "decreaseTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 
@@ -186,5 +191,6 @@ tests:
           pool_name: scrub_pool
           pg_num: 1
         scenario: "unsetScrub"
+        debug_enable: False
       delete_pools:
         - scrub_pool

--- a/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
@@ -117,6 +117,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "default"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -131,6 +132,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "begin_end_time_equal"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -145,6 +147,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "beginTime gt endTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -159,6 +162,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "beginTime gt endTime lt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -173,9 +177,9 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "beginTime and endTime gt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
-      comments: Active Bug#2312538
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371
@@ -188,6 +192,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "decreaseTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -202,6 +207,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "unsetScrub"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 

--- a/suites/squid/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/squid/rados/tier-2_rados_test-scrubbing.yaml
@@ -1,6 +1,6 @@
 # Suite contains tests for replica-1 non-resilient pool
 # conf: conf/squid/rados/7-node-cluster.yaml
-# RHOS-d run duration: 700 mins
+# RHOS-d run duration: 200 mins
 # move from tier-2 to tier-3 and move to weekly
 tests:
 
@@ -121,6 +121,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "default"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -135,6 +136,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "begin_end_time_equal"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -149,6 +151,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "beginTime gt endTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -163,6 +166,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "beginTime gt endTime lt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -177,9 +181,9 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "beginTime and endTime gt currentTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
-      comments: Active Bug#2312538
   - test:
       name: Decrease scrub time
       polarion-id: CEPH-9371
@@ -192,6 +196,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "decreaseTime"
+        debug_enable: False
       delete_pools:
         - scrub_pool
   - test:
@@ -206,6 +211,7 @@ tests:
           pg_num: 1
           disable_pg_autoscale: true
         scenario: "unsetScrub"
+        debug_enable: False
       delete_pools:
         - scrub_pool
 

--- a/tests/rados/scheduled_scrub_scenarios.py
+++ b/tests/rados/scheduled_scrub_scenarios.py
@@ -18,9 +18,9 @@ log = Log(__name__)
 
 
 def run(ceph_cluster, **kw):
-    osd_scrub_min_interval = 60
-    osd_scrub_max_interval = 3600
-    osd_deep_scrub_interval = 3600
+    osd_scrub_min_interval = 10
+    osd_scrub_max_interval = 300
+    osd_deep_scrub_interval = 300
 
     log.info(run.__doc__)
     config = kw["config"]
@@ -29,16 +29,22 @@ def run(ceph_cluster, **kw):
     mon_obj = MonConfigMethods(rados_obj=rados_obj)
 
     test_scenarios = ["scrub", "deep-scrub"]
+    # test_scenarios = ["deep-scrub"]
 
     for test_input in test_scenarios:
         # Creating replicated pool
         rp_config = config.get("replicated_pool")
         pool_name = rp_config["pool_name"]
+        log.info(f"===Start the  validation of the {test_input}=======")
+        if config.get("debug_enable"):
+            log.info("Set the OSD logs to 20")
+            mon_obj.set_config(section="osd", name="debug_osd", value="20/20")
 
         if not rados_obj.create_pool(name=pool_name, **rp_config):
             log.error("Failed to create the  Pool")
             return 1
-        rados_obj.bench_write(pool_name=pool_name, rados_write_duration=10)
+        rados_obj.bench_write(pool_name=pool_name, byte_size="5K", max_objs=200)
+        # rados_obj.bench_write(pool_name=, rados_write_duration=5)
         pg_id = rados_obj.get_pgid(pool_name=pool_name)
         log.info(f"The pg id is -{pg_id}")
         flag = wait_for_clean_pg_sets(rados_obj)
@@ -47,6 +53,12 @@ def run(ceph_cluster, **kw):
                 "The cluster did not reach active + Clean state after add capacity"
             )
             return 1
+        leader_mon_daemon = rados_obj.run_ceph_command(cmd="ceph mon stat")["leader"]
+        mon_host = rados_obj.fetch_host_node(
+            daemon_type="mon", daemon_id=leader_mon_daemon
+        )
+        init_time, _ = mon_host.exec_command(cmd="date '+%Y-%m-%d %H:%M:%S'", sudo=True)
+        log.info(f"The cluster time before  testing is - {init_time}")
         try:
             (
                 scrub_begin_hour,
@@ -85,10 +97,7 @@ def run(ceph_cluster, **kw):
 
             # set begin hour and end hour greater than current time
             # CEPH-9367 & CEPH 9368
-            if (
-                config.get("scenario") == "beginTime and endTime gt currentTime"
-                or config.get("scenario") == "decreaseTime"
-            ):
+            if config.get("scenario") == "beginTime and endTime gt currentTime":
                 (
                     scrub_begin_hour,
                     scrub_begin_weekday,
@@ -98,6 +107,10 @@ def run(ceph_cluster, **kw):
                 log.info(
                     f'{"Setting scrub start is greater then end_hour and current time is greater than end hour"}'
                 )
+                osd_scrub_min_interval = 86400
+                osd_scrub_max_interval = 604800
+                osd_deep_scrub_interval = 604800
+
             # unset the scrub.CEPH-9374
             if config.get("scenario") == "unsetScrub":
                 rados_obj.set_osd_flags("set", "noscrub")
@@ -141,7 +154,14 @@ def run(ceph_cluster, **kw):
                 )
                 rados_obj.set_osd_configuration("osd_scrub_end_hour", scrub_end_hour)
 
+            # Printing the scrub parameter values
+            get_parameter_configuration(mon_obj)
             status = chk_scrub_or_deepScrub_status(rados_obj, test_input, pg_id[-1])
+            end_time, _ = mon_host.exec_command(
+                cmd="date '+%Y-%m-%d %H:%M:%S'", sudo=True
+            )
+            log.info(f"The cluster time after testing is - {end_time}")
+
             # Checking the failure case
             if status is False and (
                 config.get("scenario") == "default"
@@ -159,6 +179,7 @@ def run(ceph_cluster, **kw):
             ) and status is True:
                 log.info(f"{test_input} validation Failed")
                 return 1
+            log.info(f"Deletion of the pool after the {test_input} validation")
             method_should_succeed(rados_obj.delete_pool, pool_name)
             time.sleep(10)
             flag = wait_for_clean_pg_sets(rados_obj)
@@ -167,6 +188,7 @@ def run(ceph_cluster, **kw):
                     "The cluster did not reach active + Clean state after add capacity"
                 )
                 return 1
+            log.info(f"===End of the  validation of the {test_input}=======")
         except Exception as err:
             exc_type, exc_obj, exc_tb = sys.exc_info()
             fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
@@ -179,11 +201,18 @@ def run(ceph_cluster, **kw):
             log.info(
                 "\n \n ************** Execution of finally block begins here *************** \n \n"
             )
+            mon_obj.remove_config(section="osd", name="debug_osd")
             method_should_succeed(rados_obj.delete_pool, pool_name)
             remove_parameter_configuration(mon_obj)
             rados_obj.set_osd_flags("unset", "noscrub")
             rados_obj.set_osd_flags("unset", "nodeep-scrub")
             time.sleep(10)
+            flag = wait_for_clean_pg_sets(rados_obj)
+            if not flag:
+                log.error(
+                    "The cluster did not reach active + Clean state after add capacity"
+                )
+                return 1
             # log cluster health
             rados_obj.log_cluster_health()
     log.error(f'{"Schedule scrub & deep-scrub validation success"}')
@@ -220,7 +249,7 @@ def chk_scrub_or_deepScrub_status(rados_object, action, pg_id):
     if action == "scrub":
         try:
             status = rados_object.start_check_scrub_complete(
-                pg_id=pg_id, user_initiated=False, wait_time=5400
+                pg_id=pg_id, user_initiated=False, wait_time=900
             )
             log.info("Verification of the scrub is completed")
         except Exception as err:
@@ -229,10 +258,34 @@ def chk_scrub_or_deepScrub_status(rados_object, action, pg_id):
     else:
         try:
             status = rados_object.start_check_deep_scrub_complete(
-                pg_id=pg_id, user_initiated=False, wait_time=5400
+                pg_id=pg_id, user_initiated=False, wait_time=900
             )
             log.info("Verification of the deep-scrub is completed")
         except Exception as err:
             log.error(f"The error is-{err}")
             status = False
     return status
+
+
+def get_parameter_configuration(mon_obj):
+    """
+    Used to get the  osd scrub parameter change values
+    Args:
+        mon_obj: monitor object
+    Returns : None
+    """
+    log.info("The scrub parameter values are:  ")
+    out_put = mon_obj.get_config(section="osd", param="osd_scrub_min_interval")
+    log.info(f"The osd_scrub_min_interval parameter value is - {out_put}")
+    out_put = mon_obj.get_config(section="osd", param="osd_scrub_max_interval")
+    log.info(f"The osd_scrub_max_interval parameter value is - {out_put}")
+    out_put = mon_obj.get_config(section="osd", param="osd_deep_scrub_interval")
+    log.info(f"The osd_deep_scrub_interval parameter value is - {out_put}")
+    out_put = mon_obj.get_config(section="osd", param="osd_scrub_begin_week_day")
+    log.info(f"The osd_scrub_begin_week_day parameter value is - {out_put}")
+    out_put = mon_obj.get_config(section="osd", param="osd_scrub_end_week_day")
+    log.info(f"The osd_scrub_end_week_day parameter value is - {out_put}")
+    out_put = mon_obj.get_config(section="osd", param="osd_scrub_begin_hour")
+    log.info(f"The osd_scrub_begin_hour parameter value is - {out_put}")
+    out_put = mon_obj.get_config(section="osd", param="osd_scrub_end_hour")
+    log.info(f"The osd_scrub_end_hour parameter value is - {out_put}")


### PR DESCRIPTION
# Description

Reducing the execution time of scheduled scrub test suite.
Previously this scheduled scrub verification test suites execution took 700 minutes(11-12 hours). This execution time was reduced to 200 minutes(Around 3 hours).

Jira task- https://issues.redhat.com/browse/RHCEPHQE-17149

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
