### PR TITLE
[RADOS] TFA fix for OSD superblock redundancy false failure

### DIFF
--- a/tests/rados/test_osd_superblock.py
+++ b/tests/rados/test_osd_superblock.py
@@ -78,7 +78,7 @@ def run(ceph_cluster, **kw):
                 osd_id=osd_id, pgid="meta", obj="osd_superblock", key="osd_superblock"
             )
             log.info(f"osd_superblock OMAP data: \n {out}")
-        except UnicodeDecodeError:
+        except Exception:
             log.info("OMAP content not in utf-8 encoding, skipping logging")
 
         # create a garbage file to corrupt osd_superblock object


### PR DESCRIPTION
# Description

Sleep time provided during OSD restart was not enough to let the OSD boot up, so before OSD could start, we were trying to execute the next desired command using ceph-bluestore-tool through CBT automated module. The CBT run command stops the OSDs and then proceeds to the run the command, but when it tries to stop the OSD, it finds that OSD is already in `stopped` state because it is yet to boot up after `systemctl restart` has been triggered, now by the time the actual command gets executed, OSD is UP and therefore the execution fails as OSD is supposed to be in `stopped` state.

Pass logs -
Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-GBYAHU
Squid:

Signed-off-by: Harsh Kumar <hakumar@redhat.com>