### PR TITLE
RHCEPHQE-16887 | CEPH-83604474: Test to verify MAX_AVAIL updation OSD removal

### DIFF
--- a/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -112,21 +112,6 @@ tests:
           mgr: "allow *"
 
   - test:
-      name: Configure email alerts
-      module: rados_prep.py
-      polarion-id: CEPH-83574472
-      config:
-        email_alerts:
-          smtp_host: smtp.corp.redhat.com
-          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
-          smtp_port: 25
-          interval: 10
-          smtp_destination:
-            - pdhiran@redhat.com
-          smtp_from_name: EC 2+2@4 cluster alerts
-      desc: Configure email alerts on ceph cluster
-
-  - test:
       name: Enable logging to file
       module: rados_prep.py
       config:
@@ -196,33 +181,33 @@ tests:
           delete_pool: true
       desc: Verify Recovery of EC pool with only "k" shards available
 
-  - test:
-      name: EC pool LC
-      module: rados_prep.py
-      polarion-id: CEPH-83571632
-      config:
-        ec_pool:
-          create: true
-          pool_name: test_ec_pool
-          pg_num: 64
-          k: 2
-          m: 2
-          plugin: jerasure
-          crush-failure-domain: host
-          disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
-        set_pool_configs:
-          pool_name: test_ec_pool
-          configurations:
-            pg_num: 32
-            pgp_num: 32
-            pg_autoscale_mode: 'on'
-            compression_mode: force
-            compression_algorithm: snappy
-        delete_pools:
-          - test_ec_pool
-      desc: Create, modify & delete EC pools and run IO
+#  - test:
+#      name: EC pool LC
+#      module: rados_prep.py
+#      polarion-id: CEPH-83571632
+#      config:
+#        ec_pool:
+#          create: true
+#          pool_name: test_ec_pool
+#          pg_num: 64
+#          k: 2
+#          m: 2
+#          plugin: jerasure
+#          crush-failure-domain: host
+#          disable_pg_autoscale: true
+#          rados_write_duration: 50
+#          rados_read_duration: 30
+#        set_pool_configs:
+#          pool_name: test_ec_pool
+#          configurations:
+#            pg_num: 32
+#            pgp_num: 32
+#            pg_autoscale_mode: 'on'
+#            compression_mode: force
+#            compression_algorithm: snappy
+#        delete_pools:
+#          - test_ec_pool
+#      desc: Create, modify & delete EC pools and run IO
 
   - test:
       name: EC pool with Overwrites
@@ -296,39 +281,39 @@ tests:
             byte_size: 10KB
       desc: Verification of the effect of compression on erasure coded pools
 
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_7
-              pool_name: ec86_pool7
-              pool_type: erasure
-              pg_num: 32
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_7
+#              pool_name: ec86_pool7
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-  - test:
-      name: ceph-bluestore-tool utility
-      module: test_bluestoretool_workflows.py
-      polarion-id: CEPH-83571692
-      desc: Verify ceph-bluestore-tool functionalities
-
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+#  - test:
+#      name: ceph-bluestore-tool utility
+#      module: test_bluestoretool_workflows.py
+#      polarion-id: CEPH-83571692
+#      desc: Verify ceph-bluestore-tool functionalities
+#
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
   - test:
       name: Verify premerge PGS during PG split
@@ -388,80 +373,80 @@ tests:
         pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_10
-              pool_name: ec86_pool10
-              pool_type: erasure
-              pg_num: 32
-              k: 2
-              m: 2
-              crush-failure-domain: host
-              plugin: jerasure
-              target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_10
+#              pool_name: ec86_pool10
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              crush-failure-domain: host
+#              plugin: jerasure
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-  - test:
-      name: Autoscaler test - pool pg_num_min
-      module: pool_tests.py
-      polarion-id: CEPH-83573425
-      config:
-        verify_pg_num_min:
-          configurations:
-            pool-1:
-              profile_name: ec86_11
-              pool_name: ec86_pool11
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+#  - test:
+#      name: Autoscaler test - pool pg_num_min
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573425
+#      config:
+#        verify_pg_num_min:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_11
+#              pool_name: ec86_pool11
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num_min: 16
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
-  - test:
-      name: client pg access
-      module: test_client_pg_access.py
-      polarion-id: CEPH-83571713
-      config:
-        verify_client_pg_access:
-          num_snapshots: 20
-          num_objects: 250
-          configurations:
-            pool-1:
-              profile_name: ec86_12
-              pool_name: ec86_pool12
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              disable_pg_autoscale: true
-      desc: many clients clients accessing same PG with bluestore as backend
+#  - test:
+#      name: client pg access
+#      module: test_client_pg_access.py
+#      polarion-id: CEPH-83571713
+#      config:
+#        verify_client_pg_access:
+#          num_snapshots: 20
+#          num_objects: 250
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_12
+#              pool_name: ec86_pool12
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              disable_pg_autoscale: true
+#      desc: many clients clients accessing same PG with bluestore as backend
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-4
-        pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
-      desc: Migrating data between different pools. Scenario-2. RE -> EC
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-4
+#        pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
+#      desc: Migrating data between different pools. Scenario-2. RE -> EC
 
   - test:
       name: Migrate data bw pools.
