### PR TITLE
integrating rgw MOD hotfix 404 again bz veritifcation tests

### DIFF
--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -218,3 +218,15 @@ tests:
       config:
         script-name: test_swift_basic_ops.py
         config-file-name: test_s3_and_swift_versioning.yaml
+
+  # test MOD hotfix bz: complete and abort multipart upload race causes obj download failure after gc kicks in
+
+  - test:
+      name: test MOD hotfix bz - 404 again
+      desc: complete and abort multipart upload race causes obj download failure after gc kicks in
+      polarion-id: CEPH-83604471
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart_upload_complete_abort_race.yaml
+      comments: known issue BZ 2331908

--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -260,3 +260,15 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth2.yaml
+
+  # test MOD hotfix bz: complete and abort multipart upload race causes obj download failure after gc kicks in
+
+  - test:
+      name: test MOD hotfix bz - 404 again
+      desc: complete and abort multipart upload race causes obj download failure after gc kicks in
+      polarion-id: CEPH-83604471
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart_upload_complete_abort_race.yaml
+      comments: known issue BZ 2331908

--- a/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -122,7 +122,7 @@ tests:
                         nodes:
                           - node5
       desc: RHCS cluster deployment and rgw deployment with ssl cert generation
-      polarion-id: CEPH-83575222
+      polarion-id: CEPH-83604472
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster and rgw with ssl gen-cert

--- a/suites/squid/rgw/tier-4-rgw.yaml
+++ b/suites/squid/rgw/tier-4-rgw.yaml
@@ -279,3 +279,15 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth2.yaml
+
+  # test MOD hotfix bz: complete and abort multipart upload race causes obj download failure after gc kicks in
+
+  - test:
+      name: test MOD hotfix bz - 404 again
+      desc: complete and abort multipart upload race causes obj download failure after gc kicks in
+      polarion-id: CEPH-83604471
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart_upload_complete_abort_race.yaml
+      comments: known issue BZ 2331908


### PR DESCRIPTION
this PR is to automate MOD hotfix bz verification 404 again
basically to test whether a race between complete and abort multipart upload, after gc causes object download failure with 404.

depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/651

bz: https://bugzilla.redhat.com/show_bug.cgi?id=2331908

polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83604471

pass logs with cephci on the hotfix build: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_MOD_hotfix_404_again/cephci-run-D2ZINI/


also replacing the rgw ssl deployment with cephadm test polarion with below one: 
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83604472

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
