### PR TITLE
Fixing create OSD pool method

### DIFF
--- a/suites/reef/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/reef/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -182,145 +182,7 @@ tests:
       desc: File and Directory Layout Lifecycle Operations
       abort-on-fail: false
   - test:
-      name: subvolumegroup creation on desired data pool
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
-      polarion-id: CEPH-83574164
-      desc: subvolumegroup creation with desired data pool_layout
       abort-on-fail: false
-  - test:
-      name: Subvolume Resize
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
-      polarion-id: CEPH-83574193
-      desc: subvolume resize
-      abort-on-fail: false
-  - test:
-      name: Delete subvolume name that does not exist
-      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
-      polarion-id: CEPH-83574182
-      desc: Delete subvolume_group name that does not exist
-      abort-on-fail: false
-  - test:
-      name: Remove subvolume group name does not exist with force option
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
-      polarion-id: CEPH-83574169
-      desc: Remove subvolume group name does not exist with force option
-      abort-on-fail: false
-  - test:
-      name: delete_non_exist_subvol_group
-      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
-      polarion-id: CEPH-83574168
-      desc: delete_non_exist_subvol_group
-      abort-on-fail: false
-  - test:
-      name: Create a subvolume in a non-existent subvolume group
-      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
-      polarion-id: CEPH-83574162
-      desc: Create a subvolume in a non-existent subvolume group
-      abort-on-fail: false
-  - test:
-      name: Verify data movement bw FS created on Replicated Pool and EC Pool
-      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
-      polarion-id: CEPH-83573637
-      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
-      abort-on-fail: false
-  - test:
-      name: Arbitrary pool removal on cephfs volume deletion
-      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
-      polarion-id: CEPH-83574158
-      desc: Verify if the arbitraty pool is also deleted upon volume deletion
-      abort-on-fail: false
-  - test:
-      name: cephfs_vol_mgmt_create_vol_component_exist_name
-      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
-      polarion-id: CEPH-83573428
-      desc: cephfs_vol_mgmt_create_vol_component_exist_name
-      abort-on-fail: false
-  - test:
-      name: cephfs_vol_mgmt_pool_name_option_test
-      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
-      polarion-id: CEPH-83573528
-      desc: cephfs_vol_mgmt_pool_name_option_test
-      abort-on-fail: false
-  - test:
-      name: Checking default subvolume gid and uid
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
-      polarion-id: CEPH-83574181
-      desc: Checking default subvolume gid and uid
-      abort-on-fail: false
-  - test:
-      name: Checking default subvolume group gid and uid
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
-      polarion-id: CEPH-83574161
-      desc: Checking default subvolume group gid and uid
-      abort-on-fail: false
-  - test:
-      name: cephfs_vol_mgmt_invalid_pool_layout
-      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
-      polarion-id: CEPH-83574163
-      desc: cephfs_vol_mgmt_invalid_pool_layout
-      abort-on-fail: false
-  - test:
-      name: volume_permission_test
-      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
-      polarion-id: CEPH-83574190
-      desc: volume_permission_test
-      abort-on-fail: false
-  - test:
-      name: subvolume_creation_invalid_pool_layout
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
-      polarion-id: CEPH-83574192
-      desc: subvolume_creation_invalid_pool_layout
-      abort-on-fail: false
-  - test:
-      name: subvolume_isolated_namespace
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
-      polarion-id: CEPH-83574187
-      desc: subvolume_isolated_namespace
-      abort-on-fail: false
-  - test:
-      name: Create cephfs subvolumegroup with desired permissions test
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
-      polarion-id: CEPH-83574165
-      desc: cephfs subvolumegroup with different octal modes
-      abort-on-fail: false
-  - test:
-      name: add datapools to existing FS
-      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
-      polarion-id: CEPH-83574331
-      desc: add datapools to existing FS
-      abort-on-fail: false
-  - test:
-      name: Creating fs volume,sub-volume,sub-volume group with existing names
-      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
-      polarion-id: CEPH-83574331
-      desc: Creating fs volume,sub-volume,sub-volume group with existing names
-      abort-on-fail: false
-  - test:
-      name: Subvolume Auto clean up after failed creating subvolume
-      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
-      polarion-id: CEPH-83574188
-      desc: Subvolume Auto clean up after failed creating subvolume
-      abort-on-fail: false
-  - test:
-      name: Subvolume metadata creation, delete and modifying test
-      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
-      polarion-id: CEPH-83575032
-      desc: Subvolume metadata creation, delete and modifying test
-      abort-on-fail: false
-  - test:
-      name: cephfs_vol_mgmt_fs_life_cycle
-      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
-      polarion-id: CEPH-11333
-      desc: File system life cycle
-      abort-on-fail: false
-  - test:
-      name: Test fs volume creation, run IO & deletion in loop for 5 times
-      module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
-      polarion-id: CEPH-83604070
-      desc: Test fs volume creation, run IO & deletion in loop for 5 times
-      abort-on-fail: false
-  - test:
-      abort-on-fail: true
       desc: "test cephfs nfs export path"
       module: cephfs_nfs.nfs_export_path.py
       name: "cephfs nfs export path"
