### PR TITLE
Enhancing the bluestore_min_alloc_size for printing of log lines for _open_super_meta min_alloc_size

### DIFF
--- a/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -2,7 +2,9 @@
 # CLuster should have atleast 6 OSD hosts for testing.
 # Suited best for BM pipeline.
 # Can be run on RHOS-d env as well.
-# RHOS-d run duration: 60 mins (clay-ecpool tests)
+# RHOS-d run duration: 60 mins (clay-ecpool tests) 
+# Suite contains ISA erasure code plugin
+
 tests:
   - test:
       name: setup install pre-requisistes
@@ -314,3 +316,57 @@ tests:
           - rpool_2
           - rpool_3
           - ecpool_test_2
+
+Below test is added for ISA erasure code plugin
+  
+  - test:
+      name: EC pool with ISA plugin
+      module: rados_prep.py
+      polarion-id: CEPH-83606527
+      config:
+        ec_pool:
+          create: true
+          pool_name: test_isa_ec_pool
+          pg_num: 64
+          k: 2
+          m: 2
+          plugin: isa
+          disable_pg_autoscale: true
+          rados_write_duration: 50
+          rados_read_duration: 30
+        set_pool_configs:
+          pool_name: test_isa_ec_pool
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - test_isa_ec_pool
+      desc: Create, modify & delete ISA EC pools and run IO
+
+  - test:
+      name: ISA plugin for EC pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83606782
+      config:
+        ec_pool:
+          create: true
+          pool_name: isa_ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: isa
+          rados_write_duration: 50
+          rados_read_duration: 30
+          test_overwrites_pool: true
+          metadata_pool: isa_re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - isa_ec_pool_overwrite
+          - isa_re_pool_overwrite
+      desc: ISA EC pool with Overwrites & create RBD pool


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2183485

1. Capture logs during the boot process using journalctl:
We leverage journalctl to capture and display the log lines during the OSD boot sequence.
2. Track OSD boot start and end timestamps:
The start and end times of the OSD boot process are recorded to ensure accurate log retrieval for the specified period.
3. Store log data for analysis:
Logs are retrieved and stored for later analysis, capturing important events during the OSD startup.
4. An if condition is added to specifically capture and log entries related to _open_super_meta min_alloc_size, ensuring that relevant log lines are outputted when present.
 lternative Method to Verify min_alloc_size in RHCS 5 via OSD Boot Logs


