### PR TITLE
Rearranged the sequence to prioritize non-disruptive tests 

### DIFF
--- a/suites/squid/cephfs/tier-4_cephfs_system.yaml
+++ b/suites/squid/cephfs/tier-4_cephfs_system.yaml
@@ -149,6 +149,18 @@ tests:
           "filesystem": "cephfs_1"
           "mount_dir": ""
   - test:
+        abort-on-fail: false
+        desc: "MDS admin socket dump testing"
+        module: cephfs_system.mds_admin_daemon_socket_dump.py
+        polarion-id: CEPH-83572891
+        name: "MDS admin socket dump testing"
+  - test:
+        abort-on-fail: false
+        desc: "MDS admin socket perf flush log testing"
+        module: cephfs_system.mds_admin_daemon_socket_perf_flush_log.py
+        polarion-id: CEPH-83572890
+        name: "MDS admin socket perf flush log testing"
+  - test:
       abort-on-fail: false
       desc: "MON node power failure, with client IO"
       module: cephfs_system.mon_failure_with_client_IO.py
@@ -226,18 +238,6 @@ tests:
       module: cephfs_system.mds_shutdown_together_io_continue.py
       polarion-id: CEPH-11240
       name: "mds_shutdown_together_io_continue.py"
-  - test:
-      abort-on-fail: false
-      desc: "MDS admin socket dump testing"
-      module: cephfs_system.mds_admin_daemon_socket_dump.py
-      polarion-id: CEPH-83572891
-      name: "MDS admin socket dump testing"
-  - test:
-      abort-on-fail: false
-      desc: "MDS admin socket perf flush log testing"
-      module: cephfs_system.mds_admin_daemon_socket_perf_flush_log.py
-      polarion-id: CEPH-83572890
-      name: "MDS admin socket perf flush log testing"
   - test:
       abort-on-fail: false
       desc: "StandbyReplay MDS node failures ops with client IO"


### PR DESCRIPTION
Rearranged the sequence to prioritize non-disruptive tests at the beginning.

Testing could not be performed due to insufficient space in RHOS-D. 
It will be included in the upcoming weekly test runs.

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
