### PR TITLE
inventory file update : jdk or oathtool

### DIFF
--- a/conf/inventory/rhel-8.10.0-x86_64-rgw.yaml
+++ b/conf/inventory/rhel-8.10.0-x86_64-rgw.yaml
@@ -1,0 +1,49 @@
+---
+version_id: 8.10
+id: rhel
+instance:
+  create:
+    image-name: RHEL-8.10.0-x86_64-ga-latest
+    vm-size: ci.standard.medium
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: true
+    disable_root: false
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4eHmz10szeHNS3dNejKokW85ksB+iR4HGOFsmQM11Ni68Nm5aqEKvkOZU8TpY92vpCQL0A68GlrXB845cACdyk6HUJYyNNNMC43l1FYWOwjMqQBSdj8W3VQDTA6eiG60mt5fgI8fyR38rKzIA1MnTBkSSjuh5kQVJ9bdEp3GuY5oc8vxDNBlGJ6LYnyEWt/pqL2J+mpjqnOjsC+EbE2exhP9O+mvzpQiyo/+dEN1COwX3//pNRXGfOSeOczHNsJE8Eu+j/n/BlW57++sJyFMkzS7bUxMSGM6quvjQZ7RT1c5JM6vLEiQyzQxoRgzY93h1yKlOstBi0NamtpqHQZGP kdreyer@redhat.com
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser:pass123
+      expire: false
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
+      - subscription-manager clean
+      - timedatectl set-timezone Etc/UTC
+      - hostnamectl set-hostname $(hostname -s)
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+      - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
+      - update-ca-trust
+      - touch /ceph-qa-ready
+      - mkdir -p /root/rgw_rpms
+      - curl -k -o /root/rgw_rpms/jdk.rpm https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+      - curl -k -o /root/rgw_rpms/oathtool.rpm https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el8.x86_64.rpm
+
+    final_message: "Ready for ceph qa testing"

