### PR TITLE
adding rename scenario in tier-1

### DIFF
--- a/tests/cephfs/cephfs_snapshot_management.py
+++ b/tests/cephfs/cephfs_snapshot_management.py
@@ -1,6 +1,5 @@
 import traceback
 
-from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from utility.log import Log
 
@@ -62,9 +61,11 @@ def run(ceph_cluster, **kw):
             f"cephfs.{fs_name}.data" if not erasure else f"cephfs.{fs_name}.data-ec"
         )
         fs_details = fs_util.get_fs_info(client1, fs_name)
-
         if not fs_details:
             fs_util.create_fs(client1, fs_name)
+        new_name = "renamed_fs2"
+        fs_util.rename_volume(client1, fs_name, new_name)
+        fs_name = new_name
         commands = [
             f"ceph fs subvolumegroup create {fs_name} snap_group {pool_name}",
             f"ceph fs subvolume create {fs_name} snap_vol --size 5368706371 --group_name snap_group",
@@ -72,9 +73,6 @@ def run(ceph_cluster, **kw):
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)
             results.append(f"{command} successfully executed")
-
-        if not fs_util.wait_for_mds_process(client1, f"{fs_name}"):
-            raise CommandFailed("Failed to start MDS deamons")
         log.info("Get the path of sub volume")
         subvol_path, rc = client1.exec_command(
             sudo=True, cmd=f"ceph fs subvolume getpath {fs_name} snap_vol snap_group"
@@ -136,7 +134,6 @@ def run(ceph_cluster, **kw):
             f"ceph fs subvolume rm {fs_name} snap_vol --group_name snap_group",
             f"ceph fs subvolumegroup rm {fs_name} snap_group",
             "ceph config set mon mon_allow_pool_delete true",
-            f"ceph fs volume rm {fs_name} --yes-i-really-mean-it",
             "rm -rf /mnt/mycephfs1",
         ]
         for command in commands:
@@ -153,3 +150,5 @@ def run(ceph_cluster, **kw):
         log.info(e)
         log.info(traceback.format_exc())
         return 1
+    finally:
+        fs_util.rename_volume(client1, new_name, "cephfs_new")

--- a/tests/cephfs/cephfs_volume_management.py
+++ b/tests/cephfs/cephfs_volume_management.py
@@ -4,6 +4,7 @@ from time import sleep
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utils import FsUtils
+from tests.cephfs.cephfs_utilsV1 import FsUtils as FsUtils_v1
 from utility.log import Log
 
 log = Log(__name__)
@@ -60,16 +61,19 @@ def run(ceph_cluster, **kw):
         tc1 = "83573446"
         log.info(f"Execution of testcase {tc1} started")
         log.info("Create and list a volume")
+        fs_name_old = "cephfs_new"
         commands = [
             "ceph fs volume create cephfs_new",
             "ceph fs ls | grep cephfs_new",
             "ceph osd lspools | grep cephfs.cephfs_new",
             "ceph fs volume ls | grep cephfs_new",
         ]
+
         for command in commands:
             client1.exec_command(sudo=True, cmd=command)
             results.append(f"{command} successfully executed")
