### PR TITLE
integrating inditex hotfix bz tests: CORS presigned put url

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -291,3 +291,12 @@ tests:
       config:
         script-name: ../aws/test_acl.py
         config-file-name: ../../aws/configs/test_public_read_write_acl.yaml
+
+  - test:
+      name: Test Inditex hotfix bz, CORS presigned put url
+      desc: CORS ACL's prevents access to buckets with presigned PUT URI's with ACL private header
+      polarion-id: CEPH-83604475
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_cors_using_curl.py
+        config-file-name: ../../curl/configs/test_cors_presigned_put_url_using_curl.yaml

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -312,3 +312,12 @@ tests:
       config:
         script-name: ../aws/test_acl.py
         config-file-name: ../../aws/configs/test_public_read_write_acl.yaml
+
+  - test:
+      name: Test Inditex hotfix bz, CORS presigned put url
+      desc: CORS ACL's prevents access to buckets with presigned PUT URI's with ACL private header
+      polarion-id: CEPH-83604475
+      module: sanity_rgw.py
+      config:
+        script-name: ../curl/test_cors_using_curl.py
+        config-file-name: ../../curl/configs/test_cors_presigned_put_url_using_curl.yaml


### PR DESCRIPTION
depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/655

CORS ACL's prevents access to buckets with presigned PUT URI's with ACL:private header
hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2299642
polarion: https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83604475

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_hotfix_inditex_cors_presigned_put_url/cephci-run-NJQ4LA/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
