### PR TITLE
TFA fix for iozone setup failure in fsutilsV1

### DIFF
--- a/tests/cephfs/cephfs_IO_lib.py
+++ b/tests/cephfs/cephfs_IO_lib.py
@@ -220,7 +220,7 @@ class FSIO(object):
                     if iozone_params.get(io_param):
                         io_params[io_param] = iozone_params[io_param]
 
-            iozone_path = "/home/cephuser/iozone3_506/src/current/iozone"
+            iozone_path = "iozone"
             iozone_cmd = f"{iozone_path} -a"
             if io_params["throughput_test"]:
                 iozone_cmd = f"{iozone_path} -t {io_params['threads']}"

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -85,7 +85,6 @@ class FsUtils(object):
                     client=self.clients[0]
                 )  # daemons_value will use the default value
 
-    @retry(CommandFailed, tries=3, delay=60)
     def prepare_clients(self, clients, build):
         """
         Installs all the required rpms and clones the tools required for running Tests on clients
@@ -128,9 +127,15 @@ class FsUtils(object):
                     cmd="git clone https://github.com/bengland2/smallfile.git"
                 )
             if "iozone" not in out:
-                cmd = "cd /home/cephuser;wget http://www.iozone.org/src/current/iozone3_506.tar;"
-                cmd += "tar xvf iozone3_506.tar;cd iozone3_506/src/current/;make;make linux"
-                client.node.exec_command(cmd=cmd)
+                cmd_list = [
+                    "cd /home/cephuser;wget http://www.iozone.org/src/current/iozone3_506.tar;",
+                    "cd /home/cephuser;tar xvf iozone3_506.tar",
+                    "sudo yum install make -y --nogpgcheck",
+                    "cd /home/cephuser/iozone3_506/src/current/;make;make linux",
+                    "export PATH=$PATH:/home/cephuser/iozone3_506/src/current/",
+                ]
+                for cmd in cmd_list:
+                    client.node.exec_command(cmd=cmd)
             out, rc = client.node.exec_command(
                 sudo=True, cmd="rpm -qa | grep -w 'dbench'", check_ec=False
             )


### PR DESCRIPTION
# Description

Jira: https://issues.redhat.com/browse/RHCEPHQE-17985

Failure was due to make not installed by default on rhel-8, added cmd to install make before running it.

Failed logs:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-EVV2AV
Passed logs with fix: 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-AFD2Q5 

squid/rhel-9 passed logs with fix:
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-G9E05O/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
