### PR TITLE
adding support for testing lc transition and expiration at scale

### DIFF
--- a/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
+++ b/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
@@ -21,7 +21,7 @@ tests:
             drivers: # if drivers are not specified will use one of the rgw node
               - mero003
               - mero004
-            fill_percent: 30
+            fill_percent: 10
       desc: prepare and push cosbench fill workload
       module: push_cosbench_workload.py
       name: push cosbench fill workload
@@ -36,7 +36,7 @@ tests:
             drivers: # if drivers are not specified will use one of the rgw node
               - mero003
               - mero004
-            fill_percent: 30
+            fill_percent: 10
             workload_type: hybrid
             run_time: 3600 # value in seconds
       desc: initiate cosbench hybrid workload
@@ -309,7 +309,7 @@ tests:
                   drivers:
                     - mero003
                     - mero004
-                  fill_percent: 35
+                  fill_percent: 10
                   workload_type: symmetrical
                   record_sync_on_site: ceph-sec
                   bucket_prefix: cosbench01-bkt-
@@ -327,7 +327,7 @@ tests:
                   drivers:
                     - mero011
                     - mero013
-                  fill_percent: 35
+                  fill_percent: 10
                   workload_type: symmetrical
                   record_sync_on_site: ceph-pri
                   bucket_prefix: cosbench01-bkt-
@@ -447,6 +447,114 @@ tests:
             module: sanity_rgw_multisite.py
             name: sync error check in secondary
             polarion-id: CEPH-83572752
+
+  # lc expiration and transition tests at scale
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            controllers:
+              - mero003
+            drivers:
+              - mero003
+              - mero004
+            record_sync_on_site: ceph-sec
+            bucket_prefix: cosbench01-lc-bkt-
+            number_of_buckets: 2
+            number_of_objects: 300000 # 300K objects per each bucket
+            object_prefix: key1-
+            objects_size_type: small
+      desc: prepare and push cosbench fill workload of 600K objects, 300K each in 2 buckets
+      module: push_cosbench_workload.py
+      name: push cosbench fill workload 600K objects
+      polarion-id: CEPH-83574428
+
+  - test:
+      name: Test Bucket Lifecycle transition on 600K objects
+      desc: Test object transition for Prefix and tag based filter and for more than one days
+      polarion-id: CEPH-83574046
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_tran_on_600K_objects.yaml
+            timeout: 14000
+            test-config:
+              user_names: [ "cosbench01" ]
+              user_remove: false
+              bucket_count: 2
+              bucket_names: [ "cosbench01-lc-bkt-1", "cosbench01-lc-bkt-2"]
+              objects_size_range:
+                min: 5
+                max: 15
+              objects_count: 300000 # 300K
+              parallel_lc: True
+              test_lc_transition: True
+              pool_name: data.cold
+              storage_class: cold
+              ec_pool_transition: False
+              multiple_transitions: False
+              actual_lc_days: 1
+              rgw_lc_debug_interval: 300
+              rgw_lc_max_wp_worker: 10
+              test_ops:
+                create_bucket: false
+                create_object: false
+                enable_versioning: false
+                version_count: 1
+                lc_grace_time: 7200 # 300K objects transition takes 1.5 hr, setting it as 2hr with buffer
+                set_ceph_configs_to_all_daemons: true
+              lifecycle_conf:
+                - ID: LC_Rule_1
+                  Filter:
+                    Prefix: key1-
+                  Status: Enabled
+                  Transitions:
+                    - Days: 1
+                      StorageClass: cold
+
+  - test:
+      name: Test Bucket Lifecycle Object_expiration on 600K objects
+      desc: Test object expiration for Prefix and tag based filter and for more than one days
+      polarion-id: CEPH-83575432
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_bucket_lifecycle_object_expiration_transition.py
+            config-file-name: test_lc_exp_on_600K_objects.yaml
+            timeout: 14000
+            test-config:
+              user_names: [ "cosbench01" ]
+              user_remove: false
+              bucket_count: 2
+              bucket_names: ["cosbench01-lc-bkt-1", "cosbench01-lc-bkt-2"]
+              objects_count: 300000 # 300K
+              parallel_lc: True
+              actual_lc_days: 0
+              rgw_lc_debug_interval: 300
+              rgw_lc_max_wp_worker: 10
+              objects_size_range:
+                min: 5
+                max: 15
+              test_ops:
+                create_object: false
+                create_bucket: false
+                delete_bucket_object: true
+                version_count: 1
+                lc_grace_time: 7200 # 300K objects expiration takes 1.5 hr, setting it as 2hr with buffer
+                test_lc_on_other_site: True
+                other_site_master: false
+                set_ceph_configs_to_all_daemons: True
+              lifecycle_conf:
+                - ID: LC_Rule_1
+                  Filter:
+                    Prefix: key1
+                  Status: Enabled
+                  Expiration:
+                    Date: "2019-02-17"
+
 
 # Please keep below(distruptive) testcases at the end of the suites only
   - test:

--- a/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
@@ -199,3 +199,66 @@ tests:
         commands:
           - "radosgw-admin bucket rm --bucket test-bucket-1 --purge-data"
           - "radosgw-admin bucket list"
