### PR TITLE
Adhering to change in behavior for mirror token creation

### DIFF
--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_info.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_info.py
@@ -91,14 +91,14 @@ def run(ceph_cluster, **kw):
             long_running=True,
         )
         fs_volume_info_dict = fs_util.collect_fs_volume_info_for_validation(
-            client1, volume_name, human_readable=True
+            client1, volume_name, human_readable=False
         )
 
         assert (
-            fs_volume_info_dict["data_used"].strip() != "0"
+            fs_volume_info_dict["data_used"] != 0
         ), "Used size should reflect data written"
         log.info(
-            f"Verified: Data write reflected in used size. {fs_volume_info_dict['data_used'].strip()}"
+            f"Verified: Data write reflected in used size. {fs_volume_info_dict['data_used']}"
         )
 
         log.info("Step 4: Create Subvolume Group and Add Subvolumes")
@@ -126,13 +126,13 @@ def run(ceph_cluster, **kw):
             long_running=True,
         )
         volume_info = fs_util.collect_fs_volume_info_for_validation(
-            client1, volume_name, human_readable=True
+            client1, volume_name, human_readable=False
         )
-        data_pool_used_kernel = volume_info["data_used"].strip()
+        data_pool_used_kernel = volume_info["data_used"]
         log.info(volume_info)
         assert (
-            data_pool_used_kernel > fs_volume_info_dict["data_used"].strip()
-        ), f"Used size should reflect data written {fs_volume_info_dict['data_used'].strip()}"
+            data_pool_used_kernel > fs_volume_info_dict["data_used"]
+        ), f"Used size should reflect data written {fs_volume_info_dict['data_used']}"
 
         log.info("Step 5: Delete Subvolumes and Validate Usage During Deletion")
         fs_util.remove_subvolume(client1, volume_name, subvolume_name, validate=False)


### PR DESCRIPTION
# Description
Adhering to change in behavior for mirror token creation 
**Problem :** 
According to [Bugzilla #2304288](https://bugzilla.redhat.com/show_bug.cgi?id=2304288), there is a change in behavior from the previous build to Squid.

**Solution:**
To address this, we have added an additional -n option when creating the token for users with read (r), read-write (rw), or read-write-plus (rwp) permissions to MDS. The token creation should now fail for these users as expected.

Logs :  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-UP346E/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
