### PR TITLE
RHCEPHQE-17401: Refactor with context in parallel module.

### DIFF
--- a/tests/parallel/test_parallel.py
+++ b/tests/parallel/test_parallel.py
@@ -48,14 +48,12 @@ def run(**kwargs):
         parallel_tests = kwargs["parallel"]
         parallel_tcs = manager.list()
         max_time = kwargs.get("config", {}).get("max_time", None)
-        wait_till_complete = kwargs.get("config", {}).get("wait_till_complete", True)
         cancel_pending = kwargs.get("config", {}).get("cancel_pending", False)
         parallel_log.info(kwargs)
 
         with parallel(
             thread_pool=False,
             timeout=max_time,
-            shutdown_wait=wait_till_complete,
             shutdown_cancel_pending=cancel_pending,
         ) as p:
             for test in parallel_tests:


### PR DESCRIPTION
# Description

The initial design populated the results only when it had completed successfully. This could be a impact when qe is refering the values during the context.

In this PR, the futures.as_completed is not used instead the timeout is controlled via datetime methods. Also, results are continued to be appended at the end of the method.

The iteration is modified to use `_futures` instead of _results. This way we can capture details on the cancelled threads also.

- [x] Review the automation design
- [x] Implement the test script and perform test runs

*Unit Testing*
[Logs](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-2RNY20/)

```
(venv) psathyan@magna002:~/src/cephci$ cat utest_parallel.py
from ceph.parallel import parallel

def trigger(param):
    print(f"I got this varlue {param}")
    return param


with parallel() as p:
    for x in range(5):
        p.spawn(trigger, x)

    for r in p:
        print(f"The retrived result is {r}")

print("The number threads spawned is", p.count)
print("-" * 20)
for r in p:
    print(f"Outside results retrival value is {r}")

(venv) psathyan@magna002:~/src/cephci$ python utest_parallel.py
I got this varlue 0
I got this varlue 1
I got this varlue 2
I got this varlue 3
The retrived result is 0
I got this varlue 4
The retrived result is 1
The retrived result is 2
The retrived result is 3
The retrived result is 4
The number threads spawned is 5
--------------------
Outside results retrival value is 0
Outside results retrival value is 1
Outside results retrival value is 2
Outside results retrival value is 3
Outside results retrival value is 4
```