@@ -470,6 +332,162 @@ tests:
       module: cephfs_nfs.nfs_multiple_export_using_single_conf.py
       name: "nfs_multiple_export_using_single_conf"
       polarion-id: "CEPH-83575082"
+  - test:
+      name: subvolumegroup creation on desired data pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_pool_layout.py
+      polarion-id: CEPH-83574164
+      desc: subvolumegroup creation with desired data pool_layout
+      abort-on-fail: false
+  - test:
+      name: Subvolume Resize
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_resize.py
+      polarion-id: CEPH-83574193
+      desc: subvolume resize
+      abort-on-fail: false
+  - test:
+      name: Delete subvolume name that does not exist
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvolume.py
+      polarion-id: CEPH-83574182
+      desc: Delete subvolume_group name that does not exist
+      abort-on-fail: false
+  - test:
+      name: Remove subvolume group name does not exist with force option
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_group_force.py
+      polarion-id: CEPH-83574169
+      desc: Remove subvolume group name does not exist with force option
+      abort-on-fail: false
+  - test:
+      name: delete_non_exist_subvol_group
+      module: cephfs_vol_management.cephfs_vol_mgmt_delete_non_exist_subvol_group.py
+      polarion-id: CEPH-83574168
+      desc: delete_non_exist_subvol_group
+      abort-on-fail: false
+  - test:
+      name: Create a subvolume in a non-existent subvolume group
+      module: cephfs_vol_management.cephfs_vol_mgmt_non_exist_subvol_group.py
+      polarion-id: CEPH-83574162
+      desc: Create a subvolume in a non-existent subvolume group
+      abort-on-fail: false
+  - test:
+      name: Verify data movement bw FS created on Replicated Pool and EC Pool
+      module: cephfs_vol_management.cephfs_vol_mgmt_data_migrate.py
+      polarion-id: CEPH-83573637
+      desc: Verify if the FS data can be moved from an existing Replicated Datapool to EC datapool
+      abort-on-fail: false
+  - test:
+      name: Arbitrary pool removal on cephfs volume deletion
+      module: cephfs_vol_management.cephfs_vol_mgmt_arbitrary_pool_removal.py
+      polarion-id: CEPH-83574158
+      desc: Verify if the arbitraty pool is also deleted upon volume deletion
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_create_vol_component_exist_name
+      module: cephfs_vol_management.cephfs_vol_mgmt_create_vol_component_exist_name.py
+      polarion-id: CEPH-83573428
+      desc: cephfs_vol_mgmt_create_vol_component_exist_name
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_pool_name_option_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_pool_name_option_test.py
+      polarion-id: CEPH-83573528
+      desc: cephfs_vol_mgmt_pool_name_option_test
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_gid_uid.py
+      polarion-id: CEPH-83574181
+      desc: Checking default subvolume gid and uid
+      abort-on-fail: false
+  - test:
+      name: Checking default subvolume group gid and uid
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_gid_uid.py
+      polarion-id: CEPH-83574161
+      desc: Checking default subvolume group gid and uid
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_invalid_pool_layout.py
+      polarion-id: CEPH-83574163
+      desc: cephfs_vol_mgmt_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: volume_permission_test
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_permissions.py
+      polarion-id: CEPH-83574190
+      desc: volume_permission_test
+      abort-on-fail: false
+  - test:
+      name: subvolume_creation_invalid_pool_layout
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_invalid_pool_layout.py
+      polarion-id: CEPH-83574192
+      desc: subvolume_creation_invalid_pool_layout
+      abort-on-fail: false
+  - test:
+      name: subvolume_isolated_namespace
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_isolated_namespace.py
+      polarion-id: CEPH-83574187
+      desc: subvolume_isolated_namespace
+      abort-on-fail: false
+  - test:
+      name: Create cephfs subvolumegroup with desired permissions test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_octal_modes.py
+      polarion-id: CEPH-83574165
+      desc: cephfs subvolumegroup with different octal modes
+      abort-on-fail: false
+  - test:
+      name: add datapools to existing FS
+      module: cephfs_vol_management.cephfs_vol_mgmt_add_datapool_to_existing_fs.py
+      polarion-id: CEPH-83574331
+      desc: add datapools to existing FS
+      abort-on-fail: false
+  - test:
+      name: Creating fs volume,sub-volume,sub-volume group with existing names
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_with_exist_names.py
+      polarion-id: CEPH-83574331
+      desc: Creating fs volume,sub-volume,sub-volume group with existing names
+      abort-on-fail: false
+  - test:
+      name: Subvolume Auto clean up after failed creating subvolume
+      module: cephfs_vol_management.cephfs_vol_mgmt_auto_clean_up.py
+      polarion-id: CEPH-83574188
+      desc: Subvolume Auto clean up after failed creating subvolume
+      abort-on-fail: false
+  - test:
+      name: Subvolume metadata creation, delete and modifying test
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolume_metadata.py
+      polarion-id: CEPH-83575032
+      desc: Subvolume metadata creation, delete and modifying test
+      abort-on-fail: false
+  - test:
+      name: cephfs_vol_mgmt_fs_life_cycle
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_life_cycle.py
+      polarion-id: CEPH-11333
+      desc: File system life cycle
+      abort-on-fail: false
+  - test:
+      name: Test fs volume creation, run IO & deletion in loop for 5 times
+      module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
+      polarion-id: CEPH-83604070
+      desc: Test fs volume creation, run IO & deletion in loop for 5 times
+      abort-on-fail: false
+  - test:
+      name: volume related scenarios(delete,rename)
+      module: cephfs_vol_management.cephfs_vol_mgmt_volume_scenarios.py
+      polarion-id: CEPH-83603354
+      desc: volume related scenarios(delete,rename)
+      abort-on-fail: false
+  - test:
+      name: cephfs subvolumegroup scenarios
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvolgroup_scenarios.py
+      polarion-id: CEPH-83604079
+      desc: cephfs subvolumegroup scenarios
+      abort-on-fail: false
+  - test:
+      name: cephfs subvolume idempoence earmark
+      module: cephfs_vol_management.cephfs_vol_mgmt_subvol_idempotence_earmark.py
+      polarion-id: CEPH-83604184
+      desc: cephfs subvolume idempoence earmark
+      abort-on-fail: false
   - test:
       name: CephFS Volume Operations
       module: cephfs_vol_management.cephfs_vol_mgmt_test_volume.py

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1297,9 +1297,10 @@ class FsUtils(object):
         return cmd_out, cmd_rc
 
     def create_osd_pool(
+        self,
         client,
         pool_name,
-        pg_num=64,
+        pg_num=None,
         pgp_num=None,
         erasure=False,
         validate=True,
@@ -1307,73 +1308,47 @@ class FsUtils(object):
     ):
         """
         Creates an OSD pool with given arguments.
-        Supports optional arguments for customization.
-
+        It supports the following optional arguments:
         Args:
-            client: Ceph client
-            pool_name: Name of the pool to create
-            pg_num: Number of placement groups (default: 64)
-            pgp_num: Number of placement groups for placement (optional)
-            erasure: Whether to create an erasure-coded pool (default: False)
-            validate: Whether to validate the pool creation (default: True)
+            client:
+            pool_name:
+            pg_num: int
+            pgp_num: int
+            erasure: bool
+            validate: bool
             **kwargs:
-                erasure_code_profile: Erasure code profile name
-                crush_rule_name: CRUSH rule name
-                expected_num_objects: Expected number of objects
-                autoscale_mode: Autoscale mode (on, off, warn)
-                check_ec: Whether to check the execution code (default: True)
-
+                erasure_code_profile: str
+                crush_rule_name: str
+                expected_num_objects: int
+                autoscale_mode: str (on, off, warn)
+                check_ec: bool (default: True)
         Returns:
-            Tuple containing the command output and return code.
+            Returns the cmd_out and cmd_rc for the create command.
         """