@@ -488,60 +473,60 @@ tests:
       desc: Migrating data between different pools. Scenario-4. Ec -> EC
 
 # Blocked due to BZ 2172795. Bugzilla fixed.
-  - test:
-      name: Verify cluster behaviour during PG autoscaler warn
-      module: pool_tests.py
-      polarion-id:  CEPH-83573413
-      config:
-        verify_pool_warnings:
-          pool_configs:
-            - type: erasure
-              conf: sample-pool-4
-          pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
-      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+#  - test:
+#      name: Verify cluster behaviour during PG autoscaler warn
+#      module: pool_tests.py
+#      polarion-id:  CEPH-83573413
+#      config:
+#        verify_pool_warnings:
+#          pool_configs:
+#            - type: erasure
+#              conf: sample-pool-4
+#          pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
+#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
-  - test:
-      name: Scrub enhancement
-      module: test_scrub_enhancement.py
-      desc: Verify scrub enhancement feature
-      polarion-id: CEPH-83575885
-      config:
-        create_pools:
-          - create_pool:
-              pg_num: 1
-              pg_num_max: 1
-              profile_name: ec86_13
-              pool_name: ec86_pool13
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-        delete_pools:
-          - ec86_pool13
+#  - test:
+#      name: Scrub enhancement
+#      module: test_scrub_enhancement.py
+#      desc: Verify scrub enhancement feature
+#      polarion-id: CEPH-83575885
+#      config:
+#        create_pools:
+#          - create_pool:
+#              pg_num: 1
+#              pg_num_max: 1
+#              profile_name: ec86_13
+#              pool_name: ec86_pool13
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#        delete_pools:
+#          - ec86_pool13
 
-  - test:
-      name: Limit slow request details to cluster log
-      module: test_slow_op_requests.py
-      desc: Limit slow request details to cluster log
-      polarion-id: CEPH-83574884
-      config:
-        create_pools:
-          - create_pool:
-              profile_name: ec86_14
-              pool_name: ec86_pool14
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - ec86_pool14
+#  - test:
+#      name: Limit slow request details to cluster log
+#      module: test_slow_op_requests.py
+#      desc: Limit slow request details to cluster log
+#      polarion-id: CEPH-83574884
+#      config:
+#        create_pools:
+#          - create_pool:
+#              profile_name: ec86_14
+#              pool_name: ec86_pool14
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num: 64
+#              rados_write_duration: 1000
+#              byte_size: 1024
+#              osd_max_backfills: 16
+#              osd_recovery_max_active: 16
+#        delete_pools:
+#          - ec86_pool14
 
   - test:
       name: Robust rebalancing - in progress osd replacement

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -189,6 +189,16 @@ tests:
           pool_name: test-max-avail
           obj_nums: 5
           delete_pool: true
+
+  - test:
+      name: Verify MAX_AVAIL variance when OSDs are removed
+      desc: MAX_AVAIL value update correctly when OSDs are removed
+      module: test_cephdf.py
+      polarion-id: CEPH-83604474
+      config:
+        cephdf_max_avail_osd_rm: false
+      comments: bug to be fixed - BZ-2277857
+
   - test:
       name: Compression algorithms - modes
       module: rados_prep.py

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -144,22 +144,6 @@ tests:
           mds: "allow *"
           mgr: "allow *"
 
-
-  - test:
-      name: Configure email alerts
-      module: rados_prep.py
-      polarion-id: CEPH-83574472
-      config:
-        email_alerts:
-          smtp_host: smtp.corp.redhat.com
-          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
-          smtp_port: 25
-          interval: 10
-          smtp_destination:
-            - pdhiran@redhat.com
-          smtp_from_name: EC 2+2@4 cluster alerts
-      desc: Configure email alerts on ceph cluster
-
   - test:
       name: Enable logging to file
       module: rados_prep.py
