### PR TITLE
Reverting the registry conf changes

### DIFF
--- a/tests/misc_env/install_prereq.py
+++ b/tests/misc_env/install_prereq.py
@@ -423,15 +423,6 @@ def registry_login(ceph, distro_ver):
     auths_dict = {"auths": auths}
     ceph.exec_command(sudo=True, cmd="mkdir -p ~/.docker")
     ceph.exec_command(cmd="mkdir -p ~/.docker")
-    ceph.exec_command(
-        cmd=(
-            "echo -e '\\n[[registry]]\\n"
-            'location = "registry-proxy.engineering.redhat.com"\\n'
-            "insecure = true\\n"
-            "ibm-build = true' | sudo tee -a /etc/containers/registries.conf"
-        )
-    )
-
     auths_file_sudo = ceph.remote_file(
         sudo=True, file_name="/root/.docker/config.json", file_mode="w"
     )


### PR DESCRIPTION
# Description

Reverting the registry conf changes 
Revert of https://github.com/red-hat-storage/cephci/pull/4426  


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
