### PR TITLE
Test bucket listing does not cause abnormal client IO

### DIFF
--- a/suites/reef/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/reef/rgw/baremetal/scale_rgw_single_site.yaml
@@ -141,3 +141,12 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_10k_bucket.yaml
         timeout: 9000
+  - test:
+      name: Test bucket listing not cause abnormal client IO
+      desc: Test bucket listing not cause abnormal client IO
+      polarion-id: CEPH-83605383
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_listing_fake_mp.yaml
+      comments: Bug 2329090

--- a/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
@@ -146,3 +146,12 @@ tests:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_disable_and_enable_dynamic_resharding_with_10k_bucket.yaml
         timeout: 9000
+  - test:
+      name: Test bucket listing not cause abnormal client IO
+      desc: Test bucket listing not cause abnormal client IO
+      polarion-id: CEPH-83605383
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_listing.py
+        config-file-name: test_bucket_listing_fake_mp.yaml
+      comments: Bug 2329090


### PR DESCRIPTION
# Description
Test bucket listing does not cause abnormal client IO

Apple automation for bucket list causing abnormal client IO.
https://bugzilla.redhat.com/show_bug.cgi?id=2327880
https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83605383
ceph-qe-scripts pr : https://github.com/red-hat-storage/ceph-qe-scripts/pull/664/
pass logs http://magna002.ceph.redhat.com/cephci-jenkins/vidushi-runs/logs_test_bucket_listing_fake_mp_1

passed logs with parallel execution takes 56mins : http://magna002.ceph.redhat.com/cephci-jenkins/vidushi-runs/logs_test_bucket_listing_fake_mp_4