@@ -230,33 +214,33 @@ tests:
           delete_pool: true
       desc: Verify Recovery of EC pool with only "k" shards available
 
-  - test:
-      name: EC pool LC
-      module: rados_prep.py
-      polarion-id: CEPH-83571632
-      config:
-        ec_pool:
-          create: true
-          pool_name: test_ec_pool
-          pg_num: 64
-          k: 2
-          m: 2
-          plugin: jerasure
-          crush-failure-domain: host
-          disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
-        set_pool_configs:
-          pool_name: test_ec_pool
-          configurations:
-            pg_num: 32
-            pgp_num: 32
-            pg_autoscale_mode: 'on'
-            compression_mode: force
-            compression_algorithm: snappy
-        delete_pools:
-          - test_ec_pool
-      desc: Create, modify & delete EC pools and run IO
+#  - test:
+#      name: EC pool LC
+#      module: rados_prep.py
+#      polarion-id: CEPH-83571632
+#      config:
+#        ec_pool:
+#          create: true
+#          pool_name: test_ec_pool
+#          pg_num: 64
+#          k: 2
+#          m: 2
+#          plugin: jerasure
+#          crush-failure-domain: host
+#          disable_pg_autoscale: true
+#          rados_write_duration: 50
+#          rados_read_duration: 30
+#        set_pool_configs:
+#          pool_name: test_ec_pool
+#          configurations:
+#            pg_num: 32
+#            pgp_num: 32
+#            pg_autoscale_mode: 'on'
+#            compression_mode: force
+#            compression_algorithm: snappy
+#        delete_pools:
+#          - test_ec_pool
+#      desc: Create, modify & delete EC pools and run IO
 
   - test:
       name: EC pool with Overwrites
@@ -330,39 +314,39 @@ tests:
             byte_size: 10KB
       desc: Verification of the effect of compression on erasure coded pools
 
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_7
-              pool_name: ec86_pool7
-              pool_type: erasure
-              pg_num: 32
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_7
+#              pool_name: ec86_pool7
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-  - test:
-      name: ceph-bluestore-tool utility
-      module: test_bluestoretool_workflows.py
-      polarion-id: CEPH-83571692
-      desc: Verify ceph-bluestore-tool functionalities
-
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+#  - test:
+#      name: ceph-bluestore-tool utility
+#      module: test_bluestoretool_workflows.py
+#      polarion-id: CEPH-83571692
+#      desc: Verify ceph-bluestore-tool functionalities
+#
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
   - test:
       name: Verify premerge PGS during PG split
@@ -422,80 +406,80 @@ tests:
         pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_10
-              pool_name: ec86_pool10
-              pool_type: erasure
-              pg_num: 32
-              k: 2
-              m: 2
-              crush-failure-domain: host
-              plugin: jerasure
-              target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_10
+#              pool_name: ec86_pool10
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              crush-failure-domain: host
+#              plugin: jerasure
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-  - test:
-      name: Autoscaler test - pool pg_num_min
-      module: pool_tests.py
-      polarion-id: CEPH-83573425
-      config:
-        verify_pg_num_min:
-          configurations:
-            pool-1:
-              profile_name: ec86_11
-              pool_name: ec86_pool11
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+#  - test:
+#      name: Autoscaler test - pool pg_num_min
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573425
+#      config:
+#        verify_pg_num_min:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_11
+#              pool_name: ec86_pool11
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num_min: 16
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
-  - test:
-      name: client pg access
-      module: test_client_pg_access.py
-      polarion-id: CEPH-83571713
-      config:
-        verify_client_pg_access:
-          num_snapshots: 20
-          num_objects: 250
-          configurations:
-            pool-1:
-              profile_name: ec86_12
-              pool_name: ec86_pool12
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              disable_pg_autoscale: true
-      desc: many clients clients accessing same PG with bluestore as backend
+#  - test:
+#      name: client pg access
+#      module: test_client_pg_access.py
+#      polarion-id: CEPH-83571713
+#      config:
+#        verify_client_pg_access:
+#          num_snapshots: 20
+#          num_objects: 250
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_12
+#              pool_name: ec86_pool12
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              disable_pg_autoscale: true
+#      desc: many clients clients accessing same PG with bluestore as backend
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-5
-        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
-      desc: Migrating data between different pools. Scenario-2. RE -> EC
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-5
+#        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
+#      desc: Migrating data between different pools. Scenario-2. RE -> EC
 
   - test:
       name: Migrate data bw pools.
