### PR TITLE
Moving file creation ops to client node

### DIFF
--- a/suites/squid/cephfs/tier-2_cephfs_test-multi-mds.yaml
+++ b/suites/squid/cephfs/tier-2_cephfs_test-multi-mds.yaml
@@ -130,7 +130,7 @@ tests:
       abort-on-fail: false
       config:
         num_of_osds: 28
-        num_of_files: 1000
+        num_of_files: 100000
   - test:
       name: Repeated MDS restarts
       module: cephfs_multi_mds.test_cephfs_multimds_repeated_restart_mds.py

--- a/tests/cephfs/cephfs_multi_mds/create_files.sh
+++ b/tests/cephfs/cephfs_multi_mds/create_files.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Check for correct number of arguments
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <path> <num_of_files> <batch_size>"
+  exit 1
+fi
+
+# Command-line arguments
+path="$1"          # First argument: target directory
+num_of_files="$2"  # Second argument: total number of files
+batch_size="$3"    # Third argument: batch size
+
+# Validate numeric inputs
+if ! [[ "$num_of_files" =~ ^[0-9]+$ ]] || ! [[ "$batch_size" =~ ^[0-9]+$ ]]; then
+  echo "Error: num_of_files and batch_size must be positive integers."
+  exit 1
+fi
+
+# Ensure the target directory exists
+sudo mkdir -p "$path"
+
+# Main loop for file creation
+for ((i = 0; i < num_of_files; i += batch_size)); do
+  batch_end=$((i + batch_size))
+  if ((batch_end > num_of_files)); then
+    batch_end=$num_of_files
+  fi
+
+  for ((j = i; j < batch_end; j++)); do
+    file_path="$path/file_$j.txt"
+    printf "Created file %d\n" "$j" > "$file_path"
+  done
+done
+
+echo "File creation completed!"
+
+##Creating file: /mnt/cephfs-func1_fuse0o2fbln9nk_2/file_99998.txt
+  #Creating file: /mnt/cephfs-func1_fuse0o2fbln9nk_2/file_99999.txt
+  #
+  #real	77m25.091s
+  #user	11m34.726s
+  #sys	16m52.106s

--- a/tests/cephfs/cephfs_multi_mds/test_cephfs_multimds_functional.py
+++ b/tests/cephfs/cephfs_multi_mds/test_cephfs_multimds_functional.py
@@ -593,7 +593,7 @@ def run(ceph_cluster, **kw):
         log.info("Cleaning up the system")
         all_paths = kernel_subvol_mount_paths + fuse_subvol_mount_paths
         for path in all_paths:
-            clients[0].exec_command(sudo=True, cmd=f"rm -rf {path}*")
+            clients[0].exec_command(sudo=True, cmd=f"find {path} -type f -delete")
             clients[0].exec_command(sudo=True, cmd=f"umount -l {path}")
             clients[0].exec_command(sudo=True, cmd=f"rm -rf {path}")
         log.info("Delete Subvolumes for both filesystems")

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -4464,16 +4464,18 @@ os.system('sudo systemctl start  network')
                 clients.exec_command(sudo=True, cmd=create_path_cmd)
 
             log.info(f"Path exists or created successfully: {path}")
+            file = "create_files.sh"
+            clients.upload_file(
+                sudo=True,
+                src="tests/cephfs/cephfs_multi_mds/create_files.sh",
+                dst=f"/root/{file}",
+            )
 
-            for i in range(0, num_of_files, batch_size):
-                batch_end = min(i + batch_size, num_of_files)
-                for j in range(i, batch_end):
-                    file_path = os.path.join(path, f"file_{j}.txt")
-                    create_file_cmd = (
-                        f"echo 'Created files {j}' | sudo tee {file_path} > /dev/null"
-                    )
-                    clients.exec_command(sudo=True, cmd=create_file_cmd)
-                log.info(f"Created files {i} to {batch_end - 1}")
+            clients.exec_command(
+                sudo=True,
+                cmd=f"bash /root/{file} {path} {num_of_files} {batch_size}",
+                timeout=3600,
+            )
             log.info(f"Successfully created {num_of_files} files in {path}")
         except Exception as e:
             log.error(f"An error occurred: {e}")


### PR DESCRIPTION
# Description
Moving file creation ops to client node

Problem: 
Creation of 100000 files is taking longer time (approx 4 days) 
logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DSJ960/

Solution: 
Moved creation to client node now it is completing in 2 hours
Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-BSL7Q4/ 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-X5QM1K/ 


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
