### PR TITLE
Adding cluster configs to test_parallel

### DIFF
--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -4,9 +4,9 @@ import glob
 import importlib
 import logging
 import os
+import random
 import string
 from multiprocessing import Manager
-from random import random
 from time import sleep
 
 from ceph.ceph import CommandFailed
@@ -147,6 +147,13 @@ def execute(test, args, results, parallel_tcs):
         # Merging configurations safely
         test_config = args.get("config", {}).copy()
         test_config.update(test.get("config", {}))
+        if "clusters" in test:
+            clusters_config = test.get("clusters", {})
+            for cluster_name, cluster_data in clusters_config.items():
+                # Extract and merge the cluster-specific configurations into the root
+                if "config" in cluster_data:
+                    test_config.update(cluster_data["config"])
+        test_logger.info(test_config)
         tc["name"] = test.get("name")
         tc["desc"] = test.get("desc")
         tc["log-link"] = log_url


### PR DESCRIPTION
# Description


### Adding Cluster Configurations to `test_parallel`

#### Problem:
In recent updates to `test_parallel`, we added test configurations under `test` but overlooked the configurations present in the `clusters` section. This led to inconsistencies in how configurations were applied during execution.

#### Solution:
This change unifies all configurations from `test` and `clusters` into a single configuration object. This ensures consistency.

#### Current Behavior:
When running tests with multiple clusters in `test_parallel`, the test executes on all clusters, even if a specific cluster is explicitly mentioned. 

**Example:**
```yaml
- test:
    name: Retrieve the versions of the cluster parallelly
    desc: Retrieve the versions of the cluster parallelly
    module: test_parallel.py
    parallel:
      - test:
          clusters:
            ceph-pri:
              config:
                cephadm: true
                commands:
                  - "ceph versions"
          desc: Retrieve the versions of the cluster in primary
          polarion-id: CEPH-83575200
          module: exec.py
          name: Retrieve the versions of the cluster in primary
      - test:
          clusters:
            ceph-sec:
              config:
                cephadm: true
                commands:
                  - "ceph versions"
          desc: Retrieve the versions of the cluster in secondary
          polarion-id: CEPH-83575200
          module::  exec.py
          name: Retrieve the versions of the cluster in secondary
```

With this setup:
- The `ceph versions` command executes twice on **each cluster**, resulting in 4 executions (2 per cluster). 
- This behavior existed even before the logging changes but has become noticeable now with separate logs for each execution. 

**Example Logs:http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-I6OJ8T
Old Log with out changes :http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Sanity/19.2.0-48/219/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest/Retrieve_the_versions_of_the_cluster_parallelly_0.log

#### Desired Behavior:
To execute the command once per cluster, the suite definition should be updated to unify the configurations, as shown below:

**Correct Suite Definition:**
```yaml
- test:
    name: Retrieve the versions of the cluster parallelly
    desc: Retrieve the versions of the cluster parallelly
    module: test_parallel.py
    config:
          cephadm: true
          commands:
            - "ceph versions"    
    parallel:
      - test:           
          desc: Retrieve the versions of the cluster in primary
          polarion-id: CEPH-83575200
          module: exec.py
          name: Retrieve the versions of the cluster in primary
```

This approach ensures that:
1. Configurations are unified across `test` and `clusters`.
2. Each cluster's configurations are applied correctly, and the commands are executed as intended.

Current Limitations in Framework:

The framework does not support executing different commands across multiple clusters when using test_parallel, due to the for loop in run.py 
https://github.com/red-hat-storage/cephci/blob/21dbf8ef33447674fae7dbcca409b00d5569652f/run.py#L725 

Commands can only be restricted to specific clusters by explicitly providing cluster details in the test case configuration.
https://github.com/red-hat-storage/cephci/blob/21dbf8ef33447674fae7dbcca409b00d5569652f/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_seq_6x_to_8x.yaml#L180

We can not execute the tests parallelly on both clusters at the same time. 

--- 

Let me know if you need further refinements!
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
