### PR TITLE
RHCEPHQE-17658: [IO Tool Integration] - Including dbench & postgresIO workflow

### DIFF
--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -97,7 +97,7 @@ def run(ceph_cluster, **kw):
         try:
             fs_util.prepare_clients(clients, build)
             fs_util.auth_list(clients)
-            client1 = clients[3]
+            client1 = clients[0]
 
             # Creation of FS
             fs_util.create_fs(client1, fs_name)

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -74,15 +74,30 @@ def run(ceph_cluster, **kw):
             "subvol_name": f"{subvolume_name}_4",
             "group_name": subvolume_group_name,
         },
+        {
+            "vol_name": fs_name,
+            "subvol_name": f"{subvolume_name}_5",
+            "group_name": subvolume_group_name,
+        },
+        {
+            "vol_name": fs_name,
+            "subvol_name": f"{subvolume_name}_6",
+            "group_name": subvolume_group_name,
+        },
     ]
 
     # Run the FS lifecycle for 5 iteration
     for i in range(1, 6):
-        log.info(f"Loop {i}: Started file system lifecycle")
+        log.info(
+            "\n"
+            "\n---------------***************---------------"
+            f"\n     Loop {i}: Started file system lifecycle"
+            "\n---------------***************---------------"
+        )
         try:
             fs_util.prepare_clients(clients, build)
             fs_util.auth_list(clients)
-            client1 = clients[0]
+            client1 = clients[3]
 
             # Creation of FS
             fs_util.create_fs(client1, fs_name)
@@ -99,6 +114,12 @@ def run(ceph_cluster, **kw):
                 log.info(f"Subvolume Info before IO: {subvolume_size_subvol}")
 
             # Mounting Subvolume1 on Fuse
+            log.info(
+                "\n"
+                "\n---------------***************---------------------"
+                "\n  Step 1: Mounting Subvolume1 on Fuse - SmallFile  "
+                "\n---------------***************---------------------"
+            )
             log.info(f"Mount subvolume {subvolume_name}_1 on Fuse Client")
             mounting_dir = "".join(
                 random.choice(string.ascii_lowercase + string.digits)
@@ -129,6 +150,12 @@ def run(ceph_cluster, **kw):
             )
 
             # Mounting Subvolume2 on Kernel
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------"
+                "\n  Step 2: Mounting Subvolume2 on Kernel - SmallFile  "
+                "\n---------------***************-----------------------"
+            )
             log.info(f"Mount subvolume {subvolume_name}_2 on Kernel Client")
             kernel_mount_dir = f"/mnt/cephfs_kernel{mounting_dir}_1/"
             mon_node_ips = fs_util.get_mon_node_ips()
@@ -156,6 +183,12 @@ def run(ceph_cluster, **kw):
             )
 
             # Mounting Subvolume3 on nfs
+            log.info(
+                "\n"
+                "\n---------------***************---------------------"
+                "\n  Step 3: Mounting Subvolume3 on NFS - SmallFile   "
+                "\n---------------***************---------------------"
+            )
             log.info(f"Mount subvolume {subvolume_name}_3 on NFS Client")
             nfs_servers = ceph_cluster.get_ceph_objects("nfs")
             nfs_server = nfs_servers[0].node.hostname
@@ -209,6 +242,12 @@ def run(ceph_cluster, **kw):
             )
 
             # Mounting Subvolume4 on Kernel - Run dbench
+            log.info(
+                "\n"
+                "\n---------------***************---------------------"
+                "\n  Step 4: Mounting Subvolume4 on Kernel - Dbench   "
+                "\n---------------***************---------------------"
+            )
             log.info(f"Mount subvolume {subvolume_name}_4 on Kernel Client")
             kernel_mount_dir_dbench = f"/mnt/cephfs_kernel{mounting_dir}_4/"
             mon_node_ips = fs_util.get_mon_node_ips()
@@ -260,6 +299,123 @@ def run(ceph_cluster, **kw):
             fs_health_status = fs_util.get_ceph_health_status(client1)
             log.debug(f"Output of FS Health status: {fs_health_status}")
 