@@ -522,60 +506,60 @@ tests:
       desc: Migrating data between different pools. Scenario-4. Ec -> EC
 
 # Blocked due to BZ 2172795. Bugzilla fixed.
-  - test:
-      name: Verify cluster behaviour during PG autoscaler warn
-      module: pool_tests.py
-      polarion-id:  CEPH-83573413
-      config:
-        verify_pool_warnings:
-          pool_configs:
-            - type: erasure
-              conf: sample-pool-5
-          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
-      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+#  - test:
+#      name: Verify cluster behaviour during PG autoscaler warn
+#      module: pool_tests.py
+#      polarion-id:  CEPH-83573413
+#      config:
+#        verify_pool_warnings:
+#          pool_configs:
+#            - type: erasure
+#              conf: sample-pool-5
+#          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
+#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
-  - test:
-      name: Scrub enhancement
-      module: test_scrub_enhancement.py
-      desc: Verify scrub enhancement feature
-      polarion-id: CEPH-83575885
-      config:
-        create_pools:
-          - create_pool:
-              pg_num: 1
-              pg_num_max: 1
-              profile_name: ec86_13
-              pool_name: ec86_pool13
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-        delete_pools:
-          - ec86_pool13
+#  - test:
+#      name: Scrub enhancement
+#      module: test_scrub_enhancement.py
+#      desc: Verify scrub enhancement feature
+#      polarion-id: CEPH-83575885
+#      config:
+#        create_pools:
+#          - create_pool:
+#              pg_num: 1
+#              pg_num_max: 1
+#              profile_name: ec86_13
+#              pool_name: ec86_pool13
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#        delete_pools:
+#          - ec86_pool13
 
-  - test:
-      name: Limit slow request details to cluster log
-      module: test_slow_op_requests.py
-      desc: Limit slow request details to cluster log
-      polarion-id: CEPH-83574884
-      config:
-        create_pools:
-          - create_pool:
-              profile_name: ec86_14
-              pool_name: ec86_pool14
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - ec86_pool14
+#  - test:
+#      name: Limit slow request details to cluster log
+#      module: test_slow_op_requests.py
+#      desc: Limit slow request details to cluster log
+#      polarion-id: CEPH-83574884
+#      config:
+#        create_pools:
+#          - create_pool:
+#              profile_name: ec86_14
+#              pool_name: ec86_pool14
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num: 64
+#              rados_write_duration: 1000
+#              byte_size: 1024
+#              osd_max_backfills: 16
+#              osd_recovery_max_active: 16
+#        delete_pools:
+#          - ec86_pool14
 
   - test:
       name: Robust rebalancing - in progress osd replacement

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -194,6 +194,15 @@ tests:
         cephdf_max_avail_osd_expand: true
 
   - test:
+      name: Verify MAX_AVAIL variance when OSDs are removed
+      desc: MAX_AVAIL value update correctly when OSDs are removed
+      module: test_cephdf.py
+      polarion-id: CEPH-83604474
+      config:
+        cephdf_max_avail_osd_rm: false
+      comments: bug to be fixed - BZ-2277178
+
+  - test:
       name: Compression algorithms - modes
       module: rados_prep.py
       polarion-id: CEPH-83571670

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -144,22 +144,6 @@ tests:
           mds: "allow *"
           mgr: "allow *"
 
-
-  - test:
-      name: Configure email alerts
-      module: rados_prep.py
-      polarion-id: CEPH-83574472
-      config:
-        email_alerts:
-          smtp_host: smtp.corp.redhat.com
-          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
-          smtp_port: 25
-          interval: 10
-          smtp_destination:
-            - pdhiran@redhat.com
-          smtp_from_name: EC 2+2@4 cluster alerts
-      desc: Configure email alerts on ceph cluster
-
   - test:
       name: Enable logging to file
       module: rados_prep.py
@@ -230,33 +214,33 @@ tests:
           delete_pool: true
       desc: Verify Recovery of EC pool with only "k" shards available
 
