### PR TITLE
integrating rgw public-access-block tests into cephci

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_regression.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_regression.yaml
@@ -934,3 +934,49 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_process_without_applying_rule.yaml
+
+
+  # test customer RFE: Public access block
+
+  - test:
+      name: test public access block pre bucket policy
+      desc: test public access block pre bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_pre_bucket_policy.yaml
+  - test:
+      name: test public access block post bucket policy
+      desc: test public access block post bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_post_bucket_policy.yaml
+  - test:
+      name: test public access block - BlockPublicAcls
+      desc: test public access block - BlockPublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_acl.yaml
+      comments: known issue - Bug 2344639
+  - test:
+      name: test public access block - IgnorePublicAcls
+      desc: test public access block - IgnorePublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_ignore_acl.yaml
+  - test:
+      name: test public access block - RestrictPublicBuckets
+      desc: test public access block - RestrictPublicBuckets
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_restricted_public_buckets.yaml
+      comments: known issue - Bug 2344730

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -668,3 +668,49 @@ tests:
       config:
         script-name: user_create.py
         config-file-name: test_user_modify_with_placementid.yaml
+
+
+  # test customer RFE: Public access block
+
+  - test:
+      name: test public access block pre bucket policy
+      desc: test public access block pre bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_pre_bucket_policy.yaml
+  - test:
+      name: test public access block post bucket policy
+      desc: test public access block post bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_post_bucket_policy.yaml
+  - test:
+      name: test public access block - BlockPublicAcls
+      desc: test public access block - BlockPublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_acl.yaml
+      comments: known issue - Bug 2344639
+  - test:
+      name: test public access block - IgnorePublicAcls
+      desc: test public access block - IgnorePublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_ignore_acl.yaml
+  - test:
+      name: test public access block - RestrictPublicBuckets
+      desc: test public access block - RestrictPublicBuckets
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_restricted_public_buckets.yaml
+      comments: known issue - Bug 2344730

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -310,3 +310,49 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_multipart_upload_with_tagging.yaml
+
+
+  # test customer RFE: Public access block
+
+  - test:
+      name: test public access block pre bucket policy
+      desc: test public access block pre bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_pre_bucket_policy.yaml
+  - test:
+      name: test public access block post bucket policy
+      desc: test public access block post bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_post_bucket_policy.yaml
+  - test:
+      name: test public access block - BlockPublicAcls
+      desc: test public access block - BlockPublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_acl.yaml
+      comments: known issue - Bug 2344639
+  - test:
+      name: test public access block - IgnorePublicAcls
+      desc: test public access block - IgnorePublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_ignore_acl.yaml
+  - test:
+      name: test public access block - RestrictPublicBuckets
+      desc: test public access block - RestrictPublicBuckets
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_restricted_public_buckets.yaml
+      comments: known issue - Bug 2344730

--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -314,3 +314,49 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_multipart_upload_with_tagging.yaml
+
+
+  # test customer RFE: Public access block
+
+  - test:
+      name: test public access block pre bucket policy
+      desc: test public access block pre bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_pre_bucket_policy.yaml
+  - test:
+      name: test public access block post bucket policy
+      desc: test public access block post bucket policy
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_post_bucket_policy.yaml
+  - test:
+      name: test public access block - BlockPublicAcls
+      desc: test public access block - BlockPublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_acl.yaml
+      comments: known issue - Bug 2344639
+  - test:
+      name: test public access block - IgnorePublicAcls
+      desc: test public access block - IgnorePublicAcls
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_ignore_acl.yaml
+  - test:
+      name: test public access block - RestrictPublicBuckets
+      desc: test public access block - RestrictPublicBuckets
+      polarion-id: CEPH-83575582
+      module: sanity_rgw.py
+      config:
+        script-name: test_bucket_policy_ops.py
+        config-file-name: test_public_access_block_restricted_public_buckets.yaml
+      comments: known issue - Bug 2344730


### PR DESCRIPTION
depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/672

customer bz: https://bugzilla.redhat.com/show_bug.cgi?id=2064260
polarion: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575582

pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_public_access_block/cephci-run-IRSNWO/

failures are product bugs, filed below bz's for them:
[Bug 2344639](https://bugzilla.redhat.com/show_bug.cgi?id=2344639) - [rgw] public-access-block with BlockPublicAcls set on a Bucket is denying normal object upload without any public-acl in the request

[Bug 2344730](https://bugzilla.redhat.com/show_bug.cgi?id=2344730) - [rgw] public-access-block with RestrictPublicBuckets set and then bucket policy with public access set on a bucket is still allowing anonymous public access to the bucket





# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
