### PR TITLE
Added iscsi validations

### DIFF
--- a/ceph/iscsi/gateway.py
+++ b/ceph/iscsi/gateway.py
@@ -65,6 +65,9 @@ class GWCLI:
     def list(self, **kwargs):
         return self.exec_gw_cli("ls", self.path, **kwargs)
 
+    def export(self):
+        return self.exec_gw_cli("export", self.path)
+
     class Disks:
         path = "/disks"
 
@@ -114,9 +117,11 @@ class GWCLI:
             def __init__(self, parent):
                 self.parent = parent
 
-            def create(self, iqn, **kwargs):
+            def add(self, iqn, **kwargs):
                 return self.parent.exec_gw_cli(
-                    "create", self.path.format(IQN=iqn), **kwargs
+                    "add",
+                    self.path.format(IQN=iqn),
+                    **kwargs,
                 )
 
             def delete(self, iqn, **kwargs):

--- a/conf/reef/iscsi/ceph_iscsi_functional.yaml
+++ b/conf/reef/iscsi/ceph_iscsi_functional.yaml
@@ -1,0 +1,44 @@
+globals:
+  - ceph-cluster:
+      name: ceph
+      vm-size: ci.standard.large
+      node1:
+        role:
+          - _admin
+          - installer
+          - mon
+          - mgr
+      node2:
+        role:
+          - mon
+          - mgr
+      node3:
+        role:
+          - mon
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node4:
+        role:
+          - mds
+          - osd
+        no-of-volumes: 4
+        disk-size: 20
+      node5:
+        role:
+          - mds
+          - osd
+          - iscsi
+        no-of-volumes: 4
+        disk-size: 20
+      node6:
+        role:
+          - iscsi
+        no-of-volumes: 4
+        disk-size: 20
+      node7:
+        role:
+          - client
+      node8:
+        role:
+          - client

--- a/suites/reef/iscsi/iscsi_sanity.yaml
+++ b/suites/reef/iscsi/iscsi_sanity.yaml
@@ -1,0 +1,101 @@
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  #  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node7
+          - node8
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client for iSCSI gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: Configure Ceph client for iSCSI tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      name: Ceph iSCSI Sanity e2e test
+      desc: Configure iSCSI gateways, initiators and run IO
+      module: iscsi_test.py
+      polarion-id: CEPH-83605167
+      destroy-clster: false
+      config:
+        gw_nodes:
+          - node5
+          - node6
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+            pool: rbd
+        install: true
+        cleanup:
+          - initiators
+          - gateway
+          - pool
+        targets:
+          - iqn: iscsi-target1
+            gateways:
+              - node5
+              - node6
+            hosts:
+              - client_iqn: iqn.2025-01.com.redhat.iscsi-gw:rh-client
+                disks:
+                - count: 5
+                  size: 1G
+        initiators:
+          - iqn: iqn.2025-01.com.redhat.iscsi-gw:rh-client
+            node: node7
+            type: linux
+            target: all

--- a/suites/squid/iscsi/iscsi_sanity.yaml
+++ b/suites/squid/iscsi/iscsi_sanity.yaml
@@ -81,9 +81,9 @@ tests:
             pool: rbd
         install: true
         cleanup:
+          - initiators
           - gateway
           - pool
-          - initiators
         targets:
           - iqn: iscsi-target1
             gateways:

--- a/tests/iscsi/iscsi_test.py
+++ b/tests/iscsi/iscsi_test.py
@@ -27,6 +27,12 @@ def teardown(ceph_cluster, iscsi, rbd_obj, config):
         for initiator in iscsi.initiators:
             initiator.cleanup()
 
+    # Delete the Individual iSCSI Targets
+    if "targets" in config["cleanup"]:
+        gwnode = iscsi.gateways[0]
+        for target in config["targets"]:
+            gwnode.gwcli.target.delete(target["iqn"])
+
     # Delete the gateway
     if "gateway" in config["cleanup"]:
         delete_iscsi_service(ceph_cluster, config)


### PR DESCRIPTION
# Description

- Added validations on iscsi sanity. Every entity configured is cross-verified with export configuration data.
- Added sanity for reef builds

```

All test logs located here: /Users/sunilkumarn/logs/8_0-z2-iscsi-validations-07

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Ceph iSCSI Sanity e2e test       Configure iSCSI gateways, initiators and run IO                0:06:38.793412                   Pass
```