### PR TITLE
Fixing Rados CIDR blocklisting test suite post Cluster config consolidation

### DIFF
--- a/conf/reef/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/reef/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -6,7 +6,7 @@ globals:
       name: ceph
       node1:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - _admin
           - mon
@@ -17,7 +17,7 @@ globals:
           - prometheus
       node2:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - rgw
@@ -26,7 +26,7 @@ globals:
         disk-size: 15
       node3:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -35,7 +35,7 @@ globals:
         disk-size: 15
       node4:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - rgw
@@ -44,7 +44,7 @@ globals:
         disk-size: 15
       node5:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - nfs
@@ -52,7 +52,7 @@ globals:
         disk-size: 15
       node6:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - rgw
@@ -64,12 +64,12 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_2
+          - provider_net_cci_16
         role:
           - client
       node8:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -78,7 +78,7 @@ globals:
         disk-size: 15
       node9:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - mon
@@ -87,7 +87,7 @@ globals:
         disk-size: 15
       node10:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - nfs
@@ -95,7 +95,7 @@ globals:
         disk-size: 15
       node11:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -104,21 +104,21 @@ globals:
         disk-size: 15
       node12:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd-bak
         no-of-volumes: 4
         disk-size: 15
       node13:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd-bak
         no-of-volumes: 4
         disk-size: 15
       node14:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - rgw
           - mds
@@ -130,7 +130,7 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_2
+          - provider_net_cci_16
         role:
           - client
       node16:
@@ -138,7 +138,7 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_5
+          - provider_net_cci_13
         role:
           - client
       node17:
@@ -146,6 +146,6 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_5
+          - provider_net_cci_13
         role:
           - client

--- a/conf/squid/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -6,7 +6,7 @@ globals:
       name: ceph
       node1:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - _admin
           - mon
@@ -17,7 +17,7 @@ globals:
           - prometheus
       node2:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - rgw
@@ -26,7 +26,7 @@ globals:
         disk-size: 15
       node3:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -35,7 +35,7 @@ globals:
         disk-size: 15
       node4:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - rgw
@@ -44,7 +44,7 @@ globals:
         disk-size: 15
       node5:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - nfs
@@ -52,7 +52,7 @@ globals:
         disk-size: 15
       node6:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - rgw
@@ -64,12 +64,12 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_2
+          - provider_net_cci_16
         role:
           - client
       node8:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -78,7 +78,7 @@ globals:
         disk-size: 15
       node9:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - mon
@@ -87,7 +87,7 @@ globals:
         disk-size: 15
       node10:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd
           - nfs
@@ -95,7 +95,7 @@ globals:
         disk-size: 15
       node11:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - mon
           - mgr
@@ -104,21 +104,21 @@ globals:
         disk-size: 15
       node12:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd-bak
         no-of-volumes: 4
         disk-size: 15
       node13:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - osd-bak
         no-of-volumes: 4
         disk-size: 15
       node14:
         networks:
-          - shared_net_15
+          - provider_net_cci_15
         role:
           - rgw
           - mds
@@ -130,7 +130,7 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_2
+          - provider_net_cci_16
         role:
           - client
       node16:
@@ -138,7 +138,7 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_5
+          - provider_net_cci_13
         role:
           - client
       node17:
@@ -146,6 +146,6 @@ globals:
           openstack: RHEL-9.4.0-x86_64-ga-latest
           ibmc: rhel-91-server-released
         networks:
-          - shared_net_5
+          - provider_net_cci_13
         role:
           - client

--- a/conf/squid/rados/13-node-cluster-4-clients.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients.yaml
@@ -43,6 +43,8 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node5:
+        networks:
+          - shared_net_15
         role:
           - osd
           - nfs
@@ -66,6 +68,8 @@ globals:
         role:
           - client
       node8:
+        networks:
+          - shared_net_15
         role:
           - mon
           - mgr
@@ -73,6 +77,8 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node9:
+        networks:
+          - shared_net_15
         role:
           - osd
           - mon
@@ -80,12 +86,16 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node10:
+        networks:
+          - shared_net_15
         role:
           - osd
           - nfs
         no-of-volumes: 4
         disk-size: 15
       node11:
+        networks:
+          - shared_net_15
         role:
           - mon
           - mgr
@@ -93,16 +103,22 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node12:
+        networks:
+          - shared_net_15
         role:
           - osd-bak
         no-of-volumes: 4
         disk-size: 15
       node13:
+        networks:
+          - shared_net_15
         role:
           - osd-bak
         no-of-volumes: 4
         disk-size: 15
       node14:
+        networks:
+          - shared_net_15
         role:
           - rgw
           - mds

--- a/suites/pacific/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/pacific/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,5 +1,6 @@
 # Suite contains tests related to CIDR blocklisting of ceph clients
 # This is Openstack only test suite.
+# conf: 13-node-cluster-4-clients.yaml
 
 tests:
   - test:
@@ -96,7 +97,7 @@ tests:
               command: add
               id: client.1                      # client Id (<type>.<Id>)
               nodes:
-                  - node8:
+                  - node15:
                       release: 5
                   - node7:
                       release: 5
@@ -117,7 +118,7 @@ tests:
               command: add
               id: client.2                     # client Id (<type>.<Id>)
               nodes:
-                - node9:
+                - node16:
                     release: 5
               install_packages:
                 - ceph-common
@@ -135,7 +136,7 @@ tests:
             config:
               command: add
               id: client.3                      # client Id (<type>.<Id>)
-              node: node10                       # client node
+              node: node17                       # client node
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/quincy/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/quincy/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,5 +1,6 @@
 # Suite contains tests related to CIDR blocklisting of ceph clients
 # This is Openstack only test suite.
+# conf: 13-node-cluster-4-clients.yaml
 
 tests:
   - test:
@@ -96,7 +97,7 @@ tests:
               command: add
               id: client.1                      # client Id (<type>.<Id>)
               nodes:
-                  - node8:
+                  - node15:
                       release: 5
                   - node7:
                       release: 5
@@ -117,7 +118,7 @@ tests:
               command: add
               id: client.2                     # client Id (<type>.<Id>)
               nodes:
-                - node9:
+                - node16:
                     release: 6
               install_packages:
                 - ceph-common
@@ -135,7 +136,7 @@ tests:
             config:
               command: add
               id: client.3                      # client Id (<type>.<Id>)
-              node: node10                       # client node
+              node: node17                       # client node
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,6 +1,6 @@
 # Suite contains tests related to CIDR blocklisting of ceph clients
 # This is Openstack only test suite.
-# conf: 6-node-cluster-4-clients.yaml
+# conf: 13-node-cluster-4-clients.yaml
 # RHOS-d run duration: 50 mins + 50 min (slow_ops) + 20 min (recovery_tests)
 tests:
   - test:
@@ -97,7 +97,7 @@ tests:
               command: add
               id: client.1                      # client Id (<type>.<Id>)
               nodes:
-                  - node8:
+                  - node15:
                       release: 6
                   - node7:
                       release: 6
@@ -118,7 +118,7 @@ tests:
               command: add
               id: client.2                     # client Id (<type>.<Id>)
               nodes:
-                - node9:
+                - node16:
                     release: 7
               install_packages:
                 - ceph-common
@@ -136,7 +136,7 @@ tests:
             config:
               command: add
               id: client.3                      # client Id (<type>.<Id>)
-              node: node10                       # client node
+              node: node17                       # client node
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -1,4 +1,4 @@
-# Use cluster-conf file: conf/reef/rados/stretch-mode-host-location-attrs.yaml
+# conf: 13-node-cluster-4-clients.yaml
 # Stretch mode tests performing site down scenarios
 
 # This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
@@ -140,7 +140,7 @@ tests:
         id: client.1                      # client Id (<type>.<Id>)
         nodes:
           - node7:
-              release: 6
+              release: 7
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,6 +1,6 @@
 # Suite contains tests related to CIDR blocklisting of ceph clients
 # This is Openstack only test suite.
-# conf: 6-node-cluster-4-clients.yaml
+# conf: 13-node-cluster-4-clients.yaml
 # RHOS-d run duration: 50 mins + 50 min (slow_ops) + 20 min (recovery_tests)
 tests:
   - test:
@@ -97,7 +97,7 @@ tests:
               command: add
               id: client.1                      # client Id (<type>.<Id>)
               nodes:
-                  - node8:
+                  - node15:
                       release: 6
                   - node7:
                       release: 6
@@ -118,7 +118,7 @@ tests:
               command: add
               id: client.2                     # client Id (<type>.<Id>)
               nodes:
-                - node9:
+                - node16:
                     release: 7
               install_packages:
                 - ceph-common
@@ -136,7 +136,7 @@ tests:
             config:
               command: add
               id: client.3                      # client Id (<type>.<Id>)
-              node: node10                       # client node
+              node: node17                       # client node
               install_packages:
                 - ceph-common
               copy_admin_keyring: true          # Copy admin keyring to node

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -1,6 +1,5 @@
-# Use cluster-conf file: conf/squid/rados/stretch-mode-host-location-attrs.yaml
 # Stretch mode tests performing site down scenarios
-
+# conf: 13-node-cluster-4-clients.yaml
 # This test case is Openstack only and cannot be run in Baremetal env due to test constrains.
 # Stretch mode deployment in BM is run by suite : suites/squid/rados/deploy-stretch-cluster-mode.yaml
 

--- a/tests/rados/test_stretch_deployment_with_placement.py
+++ b/tests/rados/test_stretch_deployment_with_placement.py
@@ -91,7 +91,7 @@ def run(ceph_cluster, **kw):
         )
         cmd = "ceph osd tree"
         tree_op, _ = client_node.exec_command(cmd=cmd, sudo=True)
-        datacenters = re.findall(r"\n(-\d+)\s+([\d.]+)\s+datacenter\s+(\w+)", tree_op)
+        datacenters = re.findall(r"\s*(-\d+)\s+([\d.]+)\s+datacenter\s+(\w+)", tree_op)
         weights = [(weight, name) for _, weight, name in datacenters]
         for dc in weights:
             log.debug(f"Datacenter: {dc[0]}, Weight: {dc[1]}")


### PR DESCRIPTION


1. The client nodes used in CIDR blocklisting test had to be updated post consolidating the test conf files in rados. Updated the client nodes in the suite file
2. Updated the stretch suite conf for new conf, and also added the same conf for RHOS-D env
