### PR TITLE
Test Metadata sync fairness with a large number of user creation

### DIFF
--- a/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
+++ b/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
@@ -89,6 +89,19 @@ tests:
       polarion-id: CEPH-83575382
 
   - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_Mbuckets_with_Nobjects_sync_fairness.yaml
+            verify-io-on-site: ["ceph-sec"]
+      desc: Test metadata sync fairness
+      module: sanity_rgw_multisite.py
+      name: Test metadata sync fairness
+      polarion-id: CEPH-83575843
+
+  - test:
       clusters:
         ceph-pri:
           config:


### PR DESCRIPTION
Steps :
add a large number of users each having 1 bucket to create a huge metadata backlog. With the recent sync fairness changes for metadata, this metadata should be synced quickly.

Polarion ID : CEPH-83575843

Pass log : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/sync_fairness.txt

This test was executed on a VM environment , and we can see that it was successful 