+
+  # test lc expiration while object upload is in progress
+  - test:
+      name: test lc expiration while object upload is in progress
+      desc: test lc expiration while object upload is in progress
+      module: test_parallel.py
+      parallel:
+        - test:
+            desc: prepare and push cosbench fill workload for 600K objects upload, 300K each in 2 buckets
+            module: push_cosbench_workload.py
+            name: push cosbench fill workloadof 600K objects, 300K objects each in 2 buckets # 600K objects takes 1.5hr to complete
+            polarion-id: CEPH-83574428
+            config:
+              controllers:
+                - node6
+              drivers:
+                count: 2
+                hosts:
+                  - node5
+                  - node6
+              bucket_prefix: cosbench01-lc-bkt-
+              number_of_buckets: 2
+              number_of_objects: 300000 # 300K objects per each bucket
+              object_upload_retry_limit: 50
+              object_prefix: key1-
+              objects_size_type: small
+        - test:
+            name: Test Bucket Lifecycle Object_expiration on 600K objects with debug_interval 3600
+            desc: Test object expiration for Prefix and tag based filter and for more than one days
+            polarion-id: CEPH-83575432
+            module: sanity_rgw.py
+            config:
+              script-name: test_bucket_lifecycle_object_expiration_transition.py
+              config-file-name: test_lc_exp_on_2M_objects.yaml
+              timeout: 14000
+              test-config:
+                user_names: [ "cosbench01" ]
+                user_remove: false
+                bucket_count: 2
+                bucket_names: [ "cosbench01-lc-bkt-1", "cosbench01-lc-bkt-2" ]
+                objects_count: 300000
+                parallel_lc: True
+                actual_lc_days: 0
+                rgw_lc_debug_interval: 3600
+                rgw_lifecycle_work_time: "00:00-23:59"
+                rgw_lc_max_wp_worker: 10
+                objects_size_range:
+                  min: 5
+                  max: 15
+                test_ops:
+                  create_object: false
+                  create_bucket: false
+                  delete_bucket_object: true
+                  version_count: 1
+                  lc_grace_time: 10800 # 300k objects takes 1.5hr to expire, as lc kicks in after 1hr, setting it as 3hr with buffer
+                  set_ceph_configs_to_all_daemons: True
+                lifecycle_conf:
+                  - ID: LC_Rule_1
+                    Filter:
+                      Prefix: key1
+                    Status: Enabled
+                    Expiration:
+                      Date: "2019-02-17"

--- a/tests/rgw/sanity_rgw.py
+++ b/tests/rgw/sanity_rgw.py
@@ -182,8 +182,8 @@ def run(ceph_cluster, **kw):
 
     if test_config["config"]:
         log.info("creating custom config")
-        f_name = test_folder + config_dir + config_file_name
-        remote_fp = exec_from.remote_file(file_name=f_name, file_mode="w")
+        f_name = f"/home/cephuser/{test_folder}" + config_dir + config_file_name
+        remote_fp = exec_from.remote_file(file_name=f_name, file_mode="w", sudo=True)
         remote_fp.write(yaml.dump(test_config, default_flow_style=False))
 
     cmd_env = " ".join(config.get("env-vars", []))


### PR DESCRIPTION
this PR contains below changes:

1. passing user_name, bucket_name as well with the test config so that lc process on them instead of recreating.
2. fixed minor issue in sanity_rgw.py while passing test_config from test. it was failing with No such file error because of the path includes ~/rgw-tests instead of /home/cephuser/rgw-tests
3. testcase automation of set lc while object upload is in progress is achieved with parallel block.(but the log index.html doesn't show log link of cosbench workload. need to raise cephci issue for it)
4. lc transition testcase is actually a tier-3 rgw component testcase, but I have included it in mero_multisite suite so that object upload will happen once followed by lc transition followed by lc expiration.
5. 100K objects transition/expiration is taking 30 min with `rgw_lc_max_wp_worker` and `rgw_lc_max_worker` set to 10. pass logs are with 2 buckets each containing 100K objects tran/exp. so based on that calculation, lc_grace_time is set to 2hr(with buffer) for 2 buckets tran/exp each containing 300K objects.
6. However parallel object upload and lc exp have debug_interval set to 3600, so for 300K objects deletion it has to wait for 1hr(debug_interval) + 1.5hr(lc exp time) + 0.5hr(buffer) = 3hr total
7. reduced higher fill percentages in the fill workload from 30, 35 to 10 in `mero_scale_rgw_multi_site.yaml`. as it is taking 2 days to fill the cluster with 5KB to 50MB size. fail log: http://magna002.ceph.redhat.com/cephci-jenkins/results/baremetal/RH/8.0/rhel-9/19.2.0-90/rgw/55/mero_scale_rgw_multi_site/
8. introduced two new cosbench workload xml related parameters called `objects_size_type` (useful to mention object size range as small/medium) and `object_upload_retry_limit` (useful to retry object upload to decrease failure percent incase of parallel testcases rgw restarts or any other glitches)


depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/679

polarion:
[CEPH-83574046 - Test transition 12: Test bulk transition of objects (around ~1 to 2M)](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83574046)
[CEPH-83575432 - Deleting millions of objects via LC from Primary](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83575432)
[CEPH-83574800 - Scale tests [LC]: Delete saturation tests with lc_debug_interval = 3600](https://polarion.engineering.redhat.com/polarion/redirect/project/CEPH/workitem?id=CEPH-83574800)


sample pass logs with 5000 objects:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-7YO4D3/
(failure is because of timing issue, exp took more time than expected, will provide pass log on 2M objects)


pass log for parallel object and lc expiration on mero single site cluster: with 100K objects: http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-EGQZEH/


incremental pass logs for lc transition and expiration tests with 100K objects on multisite scale cluster(as mero multisite is in error state, tested on extensa):
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-CLSM5S/ (haproxy and cosbench deployment)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-X9FP0I/ (lc transition failed because of sync rgw crash)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/cephci-run-TZR29T/ (lc exp failed because of of rga command incorrect, automation issue at the end of the testcase)
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/test_lc_exp_on_600K_objects.console.log(updated pass log for lc exp test)


sample pass logs for existing configs of lc transition and expiration:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/test_lc_transition_with_prefix_rule.console.log
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_lc_baremetal_changes/test_lc_rule_prefix_and_tag.console.log

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
