### PR TITLE
fix status_cmd in remove_custom_host function

### DIFF
--- a/ceph/rados/serviceability_workflows.py
+++ b/ceph/rados/serviceability_workflows.py
@@ -225,7 +225,7 @@ class ServiceabilityMethods:
         Returns:
             None | raises exception in case of failure
         """
-        status_cmd = ""
+        status_cmd = "ceph orch osd rm status -f json"
         try:
 
             def wait_osd_operation_status(status_cmd):
@@ -286,7 +286,6 @@ class ServiceabilityMethods:
                     if osd_id in osd_out_list:
                         osd_utils.osd_remove(self.cluster, osd_id=osd_id, zap=True)
                         time.sleep(10)
-                        status_cmd = "ceph orch osd rm status -f json"
                         if wait_osd_operation_status(status_cmd):
                             log.info("The OSD successfully removed")
                         else:


### PR DESCRIPTION
Command to fix automation issue where remove_custom_host() fails when osd_out_list is empty.

**Issue**: status_cmd in line number 228 is empty and command is updated only inside if condition in line number 289. It is causing issue with status_cmd usage in line number 318. empty string is being executed for the function which is caused test failure.

**Error faced during execution**:
2025-01-15 11:10:03,152 - cephci - serviceability_workflows:317 - DEBUG - Started drain operation on node : depressa009
2025-01-15 11:10:03,153 - cephci - serviceability_workflows:241 - DEBUG - 
                      The logic used to verify the OSD is removed or not is-
                      case1: If the ceph is still in process of removing the OSD the command generated
                      the proper json output.The json.loads method loads the output without any failure.
                      case2: If the OSDs are removed from the node then the command wont generate any output.
                      In this case the json.loads method throws the JSONDecodeError exception.This is the
                      confirmation that the OSDs removal are completed. 
2025-01-15 11:10:03,479 - cephci - ceph:1570 - INFO - Execute cephadm shell --  on 10.0.65.117
2025-01-15 11:20:04,916 - cephci - ceph:1621 - ERROR - cephadm shell --  failed to execute within 600 seconds.
2025-01-15 11:20:04,919 - cephci - serviceability_workflows:357 - ERROR - Failed with exception: None
2025-01-15 11:20:04,919 - cephci - serviceability_workflows:358 - ERROR - 
Traceback (most recent call last):
  File "/Users/vipinms/cephci-venv/lib/python3.9/site-packages/paramiko/channel.py", line 745, in recv_stderr
    out = self.in_stderr_buffer.read(nbytes, self.timeout)
  File "/Users/vipinms/cephci-venv/lib/python3.9/site-packages/paramiko/buffered_pipe.py", line 154, in read
    raise PipeTimeout()
paramiko.buffered_pipe.PipeTimeout

**Pass logs**: http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_vips_ceph_tier_4_25_01_17_06_37_05/ 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
