### PR TITLE
[cephci] Integration of polarion id CEPH-9337 and CEPH-9336

### DIFF
--- a/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
@@ -122,3 +122,21 @@ tests:
       config:
         script-name: ../curl/test_rgw_using_curl.py
         config-file-name: ../../curl/configs/test_rgw_using_curl.yaml
+
+  - test:
+      name: test storage policy to use customized placement for S3
+      desc: Test storage policy to use customized placement for S3
+      polarion-id: CEPH-9337
+      module: sanity_rgw.py
+      config:
+        script-name: test_storage_policy.py
+        config-file-name: test_storage_policy_s3.yaml
+
+  - test:
+      name: test storage policy to use customized placement for Swift
+      desc: Test storage policy to use customized placement for Swift
+      polarion-id: CEPH-9336
+      module: sanity_rgw.py
+      config:
+        script-name: test_storage_policy.py
+        config-file-name: test_storage_policy_swift.yaml

--- a/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
@@ -198,3 +198,21 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+
+  - test:
+      name: test storage policy to use customized placement for S3
+      desc: Test storage policy to use customized placement for S3
+      polarion-id: CEPH-9337
+      module: sanity_rgw.py
+      config:
+        script-name: test_storage_policy.py
+        config-file-name: test_storage_policy_s3.yaml
+
+  - test:
+      name: test storage policy to use customized placement for Swift
+      desc: Test storage policy to use customized placement for Swift
+      polarion-id: CEPH-9336
+      module: sanity_rgw.py
+      config:
+        script-name: test_storage_policy.py
+        config-file-name: test_storage_policy_swift.yaml


### PR DESCRIPTION
# Description
dependent on pr: https://github.com/red-hat-storage/ceph-qe-scripts/pull/677
log: 
     complete log:  http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-DINRDW/
     s3 log:  http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-DINRDW/test_storage_policy_to_use_customized_placement_for_S3_0.log
     swift log:  http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-DINRDW/test_storage_policy_to_use_customized_placement_for_Swift_0.log


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
