### PR TITLE
Add cluster configuration for replication regression suites

### DIFF
--- a/conf/squid/common/5node-1client-ecpool-replica1.yaml
+++ b/conf/squid/common/5node-1client-ecpool-replica1.yaml
@@ -1,0 +1,53 @@
+# Test Suite to test EC 8+6 MSR pool on 4 nodes + replica1 cluster
+# Deployment for all the ceph daemons , with 3 mon, 3 mgr, 24 OSD, 3 MDS, 3 RGW daemons
+globals:
+  - ceph-cluster:
+      name: ceph
+      node1:
+          role:
+            - _admin
+            - installer
+            - osd
+            - mon
+            - mgr
+            - rgw
+          no-of-volumes: 6
+          disk-size: 15
+      node2:
+          role:
+            - mgr
+            - rgw
+            - mon
+            - osd
+            - mds
+            - _admin
+            - prometheus
+          no-of-volumes: 6
+          disk-size: 15
+      node3:
+          role:
+            - mds
+            - mon
+            - mgr
+            - grafana
+            - osd
+          no-of-volumes: 6
+          disk-size: 15
+      node4:
+          role:
+            - osd
+            - rgw
+            - mds
+            - node-exporter
+            - alertmanager
+          no-of-volumes: 6
+          disk-size: 15
+      node5:
+        role:
+          - _admin
+          - osd-bak
+        no-of-volumes: 6
+        disk-size: 15
+      node6:
+        role:
+          - client

--- a/suites/squid/common/regression/ecpool-replica1-deploy-and-configure.yaml
+++ b/suites/squid/common/regression/ecpool-replica1-deploy-and-configure.yaml
@@ -1,0 +1,129 @@
+# Deployment for Ceph cluster across 5 nodes & 1 client
+# conf: conf/squid/common/5-node-1client-ecpool-replica1.yaml
+tests:
+  - test:
+      name: setup install pre-requisites
+      desc: Setup phase to deploy the required pre-requisites for running the tests.
+      module: install_prereq.py
+      abort-on-fail: true
+
+  - test:
+      name: cluster deployment
+      desc: Execute the cluster deployment workflow.
+      module: test_cephadm.py
+      polarion-id:
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              base_cmd_args:
+                verbose: true
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                nodes:
+                  - node1
+                  - node2
+                  - node3
+                  - node4
+                attach_ip_address: true
+                labels: apply-all-labels
+
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+
+          - config:
+              command: shell
+              args:          # arguments to ceph orch
+                - ceph
+                - fs
+                - volume
+                - create
+                - cephfs
+
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+
+          - config:
+              command: apply
+              service: mds
+              base_cmd_args:          # arguments to ceph orch
+                verbose: true
+              pos_args:
+                - cephfs              # name of the filesystem
+              args:
+                placement:
+                  nodes:
+                    - node2
+                    - node3
+                  limit: 2            # no of daemons
+                  sep: " "            # separator to be used for placements
+      destroy-cluster: false
+      abort-on-fail: true
+
+  - test:
+      name: Configure client admin
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        node: node6                       # client node
+        install_packages:
+          - ceph-common
+          - ceph-base
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps:                             # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+


### PR DESCRIPTION
Have kept the conf file same that'd be used for EC pool and replica1 - https://github.com/red-hat-storage/cephci/blob/main/conf/squid/rados/4-node-ec-cluster-1-client.yaml

run.py with both of these files was successful

```
TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
setup install pre-requisites     Setup phase to deploy the required pre-requisites for runnin   0:07:33.958708                   Pass                             
cluster deployment               Execute the cluster deployment workflow.                       0:18:32.148327                   Pass                             
Configure client admin           Configures client admin node on cluster                        0:01:07.172940                   Pass                             
Set configs for 4 node cluster   Set configs for 4 node cluster                                 0:00:11.055796                   Pass      
```                       


