### PR TITLE
Integration of s3 restore feature

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_3_way_multisite.yaml
@@ -444,6 +444,16 @@ tests:
       module: sanity_rgw_multisite.py
       name: create non-tenanted user
       polarion-id: CEPH-83575199
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_cloud_transition_restore_object.yaml
+      desc: test s3 object restore and download, and restore attrs
+      module: sanity_rgw_multisite.py
+      name: test s3 object restore and download, and restore attrs
+      polarion-id: CEPH-83591622 #CEPH-83591672 #CEPH-83591621
 
   - test:
       clusters:

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -574,7 +574,11 @@ def set_config_param(node):
     rgw_process_name = rgw_process[0].split()[0]
 
     # add the configuration/s to be set on service
-    configs = ["rgw_max_objs_per_shard 5", "rgw_lc_debug_interval 30"]
+    configs = [
+        "rgw_max_objs_per_shard 5",
+        "rgw_lc_debug_interval 30",
+        "rgw_restore_debug_interval 30",
+    ]
     for config_cmd in configs:
         node.exec_command(cmd=f"ceph config set client.{rgw_process_name} {config_cmd}")
 


### PR DESCRIPTION
# Description
Integration of s3 restore feature


Note:

The time for object restoration interval has been 7 days which is 210 seconds (based on the 30 seconds proxy LC debug interval.)
210 seconds also ensures an object is restored and downloaded within that interval, after which the objects would not be accessed.
logs
[deploy_cluster_0.log](https://github.com/user-attachments/files/18313624/deploy_cluster_0.log)
[setup_2-way_multisite_0.log](https://github.com/user-attachments/files/18313625/setup_2-way_multisite_0.log)
[create_non-tenanted_user_0.log](https://github.com/user-attachments/files/18313627/create_non-tenanted_user_0.log)
[configure_client_0.log](https://github.com/user-attachments/files/18313633/configure_client_0.log)
[test_s3_object_restore_and_download,_and_restore_attrs_0.log](https://github.com/user-attachments/files/18320842/test_s3_object_restore_and_download._and_restore_attrs_0.log)

