### PR TITLE
[cephci V3] remove redundent testcase from multiple place

### DIFF
--- a/suites/squid/rgw/migrate_default_single_to_multisite.yaml
+++ b/suites/squid/rgw/migrate_default_single_to_multisite.yaml
@@ -172,23 +172,9 @@ tests:
             config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
             run-on-haproxy: true
       desc: test M buckets compression on haproxy node
-      polarion-id: CEPH-83575199
+      polarion-id: CEPH-83575435
       module: sanity_rgw_multisite.py
       name: test M buckets compression on haproxy node
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            set-env: true
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_multipart_haproxy.yaml
-            run-on-haproxy: true
-            timeout: 5000
-      desc: test M buckets multipart uploads on haproxy node
-      module: sanity_rgw_multisite.py
-      name: test M buckets multipart uploads on haproxy node
-      polarion-id: CEPH-83575433
 
 #Convert single site to multisite with default configuration
   - test:
@@ -244,19 +230,6 @@ tests:
       polarion-id: CEPH-83575473
       module: sanity_rgw_multisite.py
       name: test rgw restore index tool on versioned bucket
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            config-file-name: test_Mbuckets_with_Nobjects_no_reshard_haproxy.yaml
-            script-name: test_Mbuckets_with_Nobjects.py
-            run-on-haproxy: true
-            timeout: 5000
-      desc: Execute M buckets with N objects on primary and verify on secondary cluster
-      polarion-id: CEPH-83575575
-      module: sanity_rgw_multisite.py
-      name: m buckets with n objects
 
   - test:
       name: RGW multipart object expiration through lc

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -230,18 +230,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_manual_resharding_greenfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec"]
-      desc: Test manual resharding on greenfield deployment
-      abort-on-fail: true
-      module: sanity_rgw_multisite.py
-      name: Manual Resharding tests on Primary cluster
-      polarion-id: CEPH-83574734
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             config-file-name: test_bucket_create_del.yaml
             script-name: test_Mbuckets_with_Nobjects.py
       desc: bucket create and delete operation
@@ -272,48 +260,6 @@ tests:
             config-file-name: test_bucket_listing_flat_unordered.yaml
             monitor-consistency-bucket-stats: true
   - test:
-      name: test aws4 signature version on primary
-      desc: test_Mbuckets_with_Nobjects_aws4 on primary
-      polarion-id: CEPH-9637
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_aws4.yaml
-  - test:
-      name: test encryption on primary
-      desc: test_Mbuckets_with_Nobjects_enc on primary
-      polarion-id: CEPH-11358 # also applies to CEPH-11361
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-  - test:
-      name: multipart upload on primary
-      desc: test_Mbuckets_with_Nobjects_multipart on primary
-      polarion-id: CEPH-14265
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-  - test:
-      name: LargeObjGet_GC on primary
-      desc: test_LargeObjGet_GC on primary
-      polarion-id: CEPH-83574416
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_LargeObjGet_GC.py
-            config-file-name: test_LargeObjGet_GC.yaml
-  - test:
       name: modify bucket policy on primary
       desc: test_bucket_policy_modify.yaml on primary
       polarion-id: CEPH-11214
@@ -324,17 +270,6 @@ tests:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_bucket_policy_modify.yaml
             verify-io-on-site: ["ceph-sec"]
-  - test:
-      name: test encryption on primary
-      desc: test_Mbuckets_with_Nobjects_enc on primary
-      polarion-id: CEPH-11358 # also applies to CEPH-11361
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
   - test:
       name:  datalog omap offload on secondary
       desc: Execute datalog omap offload on secondary
@@ -517,17 +452,6 @@ tests:
       name: Setting sse_kms configs with kmip backend for gklm
 
   # GKLM tests
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload.yaml
-      desc: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload
-      module: sanity_rgw_multisite.py
-      name: test_sse_kms_kmip_gklm_per_bucket_encryption_normal_object_upload
-      polarion-id: CEPH-83592485
   - test:
       clusters:
         ceph-pri:
@@ -543,44 +467,11 @@ tests:
         ceph-pri:
           config:
             script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled.yaml
-      desc: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
-      module: sanity_rgw_multisite.py
-      name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
-      polarion-id: CEPH-83592485
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_kmip_gklm_per_object.yaml
       desc: test_sse_kms_kmip_gklm_per_object
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_object
       polarion-id: CEPH-83592485
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_kms_kmip_gklm_per_object_versioninig_enabled.yaml
-      desc: test_sse_kms_kmip_gklm_per_object_versioninig_enabled
-      module: sanity_rgw_multisite.py
-      name: test_sse_kms_kmip_gklm_per_object_versioninig_enabled
-      polarion-id: CEPH-83592485
-
-
-  - test:
-      name: bucket sync command crash check on secondary
-      desc: Execute bucket sync command to check command is not crashing on secondary
-      polarion-id: CEPH-83574706
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name:  test_Mbuckets_with_Nobjects.py
-            config-file-name:  test_bucket_sync_cmd_crash.yaml
-            verify-io-on-site: ["ceph-pri"]
   - test:
       name: Bucket Granular Sync policy tests
       desc: test_multisite_mirror_sync_policy.yaml on primary

--- a/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_archive_ms_upgrade_71GA_to_8x_latest.yaml
@@ -377,6 +377,7 @@ tests:
             command: start
             service: upgrade
             verify_cluster_health: true
+
   - test:
       name: Verify DBR feature enabled on upgraded cluster
       desc: Check DBR feature enabled on upgraded cluster

--- a/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
@@ -293,18 +293,6 @@ tests:
       polarion-id: CEPH-83575199
 
   # Baseline tests before upgrade
-  - test:
-      name: Bucket Granular Sync policy test for prefix and tag
-      desc: Bucket sync policy test for prefix and tag
-      polarion-id: CEPH-83575133
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_syncpolicy_prefix_tag.py
-            config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
-            verify-io-on-site: ["ceph-sec"]
-
 
   - test:
       clusters:
@@ -329,19 +317,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
       polarion-id: CEPH-11019
-
-  # Bucket Listing Tests
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered.yaml
-      desc: test duration for ordered listing of bucket with top level objects
-      module: sanity_rgw_multisite.py
-      name: ordered listing of buckets pre upgrade
-      polarion-id: CEPH-83573545
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_datalog_and_crash.yaml
@@ -351,8 +351,8 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name:  test_Mbuckets_with_Nobjects.py
-            config-file-name:  test_datalog_trim_command.yaml
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_datalog_trim_command.yaml
 
   - test:
       name: bucket granular sync policy on bucket with flow directional and storage class
@@ -374,8 +374,8 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name:  test_Mbuckets_with_Nobjects.py
-            config-file-name:  test_bucket_sync_cmd_crash.yaml
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_bucket_sync_cmd_crash.yaml
             verify-io-on-site: ["ceph-sec"]
 
   - test:
@@ -386,6 +386,6 @@ tests:
       clusters:
         ceph-sec:
           config:
-            script-name:  test_Mbuckets_with_Nobjects.py
-            config-file-name:  test_bucket_sync_cmd_crash.yaml
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_bucket_sync_cmd_crash.yaml
             verify-io-on-site: ["ceph-pri"]

--- a/suites/squid/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_ecpool_regression_test.yaml
@@ -295,17 +295,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
   - test:
-      name: test encryption on primary
-      desc: test_Mbuckets_with_Nobjects_enc on primary
-      polarion-id: CEPH-11358 # also applies to CEPH-11361
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-  - test:
       name: test sharding on primary
       desc: test_Mbuckets_with_Nobjects_sharding on primary
       polarion-id: CEPH-83573597 # also applies to CEPH-83573593
@@ -372,7 +361,7 @@ tests:
   - test:
       name: listing flat unordered buckets on primary
       desc: test_bucket_listing_flat_unordered.yaml on secondary
-      polarion-id: CEPH-83573545
+      polarion-id: CEPH-83574826
       module: sanity_rgw_multisite.py
       clusters:
         ceph-pri:
