### PR TITLE
[RADOS] Add ceph-bluestore-tool coverage for live OSDs

### DIFF
--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -354,9 +354,13 @@ def run(ceph_cluster, **kw):
             for node in ["node12", "node13"]:
                 # create 10G LVMs on backup nodes
                 node_obj = node12_obj if node == "node12" else node13_obj
-                empty_devices = rados_obj.get_available_devices(
-                    node_name=node_obj.hostname, device_type="hdd"
-                )
+                for _ in range(3):
+                    empty_devices = rados_obj.get_available_devices(
+                        node_name=node_obj.hostname, device_type="hdd"
+                    )
+                    if empty_devices:
+                        break
+                    time.sleep(15)
                 if len(empty_devices) < 1:
                     log.error(
                         f"Need at least 1 spare disk available on host {node_obj.hostname}"

--- a/tests/rados/test_cephvolume_workflows.py
+++ b/tests/rados/test_cephvolume_workflows.py
@@ -52,11 +52,9 @@ def run(ceph_cluster, **kw):
     volumeobject = CephVolumeWorkflows(node=cephadm)
 
     try:
-
         if config.get("zap_with_destroy_flag") or config.get(
             "zap_without_destroy_flag"
         ):
-
             options_list = [
                 ["device"],
                 ["osd_id"],
@@ -70,7 +68,6 @@ def run(ceph_cluster, **kw):
                 options_list = [option + ["--destroy"] for option in options_list]
 
             for option in options_list:
-
                 if (
                     config.get("zap_without_destroy_flag")
                     and len(option) == 1
@@ -193,7 +190,6 @@ def run(ceph_cluster, **kw):
                 )
 
                 if config.get("zap_without_destroy_flag"):
-
                     log.info(
                         f"Proceeding to check if file system is removed from OSD {osd_id}"
                     )
@@ -320,7 +316,7 @@ def run(ceph_cluster, **kw):
                         host=osd_host,
                     )
 
-                wait_for_osd_daemon_state(osd_host, osd_id, "up")
+                wait_for_osd_daemon_state(rados_obj.client, osd_id, "up")
 
                 log.info(
                     f"Successfully added back osd {osd_id} to cluster\n"

--- a/tests/rados/test_replica1.py
+++ b/tests/rados/test_replica1.py
@@ -89,7 +89,7 @@ def run(ceph_cluster, **kw):
 
             # divide OSDs into different device classes(replicated)
             replicated_osd = " ".join(
-                [osd_id for osd_id in osd_list if int(osd_id) % 2 != 0]
+                [str(osd_id) for osd_id in osd_list if int(osd_id) % 2 != 0]
             )
             cephadm.shell(
                 [f"ceph osd crush set-device-class replicated {replicated_osd}"]


### PR DESCRIPTION
# Description
Jira: [RHCEPHQE-17159](https://issues.redhat.com/browse/RHCEPHQE-17159)
Adds automation coverage for ceph-bluestore-tool and ceph-objectstore-tool commands for live OSDs

Logs:
Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-IJIN7V/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