-  - test:
-      name: EC pool LC
-      module: rados_prep.py
-      polarion-id: CEPH-83571632
-      config:
-        ec_pool:
-          create: true
-          pool_name: test_ec_pool
-          pg_num: 64
-          k: 2
-          m: 2
-          plugin: jerasure
-          crush-failure-domain: host
-          disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
-        set_pool_configs:
-          pool_name: test_ec_pool
-          configurations:
-            pg_num: 32
-            pgp_num: 32
-            pg_autoscale_mode: 'on'
-            compression_mode: force
-            compression_algorithm: snappy
-        delete_pools:
-          - test_ec_pool
-      desc: Create, modify & delete EC pools and run IO
+#  - test:
+#      name: EC pool LC
+#      module: rados_prep.py
+#      polarion-id: CEPH-83571632
+#      config:
+#        ec_pool:
+#          create: true
+#          pool_name: test_ec_pool
+#          pg_num: 64
+#          k: 2
+#          m: 2
+#          plugin: jerasure
+#          crush-failure-domain: host
+#          disable_pg_autoscale: true
+#          rados_write_duration: 50
+#          rados_read_duration: 30
+#        set_pool_configs:
+#          pool_name: test_ec_pool
+#          configurations:
+#            pg_num: 32
+#            pgp_num: 32
+#            pg_autoscale_mode: 'on'
+#            compression_mode: force
+#            compression_algorithm: snappy
+#        delete_pools:
+#          - test_ec_pool
+#      desc: Create, modify & delete EC pools and run IO
 
   - test:
       name: EC pool with Overwrites
@@ -330,39 +314,39 @@ tests:
             byte_size: 10KB
       desc: Verification of the effect of compression on erasure coded pools
 
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_7
-              pool_name: ec86_pool7
-              pool_type: erasure
-              pg_num: 32
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_7
+#              pool_name: ec86_pool7
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-  - test:
-      name: ceph-bluestore-tool utility
-      module: test_bluestoretool_workflows.py
-      polarion-id: CEPH-83571692
-      desc: Verify ceph-bluestore-tool functionalities
-
-  - test:
-      name: ceph-objectstore-tool utility
-      module: test_objectstoretool_workflows.py
-      polarion-id: CEPH-83581811
-      desc: Verify ceph-objectstore-tool functionalities
+#  - test:
+#      name: ceph-bluestore-tool utility
+#      module: test_bluestoretool_workflows.py
+#      polarion-id: CEPH-83571692
+#      desc: Verify ceph-bluestore-tool functionalities
+#
+#  - test:
+#      name: ceph-objectstore-tool utility
+#      module: test_objectstoretool_workflows.py
+#      polarion-id: CEPH-83581811
+#      desc: Verify ceph-objectstore-tool functionalities
 
   - test:
       name: Verify premerge PGS during PG split
@@ -423,80 +407,80 @@ tests:
         pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
       desc: Verify that scrub & deep-scrub logs are captured in OSD logs
 
-  - test:
-      name: Autoscaler test - pool target size ratio
-      module: pool_tests.py
-      polarion-id: CEPH-83573424
-      config:
-        verify_pool_target_ratio:
-          configurations:
-            pool-1:
-              profile_name: ec86_10
-              pool_name: ec86_pool10
-              pool_type: erasure
-              pg_num: 32
-              k: 2
-              m: 2
-              crush-failure-domain: host
-              plugin: jerasure
-              target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+#  - test:
+#      name: Autoscaler test - pool target size ratio
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573424
+#      config:
+#        verify_pool_target_ratio:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_10
+#              pool_name: ec86_pool10
+#              pool_type: erasure
+#              pg_num: 32
+#              k: 2
+#              m: 2
+#              crush-failure-domain: host
+#              plugin: jerasure
+#              target_size_ratio: 0.8
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
-  - test:
-      name: Autoscaler test - pool pg_num_min
-      module: pool_tests.py
-      polarion-id: CEPH-83573425
-      config:
-        verify_pg_num_min:
-          configurations:
-            pool-1:
-              profile_name: ec86_11
-              pool_name: ec86_pool11
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
-              delete_pool: true
-      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+#  - test:
+#      name: Autoscaler test - pool pg_num_min
+#      module: pool_tests.py
+#      polarion-id: CEPH-83573425
+#      config:
+#        verify_pg_num_min:
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_11
+#              pool_name: ec86_pool11
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num_min: 16
+#              rados_write_duration: 50
+#              rados_read_duration: 50
+#              delete_pool: true
+#      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
-  - test:
-      name: client pg access
-      module: test_client_pg_access.py
-      polarion-id: CEPH-83571713
-      config:
-        verify_client_pg_access:
-          num_snapshots: 20
-          num_objects: 250
-          configurations:
-            pool-1:
-              profile_name: ec86_12
-              pool_name: ec86_pool12
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              disable_pg_autoscale: true
-      desc: many clients clients accessing same PG with bluestore as backend
+#  - test:
+#      name: client pg access
+#      module: test_client_pg_access.py
+#      polarion-id: CEPH-83571713
+#      config:
+#        verify_client_pg_access:
+#          num_snapshots: 20
+#          num_objects: 250
+#          configurations:
+#            pool-1:
+#              profile_name: ec86_12
+#              pool_name: ec86_pool12
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              disable_pg_autoscale: true
+#      desc: many clients clients accessing same PG with bluestore as backend
 
