### PR TITLE
Revert to merge action for mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,8 +9,8 @@ pull_request_rules:
       - "check-success=tox (3.9.18)"
       - check-success=WIP
     actions:
-      queue:
-        merge_method: merge
+      merge:
+        method: merge
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
# Description

mergify bot is creating two commits for each PR. This is a bit confusing when reviewing the history from CLI. Hence, in this PR we are moving the action back to merge.

- [x] Review the automation design

*Concern*

```
fc6d48e7 (HEAD -> main, upstream/main, origin/main) Merge pull request #4340 from hmaheswa/MOD_hotfix_404_again
adf12b41 Merge branch 'main' into MOD_hotfix_404_again    <--- creates a merge instead of a rebase
88fad30b Merge pull request #4362 from sumabai/8.0
156e51e4 Merge branch 'main' into 8.0                                       <-- creates a merge... which is not required.
7ffa1380 Merge pull request #4341 from ckulal/cephci-put-acls
3015d034 Merge branch 'main' into cephci-put-acls
```