### PR TITLE
Enhancing the bluestore_min_alloc_size for printing of log lines for _open_super_meta min_alloc_size

### DIFF
--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -166,6 +166,12 @@ def run(ceph_cluster, **kw):
 
                 daemon_alloc_size_hdd = int(json_out["bluestore_min_alloc_size_hdd"])
                 daemon_alloc_size_ssd = int(json_out["bluestore_min_alloc_size_ssd"])
+                log.debug(
+                    f"Bluestore min alloc size hdd for daemon config show is: {daemon_alloc_size_hdd}"
+                )
+                log.debug(
+                    f"Bluestore min alloc size ssd for daemon config show is: {daemon_alloc_size_ssd}"
+                )
 
                 if not (
                     daemon_alloc_size_hdd
@@ -179,8 +185,6 @@ def run(ceph_cluster, **kw):
                     )
                     raise Exception("The output from ceph daemon is not as expected")
                 log.info("Ceph daemon is verified")
-
-                return 0
 
             mon_obj.set_config(
                 section="osd",
@@ -225,12 +229,43 @@ def run(ceph_cluster, **kw):
 
                 # Adding the removed OSD back and checking the cluster status
 
+                start_time, _ = test_host.exec_command(
+                    cmd="sudo date '+%Y-%m-%d %H:%M:%S'"
+                )
+
                 log.debug("Adding the removed OSD back and checking the cluster status")
                 utils.add_osd(ceph_cluster, test_host.hostname, dev_path, target_osd)
                 method_should_succeed(
                     wait_for_device_rados, test_host, target_osd, action="add"
                 )
                 time.sleep(30)
+
+                end_time, _ = test_host.exec_command(
+                    cmd="sudo date '+%Y-%m-%d %H:%M:%S'"
+                )
+
+                log_veri = rados_obj.get_journalctl_log(
+                    start_time=start_time,
+                    end_time=end_time,
+                    daemon_type="osd",
+                    daemon_id=target_osd,
+                )
+                log.debug(f"The log lines for the OSD: {target_osd} is :{log_veri}")
+
+                # If _open_super_meta min_alloc_size is found in the logs, print the log lines
+                if f"_open_super_meta min_alloc_size {hex(4096)}" in log_veri:
+                    log.info(
+                        f"Found '_open_super_meta min_alloc_size {hex(4096)}' in the logs for OSD {target_osd}"
+                    )
+                else:
+                    log.error(
+                        f"Error: '_open_super_meta min_alloc_size' not found in the logs for OSD {target_osd}"
+                    )
+                    raise Exception(
+                        f"Desired log '_open_super_meta min_alloc_size {hex(4096)}'"
+                        "not found for OSD {target_osd}"
+                    )
+
                 log.debug(
                     "Completed addition of OSD post removal. Checking bluestore_min_alloc_size value post OSD addition"
                 )
@@ -267,12 +302,12 @@ def run(ceph_cluster, **kw):
 
                 show_config_hdd = int(
                     mon_obj.show_config(
-                        daemon="osd", id=osd_id, param="bluestore_min_alloc_size_hdd"
+                        daemon="osd", id=rm_osd, param="bluestore_min_alloc_size_hdd"
                     )
                 )
                 show_config_ssd = int(
                     mon_obj.show_config(
-                        daemon="osd", id=osd_id, param="bluestore_min_alloc_size_ssd"
+                        daemon="osd", id=rm_osd, param="bluestore_min_alloc_size_ssd"
                     )
                 )
 
@@ -288,11 +323,17 @@ def run(ceph_cluster, **kw):
 
                 # determine osd's block device path
                 json_out = mon_obj.daemon_config_show(
-                    daemon_type="osd", daemon_id=osd_id
+                    daemon_type="osd", daemon_id=rm_osd
                 )
 
                 daemon_alloc_size_hdd = int(json_out["bluestore_min_alloc_size_hdd"])
                 daemon_alloc_size_ssd = int(json_out["bluestore_min_alloc_size_ssd"])
+                log.debug(
+                    f"Bluestore min alloc size hdd for daemon config show is: {daemon_alloc_size_hdd}"
+                )
+                log.debug(
+                    f"Bluestore min alloc size ssd for daemon config show is: {daemon_alloc_size_ssd}"
+                )
 
                 if not (
                     daemon_alloc_size_hdd


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2183485

1. Capture logs during the boot process using journalctl.
2. journalctl to capture and display the log lines during the OSD boot sequence.
3. Track OSD boot start and end timestamps.
4. The start and end times of the OSD boot process are recorded to ensure accurate log retrieval for the specified period.
5. Logs are retrieved and stored for later analysis, capturing important events during the OSD startup.
6. An if condition is added to specifically capture and log entries related to _open_super_meta min_alloc_size, ensuring that relevant log lines are outputted when present.

