### PR TITLE
[Conf] Remove additional `mgr` daemon from sanity conf

### DIFF
--- a/conf/squid/common/5node-2client-rh.yaml
+++ b/conf/squid/common/5node-2client-rh.yaml
@@ -22,7 +22,6 @@ globals:
       node3:
         role:
           - mon
-          - mgr
           - crash
           - rgw
           - nfs
@@ -32,7 +31,6 @@ globals:
       node4:
         role:
           - mon
-          - mgr
           - crash
           - grafana
           - mds
@@ -42,10 +40,9 @@ globals:
       node5:
         role:
           - mon
-          - mgr
           - crash
-          - mds
           - prometheus
+          - mds
           - osd
         no-of-volumes: 6
         disk-size: 40


### PR DESCRIPTION
Remove additional `mgr` daemons of `node4` & `node5` from sanity cluster config