-        # Additional configuration for erasure-coded pools
         if erasure:
-            log.info(
-                f"Setting allow_ec_overwrites to true for erasure-coded pool: {pool_name}"
-            )
-            client.exec_command(
-                sudo=True, cmd=f"ceph osd pool set {pool_name} allow_ec_overwrites true"
-            )
+            pool_cmd = f"ceph osd pool create {pool_name} {pg_num or ''} {pgp_num or ''} erasure"
+            if kwargs.get("erasure_code_profile"):
+                pool_cmd += f" {kwargs.get('erasure_code_profile')}"
+        else:
+            pool_cmd = f"ceph osd pool create {pool_name} {pg_num or ''} {pgp_num or ''} replicated"
 
-        # Determine pool type
-        pool_type = "erasure" if erasure else "replicated"
-        log.info(f"Creating {pool_type} OSD pool: {pool_name}")
-
-        # Build the pool creation command
-        pool_cmd = f"ceph osd pool create {pool_name} {pg_num} {pgp_num or ''} {pool_type}".strip()
-
-        # Append erasure code profile if specified
-        if erasure and kwargs.get("erasure_code_profile"):
-            pool_cmd += f" {kwargs['erasure_code_profile']}"
-
-        # Append CRUSH rule name if specified
         if kwargs.get("crush_rule_name"):