-        wait_for_process(client1, "cephfs_new")
+        new_name = "renamed_fs1"
+        FsUtils_v1.rename_volume(client1, fs_name_old, new_name)
         commands = [
             "ceph config set mon mon_allow_pool_delete true",
             "ceph fs volume rm cephfs_new --yes-i-really-mean-it",
@@ -79,7 +83,7 @@ def run(ceph_cluster, **kw):
             results.append(f"{command} successfully executed")
 
         verifyremove_command = [
-            "ceph fs ls | grep cephfs_new",
+            f"ceph fs ls | grep {new_name}",
             "ceph osd lspools | grep cephfs.cephfs_new",
         ]
         for command in verifyremove_command:
@@ -94,6 +98,8 @@ def run(ceph_cluster, **kw):
         return 0
 
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
+    finally:
+        FsUtils_v1.rename_volume(client1, new_name, "cephfs_new")

--- a/tests/cephfs/client_authorize.py
+++ b/tests/cephfs/client_authorize.py
@@ -84,16 +84,13 @@ def run(ceph_cluster, **kw):
 
         test_data = kw.get("test_data")
         fs_util = FsUtils(ceph_cluster, test_data=test_data)
-        erasure = (
-            FsUtils.get_custom_config_value(test_data, "erasure")
-            if test_data
-            else False
-        )
         client = ceph_cluster.get_ceph_objects("client")
         mon_node_ip = fs_util.get_mon_node_ips()
         mon_node_ip = ",".join(mon_node_ip)
         fs_count = 1
-        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_name_old = "cephfs_new"
+        fs_name = "renamed_fs4"
+        fs_util.rename_volume(client[0], fs_name_old, fs_name)
         fs_details = fs_util.get_fs_info(client[0], fs_name)
 
         if not fs_details:
@@ -442,10 +439,12 @@ def run(ceph_cluster, **kw):
         return 0
 
     except CommandFailed as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
+    finally:
+        fs_util.rename_volume(client[0], fs_name, "cephfs_new")

--- a/tests/cephfs/dir_pinning.py
+++ b/tests/cephfs/dir_pinning.py
@@ -34,11 +34,6 @@ def run(ceph_cluster, **kw):
         fs_util = FsUtils(ceph_cluster)
         test_data = kw.get("test_data")
         fs_util_v1 = FsUtilsV1(ceph_cluster, test_data=test_data)
-        erasure = (
-            FsUtilsV1.get_custom_config_value(test_data, "erasure")
-            if test_data
-            else False
-        )
         clients = ceph_cluster.get_ceph_objects("client")
         build = config.get("build", config.get("rhbuild"))
         client_info, rc = fs_util.get_clients(build)
@@ -55,7 +50,9 @@ def run(ceph_cluster, **kw):
         tc = "11227"
         dir_name = "dir"
         log.info(f"Running cephfs {tc} test case")
-        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_name_old = "cephfs_new"
+        fs_name = "renamed_fs5"
+        fs_util_v1.rename_volume(client1[0], fs_name_old, fs_name)
         fs_details = fs_util_v1.get_fs_info(clients[0], fs_name)
 
         if not fs_details:
@@ -372,8 +369,8 @@ def run(ceph_cluster, **kw):
         return 0
 
     except CommandFailed as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         log.info("Cleaning up!-----")
         if client3[0].pkg_type != "deb" and client4[0].pkg_type != "deb":
             rc_client = fs_util_v1.client_clean_up(
@@ -393,6 +390,8 @@ def run(ceph_cluster, **kw):
             log.info("Cleaning up successfull")
         return 1
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
+    finally:
+        fs_util_v1.rename_volume(client1[0], fs_name, "cephfs_new")

--- a/tests/cephfs/fs_kernel_mount_options.py
+++ b/tests/cephfs/fs_kernel_mount_options.py
@@ -34,12 +34,6 @@ def run(ceph_cluster, **kw):
         log.info(f"MetaData Information {log.metadata} in {__name__}")
         test_data = kw.get("test_data")
         fs_util = FsUtils(ceph_cluster, test_data=test_data)
-        erasure = (
-            FsUtils.get_custom_config_value(test_data, "erasure")
-            if test_data
-            else False
-        )
-
         config = kw.get("config")
         build = config.get("build", config.get("rhbuild"))
         clients = ceph_cluster.get_ceph_objects("client")
@@ -204,7 +198,9 @@ def run(ceph_cluster, **kw):
         umount_fs(clients[0], kernel_mounting_dir)
 
         log.info("mount with recovery_session Options")
-        default_fs = "cephfs" if not erasure else "cephfs-ec"
+        fs_name_old = "cephfs_new"
+        default_fs = "renamed_fs8"
+        fs_util.rename_volume(clients[0], fs_name_old, default_fs)
         fs_details = fs_util.get_fs_info(clients[0], default_fs)
 
         if not fs_details:
@@ -295,3 +291,4 @@ def run(ceph_cluster, **kw):
     finally:
         log.info("Clean Up in progess")
         fs_util.remove_subvolume(clients[0], **subvolume)
+        fs_util.rename_volume(clients[0], default_fs, "cephfs_new")

--- a/tests/cephfs/mds_default_values.py
+++ b/tests/cephfs/mds_default_values.py
@@ -10,20 +10,24 @@ log = Log(__name__)
 def run(ceph_cluster, **kw):
     """
     Test Cases Covered:
-    CEPH-83574284 - Deploy MDS with default values using cephadm.
+    CEPH-83574286 - Deploy mds using cephadm and increase & decrease number of mds.
     Pre-requisites :
     1. We need atleast one client node to execute this test case
 
     Test Case Flow:
     1. Create 1 file systems with --placements
-    2. Validate MDS has come up on specific hosts with the labels
+    2. Validate MDS has come up or not
+    3. Increase MDS
+    4. Validate if the MDS has come up on specific hosts
+    5. Decrease the MDS nodes.
+    6. Validate if the mds has stopped and started on specific hosts
     """
     try:
         fs_util = FsUtils(ceph_cluster)
         config = kw.get("config")
         clients = ceph_cluster.get_ceph_objects("client")
-        mds_list = ceph_cluster.get_ceph_objects("mds")
         build = config.get("build", config.get("rhbuild"))
+
         fs_util.prepare_clients(clients, build)
         fs_util.auth_list(clients)
         log.info("checking Pre-requisites")
@@ -33,15 +37,63 @@ def run(ceph_cluster, **kw):
             )
             return 1
         client1 = clients[0]
-        host_list = [mds.node.hostname for mds in mds_list]
-        fs_name = "cephfs"
-        for host in host_list:
+        nodes_list = ceph_cluster.get_nodes()
+        host_list = [node.hostname for node in nodes_list[1:5]]
+        hosts = " ".join(host_list[:2])
+        fs_name = "cephfs4"
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph fs volume create {fs_name} --placement='2 {hosts}'",
+            check_ec=False,
+        )
+
+        for host in host_list[:2]:
             if not fs_util.wait_for_mds_deamon(
                 client=client1, process_name=fs_name, host=host
             ):
                 raise CommandFailed(f"Failed to start MDS on particular nodes {host}")
