### PR TITLE
TFA fix - increase timeout for selinux

### DIFF
--- a/tests/cephfs/clients/test_selinux_relabel.py
+++ b/tests/cephfs/clients/test_selinux_relabel.py
@@ -340,7 +340,9 @@ def apply_selinux_label(client, label, path):
         None
     """
     try:
-        client.exec_command(sudo=True, cmd=f"chcon -R --type={label} {path}")
+        client.exec_command(
+            sudo=True, cmd=f"chcon -R --type={label} {path}", timeout=600
+        )
         log.info(f"Applied SELinux label {label} to {path}")
     except Exception as e:
         log.error(f"Failed to apply SELinux label {label} to {path}: {e}")


### PR DESCRIPTION
Description : 
Increasing the timeout to 600 as the current script is taking 290 seconds and sometimes crosses 300 while applying selinux labels on a path which has 1M files.

TFA Issue Log : 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-272/cephfs/63/tier-2_cephfs_test_mds_pinning/Validate_selinux_relabels_0.log
Ex : 2024-12-21 16:47:50,620 - cephci - ceph:1600 - INFO - Execution of chcon -R --type=mnt_t /mnt/cephfs_kernel6uqex5wvr0_1/test_dir_1M_files on 10.0.195.96 took 290.320275 seconds.

This has taken 290 and the default timeout is 300. Sometimes it crosses 300 sec and due to this the tests are failing.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
