### PR TITLE
Updated multisite suites for package installation

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -286,7 +286,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml

--- a/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_singlesite_to_multisite.yaml
@@ -519,7 +519,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_with_tenant_user.yaml

--- a/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_ms_test-bucket-notifications.yaml
@@ -272,7 +272,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml

--- a/suites/reef/rgw/sanity_rgw_multisite.yaml
+++ b/suites/reef/rgw/sanity_rgw_multisite.yaml
@@ -429,7 +429,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml

--- a/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms-archive.yaml
@@ -310,7 +310,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka_archive: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml

--- a/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -460,7 +460,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml

--- a/suites/reef/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
@@ -225,7 +225,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml

--- a/suites/squid/rgw/sanity_rgw_multisite.yaml
+++ b/suites/squid/rgw/sanity_rgw_multisite.yaml
@@ -363,7 +363,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml

--- a/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms-archive.yaml
@@ -311,7 +311,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka_archive: true
             script-name: test_bucket_notifications.py
             config-file-name: test_bucket_notification_kafka_broker_ms_replication_from_pri.yaml

--- a/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_async_data_notification.yaml
@@ -426,7 +426,7 @@ tests:
           config:
             run-on-rgw: true
             extra-pkgs:
-              - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+              - jdk
             install_start_kafka: true
             script-name: test_bucket_notifications.py
             config-file-name: test_sse_s3_per_bucket_with_notifications_dynamic_reshard.yaml

--- a/suites/squid/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_test_bucket_notifications.yaml
@@ -227,7 +227,7 @@ tests:
       config:
         run-on-rgw: true
         extra-pkgs:
-          - wget https://download.oracle.com/java/23/latest/jdk-23_linux-x64_bin.rpm
+          - jdk
         install_start_kafka: true
         script-name: test_bucket_notifications.py
         config-file-name: test_bucket_notification_kafka_broker_persistent_copy.yaml

--- a/tests/rgw/sanity_rgw_multisite.py
+++ b/tests/rgw/sanity_rgw_multisite.py
@@ -206,19 +206,19 @@ def run(**kw):
     lib_dir = TEST_DIR[test_version]["lib"]
     timeout = config.get("timeout", 3600)
     # install extra package which are test specific
-    distro_version_id = primary_rgw_node.distro_info["VERSION_ID"]
     if extra_pkgs:
         log.info(f"got extra pkgs: {extra_pkgs}")
-        if isinstance(extra_pkgs, dict):
-            _pkgs = extra_pkgs.get(int(distro_version_id[0]))
-            pkgs = " ".join(_pkgs)
-        else:
-            pkgs = " ".join(extra_pkgs)
-
-        exec_from.exec_command(
-            sudo=True, cmd=f"yum install -y {pkgs}", long_running=True
-        )
-
+        package_path = "/root/rgw_rpms"
+        for pkg in extra_pkgs:
+            exit_status = exec_from.exec_command(
+                sudo=True,
+                cmd=f"yum install -y {package_path}/{pkg}.rpm",
+                long_running=True,
+            )
+            if exit_status != 0:
+                exec_from.exec_command(
+                    sudo=True, cmd=f"yum install -y {pkg}", long_running=True
+                )
     log.info("flushing iptables")
     exec_from.exec_command(cmd="sudo iptables -F", check_ec=False)
 


### PR DESCRIPTION
# Description

Updated the code to download the jdk and oathtool packages via curl for local installation, while the jq package is installed directly.

pass log for jq - http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-1WFAC7/
jdk - http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-5NDXS1/

issue: https://issues.redhat.com/browse/RHCEPHQE-17703
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
