### PR TITLE
TFA fix- Preempt messages check fix

### DIFF
--- a/suites/reef/rados/tier-2_rados_test_omap.yaml
+++ b/suites/reef/rados/tier-2_rados_test_omap.yaml
@@ -149,19 +149,14 @@ tests:
             obj_end: 50
             num_keys_obj: 100
         delete_pool: true
-
   - test:
       name: Preempt scrub messages checks
       desc: Checking preempt messages in the OSDs
       module: test_rados_preempt_scrub.py
       polarion-id: CEPH-83572916
       config:
-        verify_osd_preempt:
-          configurations:
-            pool-1:
-              pool_name: preempt_pool
-              pool_type: replicated
-              pg_num: 16
+        pool_name: preempt_pool
+        pg_num: 1
         delete_pool: true
 
   - test:

--- a/suites/squid/rados/tier-2_rados_test_omap.yaml
+++ b/suites/squid/rados/tier-2_rados_test_omap.yaml
@@ -157,12 +157,8 @@ tests:
       module: test_rados_preempt_scrub.py
       polarion-id: CEPH-83572916
       config:
-        verify_osd_preempt:
-          configurations:
-            pool-1:
-              pool_name: preempt_pool
-              pool_type: replicated
-              pg_num: 16
+        pool_name: preempt_pool
+        pg_num: 1
         delete_pool: true
 
   - test:

--- a/tests/rados/test_rados_preempt_scrub.py
+++ b/tests/rados/test_rados_preempt_scrub.py
@@ -2,13 +2,14 @@
 This file contains the  methods to verify the preempt messages in the OSD logs.
 """
 
+import re
+import subprocess
 import time
 import traceback
 
 from ceph.ceph_admin import CephAdmin
 from ceph.rados.core_workflows import RadosOrchestrator
 from tests.rados.monitor_configurations import MonConfigMethods
-from tests.rados.stretch_cluster import wait_for_clean_pg_sets
 from utility.log import Log
 from utility.utils import method_should_succeed
 
@@ -18,13 +19,21 @@ log = Log(__name__)
 def run(ceph_cluster, **kw):
     """
     CEPH-83572916 - Verify that the preempted messages are generated at OSD logs during scrubbing
