### PR TITLE
 TFA in reef for rgw accounts and adding support for topic creation in account

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -249,11 +249,12 @@ tests:
   - test:
       abort-on-fail: false
       config:
-        role: "client"
         commands:
-          - "radosgw-admin account create --account-id RGW11111111111111111 --account-name Account1 --email account1@ceph.com"
           - "radosgw-admin account create --account-id RGW22222222222222222 --account-name Account2 --email account2@ceph.com"
-
+          - "radosgw-admin account create --account-id RGW11111111111111111 --account-name Account1  --email account1@ceph.com"
+          - "radosgw-admin zone modify --enable-feature notification_v2"
+          - "radosgw-admin zonegroup modify --enable-feature notification_v2"
+          - "ceph orch restart rgw.rgw.1"
       desc: Create 2 rgw accounts
       module: exec.py
       name: Create 2 rgw accounts

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -351,6 +351,7 @@ def create_s3_user(node: CephNode, user_prefix: str, data: Dict) -> None:
     """
     uid = binascii.hexlify(os.urandom(32)).decode()
     display_name = f"{user_prefix}-user"
+    log.info(f" the display name is {display_name} ")
     log.info("Creating user: {display_name}".format(display_name=display_name))
     if display_name == "iamrootalt-user":
         cmd = (
@@ -371,7 +372,7 @@ def create_s3_user(node: CephNode, user_prefix: str, data: Dict) -> None:
 
     out, err = node.exec_command(sudo=True, cmd=cmd)
     user_info = json.loads(out)
-
+    log.info(f" the user info for {display_name} is {user_info} ")
     data[user_prefix] = {
         "id": user_info["keys"][0]["user"],
         "access_key": user_info["keys"][0]["access_key"],
@@ -379,7 +380,7 @@ def create_s3_user(node: CephNode, user_prefix: str, data: Dict) -> None:
         "name": user_info["display_name"],
         "email": user_info["email"],
     }
-    if display_name == "iamrootalt-user" or "iamroot-user":
+    if display_name in ("iamrootalt-user", "iamroot-user"):
         data[user_prefix] = {
             "id": user_info["keys"][0]["user"],
             "access_key": user_info["keys"][0]["access_key"],
@@ -429,8 +430,9 @@ def create_s3_conf(
     create_s3_user(node=rgw_node, user_prefix="alt", data=data)
     create_s3_user(node=rgw_node, user_prefix="tenant", data=data)
     create_s3_user(node=rgw_node, user_prefix="iam", data=data)
-    create_s3_user(node=rgw_node, user_prefix="iamroot", data=data)
-    create_s3_user(node=rgw_node, user_prefix="iamrootalt", data=data)
+    if build.split(".")[0] >= "8":
+        create_s3_user(node=rgw_node, user_prefix="iamroot", data=data)
+        create_s3_user(node=rgw_node, user_prefix="iamrootalt", data=data)
 
     if kms_keyid:
         data["main"]["kms_keyid"] = kms_keyid


### PR DESCRIPTION
# Description
Fixing TFA in Reef for the rgw accounts and adding support for topic creation in an account and cross-account.
TFA ticket https://issues.redhat.com/browse/RHCEPHQE-17198
failure logs seen "KeyError: 'account_id' in s3tests"
Reef:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-T0J6PC/execute_s3tests_0.log


Passed logs after fix
1. Reef logs:
[execute_s3tests_0_reef.log](https://github.com/user-attachments/files/18257773/execute_s3tests_0_reef.log)

2024-12-26 15:53:53,475 - cephci - ceph:1184 - DEBUG - =========================== short test summary info ============================
2024-12-26 15:53:53,476 - cephci - ceph:1184 - DEBUG - FAILED s3tests_boto3/functional/test_s3select.py::test_alias_cyclic_refernce
2024-12-26 15:53:53,476 - cephci - ceph:1184 - DEBUG - FAILED s3tests_boto3/functional/test_s3select.py::test_schema_definition - bo...
2024-12-26 15:53:53,476 - cephci - ceph:1184 - DEBUG - = **2 failed, 546 passed, 8 skipped, 117 deselected, 11 warnings** in 1797.01s (0:29:57) =


2. Squid logs :

[Create_2_rgw_accounts_0.log](https://github.com/user-attachments/files/18257782/Create_2_rgw_accounts_0.log)
[execute_s3tests_0_squid.log](https://github.com/user-attachments/files/18257783/execute_s3tests_0_squid.log)

**ran 624 tests, 9 skipped** 
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - =========================== short test summary info ============================
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - FAILED s3tests_boto3/functional/test_iam.py::test_cross_account_bucket_acl_user_policy_grant_account_email
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - FAILED s3tests_boto3/functional/test_iam.py::test_cross_account_user_policy_bucket_acl_grant_account_email
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - FAILED s3tests_boto3/functional/test_s3select.py::test_alias_cyclic_refernce
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - FAILED s3tests_boto3/functional/test_s3select.py::test_schema_definition - bo...
2024-12-27 00:37:19,431 - cephci - ceph:1184 - DEBUG - = 4 failed, 624 passed, 9 skipped, 118 deselected, 11 warnings in 2007.80s (0:33:27) =
