### PR TITLE
[TFA] fix alloc size value in min_alloc_size validation

### DIFF
--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -253,16 +253,16 @@ def run(ceph_cluster, **kw):
                 log.debug(f"The log lines for the OSD: {target_osd} is :{log_veri}")
 
                 # If _open_super_meta min_alloc_size is found in the logs, print the log lines
-                if f"_open_super_meta min_alloc_size {hex(4096)}" in log_veri:
+                if f"_open_super_meta min_alloc_size {hex(alloc_size)}" in log_veri:
                     log.info(
-                        f"Found '_open_super_meta min_alloc_size {hex(4096)}' in the logs for OSD {target_osd}"
+                        f"Found '_open_super_meta min_alloc_size {hex(alloc_size)}' in the logs for OSD {target_osd}"
                     )
                 else:
                     log.error(
                         f"Error: '_open_super_meta min_alloc_size' not found in the logs for OSD {target_osd}"
                     )
                     raise Exception(
-                        f"Desired log '_open_super_meta min_alloc_size {hex(4096)}'"
+                        f"Desired log '_open_super_meta min_alloc_size {hex(alloc_size)}'"
                         "not found for OSD {target_osd}"
                     )
 


### PR DESCRIPTION
[TFA] 

Suite: suites/squid/rados/tier-2_rados_test_parameters.yaml
Test: Ceph bluestore_min_alloc_size tests
Magna:  http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-297/rados/27/tier-2_rados_test_parameters/Ceph_bluestore_min_alloc_size_tests_1.log
Error: 
`2025-02-09 05:15:08,988 - cephci - test_bluestore_min_alloc_size:261 - ERROR - Error: '_open_super_meta min_alloc_size' not found in the logs for OSD 6
2025-02-09 05:15:08,988 - cephci - test_bluestore_min_alloc_size:384 - ERROR - Hit Exception during OSD redeployment : Desired log '_open_super_meta min_alloc_size 0x1000'not found for OSD {target_osd}`


Fix:
test case failing because validation with hex of 8k , and validation is set with hex(4k) value 
Update validation method hex(4096) with alloc_size variable.

Pass logs:  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-VMDFV0 

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