-    1.Create pool and write data in to the pool
-    2.set the osd_shallow_scrub_chunk_max and osd_scrub_chunk_max values to 250
-    3.Start writing the data into pool and start scrub parallely
-    4.Once the scrub started check the OSD logs contain the-
-       - head preempted
-       - WaitReplicas::react(const GotReplicas&) PREEMPTED
-    5. Once the tests are complete delete the pool and remove the set values of the parameter
+    1.Create pool with 1 PG with the pg_autoscaler off
+    2.Create  objects
+    3. Set the following paramters-
+        3.1  osd_scrub_sleep ->0
+        3.2  osd_deep_scrub_keys ->1
+        3.3  osd_scrub_interval_randomize_ratio ->0
+        3.4  osd_deep_scrub_randomize_ratio -> 0
+        3.5  osd_scrub_min_interval -> 10
+        3.6  osd_scrub_max_interval -> 2000
+        3.7  osd_deep_scrub_interval -> 600
+        3.8  min_size -> 2
+        3.9  debug_osd -> 20/20
+    4. Rewrite the data into the four objects
+    5. Search the "preempted" string in the active OSDs
+    6. Once the tests are complete delete the pool and remove the set values of the parameter
     """
 
     log.info(run.__doc__)
@@ -32,196 +41,214 @@ def run(ceph_cluster, **kw):
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     rados_object = RadosOrchestrator(node=cephadm)
     mon_obj = MonConfigMethods(rados_obj=rados_object)
-    ceph_nodes = kw.get("ceph_nodes")
     installer = ceph_cluster.get_nodes(role="installer")[0]
-    pool_target_configs = config["verify_osd_preempt"]["configurations"]
 
+    log_lines = ["preempted"]
+    pool_name = config["pool_name"]
     try:
-        scrub_status_flag = False
-        # Before starting the tests check that scrubbing is not progress in the cluster
-        time_end = time.time() + 60 * 15
-        while time.time() < time_end:
-            scrub_status = check_scrub_status(rados_object)
-            if scrub_status is False:
-                scrub_status_flag = True
-                log.info("Scrubbing is not in progress.Continuing the test execution")
-                break
-            log.info("Waiting for the scrub to complete")
-            time.sleep(30)
-
-        if scrub_status_flag is False:
-            log.error(
-                "Scrubbing is in progress cannot continue the further execution of test"
-            )
+        # enable the file logging
+        if not rados_object.enable_file_logging():
+            log.error("Error while setting config to enable logging into file")
             return 1
 
-        for entry in pool_target_configs.values():
-            log.debug(
-                f"Creating {entry['pool_type']} pool on the cluster with name {entry['pool_name']}"
-            )
-            method_should_succeed(
-                rados_object.create_pool,
-                **entry,
-            )
-            log.info(f"Created the pool {entry['pool_name']}")
-            rados_object.bench_write(
-                pool_name=entry["pool_name"], rados_write_duration=90
-            )
-            flag = wait_for_clean_pg_sets(rados_object)
-            if not flag:
-                log.error(
-                    "The cluster did not reach active + Clean state after add capacity"
-                )
-                return 1
-            mon_obj.set_config(
-                section="osd", name="osd_shallow_scrub_chunk_max", value="250"
-            )
-            mon_obj.set_config(section="osd", name="osd_scrub_chunk_max", value="250")
-            mon_obj.set_config(section="osd", name="debug_osd", value="10/10")
+        init_time, _ = installer.exec_command(
+            cmd="sudo date '+%Y-%m-%dT%H:%M:%S.%3N+0000'"
+        )
+        init_time = init_time.strip()
+        rados_object.configure_pg_autoscaler(**{"default_mode": "off"})
+        method_should_succeed(rados_object.create_pool, **config)
 
-            rados_object.bench_write(
-                pool_name=entry["pool_name"], rados_write_duration=300, background=True
+        if not rados_object.bench_write(
+            pool_name=pool_name, rados_write_duration=20, max_objs=15, num_threads=1
+        ):
+            log.error(f"Failed to write objects into {pool_name}")
+            return 1
+        acting_set = rados_object.get_pg_acting_set(pool_name=pool_name)
+        log.info(f"The PG acting set is -{acting_set}")
+        set_preempt_parameter_value(mon_obj, rados_object, pool_name)
+
+        object_list = rados_object.get_object_list(pool_name)
+        rados_object.run_deep_scrub(pool=pool_name)
+        time.sleep(5)
+        for _ in range(30):
+            tmp_date = subprocess.check_output("date", text=True).strip()
+            for object in object_list:
+                if re.search(r".*object.*", object):
+                    cmd_rewrite = (
+                        f"echo {tmp_date} | rados -p {pool_name} put {object} -"
+                    )
+                    rados_object.client.exec_command(cmd=cmd_rewrite, sudo=True)
+        get_preempt_parameter_value(mon_obj, rados_object, pool_name)
+        # Wait time for starting the scheduled scrubbing
+        time.sleep(180)
+
+        # Check for 30 minutes
+        time_end = time.time() + 60 * 30
+        found_flag = False
+        while time.time() < time_end:
+            time.sleep(10)
+            end_time, _ = installer.exec_command(
+                cmd="sudo date '+%Y-%m-%dT%H:%M:%S.%3N+0000'"
             )
-
-            log_lines = [
-                "head preempted",
-                "WaitReplicas::react(const GotReplicas&) PREEMPTED",
-            ]
-
-            init_time, _ = installer.exec_command(cmd="sudo date '+%Y-%m-%d %H:%M:%S'")
-
-            rados_object.run_scrub(pool=entry["pool_name"])
-            scrub_status_flag = False
-
-            # Wait for the scrub to start for 15 minutes
-            time_end = time.time() + 60 * 45
-            count = 1
-            while time.time() < time_end:
-                scrub_status = check_scrub_status(rados_object)
-                if scrub_status is True:
-                    scrub_status_flag = True
-                    log.info("Scrubbing is in progress")
-                    break
-                log.info("Waiting for the scrub to start")
-                time.sleep(30)
-                count = count + 1
-                log.info(f"The count is -{count}")
-            total_time = count * 30
-            log.info(
-                f"The total time to start user initiated scrub is  - {total_time} seconds"
-            )
-            # check for the scrub is initiated or it is timeout
-            if scrub_status_flag is False:
-                log.error("Scrub is not initiated")
-                return 1
-            log.info("Scrub initiated")
-            time.sleep(30)
-            end_time, _ = installer.exec_command(cmd="sudo date '+%Y-%m-%d %H:%M:%S'")
-            osd_list = []
-            for node in ceph_nodes:
-                if node.role == "osd":
-                    node_osds = rados_object.collect_osd_daemon_ids(node)
-                    osd_list = osd_list + node_osds
-            log.info(f"The number of OSDs in the cluster are-{len(osd_list)}")
-
-            log_osd_count = 0
-            for osd_id in osd_list:
+            end_time = end_time.strip()
+            for osd_id in acting_set:
+                time.sleep(5)
+                log.info(f"Checking the logs at: {osd_id}")
                 if verify_preempt_log(
-                    rados_obj=rados_object,
-                    osd=osd_id,
-                    start_time=init_time,
+                    init_time=init_time,
                     end_time=end_time,
+                    rados_object=rados_object,
+                    osd_id=osd_id,
                     lines=log_lines,
                 ):
                     log.info(f"The preempted lines found at {osd_id}")
-                    log_osd_count = log_osd_count + 1
-                    time.sleep(10)
-                if log_osd_count == 2:
+                    found_flag = True
+                if found_flag:
+                    log.info(f"Logs messages are noticed at - {osd_id} osd")
                     break
-            mon_daemon = rados_object.run_ceph_command(cmd="ceph mon stat")["leader"]
-
-            # checking the ceph logs
-            mon_log = rados_object.get_journalctl_log(
-                start_time=init_time,
-                end_time=end_time,
-                daemon_type="mon",
-                daemon_id=mon_daemon,
-            )
-            log_mon_count = 0
-
-            log.info(f"The mgr log lines are - {mon_log}")
-            for line in log_lines:
-                if line in mon_log:
-                    log.info(f"The {line} found in the logs")
-                    log_mon_count = log_mon_count + 1
-            if log_osd_count == 0 and log_mon_count == 0:
-                log.error("Log lines not found in any of the OSDs and in ceph")
-                return 1
+            if found_flag:
+                break
+        if not found_flag:
+            log.error("The preempted messages are not appeared")
+            return 1
     except Exception as e:
         log.info(e)
         log.info(traceback.format_exc())
         return 1
     finally:
+
         log.info("Execution of finally block")
         if config.get("delete_pool"):
-            method_should_succeed(rados_object.delete_pool, entry["pool_name"])
+            method_should_succeed(rados_object.delete_pool, pool_name)
             log.info("deleted the pool successfully")
-        mon_obj.remove_config(section="osd", name="osd_shallow_scrub_chunk_max")
-        mon_obj.remove_config(section="osd", name="osd_scrub_chunk_max")
-        mon_obj.remove_config(section="osd", name="debug_osd")
-        # intentional wait for 5 seconds
-        time.sleep(5)
+        unset_preempt_parameter_value(mon_obj, rados_object, pool_name)
+        rados_object.disable_file_logging()
         # log cluster health
         rados_object.log_cluster_health()
 
     return 0
 
 
-def verify_preempt_log(
-    rados_obj: RadosOrchestrator, osd, start_time, end_time, lines
-) -> bool:
+def verify_preempt_log(init_time, end_time, rados_object, osd_id, lines) -> bool:
     """
     Retrieve the preempt log using journalctl command
     Args:
-        rados_obj: Rados object
-        osd: osd id
-        start_time: time to start reading the journalctl logs - format ('2022-07-20 09:40:10')
+        init_time: time to start reading the journalctl logs - format ('2022-07-20 09:40:10')
         end_time: time to stop reading the journalctl logs - format ('2022-07-20 10:58:49')
-        lines: Log lines to search in the journalctl logs
-    Returns:  True-> if the lines are exist in the journalctl logs
-              False -> if the lines are not exist in the journalctl logs
+        rados_object: Rados object
+        osd_id : osd id
+        lines: Log lines to search in the osd logs
+    Returns:  True-> if the lines are exist in the osd logs
+              False -> if the lines are not exist in the osd logs
     """
 
     log.info("Checking for the preempt messages in the OSD logs")
-    log_lines = rados_obj.get_journalctl_log(
-        start_time=start_time,
-        end_time=end_time,
-        daemon_type="osd",
-        daemon_id=osd,
+    fsid = rados_object.run_ceph_command(cmd="ceph fsid")["fsid"]
+    host = rados_object.fetch_host_node(daemon_type="osd", daemon_id=osd_id)
+    cmd_get_log_lines = f'awk \'$1 >= "{init_time}" && $1 <= "{end_time}"\' /var/log/ceph/{fsid}/ceph-osd.{osd_id}.log'
+    log_lines, err = host.exec_command(
+        sudo=True,
+        cmd=cmd_get_log_lines,
     )
-    log.debug(f"Journalctl logs are : {log_lines}")
     for line in lines:
-        if line not in log_lines:
-            log.error(f" Did not find logging on OSD : {osd}")
-            return False
-    log.info(f"Found the log lines on OSD : {osd}")
-    return True
-
-
-def check_scrub_status(osd_object):
-    """
-    Method is used to check the scrub is in progress or not
-    Args:
-        osd_obj: Rados object
-
-    Returns:  True-> if the scrubbing is in progress
-              False -> if the scrubbing is not in progress
-    """
-
-    status_report = osd_object.run_ceph_command(cmd="ceph report")
-    for entry in status_report["num_pg_by_state"]:
-        if "scrubbing" in entry["state"]:
-            log.info("Scrubbing is in progress")
+        if line in log_lines:
+            log.info(f" Found the log lines at OSD : {osd_id}")
             return True
-        log.info("Scrubbing is not in-progress")
+    log.info(f"Did not found the  log lines on OSD : {osd_id}")
     return False
+
+
+def set_preempt_parameter_value(mon_object, rados_object, pool_name):
+    """
+    Method is used to configure the  parameter values:
+    mon_object : Monitor object
+    rados_object : Rados Object
+    pool_name: pool name
+    Return -> none
+    """
+    try:
+        mon_object.set_config(section="osd", name="osd_scrub_sleep", value=0)
+        mon_object.set_config(section="osd", name="osd_deep_scrub_keys", value=1)
+        mon_object.set_config(
+            section="osd", name="osd_scrub_interval_randomize_ratio", value="0.0"
+        )
+        mon_object.set_config(
+            section="osd", name="osd_deep_scrub_randomize_ratio", value="0.0"
+        )
+        mon_object.set_config(section="osd", name="osd_scrub_min_interval", value=10)
+        mon_object.set_config(section="osd", name="osd_deep_scrub_interval", value=600)
+        rados_object.set_pool_property(pool=pool_name, props="min_size", value=2)
+        mon_object.set_config(section="osd", name="debug_osd", value="20/20")
+        time.sleep(10)
+    except Exception as error:
+        log.error(f"Configuration of parameter is failed. Error : {error}")
+        raise Exception("Error: Setting configuration failed")
+    return None
+
+
+def unset_preempt_parameter_value(mon_object, rados_object, pool_name):
+    """
+    Method is used to set the default  parameter values :
+    mon_object : Monitor object
+    rados_object : Rados Object
+    pool_name: pool name
+    Return -> None
+    """
+    try:
+        mon_object.remove_config(section="osd", name="osd_scrub_sleep")
+        mon_object.remove_config(section="osd", name="osd_deep_scrub_keys")
+        mon_object.remove_config(
+            section="osd", name="osd_scrub_interval_randomize_ratio"
+        )
+        mon_object.remove_config(section="osd", name="osd_deep_scrub_randomize_ratio")
+        mon_object.remove_config(section="osd", name="osd_scrub_min_interval")
+        mon_object.remove_config(section="osd", name="osd_scrub_max_interval")
+        mon_object.remove_config(section="osd", name="osd_deep_scrub_interval")
+        rados_object.set_pool_property(pool=pool_name, props="min_size", value=2)
+        mon_object.remove_config(section="osd", name="debug_osd")
+    except Exception as error:
+        log.error(f"Configuration of parameter to default is failed. Error : {error}")
+        raise Exception("Error: Unsetting configuration failed")
+    return None
+
+
+def get_preempt_parameter_value(mon_object, rados_object, pool_name):
+    """
+    Method is used to display the  parameter values :
+    mon_object : Monitor object
+    rados_object : Rados Object
+    pool_name: pool name
+    Return -> None
+    """
+    try:
+        log.info("The scrub parameter values are:  ")
+        out_put = mon_object.get_config(section="osd", param="osd_scrub_sleep")
+        log.info(f"The osd_scrub_sleep parameter value is - {out_put}")
+        out_put = mon_object.get_config(section="osd", param="osd_deep_scrub_keys")
+        log.info(f"The osd_deep_scrub_keys parameter value is - {out_put}")
+        out_put = mon_object.get_config(
+            section="osd", param="osd_scrub_interval_randomize_ratio"
+        )
+        log.info(
+            f"The osd_scrub_interval_randomize_ratio parameter value is - {out_put}"
+        )
+        out_put = mon_object.get_config(
+            section="osd", param="osd_deep_scrub_randomize_ratio"
+        )
+        log.info(f"The osd_deep_scrub_randomize_ratio parameter value is - {out_put}")
+        out_put = mon_object.get_config(section="osd", param="osd_scrub_min_interval")
+        log.info(f"The osd_scrub_min_interval parameter value is - {out_put}")
+        out_put = mon_object.get_config(section="osd", param="osd_scrub_max_interval")
+        log.info(f"The osd_scrub_max_interval parameter value is - {out_put}")
+        out_put = mon_object.get_config(section="osd", param="osd_deep_scrub_interval")
+        log.info(f"The osd_deep_scrub_interval parameter value is - {out_put}")
+        out_put = mon_object.get_config(section="osd", param="osd_deep_scrub_interval")
+        log.info(f"The osd_deep_scrub_interval parameter value is - {out_put}")
+        out_put = rados_object.get_pool_property(pool=pool_name, props="min_size")
+        log.info(f"The min_size parameter value is - {out_put}")
+        out_put = rados_object.get_pool_property(pool=pool_name, props="size")
+        log.info(f"The size parameter value is - {out_put}")
+    except Exception as error:
+        log.error(f"Display the parameter values is failed. Error : {error}")
+        raise Exception("Error: Display configuration failed")
+    return None


### PR DESCRIPTION
# Description

  Generating Preempt log message is modified. The messages are retrieved from the OSD logs.
The manual steps are updated at - https://issues.redhat.com/browse/RHCEPHQE-17471

 **Observations:**

     Journalctl logs are getting rotated. From the OSD log the preempted message was generated at  "2025-01-17T11:42:05.792" . In the journalctl logs ,the messages  are not recorded.  The log is rotated and messages are available from "Jan 17 11:47:08". 

**OSD Log:**

_2025-01-17T11:42:05.792+_0000 7f817cfe3640 10 osd.2 pg_epoch: 11220 pg[6.15( v 1544'113 (0'0,1544'113] local-lis/les=78/79 n=1 ec=71/61 lis/c=78/78 les/c/f=79/79/0 sis=78) [2,10,0] r=0 lpr=78 crt=1544'113 lcod 79'112 mlcod 79'112 active+clean+scrubbing [ 6.15:  ] ] scrubber<Session/Act/WaitReplicas>: FSM: WaitReplicas::react(const GotReplicas&) PREEMPTED!
**Journalctl Logs**
[root@ceph-bharath-preempt-5eu7ew-node5 3e8df308-d468-11ef-9b4d-fa163e4ae8be]# journalctl -u ceph-3e8df308-d468-11ef-9b4d-fa163e4ae8be@osd.2.service --since '2025-01-17 11:16:03' --until '2025-01-17 11:45:37'
-- No entries --
[root@ceph-bharath-preempt-5eu7ew-node5 3e8df308-d468-11ef-9b4d-fa163e4ae8be]#

[root@ceph-bharath-preempt-5eu7ew-node5 3e8df308-d468-11ef-9b4d-fa163e4ae8be]# journalctl -u ceph-3e8df308-d468-11ef-9b4d-fa163e4ae8be@osd.2.service >/tmp/text
[root@ceph-bharath-preempt-5eu7ew-node5 3e8df308-d468-11ef-9b4d-fa163e4ae8be]# cat /tmp/text | more
_Jan 17 11:47:08_ ceph-bharath-preempt-5eu7ew-node5 ceph-osd[22696]: osd.2 11452 tick_without_osd_lock
Jan 17 11:47:08 ceph-bharath-preempt-5eu7ew-node5 ceph-osd[22696]: osd.2 osd-scrub:initiate_scrub: time now:2025-01-17T11:47:08.706, recovery is active?:false
Jan 17 11:47:08 ceph-bharath-preempt-5eu7ew-node5 ceph-osd[22696]: osd.2 scrub-queue:ready_to_scrub:  @2025-01-17T11:47:08.706: registered: 54 (priority-only:false overdue-only:false load:ok time:ok repai
r-only:false)
Jan 17 11:47:08 ceph-bharath-preempt-5eu7ew-node5 ceph-osd[22696]: osd.2 pg_epoch: 11452 pg[3.6b( empty local-lis/les=88/89 n=0 ec=73/53 lis/c=88/88 les/c/f=89/89/0 sis=88) [2,12,1] r=0 lpr=88 crt=0'0 mlc
od 0'0 active+clean] start_scrubbing: <active>+<clean> (env restrictions:priority-only:false overdue-only:false load:ok time:ok repair-only:false)
Jan 17 11:47:08 ceph-bharath-preempt-5eu7ew-node5 ceph-osd[22696]: osd.2 pg_epoch: 11452 pg[3.6b( empty local-lis/les=88/89 n=0 ec=73/53 lis/c=88/88 les/c/f=89/89/0 sis=88) [2,12,1] r=0 lpr=88 crt=0'0 mlc
od 0'0 active+clean] validate_scrub_mode pg: 3.6b allow: 1/1 deep errs: 0 auto-repair: 0 (0)
  
Due to this reason the log is modified.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
