### PR TITLE
Fixing upgrade mirror suite

### DIFF
--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_6x_to_8x.yaml
@@ -152,16 +152,6 @@ tests:
       module: test_client.py
       name: configure client
   - test:
-      abort-on-fail: true
-      desc: Configure CephFS Mirroring
-      clusters:
-        ceph1:
-          config:
-            name: Validate the Synchronisation is successful upon enabling fs mirroring
-      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
-      name: Validate the Synchronisation is successful upon enabling fs mirroring.
-      polarion-id: CEPH-83574099
-  - test:
       abort-on-fail: false
       desc: "Validate snapshot synchronisation perf improvements"
       clusters:
@@ -175,6 +165,17 @@ tests:
       name: Validate snapshot synchronisation perf improvements
       polarion-id: "CEPH-83595260"
   - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
+
+  - test:
       name: Upgrade along with IOs
       module: test_parallel.py
       parallel:
@@ -183,7 +184,7 @@ tests:
             config:
               timeout: 30
               client_upgrade: 1
-              client_upgrade_node: 'node8'
+              client_upgrade_node: 'node7'
             desc: Runs IOs in parallel with upgrade process
             module: cephfs_upgrade.cephfs_io.py
             name: "creation of Prerequisites for Upgrade"
@@ -208,7 +209,7 @@ tests:
                   verify_cluster_health: false
             destroy-cluster: false
       desc: Running upgrade, mds Failure and i/o's parallelly
-      abort-on-fail: true
+      abort-on-fail: false
   - test:
       abort-on-fail: false
       desc: Validate the Synchronisation is successful upon upgrade

--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_7x_to_8x.yaml
@@ -152,16 +152,6 @@ tests:
       module: test_client.py
       name: configure client
   - test:
-      abort-on-fail: true
-      desc: Configure CephFS Mirroring
-      clusters:
-        ceph1:
-          config:
-            name: Validate the Synchronisation is successful upon enabling fs mirroring
-      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
-      name: Validate the Synchronisation is successful upon enabling fs mirroring.
-      polarion-id: CEPH-83574099
-  - test:
       abort-on-fail: false
       desc: "Validate snapshot synchronisation perf improvements"
       clusters:
@@ -174,6 +164,16 @@ tests:
       module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
       name: Validate snapshot synchronisation perf improvements
       polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
   - test:
       name: Upgrade along with IOs
       module: test_parallel.py

--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_8x.yaml
@@ -152,16 +152,6 @@ tests:
       module: test_client.py
       name: configure client
   - test:
-      abort-on-fail: true
-      desc: Configure CephFS Mirroring
-      clusters:
-        ceph1:
-          config:
-            name: Validate the Synchronisation is successful upon enabling fs mirroring
-      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
-      name: Validate the Synchronisation is successful upon enabling fs mirroring.
-      polarion-id: CEPH-83574099
-  - test:
       abort-on-fail: false
       desc: "Validate snapshot synchronisation perf improvements"
       clusters:
@@ -174,6 +164,16 @@ tests:
       module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
       name: Validate snapshot synchronisation perf improvements
       polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
   - test:
       name: Upgrade along with IOs
       module: test_parallel.py

--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_ibm_7x_to_8x.yaml
@@ -152,16 +152,6 @@ tests:
       module: test_client.py
       name: configure client
   - test:
-      abort-on-fail: true
-      desc: Configure CephFS Mirroring
-      clusters:
-        ceph1:
-          config:
-            name: Validate the Synchronisation is successful upon enabling fs mirroring
-      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
-      name: Validate the Synchronisation is successful upon enabling fs mirroring.
-      polarion-id: CEPH-83574099
-  - test:
       abort-on-fail: false
       desc: "Validate snapshot synchronisation perf improvements"
       clusters:
@@ -174,6 +164,16 @@ tests:
       module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
       name: Validate snapshot synchronisation perf improvements
       polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
   - test:
       name: Upgrade along with IOs
       module: test_parallel.py
@@ -208,7 +208,7 @@ tests:
                   verify_cluster_health: false
             destroy-cluster: false
       desc: Running upgrade, mds Failure and i/o's parallelly
-      abort-on-fail: true
+      abort-on-fail: false
   - test:
       abort-on-fail: false
       desc: Validate the Synchronisation is successful upon upgrade

--- a/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_seq_6x_to_8x.yaml
+++ b/suites/squid/cephfs/tier-0_cephfs_mirrror_upgrade_seq_6x_to_8x.yaml
@@ -152,16 +152,6 @@ tests:
       module: test_client.py
       name: configure client
   - test:
-      abort-on-fail: true
-      desc: Configure CephFS Mirroring
-      clusters:
-        ceph1:
-          config:
-            name: Validate the Synchronisation is successful upon enabling fs mirroring
-      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
-      name: Validate the Synchronisation is successful upon enabling fs mirroring.
-      polarion-id: CEPH-83574099
-  - test:
       abort-on-fail: false
       desc: "Validate snapshot synchronisation perf improvements"
       clusters:
@@ -174,6 +164,16 @@ tests:
       module: cephfs_mirroring.snapdiff_perf_improvements_across_releases.py
       name: Validate snapshot synchronisation perf improvements
       polarion-id: "CEPH-83595260"
+  - test:
+      abort-on-fail: true
+      desc: Configure CephFS Mirroring
+      clusters:
+        ceph1:
+          config:
+            name: Validate the Synchronisation is successful upon enabling fs mirroring
+      module: cephfs_mirror_upgrade.configure_cephfs_mirroring.py
+      name: Validate the Synchronisation is successful upon enabling fs mirroring.
+      polarion-id: CEPH-83574099
   - test:
       name: Upgrade along with IOs
       module: test_parallel.py

--- a/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
+++ b/tests/cephfs/cephfs_mirroring/cephfs_mirroring_utils.py
@@ -634,6 +634,14 @@ class CephfsMirroringUtils(object):
             json.JSONDecodeError: If there's an error decoding JSON from the Ceph mirror status response.
         """
         log.info("Get peer mirror status")
+        daemon_names = self.get_daemon_name(self.source_clients[0])
+
+        asok_files = self.get_asok_file(cephfs_mirror_node, fsid, daemon_names)
+        log.info(f"Admin Socket file of cephfs-mirror daemon : {asok_files}")
+        filesystem_id = self.get_filesystem_id_by_name(self.source_clients[0], fs_name)
+        log.info(f"filesystem id of {fs_name} is : {filesystem_id}")
+        peer_uuid = self.get_peer_uuid_by_name(self.source_clients[0], fs_name)
+        log.info(f"peer uuid of {fs_name} is : {peer_uuid}")
         for node, asok in asok_file.items():
             asok[0].exec_command(
                 sudo=True, cmd="dnf install -y ceph-common --nogpgcheck"


### PR DESCRIPTION
# Description
Fixing upgrade mirror suite

**Problem:**
Recently, we introduced test cases to evaluate the performance of mirroring in both the current and upgraded builds. During these tests, we remove the mirror setup, which leads to issues when validating the status after the upgrade.

**Solution:**
To resolve this, we have repositioned the test case that collects mirror statistics to the beginning of the process. Now, we first gather the initial stats, then configure the mirror, proceed with the upgrade, and finally collect the mirror stats again post-upgrade. This ensures a more accurate validation of the mirroring functionality.

Logs : http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-O3YF8K/ 

Failed Log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/8.0/rhel-9/Upgrade/19.2.0-58/54/tier-0_cephfs_mirrror_upgrade_ibm_6x_to_8x/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