+            # Mounting Subvolume5 on FUSE - Run dbench
+            log.info(
+                "\n"
+                "\n---------------***************---------------------"
+                "\n  Step 5: Mounting Subvolume5 on Fuse - Dbench     "
+                "\n---------------***************---------------------"
+            )
+            log.info(f"Mount subvolume {subvolume_name}_5 on Fuse Client")
+
+            fuse_dbench_mount_dir = f"/mnt/cephfs_fuse{mounting_dir}_5/"
+            subvol_path_fuse, rc = client1.exec_command(
+                sudo=True,
+                cmd=f"ceph fs subvolume getpath {fs_name} {subvolume_name}_5 {subvolume_group_name}",
+            )
+            fs_util.fuse_mount(
+                [client1],
+                fuse_dbench_mount_dir,
+                extra_params=f" -r {subvol_path_fuse.strip()} --client_fs {fs_name}",
+            )
+
+            with parallel() as p:
+                log.info("Start Writing IO on the subvolume using dbench")
+
+                p.spawn(
+                    fs_util.run_ios_V1,
+                    client=client1,
+                    mounting_dir=fuse_dbench_mount_dir,
+                    io_tools=["dbench"],
+                    dbench_params={"duration": 40},
+                )
+
+                # Spawn the health monitoring task
+                p.spawn(
+                    fs_util.monitor_ceph_health,
+                    client=client1,
+                    retry=4,
+                    interval=10,  # Set the interval for health checks during parallel operation
+                )
+
+            # Get ceph fs dump output
+            fs_dump_dict = fs_util.collect_fs_dump_for_validation(client1, fs_name)
+            log.debug(f"Output of FS dump: {fs_dump_dict}")
+
+            # Get ceph fs get of specific volume
+            fs_get_dict = fs_util.collect_fs_get_for_validation(client1, fs_name)
+            log.debug(f"Output of FS get: {fs_get_dict}")
+
+            # Get ceph fs status
+            fs_status_dict = fs_util.collect_fs_status_data_for_validation(
+                client1, fs_name
+            )
+            log.debug(f"Output of FS status: {fs_status_dict}")
+
+            fs_health_status = fs_util.get_ceph_health_status(client1)
+            log.debug(f"Output of FS Health status: {fs_health_status}")
+
+            # Mounting Subvolume6 on Kernel - Run postgres IO
+            log.info(
+                "\n"
+                "\n---------------***************------------------------"
+                "\n  Step 6: Mounting Subvolume6 on Kernal - PostgresIO  "
+                "\n---------------***************------------------------"
+            )
+            log.info(f"Mount subvolume {subvolume_name}_6 on Kernel Client")
+            kernel_mount_dir_pgsql = f"/mnt/cephfs_kernel{mounting_dir}_6/"
+            mon_node_ips = fs_util.get_mon_node_ips()
+            subvol_path_kernel, rc = client1.exec_command(
+                sudo=True,
+                cmd=f"ceph fs subvolume getpath {fs_name} {subvolume_name}_6 {subvolume_group_name}",
+            )
+            fs_util.kernel_mount(
+                [client1],
+                kernel_mount_dir_pgsql,
+                ",".join(mon_node_ips),
+                sub_dir=f"{subvol_path_kernel.strip()}",
+                extra_params=f",fs={fs_name}",
+            )
+
+            db_name = fs_name + "_db_kernel"
+            fs_util.setup_postgresql_IO(client1, kernel_mount_dir_pgsql, db_name)
+
+            with parallel() as p:
+                log.info("Start Writing IO on the subvolume using postgresql")
+
+                p.spawn(
+                    fs_util.run_ios_V1,
+                    client=client1,
+                    mounting_dir=kernel_mount_dir_pgsql,
+                    io_tools=["postgresIO"],
+                    postgresIO_params={"duration": 10, "db_name": db_name},
+                )
+
+                # Spawn the health monitoring task
+                p.spawn(
+                    fs_util.monitor_ceph_health,
+                    client=client1,
+                    retry=2,
+                    interval=5,  # Set the interval for health checks during parallel operation
+                )
+
+            # Get ceph fs dump output
+            fs_dump_dict = fs_util.collect_fs_dump_for_validation(client1, fs_name)
+            log.debug(f"Output of FS dump: {fs_dump_dict}")
+
+            # Get ceph fs get of specific volume
+            fs_get_dict = fs_util.collect_fs_get_for_validation(client1, fs_name)
+            log.debug(f"Output of FS get: {fs_get_dict}")
+
+            # Get ceph fs status
+            fs_status_dict = fs_util.collect_fs_status_data_for_validation(
+                client1, fs_name
+            )
+            log.debug(f"Output of FS status: {fs_status_dict}")
+
+            fs_health_status = fs_util.get_ceph_health_status(client1)
+            log.debug(f"Output of FS Health status: {fs_health_status}")
+
             for subvolume in subvolume_list:
                 subvolume_size_subvol = fs_util.get_subvolume_info(
                     client=client1, **subvolume
@@ -272,21 +428,22 @@ def run(ceph_cluster, **kw):
             return 1
 
         finally:
-            fs_util.client_clean_up(
-                "umount", fuse_clients=[client1], mounting_dir=fuse_mount_dir
-            )
+            for mount_dir in [
+                fuse_mount_dir,
+                fuse_dbench_mount_dir,
+            ]:
+                fs_util.client_clean_up(
+                    "umount", fuse_clients=[client1], mounting_dir=mount_dir
+                )
 
-            fs_util.client_clean_up(
-                "umount",
-                kernel_clients=[client1],
-                mounting_dir=kernel_mount_dir,
-            )
-
-            fs_util.client_clean_up(
-                "umount",
-                kernel_clients=[client1],
-                mounting_dir=kernel_mount_dir_dbench,
-            )
+            for mount_dir in [
+                kernel_mount_dir,
+                kernel_mount_dir_dbench,
+                kernel_mount_dir_pgsql,
+            ]:
+                fs_util.client_clean_up(
+                    "umount", kernel_clients=[client1], mounting_dir=mount_dir
+                )
 
             client1.exec_command(sudo=True, cmd=f"rm -rf {nfs_mounting_dir}/*")
             client1.exec_command(sudo=True, cmd=f"umount {nfs_mounting_dir}")


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs

Steps to configure dbench(from client node):

1. dnf config-manager --add-repo=https://download.fedoraproject.org/pub/epel/9/Everything/x86_64/
2. dnf install dbench
3. Authorise client to use the fs (From Mon nodes)
4. Run command "dbench 32 -t 1200 -D /mnt/mani1/"
5. Run 32 clients in parallel for duration of 1200 seconds against the mount path

Steps to configure PostgresIO (from client node):

1. Create a directory for PostgreSQL data on Client node under the mounted directory
2. sudo mkdir -p /mnt/mani_fs_1/postgres_data
3. Provide postgres user access to the folder
4. chown -R postgres:postgres /mnt/mani_fs_1/postgres_data
5. chmod 700 /mnt/mani_fs_1/postgres_data
6. Install postgresql and postgres-server
7. dnf install postgresql postgresql-server
8. Point PostgreSQL to use the CephFS directory for its data
9. sudo -u postgres /usr/bin/initdb -D /mnt/mani_fs_1/postgres_data
10. Edit the PostgreSQL configuration file to use the CephFS data directory - vi /usr/lib/systemd/system/postgresql.service
12. Environment=PGDATA=/mnt/mani_fs_1/postgres_data
13. systemctl daemon-reload
14. systemctl restart postgresql
15. Restart will fail. Fix by disabling the enforce option
16. Since you are running on RHEL, SELinux might be blocking access
17. sestatus
18. setenforce 0 (temporarily disable it for testing)
19. systemctl restart postgresql
20. If the service starts successfully, set the correct SELinux context for the data directory
21. chcon -R -t postgresql_db_t /mnt/mani_fs_1
22. setenforce 1
23. systemctl restart postgresql
24. Create a db
25. sudo -u postgres psql
26. CREATE DATABASE testdb; 
28. Run the initialization command
29. pgbench -i --scale=100 -U postgres -d testdb
30. The default pgbench transaction mix includes SELECT, INSERT, UPDATE, and DELETE operations.
31. pgbench -c 50 -j 4 -T 300 -U postgres -d testdb
32. This simulates 50 users performing mixed read/write transactions for 5 minutes

## Code Changes - Summary

- tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
   - Include additional subvolume
   - Run dbench and health check in parallel on the newly created subvolume
   - Handle Cleanup
   - Include additional subvolume
   - Run PostgresIO and health check in parallel on the newly created subvolume
   - Handle Cleanup
- tests/cephfs/cephfs_utilsV1.py
   - Add new entry for dbench and postgresIO in the existing io tools function
   - Include installation of dbench and postgres in the client nodes
   - Add a monitor function to check the health status while running IO parallely

## Pass Logs:

- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-17658-rerun1/
- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-17658/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
