### PR TITLE
Adding client configuration for client nodes

### DIFF
--- a/suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/reef/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -119,6 +119,32 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+        node: node10
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+        node: node11
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
   -
     test:
       abort-on-fail: false

--- a/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
+++ b/suites/squid/cephfs/tier-1_cephfs_cg_quiesce.yaml
@@ -90,6 +90,32 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.3
+        install_packages:
+          - ceph-common
+        node: node10
+      desc: "Configure the Cephfs client system 1"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        copy_admin_keyring: true
+        id: client.4
+        install_packages:
+          - ceph-common
+        node: node11
+      desc: "Configure the Cephfs client system 2"
+      destroy-cluster: false
+      module: test_client.py
+      name: "configure client"
   -
     test:
       abort-on-fail: false


### PR DESCRIPTION
# Description

Problem:
In conf file we have 4 clients but in suite file we are configuring only 2 clients. 

Failed log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/7.1/rhel-9/Regression/18.2.1-298/cephfs/203/tier-1_cephfs_cg_quiesce

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