@@ -400,15 +389,4 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_flat_ordered.yaml
-            monitor-consistency-bucket-stats: true
-  - test:
-      name: listing pseudo ordered dir only buckets on secondary
-      desc: test_bucket_listing_pseudo_ordered_dir_only on secondary
-      polarion-id: CEPH-83573651
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
             monitor-consistency-bucket-stats: true

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
@@ -303,19 +303,6 @@ tests:
       name: m buckets with n objects pre upgrade
       polarion-id: CEPH-83575435
 
-  # Bucket Listing Tests
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_unordered.yaml
-      desc: test duration for unordered listing of buckets with top level objects
-      module: sanity_rgw_multisite.py
-      name: unordered listing of buckets pre upgrade
-      polarion-id: CEPH-83573545
-
   - test:
       clusters:
         ceph-pri:
@@ -370,7 +357,7 @@ tests:
       polarion-id: CEPH-83575199
       comments: 2327402, known bug in 8.0
 
-#   # Basic swift based tests
+  # Basic swift based tests
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -305,18 +305,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            verify-io-on-site: ["ceph-sec"]
-      desc: test to create "M" buckets and "N" objects with multipart upload
-      module: sanity_rgw_multisite.py
-      name: multipart upload of M buckets with N objects
-      polarion-id: CEPH-9801
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_basic_ops.yaml
             verify-io-on-site: ["ceph-sec"]
@@ -402,17 +390,6 @@ tests:
       polarion-id: CEPH-83575199
       comments: 2327402, known bug in 8.0
   - test:
-      name: Buckets and Objects test
-      desc: test_Mbuckets_with_Nobjects_download on secondary
-      polarion-id: CEPH-14237
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
-            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-  - test:
       abort-on-fail: true
       desc: Multisite upgrade, next upgrade primary
       module: test_cephadm_upgrade.py
@@ -448,17 +425,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-
-  - test:
-      name: Granular multisite sync policy group transition
-      desc: Test multisite sync policy group transition
-      polarion-id: CEPH-83575133
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_sync_policy.py
-            config-file-name: test_sync_policy_state_change.yaml
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
@@ -424,17 +424,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered_versionsing.yaml
-      desc: test the duration for ordered listing of versioned buckets
-      module: sanity_rgw_multisite.py
-      name: ordered listing of versioned buckets post upgrade
-      polarion-id: CEPH-83573545
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             script-name: test_swift_basic_ops.py
             config-file-name: test_swift_object_expire_op.yaml
             verify-io-on-site: ["ceph-sec"]

--- a/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ssl_multisite_test_upgrade_71GA_to_8x_latest.yaml
@@ -299,30 +299,6 @@ tests:
       polarion-id: CEPH-83575199
 
   # Baseline tests before upgrade
-  - test:
-      name: Bucket Granular Sync policy test for prefix and tag
-      desc: Bucket sync policy test for prefix and tag
-      polarion-id: CEPH-83575133
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_syncpolicy_prefix_tag.py
-            config-file-name: test_multisite_syncpolicy_prefix_tag.yaml
-            verify-io-on-site: ["ceph-sec"]
-
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-            verify-io-on-site: ["ceph-sec"]
-      desc: test to create "M" buckets and "N" objects with multipart upload
-      module: sanity_rgw_multisite.py
-      name: multipart upload of M buckets with N objects
-      polarion-id: CEPH-9801
 
   - test:
       clusters:
@@ -335,19 +311,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: swift basic operations pre upgrade
       polarion-id: CEPH-11019
-
-  # Bucket Listing Tests
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_listing.py
-            config-file-name: test_bucket_listing_flat_ordered.yaml
-      desc: test duration for ordered listing of bucket with top level objects
-      module: sanity_rgw_multisite.py
-      name: ordered listing of buckets pre upgrade
-      polarion-id: CEPH-83573545
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
@@ -180,16 +180,6 @@ tests:
         script-name: ../s3cmd/test_rgw_ops_log.py
         config-file-name: ../../s3cmd/configs/test_rgw_log_details.yaml
 