-            pool_cmd += f" {kwargs['crush_rule_name']}"
-
-        # Append expected number of objects if specified
+            pool_cmd += f" {kwargs.get('crush_rule_name')}"
         if kwargs.get("expected_num_objects"):
-            pool_cmd += f" {kwargs['expected_num_objects']}"
-
-        # Set autoscale mode if specified
+            pool_cmd += f" {kwargs.get('expected_num_objects')}"
         if erasure and kwargs.get("autoscale_mode"):
-            pool_cmd += f" --autoscale-mode={kwargs['autoscale_mode']}"
+            pool_cmd += f" --autoscale-mode={kwargs.get('autoscale_mode')}"
 
-        # Execute the pool creation command
         cmd_out, cmd_rc = client.exec_command(
             sudo=True, cmd=pool_cmd, check_ec=kwargs.get("check_ec", True)
         )
 
-        log.info(f"OSD pool {pool_name} created successfully")
-
-        # Validate pool creation
         if validate:
-            log.info(f"Validating creation of OSD pool: {pool_name}")
             out, rc = client.exec_command(
                 sudo=True, cmd="ceph osd pool ls --format json"
             )
             pool_ls = json.loads(out)
             if pool_name not in pool_ls:
-                log.error(f"Creation of OSD pool {pool_name} failed")
                 raise CommandFailed(f"Creation of OSD pool: {pool_name} failed")
 
         return cmd_out, cmd_rc


### PR DESCRIPTION
# Description
Fixing create OSD pool method

**Problem:**
A change in the definition of the create_osd_pool method caused failures in the tier-1_cephfs_cg_quiesce test case. This modification was part of the tier-2_file-dir-lay_vol-mgmt_nfs suite, specifically impacting the CephFS_Volume_Operations_0 test case.

**Solution:**
The create_osd_pool method was reverted to its original definition. Both impacted suites were executed with this change, and the tests completed successfully.

tier-1_cephfs_cg_quiesce : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5DXV40 
tier-2_file-dir-lay_vol-mgmt_nfs_1.yaml : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N1BIBQ/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
