### PR TITLE
[TFA] Stretch mode mon placement causing test_stretch_Cluster_site_down_-_Data_site test case

### DIFF
--- a/conf/reef/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/reef/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -46,6 +46,8 @@ globals:
         networks:
           - provider_net_cci_15
         role:
+          - mon
+          - mgr
           - osd
           - nfs
         no-of-volumes: 4
@@ -97,8 +99,6 @@ globals:
         networks:
           - provider_net_cci_15
         role:
-          - mon
-          - mgr
           - osd
         no-of-volumes: 4
         disk-size: 15

--- a/conf/reef/rados/13-node-cluster-4-clients.yaml
+++ b/conf/reef/rados/13-node-cluster-4-clients.yaml
@@ -46,6 +46,8 @@ globals:
         networks:
           - shared_net_15
         role:
+          - mon
+          - mgr
           - osd
           - nfs
         no-of-volumes: 4
@@ -94,8 +96,6 @@ globals:
         networks:
           - shared_net_15
         role:
-          - mon
-          - mgr
           - osd
         no-of-volumes: 4
         disk-size: 15

--- a/conf/squid/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -46,6 +46,8 @@ globals:
         networks:
           - provider_net_cci_15
         role:
+          - mon
+          - mgr
           - osd
           - nfs
         no-of-volumes: 4
@@ -94,8 +96,6 @@ globals:
         networks:
           - provider_net_cci_15
         role:
-          - mon
-          - mgr
           - osd
         no-of-volumes: 4
         disk-size: 15

--- a/conf/squid/rados/13-node-cluster-4-clients.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients.yaml
@@ -46,6 +46,8 @@ globals:
         networks:
           - shared_net_15
         role:
+          - mon
+          - mgr
           - osd
           - nfs
         no-of-volumes: 4
@@ -94,8 +96,6 @@ globals:
         networks:
           - shared_net_15
         role:
-          - mon
-          - mgr
           - osd
         no-of-volumes: 4
         disk-size: 15


### PR DESCRIPTION
Issue:- 1 Mon placement in DC1 and 3 Mon placement in DC2 caused issued with test case for site down. 
Fix: To update 2 Mons in DC1 and 2 mons in DC2.

Issue link: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-79/rados/68/tier-3_rados_test-location-stretch-mode/test_stretch_Cluster_site_down_-_Data_site_0.log 

Pacific and quincy uses different conf:- conf/pacific/rados/stretch-mode-host-location-attrs.yaml 
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