-# Post upgrade tests
-  - test:
-      config:
-        script-name: test_Mbuckets_with_Nobjects.py
-        config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-      desc: test to create "M" no of buckets and "N" no of objects with download
-      module: sanity_rgw.py
-      name: download objects post upgrade
-      polarion-id: CEPH-14237
-
   - test:
       name: S3CMD small and multipart object download post upgrade
       desc: S3CMD small and multipart object download or GET

--- a/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
@@ -114,15 +114,6 @@ tests:
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
 
   - test:
-      config:
-        script-name: test_bucket_listing.py
-        config-file-name: test_bucket_listing_flat_ordered.yaml
-      desc: test duration for ordered listing of bucket with top level objects
-      module: sanity_rgw.py
-      name: ordered listing of buckets pre upgrade
-      polarion-id: CEPH-83573545
-
-  - test:
       name: S3CMD small and multipart object download pre upgrade
       desc: S3CMD small and multipart object download or GET
       polarion-id: CEPH-83575477
@@ -170,14 +161,6 @@ tests:
 
   # Post Upgrade tests
   - test:
-      name: Test rgw through CURL
-      desc: Test rgw through CURL
-      polarion-id: CEPH-83575572
-      module: sanity_rgw.py
-      config:
-        script-name: ../curl/test_rgw_using_curl.py
-        config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-  - test:
       desc: Retrieve the versions of the cluster
       module: exec.py
       name: post upgrade gather version
@@ -215,33 +198,3 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-
-  - test:
-      config:
-        script-name: test_swift_basic_ops.py
-        config-file-name: test_swift_basic_ops.yaml
-      desc: Test object operations with swift
-      module: sanity_rgw.py
-      name: swift basic operations post upgrade
-      polarion-id: CEPH-11019
-
-  - test:
-      abort-on-fail: true
-      config:
-        install:
-          - agent
-        run-on-rgw: true
-      desc: Setup and configure vault agent
-      destroy-cluster: false
-      module: install_vault.py
-      name: configure vault agent
-      polarion-id: CEPH-83575226
-
-  - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
-      desc: test_sse_s3_per_bucket_encryption_normal_object_upload
-      module: sanity_rgw.py
-      name: sse-s3 per bucket encryption test
-      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_71GA_to_8x_latest.yaml
@@ -118,15 +118,6 @@ tests:
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
 
   - test:
-      config:
-        script-name: test_bucket_listing.py
-        config-file-name: test_bucket_listing_flat_ordered.yaml
-      desc: test duration for ordered listing of bucket with top level objects
-      module: sanity_rgw.py
-      name: ordered listing of buckets pre upgrade
-      polarion-id: CEPH-83573545
-
-  - test:
       name: S3CMD small and multipart object download pre upgrade
       desc: S3CMD small and multipart object download or GET
       polarion-id: CEPH-83575477
@@ -175,15 +166,6 @@ tests:
           - "ceph versions"
 
   - test:
-      name: Test rgw through CURL
-      desc: Test rgw through CURL
-      polarion-id: CEPH-83575572
-      module: sanity_rgw.py
-      config:
-        script-name: ../curl/test_rgw_using_curl.py
-        config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
-
-  - test:
       name: S3CMD small and multipart object download post upgrade
       desc: S3CMD small and multipart object download or GET
       polarion-id: CEPH-83575477
@@ -209,15 +191,6 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-
-  - test:
-      config:
-        script-name: test_swift_basic_ops.py
-        config-file-name: test_swift_basic_ops.yaml
-      desc: Test object operations with swift
-      module: sanity_rgw.py
-      name: swift basic operations post upgrade
-      polarion-id: CEPH-11019
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -277,28 +277,6 @@ tests:
       polarion-id: CEPH-83575199
   - test:
       clusters:
-        ceph-pri:
-          config:
-            config-file-name: test_bucket_create_del.yaml
-            script-name: test_Mbuckets_with_Nobjects.py
-      desc: bucket create and delete operation
-      polarion-id: CEPH-83574811
-      module: sanity_rgw_multisite.py
-      name: bucket create and delete operation
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            run-on-rgw: true
-            config-file-name: test_multisite_async_data_notifications.yaml
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-      desc: test_async_data_notifications_on_primary
-      polarion-id: CEPH-83575231
-      module: sanity_rgw_multisite.py
-      name: test_async_data_notifications_on_primary
-  - test:
-      clusters:
         ceph-sec:
           config:
             run-on-rgw: true
@@ -359,9 +337,12 @@ tests:
       module: exec.py
       name: set sse-s3 vault configs on multisite
   - test:
-      config:
-        script-name: test_sse_s3_kms_with_vault.py
-        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
       desc: sse_s3_per_bucket_enc_multipart_upload
       module: sanity_rgw_multisite.py
       name: sse_s3_per_bucket_enc_multipart_upload
@@ -371,7 +352,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_s3_per_object_versioninig_enabled.yaml
       desc: test_sse_s3_per_object_with_versioning
@@ -383,7 +363,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object_versioninig_enabled.yaml
       desc: test_sse_kms_per_object_with_versioning
@@ -394,7 +373,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_bucket_encryption_version_enabled.yaml
       desc: test_sse_kms_per_bucket_with_versioning
@@ -406,7 +384,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_sse_s3_kms_with_vault.py
             config-file-name: test_sse_kms_per_object.yaml
       desc: test_sse_kms_per_object
@@ -461,31 +438,11 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_s3_per_object.yaml
-      desc: test_sse_s3_per_object
-      module: sanity_rgw.py
-      name: sse-s3 per object encryption test
-      polarion-id: CEPH-83575153
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             script-name: test_bucket_policy_ops.py
             config-file-name: test_sse_kms_per_bucket_with_bucket_policy.yaml
       desc: test_sse_kms_per_bucket_with_bucket_policy
       module: sanity_rgw_multisite.py
       name: test_sse_kms_per_bucket_with_bucket_policy
-      polarion-id: CEPH-83586489
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sts_using_boto.py
-            config-file-name: test_sse_s3_per_object_with_sts.yaml
-      desc: test_sse_s3_per_object_with_sts
-      module: sanity_rgw_multisite.py
-      name: test_sse_s3_per_object_with_sts
       polarion-id: CEPH-83586489
 
   # GKLM prerequisites
@@ -578,16 +535,6 @@ tests:
       desc: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
       module: sanity_rgw_multisite.py
       name: test_sse_kms_kmip_gklm_per_bucket_encryption_version_enabled
-      polarion-id: CEPH-83592485
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_sse_s3_kms_with_vault.py
-            config-file-name: test_sse_kms_kmip_gklm_per_object.yaml
-      desc: test_sse_kms_kmip_gklm_per_object
-      module: sanity_rgw_multisite.py
-      name: test_sse_kms_kmip_gklm_per_object
       polarion-id: CEPH-83592485
   - test:
       clusters:

--- a/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -284,18 +284,6 @@ tests:
       name: create non-tenanted user
 
   # IO performed should be readable on secondary
-  - test:
-      name: multipart upload on primary
-      desc: test_Mbuckets_with_Nobjects_multipart on primary
-      polarion-id: CEPH-14265
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-
   # IO should fail on read only secondary
   - test:
       name: object upload on secondary
@@ -405,18 +393,6 @@ tests:
       name: get shared realm info on secondary
 
   # IO from primary again
-  - test:
-      name: Object upload on primary
-      desc: test_Mbuckets_with_Nobjects on primary
-      polarion-id: CEPH-14265
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-sec"]
-            config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-
   - test:
       name: Datalog trimming test post restart of rgw service on primary
       desc: test datalog trimming post restart of rgw service on  on primary

--- a/suites/squid/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_granular_sync_policy.yaml
@@ -308,18 +308,6 @@ tests:
             verify-io-on-site: ["ceph-sec"]
 
   - test:
-      name: Bucket Granular Sync policy tests
-      desc: test_multisite_mirror_sync_policy.yaml on primary
-      polarion-id: CEPH-83575136
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_multisite_sync_policy.py
-            config-file-name: test_multisite_mirror_sync_policy.yaml
-            verify-io-on-site: ["ceph-sec"]
-
-  - test:
       name: Granular multisite sync policy group transition
       desc: Test multisite sync policy group transition
       polarion-id: CEPH-83575135

--- a/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_regression_test.yaml
@@ -318,17 +318,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-            script-name: test_dynamic_bucket_resharding.py
-            verify-io-on-site: ["ceph-pri", "ceph-sec" ]
-      desc: Resharding test - dynamic resharding on versioned bucket
-      name: Dynamic Resharding on versioned buckets
-      polarion-id: CEPH-83571740
-      module: sanity_rgw_multisite.py
-  - test:
-      clusters:
-        ceph-pri:
-          config:
             config-file-name: test_dynamic_resharding_quota_exceed.yaml
             script-name: test_dynamic_bucket_resharding.py
       desc: test exceeding quota limit on dynamically resharded bucket able to access bucket on secondary

--- a/suites/squid/rgw/tier-2_rgw_ms_with_haproxy_ec_22_4.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_with_haproxy_ec_22_4.yaml
@@ -299,22 +299,6 @@ tests:
       module: exec.py
       name: set sse-s3 vault configs on multisite
 
-#Performing IOs via the HAproxy node
-
-  - test:
-      clusters:
-        ceph-sec:
-          config:
-            set-env: true
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_Mbuckets_with_Nobjects_compression_haproxy.yaml
-            run-on-haproxy: true
-            monitor-consistency-bucket-stats: true
-      desc: test M buckets compression on haproxy node
-      polarion-id: CEPH-83575199
-      module: sanity_rgw_multisite.py
-      name: test M buckets compression on haproxy node
-
 # creating a test bucket on the primary site
   - test:
       clusters:
@@ -333,7 +317,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: test_bucket_lifecycle_object_expiration_transition.py
             config-file-name: test_lc_rule_prefix_non_current_days_haproxy.yaml
             run-on-haproxy: true
@@ -365,20 +348,6 @@ tests:
       module: sanity_rgw_multisite.py
       name: test LC transition on multisite with object acl set
       polarion-id: CEPH-83574048
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            extra-pkgs:
-              - jq
-            script-name: test_rgw_restore_index_tool.py
-            config-file-name: test_rgw_restore_index_versioned_buckets.yaml
-            run-on-haproxy: true
-            monitor-consistency-bucket-stats: true
-      desc: test rgw restore index tool on versioned bucket
-      polarion-id: CEPH-83575473
-      module: sanity_rgw_multisite.py
-      name: test rgw restore index tool on versioned bucket
   - test:
       clusters:
         ceph-pri:

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -111,14 +111,6 @@ tests:
       config:
         script-name: test_object_lock_no_overwrite.py
         config-file-name: test_object_lock_no_overwrite.yaml
-  - test:
-      name: S3CMD small and multipart object download
-      desc: S3CMD small and multipart object download or GET
-      polarion-id: CEPH-83575477
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_s3cmd.py
-        config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
 
   - test:
       name: Swift user with read access
@@ -172,15 +164,6 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_with_custom_worktime.yaml
-
-  - test:
-      name: Test Etag not empty for complete multipart upload in aws
-      desc: Test Etag not empty for complete multipart upload in aws
-      polarion-id: CEPH-9801
-      module: sanity_rgw.py
-      config:
-        script-name: ../aws/test_aws.py
-        config-file-name: ../../aws/configs/test_complete_multipart_upload_etag_not_empty.yaml
 
   - test:
       name: Test S3 PUT requests with non ascii characters in body

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -111,25 +111,6 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
-  # Basic Bucket Operation Tests
-  - test:
-      name: compresstion_with_zstd_type
-      desc: test compresstion with zstd type
-      polarion-id: CEPH-11350
-      module: sanity_rgw.py
-      config:
-        script-name: test_Mbuckets_with_Nobjects.py
-        config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
-
-  - test:
-      name: compresstion_with_snappy_type
-      desc: test compresstion with snappy type
-      polarion-id: CEPH-11350
-      module: sanity_rgw.py
-      config:
-        script-name: test_Mbuckets_with_Nobjects.py
-        config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
-
   # Swift basic operation
 
   - test:
@@ -335,15 +316,6 @@ tests:
         config-file-name: test_policy_torrent.yaml
 
   # Bucket Lifecycle Tests
-  - test:
-      name: object expiration for versioned buckets with filter Prefix test multiple rules.
-      desc: Test object expiration for versioned buckets with filter 'Prefix', test multiple rules.
-      polarion-id: CEPH-11177 # also applies to CEPH-11182, CEPH-11188 and CEPH-11187
-      module: sanity_rgw.py
-      config:
-        script-name: test_bucket_lifecycle_object_expiration_transition.py
-        config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
-
   - test:
       name: object expiration with expiration set to Date
       desc: Test object expiration with expiration set to Date
@@ -580,18 +552,6 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
-
-  # rate limits tests with s3cmd
-  - test:
-      name: Test Rate limits on a User and Bucket level using s3cmd
-      desc: Test Rate limits on a User and Bucket level using s3cmd
-      polarion-id: CEPH-83574910
-      module: sanity_rgw.py
-      config:
-        run-on-rgw: true
-        script-name: ../s3cmd/test_rate_limit.py
-        config-file-name: ../../s3cmd/configs/test_rate_limit.yaml
-      comments: known issue BZ 2301986
 
   # Checksum and CORS tests
   - test:

--- a/suites/squid/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/squid/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -235,30 +235,6 @@ tests:
             script-name: user_create.py
             config-file-name: tenanted_user.yaml
 
-  #  Dynamic resharding tests
-  - test:
-      name: Verify DBR feature enabled on greenfield cluster
-      desc: Check DBR feature enabled on greenfield cluster
-      abort-on-fail: true
-      module: sanity_rgw_multisite.py
-      polarion-id: CEPH-83573596
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_check_sharding_enabled.py
-            config-file-name: test_check_sharding_enabled_greenfield.yaml
-
-  - test:
-      clusters:
-        ceph-pri:
-          config:
-            config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
-            script-name: test_dynamic_bucket_resharding.py
-      desc: Resharding test - dynamic resharding on versioned bucket
-      name: Dynamic Resharding on versioned buckets
-      polarion-id: CEPH-83571740
-      module: sanity_rgw_multisite.py
-
   - test:
       clusters:
         ceph-pri:
@@ -490,14 +466,3 @@ tests:
           config:
             script-name: test_bilog_trimming.py
             config-file-name: test_bilog_trimming.yaml
-
-  - test:
-      name: bucket request payer
-      desc: Basic test for bucket request payer
-      polarion-id: CEPH-10352
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-pri:
-          config:
-            script-name: test_bucket_request_payer.py
-            config-file-name: test_bucket_request_payer.yaml

--- a/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -273,8 +273,6 @@ tests:
       module: exec.py
       name: get shared realm info on secondary
 
-
-
   # Test work flow
 
   - test:

--- a/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
+++ b/suites/squid/rgw/tier-2_rgw_sts_aswi.yaml
@@ -204,7 +204,6 @@ tests:
         script-name: test_sts_aswi.py
         config-file-name: test_sts_aswi_verify_role_policy_deny_actions.yaml
 
-
 # STS aswi tests with IBM Security Verify as Identity Provider
 
   - test:

--- a/suites/squid/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_basic_sanity_with_d3n_enabled.yaml
@@ -116,17 +116,6 @@ tests:
         config-file-name: test_lc_multiple_rule_prefix_current_days.yaml
 
   - test:
-      name: Basic ACLs Test
-      desc: Test basic acls
-      polarion-id: CEPH-14238 # also applies to CEPH-14239
-      module: sanity_rgw.py
-      config:
-        test-version: v1
-        run-on-rgw: true
-        script-name: test_acls.py
-        config-file-name: test_acls.yaml
-
-  - test:
       name: Test Rate limits on a User and Bucket level using s3cmd
       desc: Test Rate limits on a User and Bucket level using s3cmd
       polarion-id: CEPH-83574910

--- a/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -154,15 +154,6 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_multiple_delete_marker_check.yaml
 
-  - test:
-      name: S3CMD object download
-      desc: S3CMD object download or GET
-      polarion-id: CEPH-83575477
-      module: sanity_rgw.py
-      config:
-        script-name: ../s3cmd/test_s3cmd.py
-        config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
-
 # Testing s3cmd malformed url
   - test:
       name: test s3cmd put operation with malformed bucket url

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -119,17 +119,8 @@ tests:
               command: start
               service: upgrade
               base_cmd_args:
-                verbose: true
+                verbose: True
 
-  # Post Upgrade tests
-  - test:
-      name: Test rgw through CURL
-      desc: Test rgw through CURL
-      polarion-id: CEPH-83575572
-      module: sanity_rgw.py
-      config:
-        script-name: ../curl/test_rgw_using_curl.py
-        config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
   - test:
       desc: Retrieve the versions of the cluster
       module: exec.py

--- a/suites/squid/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ms_ecpool_test.yaml
@@ -320,42 +320,6 @@ tests:
       polarion-id: CEPH-83575199
 
   - test:
-      name: enable compression on secondary
-      desc: test_Mbuckets_with_Nobjects_compression on secondary
-      polarion-id: CEPH-11350
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
-            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
-
-  - test:
-      name: download objects on secondary
-      desc: test_Mbuckets_with_Nobjects_download on secondary
-      polarion-id: CEPH-14237
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
-            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-
-  - test:
-      name: test encryption on secondary
-      desc: test_Mbuckets_with_Nobjects_enc on secondary
-      polarion-id: CEPH-11358 # also applies to CEPH-11361
-      module: sanity_rgw_multisite.py
-      clusters:
-        ceph-sec:
-          config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            verify-io-on-site: ["ceph-pri"]
-            config-file-name: test_Mbuckets_with_Nobjects_enc.yaml
-
-  - test:
       name: Test large omap objects warnings via ceph status in a multisite
       desc: Test large omap objects warnings via ceph status in a multisite on secondary
       polarion-id: CEPH-83574987
@@ -412,6 +376,7 @@ tests:
           config:
             script-name: test_bucket_listing.py
             config-file-name: test_bucket_listing_pseudo_ordered_dir_only.yaml
+            monitor-consistency-bucket-stats: true
 
   - test:
       name: create tenanted user

--- a/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_regression_test.yaml
@@ -292,16 +292,6 @@ tests:
         config-file-name: test_rgw_enable_lc_threads.yaml
 
   - test:
-      name: Test single delete marker for versioned object using LC
-      desc: Test single delete marker for versioned object using LC
-      polarion-id: CEPH-83574806
-      module: sanity_rgw.py
-      config:
-        run-on-rgw: true
-        script-name: test_bucket_lifecycle_object_expiration_transition.py
-        config-file-name: test_lc_multiple_delete_marker.yaml
-
-  - test:
       name: Test NFS cluster and export create
       desc: Test NFS cluster and export create
       polarion-id: CEPH-83574597

--- a/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
+++ b/suites/squid/rgw/tier-3_archive_zone_colocate_data_zone.yaml
@@ -128,7 +128,6 @@ tests:
       name: deploy cluster
       polarion-id: CEPH-10117
 
-
   - test:
       abort-on-fail: true
       clusters:
@@ -245,7 +244,6 @@ tests:
       module: exec.py
       name: Colocate the archive zone with primary sone cluster
       polarion-id: CEPH-83573389
-
 
   # Test work flow
   - test:


### PR DESCRIPTION
# Description
 Pr to avoid redundant test cases in multiple places and multisite setup for verification then only include that test case in multisite execution

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
