### PR TITLE
TFA cephfs-top unitiate test failing

### DIFF
--- a/tests/cephfs/cephfs_top/cephfs_top_dump.py
+++ b/tests/cephfs/cephfs_top/cephfs_top_dump.py
@@ -291,6 +291,8 @@ def run(ceph_cluster, **kw):
         log.error(traceback.format_exc())
         return 1
     finally:
+        log.info("Disable mgr stats")
+        client1.exec_command(sudo=True, cmd="ceph mgr module disable stats")
         fs_util.client_clean_up(
             "umount", fuse_clients=[clients[0]], mounting_dir=fuse_mounting_dir_1
         )

--- a/tests/cephfs/cephfs_top/cephfs_top_negative_tests.py
+++ b/tests/cephfs/cephfs_top/cephfs_top_negative_tests.py
@@ -561,6 +561,8 @@ def run(ceph_cluster, **kw):
         return 1
     finally:
         crash_status_after = fs_util_v1.get_crash_ls_new(client)
+        log.info("Disable mgr stats")
+        client.exec_command(sudo=True, cmd="ceph mgr module disable stats")
         log.info(f"Crash status after Test: {crash_status_before}")
         if crash_status_before != crash_status_after:
             assert (

--- a/tests/cephfs/cephfs_top/validate_fs_top_stats.py
+++ b/tests/cephfs/cephfs_top/validate_fs_top_stats.py
@@ -365,6 +365,8 @@ def run(ceph_cluster, **kw):
         )
         fs_util.remove_fs(client1, fs_name)
         log.info("Successfully unmounted the clients")
+        log.info("Disable mgr stats")
+        client1.exec_command(sudo=True, cmd="ceph mgr module disable stats")
         client1.exec_command(
             sudo=True, cmd="mv /etc/fstab.backup /etc/fstab", check_ec=False
         )


### PR DESCRIPTION
# Description

Disabling mgr stats after using cephfs-top so that we can test cephfs-top initiate testing.

TFA issue:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Weekly/18.2.1-272/cephfs/63/tier-3_cephfs_test_cephfs-top/cephfs-top_initiate_testing_0.log

Fix logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-OM7BPW/



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
