### PR TITLE
[TFA] Fix for monitoring services deployment failure in rgw_ibm_ssl_ms_upgrade suites.

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
@@ -31,6 +31,8 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -80,6 +82,8 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_ibm_ssl_multisite_upgrade_61GA_to_71x_latest.yaml
@@ -31,7 +31,6 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
-                    orphan-initial-daemons: true
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -82,7 +81,6 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
-                    orphan-initial-daemons: true
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts

--- a/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
@@ -31,6 +31,8 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -80,6 +82,8 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    orphan-initial-daemons: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm_ssl_ms_upgrade_71GA_to_8x_latest.yaml
@@ -31,7 +31,6 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
-                    orphan-initial-daemons: true
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts
@@ -82,7 +81,6 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
-                    orphan-initial-daemons: true
                     skip-monitoring-stack: true
               - config:
                   command: add_hosts


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
 https://issues.redhat.com/browse/RHCEPHQE-17753
REEF pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/monitoring_services16/
SQUID pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/monitoring_services22/