### PR TITLE
[TFA-fix] Include rgw service deployment in baremetal execution

### DIFF
--- a/suites/squid/baremetal/deploy/rh/mero1_1admin_4node_4client.yaml
+++ b/suites/squid/baremetal/deploy/rh/mero1_1admin_4node_4client.yaml
@@ -77,6 +77,14 @@ tests:
               args:
                 - "ceph config set global osd_pool_default_pg_autoscale_mode on"
               command: shell
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: "Execute the cluster deployment workflow with label placement."
       destroy-cluster: false
       module: test_cephadm.py

--- a/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml
+++ b/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml
@@ -77,6 +77,14 @@ tests:
               args:
                 - "ceph config set global osd_pool_default_pg_autoscale_mode on"
               command: shell
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
       desc: "Execute the cluster deployment workflow with label placement."
       destroy-cluster: false
       module: test_cephadm.py

--- a/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
@@ -82,8 +82,8 @@ tests:
           - node5
           - node6
         rgw_endpoints:
-          - "node1:80"
-          - "node2:80"
+          - "node1:8080"
+          - "node2:8080"
       desc: "Configure HAproxy"
       module: haproxy.py
       name: "Configure HAproxy"


### PR DESCRIPTION
# Description
failure log: http://magna002.ceph.redhat.com/cephci-jenkins/results/baremetal/RH/8.0/rhel-9/19.2.0-59/rgw/48/ 

pass logs: 
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-QU4B65/
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-QU4B65/cluster_deployment_0.log
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-XNMVR2/


In cluster having conf:conf/baremetal/mero2_1admin_4node_4client.yaml  rgw service was not found, Since deployment suite had missed rgw service deployment
https://github.com/red-hat-storage/cephci/blob/main/suites/squid/baremetal/deploy/rh/mero_multisite_1admin_3node_along_client.yaml

[root@mero017 ~]# ceph orch ls
NAME                  PORTS                   RUNNING  REFRESHED  AGE  PLACEMENT
ingress.nfs.cephnfs   10.8.128.100:2049,9000      4/4  5m ago     2h   count:2
mds.cephfs                                        5/5  5m ago     3h   mero020;mero019;mero018;count:5
mds.cephfs-ec                                     2/2  5m ago     8h   mero019;mero018;count:2
mds.cephfs-pool-size                              2/2  2m ago     74m  count:2
mgr                                               3/3  5m ago     2d   label:mgr
mon                                               3/3  5m ago     2d   label:mon
nfs.cephfs-nfs        ?:2049                      1/1  5m ago     10h  mero020
nfs.cephnfs           ?:7007                      1/1  2m ago     89m  mero017;mero019;count:1
osd                                                44  5m ago     -    <unmanaged>
[root@mero017 ~]#

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