-  - test:
-      name: Migrate data bw pools.
-      module: test_data_migration_bw_pools.py
-      polarion-id: CEPH-83574768
-      config:
-        pool-1-type: replicated
-        pool-2-type: erasure
-        pool-1-conf: sample-pool-1
-        pool-2-conf: sample-pool-5
-        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
-      desc: Migrating data between different pools. Scenario-2. RE -> EC
+#  - test:
+#      name: Migrate data bw pools.
+#      module: test_data_migration_bw_pools.py
+#      polarion-id: CEPH-83574768
+#      config:
+#        pool-1-type: replicated
+#        pool-2-type: erasure
+#        pool-1-conf: sample-pool-1
+#        pool-2-conf: sample-pool-5
+#        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
+#      desc: Migrating data between different pools. Scenario-2. RE -> EC
 
   - test:
       name: Migrate data bw pools.
@@ -522,61 +506,61 @@ tests:
         pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
       desc: Migrating data between different pools. Scenario-4. Ec -> EC
 
-# Blocked due to BZ 2172795. Bugzilla fixed.
-  - test:
-      name: Verify cluster behaviour during PG autoscaler warn
-      module: pool_tests.py
-      polarion-id:  CEPH-83573413
-      config:
-        verify_pool_warnings:
-          pool_configs:
-            - type: erasure
-              conf: sample-pool-5
-          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
-      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+## Blocked due to BZ 2172795. Bugzilla fixed.
+#  - test:
+#      name: Verify cluster behaviour during PG autoscaler warn
+#      module: pool_tests.py
+#      polarion-id:  CEPH-83573413
+#      config:
+#        verify_pool_warnings:
+#          pool_configs:
+#            - type: erasure
+#              conf: sample-pool-5
+#          pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
+#      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
 
-  - test:
-      name: Scrub enhancement
-      module: test_scrub_enhancement.py
-      desc: Verify scrub enhancement feature
-      polarion-id: CEPH-83575885
-      config:
-        create_pools:
-          - create_pool:
-              pg_num: 1
-              pg_num_max: 1
-              profile_name: ec86_13
-              pool_name: ec86_pool13
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-        delete_pools:
-          - ec86_pool13
+#  - test:
+#      name: Scrub enhancement
+#      module: test_scrub_enhancement.py
+#      desc: Verify scrub enhancement feature
+#      polarion-id: CEPH-83575885
+#      config:
+#        create_pools:
+#          - create_pool:
+#              pg_num: 1
+#              pg_num_max: 1
+#              profile_name: ec86_13
+#              pool_name: ec86_pool13
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#        delete_pools:
+#          - ec86_pool13
 
-  - test:
-      name: Limit slow request details to cluster log
-      module: test_slow_op_requests.py
-      desc: Limit slow request details to cluster log
-      polarion-id: CEPH-83574884
-      config:
-        create_pools:
-          - create_pool:
-              profile_name: ec86_14
-              pool_name: ec86_pool14
-              pool_type: erasure
-              k: 2
-              m: 2
-              plugin: jerasure
-              crush-failure-domain: host
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - ec86_pool14
+#  - test:
+#      name: Limit slow request details to cluster log
+#      module: test_slow_op_requests.py
+#      desc: Limit slow request details to cluster log
+#      polarion-id: CEPH-83574884
+#      config:
+#        create_pools:
+#          - create_pool:
+#              profile_name: ec86_14
+#              pool_name: ec86_pool14
+#              pool_type: erasure
+#              k: 2
+#              m: 2
+#              plugin: jerasure
+#              crush-failure-domain: host
+#              pg_num: 64
+#              rados_write_duration: 1000
+#              byte_size: 1024
+#              osd_max_backfills: 16
+#              osd_recovery_max_active: 16
+#        delete_pools:
+#          - ec86_pool14
 
   - test:
       name: Robust rebalancing - in progress osd replacement

