### PR TITLE
[TFA] Fix reef client configuration issue due to ceph-base package

### DIFF
--- a/conf/reef/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/reef/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -60,9 +60,6 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node7:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_16
         role:
@@ -126,25 +123,16 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node15:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_16
         role:
           - client
       node16:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_13
         role:
           - client
       node17:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_13
         role:

--- a/conf/reef/rados/13-node-cluster-4-clients.yaml
+++ b/conf/reef/rados/13-node-cluster-4-clients.yaml
@@ -123,25 +123,16 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node15:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_2
         role:
           - client
       node16:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_5
         role:
           - client
       node17:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_5
         role:


### PR DESCRIPTION
Issue: Client configuration failing in reef due to issue in ceph-base package installation. Package selinux-policy-base >= 38.1.45-3.el9_5 not present in OS version RHEL-9.4.0-x86_64-ga-latest.

magna failures: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/7.1/rhel-9/Regression/18.2.1-294/rados/26/tier-3_rados_test-location-stretch-mode/Configure_client_admin_0.log  

Error: 
`2025-02-07 01:52:02,979 - cephci - run:854 - ERROR - yum install -y --nogpgcheck ceph-base returned Error: 
 Problem: package ceph-base-2:18.2.1-294.el9cp.x86_64 from ceph-Tools requires ceph-selinux = 2:18.2.1-294.el9cp, but none of the providers can be installed
  - conflicting requests
  - nothing provides selinux-policy-base >= 38.1.45-3.el9_5 needed by ceph-selinux-2:18.2.1-294.el9cp.x86_64 from ceph-Tools`
 
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
