### PR TITLE
ceph-ci Integration of DBR feature disabel at archive zone

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -345,3 +345,14 @@ tests:
       polarion-id: CEPH-83581990
       module: sanity_rgw_multisite.py
       name: Test LC on active for objects size expiration
+
+  - test:
+      clusters:
+         ceph-arc:
+          config:
+            script-name: test_dynamic_bucket_resharding.py
+            config-file-name: test_resharding_disable_in_archive_zone.yaml
+      desc: Test DBR feature disabel at archive zone
+      polarion-id: CEPH-83573390
+      module: sanity_rgw_multisite.py
+      name: Test DBR feature disabel at archive zone

--- a/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
@@ -346,3 +346,14 @@ tests:
       polarion-id: CEPH-83581990
       module: sanity_rgw_multisite.py
       name: Test LC on active for objects size expiration
+
+  - test:
+      clusters:
+         ceph-arc:
+          config:
+            script-name: test_dynamic_bucket_resharding.py
+            config-file-name: test_resharding_disable_in_archive_zone.yaml
+      desc: Test DBR feature disabel at archive zone
+      polarion-id: CEPH-83573390
+      module: sanity_rgw_multisite.py
+      name: Test DBR feature disabel at archive zone


### PR DESCRIPTION
# Description
ceph-ci Integration of DBR feature disabel at archive zone

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-GZUWZG/

depends on PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/673


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