--- a/suites/squid/rados/tier-4_rados_tests.yaml
+++ b/suites/squid/rados/tier-4_rados_tests.yaml
@@ -196,6 +196,15 @@ tests:
 #        cephdf_max_avail_osd_expand: true
 
   - test:
+      name: Verify MAX_AVAIL variance when OSDs are removed
+      desc: MAX_AVAIL value update correctly when OSDs are removed
+      module: test_cephdf.py
+      polarion-id: CEPH-83604474
+      config:
+        cephdf_max_avail_osd_rm: false
+      comments: bug to be fixed - BZ-2275995
+
+  - test:
       name: Compression algorithms - modes
       module: rados_prep.py
       polarion-id: CEPH-83571670

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -464,27 +464,28 @@ def run(ceph_cluster, **kw):
             log.info(out)
             assert "success" in out
 
-            # Execute ceph-bluestore-tool qfsck --path <osd_path>
-            osd_id = random.choice(osd_list)
-            log.info(
-                f"\n --------------------"
-                f"\n Running quick consistency check for OSD {osd_id}"
-                f"\n --------------------"
-            )
-            out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
-            log.info(out)
-            assert "success" in out
+            if rhbuild.split(".")[0] >= "6":
+                # Execute ceph-bluestore-tool qfsck --path <osd_path>
+                osd_id = random.choice(osd_list)
+                log.info(
+                    f"\n --------------------"
+                    f"\n Running quick consistency check for OSD {osd_id}"
+                    f"\n --------------------"
+                )
+                out = bluestore_obj.run_quick_consistency_check(osd_id=osd_id)
+                log.info(out)
+                assert "success" in out
 
-            # Execute ceph-bluestore-tool allocmap --path <osd_path>
-            osd_id = random.choice(osd_list)
-            log.info(
-                f"\n --------------------"
-                f"\n Fetching allocmap for OSD {osd_id}"
-                f"\n ---------------------"
-            )
-            out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
-            log.info(out)
-            assert "success" in out
+                # Execute ceph-bluestore-tool allocmap --path <osd_path>
+                osd_id = random.choice(osd_list)
+                log.info(
+                    f"\n --------------------"
+                    f"\n Fetching allocmap for OSD {osd_id}"
+                    f"\n ---------------------"
+                )
+                out = bluestore_obj.fetch_allocmap(osd_id=osd_id)
+                log.info(out)
+                assert "success" in out
 
             # Execute ceph-bluestore-tool repair --path <osd_path>
             osd_id = random.choice(osd_list)


### PR DESCRIPTION
[CEPH-83604474](CEPH-83604474): Test to ensure ceph df MAX_AVAIL gets updated correctly when few OSDs have been removed from the cluster

Jira tracker: [RHCEPHQE-16887](https://issues.redhat.com/browse/RHCEPHQE-16887)
Bugzilla trackers:
Quincy: [BZ-2277857](https://bugzilla.redhat.com/show_bug.cgi?id=2277857)
Reef: [BZ-2277178](https://bugzilla.redhat.com/show_bug.cgi?id=2277178)
Squid: [BZ-2275995](https://bugzilla.redhat.com/show_bug.cgi?id=2275995)

Test case modified:
- `tests/rados/test_cephdf.py`

Test suites modified:
- `suites/quincy/rados/tier-4_rados_tests.yaml`
- `suites/reef/rados/tier-4_rados_tests.yaml`
- `suites/squid/rados/tier-4_rados_tests.yaml`

Steps:
1. Creating a replicated and EC pool with default config
2. Log pool stats and verify max_avail
3. Remove 25% of OSDs from each OSD host
4. Log pool stats and verify max_avail
5. Re-deploy OSDs
6. Log pool stats and verify max_avail

Logs:
N/A

TFA fix:
- Automation regression introduced due to PR #4117 - ceph-bluestore-tool qfsck command is not valid for Pacific
- Reduce the suite execution duration for `tier-3_rados_test-4-node-ecpools.yaml`

Signed-off-by: Harsh Kumar <hakumar@redhat.com>