+        new_fs_name = "cephfs_df_fs_renamed_1"
+        fs_util.rename_volume(client1, fs_name, new_fs_name)
+        log.info("increase the mds for the filesystem")
+        hosts = " ".join(host_list)
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph orch apply mds {new_fs_name} --placement='4 {hosts}'",
+            check_ec=False,
+        )
+        for host in host_list:
+            if not fs_util.wait_for_mds_deamon(
+                client=client1, process_name=new_fs_name, host=host
+            ):
+                raise CommandFailed(f"Failed to start MDS on particular nodes {host}")
+        log.info("Decrease the mds for the filesystem")
+        hosts = " ".join(host_list[2:])
+        client1.exec_command(
+            sudo=True,
+            cmd=f"ceph orch apply mds {new_fs_name} --placement='2 {hosts}'",
+            check_ec=False,
+        )
+        for host in host_list[2:]:
+            if not fs_util.wait_for_mds_deamon(
+                client=client1, process_name=new_fs_name, host=host
+            ):
+                raise CommandFailed(f"Failed to start MDS on particular nodes {host}")
+        for host in host_list[:2]:
+            if not fs_util.wait_for_mds_deamon(
+                client=client1, process_name=new_fs_name, host=host, ispresent=False
+            ):
+                raise CommandFailed(f"Failed to stop MDS on particular nodes {host}")
+
         return 0
     except Exception as e:
         log.error(e)
         log.error(traceback.format_exc())
         return 1
+    finally:
+        commands = [
+            "ceph config set mon mon_allow_pool_delete true",
+        ]
+        for command in commands:
+            client1.exec_command(sudo=True, cmd=command)
+        fs_util.rename_volume(client1, new_fs_name, "cephfs4")
+        fs_util.remove_fs(client1, "cephfs4")

--- a/tests/cephfs/subvolume_authorize.py
+++ b/tests/cephfs/subvolume_authorize.py
@@ -180,16 +180,12 @@ def run(ceph_cluster, **kw):
 
         test_data = kw.get("test_data")
         fs_util = FsUtils(ceph_cluster, test_data=test_data)
-        erasure = (
-            FsUtils.get_custom_config_value(test_data, "erasure")
-            if test_data
-            else False
-        )
         client = ceph_cluster.get_ceph_objects("client")
         mon_node_ip = fs_util.get_mon_node_ips()
         mon_node_ip = ",".join(mon_node_ip)
-
-        fs_name = "cephfs" if not erasure else "cephfs-ec"
+        fs_name_old = "cephfs_new"
+        fs_name = "renamed_fs7"
+        fs_util.rename_volume(client[0], fs_name_old, fs_name)
         fs_details = fs_util.get_fs_info(client[0], fs_name)
 
         if not fs_details:
@@ -435,10 +431,12 @@ def run(ceph_cluster, **kw):
         return 0
 
     except CommandFailed as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
     except Exception as e:
-        log.info(e)
-        log.info(traceback.format_exc())
+        log.error(e)
+        log.error(traceback.format_exc())
         return 1
+    finally:
+        fs_util.rename_volume(client[0], fs_name, "cephfs_new")


### PR DESCRIPTION
# Description

tier-1:http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-5AJE6E/
tier-0:http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-PPJ4MF/
I have renamed the volume in the middle of tier-1 suite to validate all the functions work well even thou name is changed.
After each test case, it changed back to "cephfs_new", all the test cases are using same volume. (modified some test cases)

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
