### PR TITLE
[RBD] rename version to upstream main branches

### DIFF
--- a/suites/pacific/integrations/cvp.yaml
+++ b/suites/pacific/integrations/cvp.yaml
@@ -102,7 +102,7 @@ tests:
         - test:
             desc: "Testing rbd CLI Generic scenarios using unit-tests."
             config:
-              branch: v16.2.8
+              branch: pacific
               script_path: qa/workunits/rbd
               script: cli_generic.sh
             module: test_rbd.py

--- a/suites/pacific/interop/test-ceph-sanity.yaml
+++ b/suites/pacific/interop/test-ceph-sanity.yaml
@@ -109,7 +109,7 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: v16.2.8
+              branch: pacific
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/suites/quincy/integrations/cvp.yaml
+++ b/suites/quincy/integrations/cvp.yaml
@@ -102,7 +102,7 @@ tests:
         - test:
             desc: "Testing rbd CLI Generic scenarios using unit-tests."
             config:
-              branch: v17.2.3
+              branch: quincy
               script_path: qa/workunits/rbd
               script: cli_generic.sh
             module: test_rbd.py

--- a/suites/quincy/interop/test-ceph-sanity.yaml
+++ b/suites/quincy/interop/test-ceph-sanity.yaml
@@ -109,7 +109,7 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: v16.2.8
+              branch: quincy
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/suites/reef/interop/test-ceph-sanity.yaml
+++ b/suites/reef/interop/test-ceph-sanity.yaml
@@ -109,7 +109,7 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: v16.2.8
+              branch: reef
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"

--- a/suites/squid/interop/test-ceph-sanity.yaml
+++ b/suites/squid/interop/test-ceph-sanity.yaml
@@ -109,7 +109,7 @@ tests:
             polarion-id: CEPH-9789
         - test:
             config:
-              branch: v16.2.8
+              branch: squid
               script: cli_generic.sh
               script_path: qa/workunits/rbd
             desc: "Executing upstream RBD CLI Generic scenarios"


### PR DESCRIPTION
# Description
https://jenkins-csb-interopqe-main.dno.corp.redhat.com/job/RhelLayeredProducts/job/ceph-8.0-rhel-9-stage/3/artifact/.results/artifacts/ceph-driver-mdunn-9z4ii/cephci-run-DA3VBM/Executes_RGW,_RBD_and_FS_operations_0.log
Due to regex issue above interop test got failed,

It's been fixed under
https://github.com/ceph/ceph/commit/e5c3dd391c84d6d9c25bcf9278c402c664e164c1

hence it's good to use upstream main release branch for upsream test compare to version branch.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