--- a/conf/inventory/rhel-9.5.0-x86_64-rgw.yaml
+++ b/conf/inventory/rhel-9.5.0-x86_64-rgw.yaml
@@ -1,0 +1,53 @@
+---
+version_id: 9.5
+id: rhel
+instance:
+  create:
+    image-name: RHEL-9.5.0-x86_64-ga-latest
+    vm-size: ci.standard.medium
+
+  setup: |
+    #cloud-config
+
+    ssh_pwauth: true
+    disable_root: false
+
+    groups:
+      - cephuser
+
+    users:
+      - name: cephuser
+        primary-group: cephuser
+        sudo: ALL=(ALL) NOPASSWD:ALL
+        shell: /bin/bash
+        ssh-authorized-keys:
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4eHmz10szeHNS3dNejKokW85ksB+iR4HGOFsmQM11Ni68Nm5aqEKvkOZU8TpY92vpCQL0A68GlrXB845cACdyk6HUJYyNNNMC43l1FYWOwjMqQBSdj8W3VQDTA6eiG60mt5fgI8fyR38rKzIA1MnTBkSSjuh5kQVJ9bdEp3GuY5oc8vxDNBlGJ6LYnyEWt/pqL2J+mpjqnOjsC+EbE2exhP9O+mvzpQiyo/+dEN1COwX3//pNRXGfOSeOczHNsJE8Eu+j/n/BlW57++sJyFMkzS7bUxMSGM6quvjQZ7RT1c5JM6vLEiQyzQxoRgzY93h1yKlOstBi0NamtpqHQZGP kdreyer@redhat.com
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCyaKj0phxJTD2ZblCbujHOlH3KWx4WlEUdKWxftfBarFbN9tztClUXC4WtSDXsJeith9/JaiXkJMNulSEmZ1+WfpaS1CKiBxyy/6lzwaiqnphiIJIZu7mQTOydcc0ACIE1g/sm0yBpOQRaa28BFAlQxN5IFVzQqws1M3uSYU9iyOj8CZagnavIHMPfw7wOVX+ncUl+YIySRgsjbtrLPm1cfEcutpT8SphNOu6mKDq5jN9jVqn5j+2KxAmJRjkKmEyNXrzhTUgdBrxfJ877JkeyNfjzaptX29ms1LzJxVPV0pitJ7gHirc3LlZ8PihIdWR52Ts2BwcF86/2CB39nw+NCXSICbGmWues0m5BjIC7utGERA/fU5eE7CnTKFuUaONkL7CGqQN/7bak0E9IUJqzyRswDub93j9QyXfV305wHF4nfOeHLDKbcQHgLM1/rjs6BQMZvJlS+f+2kJHMfFD9UYCrnhdMpLXTvJ8amlF9J+HUhu7zLPNuEjJf9I4aNb0= psathyan@psathyan.remote.csb
+           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDPHFNcyrHISbDksvZcICQFpVXOjYgSHuDIjMYHzaFh+2wOZxLE6NmHwhTJDEqW1WogzdfqFa39c6b4Mhm3JFDu8fbHs/2uccVdZrAEAdXBi++SMBzDTkBjp+6RTW8xHBKBBm/xbtCS2KuSMYWCzmT1bk87ZzzOY/4ov8UAOm6g5eouR1qpohCaRVmoVVankb4FAi8VGT1McQm6eiecebKNzMUP08eidKyCfpKgObSiEFTp7grAyv8BVNNsJTgLOtwoyfJbEbZridxgEqrDhF21WpqloeiyG4YPWN3TeDYtqaedtIjcfiOizy9HmsSu8miusfvMEjFgR9G2xbpudOyv jenkins-build@ci-slave.localdomain
+
+    chpasswd:
+      list: |
+        root:passwd
+        cephuser:pass123
+      expire: false
+
+    runcmd:
+      - sed -i -e 's/^Defaults\s\+requiretty/# \0/' /etc/sudoers
+      - echo "net.core.default_qdisc=netem" > /etc/sysctl.d/1000-qdisc.conf
+      - subscription-manager clean
+      - timedatectl set-timezone Etc/UTC
+      - hostnamectl set-hostname $(hostname -s)
+      - sed -i -e 's/#PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+      - systemctl restart sshd
+      - curl -m 120 -o /etc/pki/ca-trust/source/anchors/ceph-qe-ca.pem http://magna002.ceph.redhat.com/cephci-jenkins/.cephqe-ca.pem
+      - curl -m 120 -k -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
+      - update-ca-trust
+      - touch /ceph-qa-ready
+      - mkdir -p /root/rgw_rpms
+      - curl -k -o /root/rgw_rpms/jdk.rpm https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+      - curl -k -o /root/rgw_rpms/oathtool.rpm https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+
+
+    final_message: "Ready for ceph qa testing"
+
+

--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -709,8 +709,7 @@ tests:
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa.yaml
         extra-pkgs:
-          8:
-            - https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el8.x86_64.rpm
+            - oathtool
 
   - test:
       name: multipart versioned object deletion with mfa token

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
@@ -104,7 +104,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
@@ -106,7 +106,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
@@ -104,7 +104,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -102,7 +102,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test_5-3_specific_fixes.yaml
@@ -126,7 +126,7 @@ tests:
               run-on-rgw: true
               install_common: false
               extra-pkgs:
-                - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+                - jdk
               install_start_kafka: true
               script-name: test_bucket_notifications.py
               config-file-name: test_empty_bucket_notification_kafka_broker.yaml

--- a/suites/pacific/rgw/tier-2_sse_s3_encryption.yaml
+++ b/suites/pacific/rgw/tier-2_sse_s3_encryption.yaml
@@ -152,7 +152,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_policy_ops.py
         config-file-name: test_sse_kms_per_bucket_with_bucket_policy.yaml

--- a/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_6_1_fixes.yaml
@@ -67,7 +67,7 @@ tests:
       module: sanity_rgw.py
       config:
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         run-on-rgw: true
         script-name: test_bucket_notifications.py

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -576,8 +576,7 @@ tests:
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa.yaml
         extra-pkgs:
-          9:
-            - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+            - oathtool
 
   - test:
       name: multipart versioned object deletion with mfa token

