### PR TITLE
[TFA] fix ceph-base package installation issues

### DIFF
--- a/conf/reef/rados/13-node-cluster-4-clients.yaml
+++ b/conf/reef/rados/13-node-cluster-4-clients.yaml
@@ -60,9 +60,6 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node7:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_2
         role:

--- a/conf/reef/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/reef/rados/stretch-mode-host-location-attrs.yaml
@@ -70,5 +70,8 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node8:
+        image-name:
+          openstack: RHEL-9.4.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         role:
           - client

--- a/conf/squid/rados/13-node-cluster-4-clients.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients.yaml
@@ -60,9 +60,6 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node7:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_2
         role:

--- a/conf/squid/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/squid/rados/stretch-mode-host-location-attrs.yaml
@@ -70,5 +70,8 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node8:
+        image-name:
+          openstack: RHEL-9.4.0-x86_64-ga-latest
+          ibmc: rhel-91-server-released
         role:
           - client

--- a/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
@@ -49,6 +49,18 @@ tests:
                 root: default
                 datacenter: DC2
             - service_type: mon
+              spec:
+                crush_locations:
+                  node1:
+                    - datacenter=tiebreaker
+                  node2:
+                    - datacenter=DC1
+                  node3:
+                    - datacenter=DC1
+                  node5:
+                    - datacenter=DC2
+                  node6:
+                    - datacenter=DC2
               placement:
                 label: mon
             - service_type: mgr
@@ -130,9 +142,7 @@ tests:
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
-        nodes:
-          - node8:
-              release: 6
+        nodes: node8
         install_packages:
           - ceph-common
           - ceph-base

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -23,7 +23,7 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-          rhcs-version: 6.1
+          rhcs-version: 8.0
           release: rc
           mon-ip: node1
           orphan-initial-daemons: true


### PR DESCRIPTION
**Issue:** ceph-base package installation fails with image RHEL-9.4.0-x86_64-ga-latest
**Issue logs:** http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-64/rados/62/tier-3_rados_test-location-stretch-mode/Configure_client_admin_0.log 

**error:**
025-01-25 17:22:23,674 - cephci - run:854 - ERROR - yum install -y --nogpgcheck ceph-base returned Error: 
 Problem: package ceph-base-2:19.2.0-64.el9cp.x86_64 from ceph-Tools requires ceph-selinux = 2:19.2.0-64.el9cp, but none of the providers can be installed
  - conflicting requests
  - nothing provides selinux-policy-base >= 38.1.45-3.el9_5 needed by ceph-selinux-2:19.2.0-64.el9cp.x86_64 from ceph-Tools
 and code 1 on 10.0.203.148
 
 **Pass Logs:** http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_vips_stretch_mode_upgrade_25_01_27_01_58_35/ 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
