### PR TITLE
[TFA] config restore_debug_interval supported from squid onwards

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -574,11 +574,11 @@ def set_config_param(node):
     rgw_process_name = rgw_process[0].split()[0]
 
     # add the configuration/s to be set on service
-    configs = [
-        "rgw_max_objs_per_shard 5",
-        "rgw_lc_debug_interval 30",
-        "rgw_restore_debug_interval 30",
-    ]
+    configs = ["rgw_max_objs_per_shard 5", "rgw_lc_debug_interval 30"]
+    ceph_version = node.exec_command(cmd="sudo ceph version")
+    ceph_version = ceph_version[0].split()[2].split(".")[0]
+    if int(ceph_version) >= int(19):
+        configs += ["rgw_restore_debug_interval 30"]
     for config_cmd in configs:
         node.exec_command(cmd=f"ceph config set client.{rgw_process_name} {config_cmd}")
 


### PR DESCRIPTION
# Description
[TFA] config rgw_restore_debug_interval supported from squid onwards

Issue observed in reef : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/7.1/rhel-9/Regression/18.2.1-284/rgw/22/tier-2_rgw_multisite_scenarios/create_non-tenanted_user_0.log

ceph.ceph.CommandFailed: ceph config set client.rgw.shared.pri.ceph-pri-regression-brhos6-vgigio-node5.ttahxj rgw_restore_debug_interval 30 returned Error EINVAL: unrecognized config option 'rgw_restore_debug_interval'

pass log: 
reef: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-P0I8SR/create_non-tenanted_user_0.log
squid: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-P0I8SR/create_non-tenanted_user_1.log
over all: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-P0I8SR/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