--- a/suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ssl_test_bucket_notifications.yaml
@@ -74,7 +74,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-sanity.yaml
@@ -70,7 +70,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-sasl-scheduled.yaml
@@ -72,7 +72,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test-bucket-notifications-kafka-ssl.yaml
@@ -70,7 +70,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -69,7 +69,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/suites/reef/rgw/sanity_rgw.yaml
+++ b/suites/reef/rgw/sanity_rgw.yaml
@@ -162,7 +162,7 @@ tests:
         run-on-rgw: true
         install_common: false
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
@@ -245,8 +245,7 @@ tests:
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa.yaml
         extra-pkgs:
-          9:
-            - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+            - oathtool
   - test:
       name: Bucket link and unlink
       desc: Bucket move between tenanted and non tenanted users

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -78,7 +78,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml

--- a/suites/reef/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_test.yaml
@@ -506,8 +506,7 @@ tests:
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa_multipart.yaml
         extra-pkgs:
-          9:
-            - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+            - oathtool
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -69,7 +69,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
@@ -71,7 +71,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
@@ -71,7 +71,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/reef/rgw/tier-2_ssl_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_ssl_rgw_test_bucket_notifications.yaml
@@ -74,7 +74,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/suites/squid/rgw/sanity_rgw.yaml
+++ b/suites/squid/rgw/sanity_rgw.yaml
@@ -160,7 +160,7 @@ tests:
         run-on-rgw: true
         install_common: false
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
@@ -244,8 +244,7 @@ tests:
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa.yaml
         extra-pkgs:
-          9:
-            - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+            - oathtool
   - test:
       name: Bucket link and unlink
       desc: Bucket move between tenanted and non tenanted users

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -79,7 +79,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_policy_with_tenant_user.py
         config-file-name: test_put_get_bucket_notification_with_tenant_same_and_different_user.yaml

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -498,8 +498,7 @@ tests:
         script-name: test_rgw_mfa.py
         config-file-name: test_rgw_mfa_multipart.yaml
         extra-pkgs:
-          9:
-            - https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/o/oathtool-2.6.12-1.el9.x86_64.rpm
+            - oathtool
 
   - test:
       name: incorrect syntax for mfa resync commnad appropriate usage message is displayed

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -70,7 +70,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_sasl.yaml
@@ -72,7 +72,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications_kafka_ssl.yaml
@@ -72,7 +72,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         configure_kafka_security: true
         script-name: test_bucket_notifications.py

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -370,7 +370,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_delete.yaml

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -101,8 +101,6 @@ def run(ceph_cluster, **kw):
         else config.get("run-on-haproxy", False)
     )
 
-    distro_version_id = rgw_node.distro_info["VERSION_ID"]
-
     if run_on_rgw:
         exec_from = rgw_node
         append_param = ""
@@ -116,14 +114,13 @@ def run(ceph_cluster, **kw):
     # install extra package which are test specific
     if extra_pkgs:
         log.info(f"got extra pkgs: {extra_pkgs}")
-        if isinstance(extra_pkgs, dict):
-            _pkgs = extra_pkgs.get(int(distro_version_id[0]))
-            pkgs = " ".join(_pkgs)
-        else:
-            pkgs = " ".join(extra_pkgs)
+        package_path = "/root/rgw_rpms"
+        pkgs_str = ""
+        for pkg in extra_pkgs:
+            pkgs_str += f"{package_path}/{pkg}.rpm "
 
         exec_from.exec_command(
-            sudo=True, cmd=f"yum install -y {pkgs}", long_running=True
+            sudo=True, cmd=f"yum install -y {pkgs_str}", long_running=True
         )
 
     log.info("Flushing iptables")


### PR DESCRIPTION
Centralize package versions (e.g., JDK, oathtool) in an inventory to simplify updates across suites.
log: http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-BLWG2P/Test_BucketNotification_with_users_in_same_tenant_and_different_tenant_0.log - for jdk package
log: http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-IP5QZM/multipart_versioned_object_deletion_with_mfa_token_0.log - for oathtool package

issue: https://issues.redhat.com/browse/RHCEPHQE-16965

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
