### PR TITLE
[TFA] maintenance mode tests finally block client configuration

### DIFF
--- a/tests/rados/test_stretch_site_maintenance_modes.py
+++ b/tests/rados/test_stretch_site_maintenance_modes.py
@@ -299,8 +299,16 @@ def run(ceph_cluster, **kw):
         log.debug(
             "Checking if any hosts are in Maintenance mode and if found, removing them"
         )
-        hosts = ceph_cluster.get_nodes()
+
+        hosts = list()
+        # namedTuple returns ['host1', 'host2'] for DC1 and ['host3,'host4'] for DC2.
+        for host in rados_obj.get_multi_az_stretch_site_hosts(
+            num_data_sites=len(buckets), stretch_bucket="datacenter"
+        ):
+            hosts += host
+
         for host in hosts:
+            host = ceph_cluster.get_node_by_hostname(hostname=host)
             if not host.role == "client":
                 if rados_obj.check_host_status(
                     hostname=host.hostname, status="Maintenance"


### PR DESCRIPTION
Description: Since we have updated the config file for execution as part of compaction, conf has additional nodes node12 and node13. In the finally block of maintenance mode we were accessing all nodes from config for testing. But since the additional nodes are not configured, we are observing the issue. 

Pass logs: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9.5/Test/19.2.0-92/219/tier-3_rados_test-location-stretch-mode/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
