### PR TITLE
Automation to set size for log rotate and parse dbg logs for specific…

### DIFF
--- a/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
+++ b/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
@@ -215,7 +215,15 @@ tests:
       config:
        ENABLE_LOGS : 1
        daemon_list : ['mds','client','osd','mgr','mon']
-       daemon_dbg_level : {'mds':20,'client':20,'osd':10,'mgr':10,'mon':10}
+       daemon_dbg_level : {'mds':10,'client':10,'osd':5,'mgr':5,'mon':5}
+  - test:
+      abort-on-fail: false
+      desc: "Set size limit for log rotation"
+      name: size limit for log rotation
+      module: cephfs_logs_util.py
+      config:
+        LOG_ROTATE_SIZE : 1
+        log_size : '200M'
   -
     test:
       abort-on-fail: false
@@ -294,3 +302,12 @@ tests:
       config:
        DISABLE_LOGS : 1
        daemon_list : ['mds','client','osd','mgr','mon']
+  -
+    test:
+      name: Parse dbg logs for specific strings
+      module: cephfs_logs_util.py
+      config:
+        LOG_PARSER : 1
+        daemon : 'mds'
+        expect_list : ['issue_new_caps','get_allowed_caps','"sending MClientCaps"','client_caps\(revoke']
+        unexpect_list: ['Exception','assert']


### PR DESCRIPTION
… strings

JIRA:
Set size for log rotate : https://issues.redhat.com/browse/RHCEPHQE-17348
Log parser : https://issues.redhat.com/browse/RHCEPHQE-17349

Fix Description:
Set size for log rotate : Add size str in logrotate.d conf file on each node so that for any debug log in /var/log/caph/<fsid>
when log size reaches the value set in size string, rotation triggers.
Log parser: Parse through debug logs for specified daemon for specified expected and unexpected strings and report pass when expected strings found and unexpected strings not foudn and fail if vice-versa.

File with above changes:
tests/cephfs/cephfs_system/cephfs_system_utils.py

Wrapper python script updated to use these two tools:
tests/cephfs/cephfs_logs_util.py

Test suite invoking log rotate and log parser:
suites/squid/cephfs/tier-3_cephfs_system_test.yaml

Automation logs:
set size for log rotate: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-A5LY9D
log parser: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X9RPYI
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
