### PR TITLE
Skip monitoring stack deployment

### DIFF
--- a/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
+++ b/suites/pacific/rgw/tier-1-extn_rgw_multisite-secondary-to-primary.yaml
@@ -32,6 +32,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -77,6 +78,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-sync-policy-from-primary.yaml
@@ -32,6 +32,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -77,6 +78,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -29,6 +29,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -74,6 +75,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/squid/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/squid/rgw/tier-1_rgw_multisite.yaml
@@ -31,6 +31,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,6 +77,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -31,6 +31,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,6 +77,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host


### PR DESCRIPTION
# Description

Added skip-monitoring-stack: true while bootstrapping for Pacific and squid suite files.
pass log: http://magna002.ceph.redhat.com/cephci-jenkins/mreddem/cephci-run-768WCE/

issue: https://issues.redhat.com/browse/RHCEPHQE-17933

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
