### PR TITLE
[RADOS] TFA: Reduce IOs duration in slow-op-request test to maintain cluster stability

### DIFF
--- a/conf/squid/rados/13-node-cluster-4-clients-rhos-d.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients-rhos-d.yaml
@@ -60,9 +60,6 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node7:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_16
         role:
@@ -126,25 +123,16 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node15:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_16
         role:
           - client
       node16:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_13
         role:
           - client
       node17:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - provider_net_cci_13
         role:

--- a/conf/squid/rados/13-node-cluster-4-clients.yaml
+++ b/conf/squid/rados/13-node-cluster-4-clients.yaml
@@ -123,25 +123,16 @@ globals:
         no-of-volumes: 4
         disk-size: 15
       node15:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_2
         role:
           - client
       node16:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_5
         role:
           - client
       node17:
-        image-name:
-          openstack: RHEL-9.4.0-x86_64-ga-latest
-          ibmc: rhel-91-server-released
         networks:
           - shared_net_5
         role:

--- a/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -174,43 +174,6 @@ tests:
       polarion-id: CEPH-83583664
       desc: libcephsqlite reopens database connection upon blocklisting
 
-# below test has been moved from: tier-2_rados_test-slow-op-requests.yaml
-  - test:
-      name: Limit slow request details to cluster log
-      module: test_slow_op_requests.py
-      desc: Limit slow request details to cluster log
-      polarion-id: CEPH-83574884
-      config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool2
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool3
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
-
 # below tests have been moved from: tier-3_rados-recovery_tests.yaml
 # commented until a definite method to
 # trigger Async recovery is found
@@ -227,12 +190,51 @@ tests:
 #                pool_name: async_recover
 #                pg_num: 16
 #          desc: Verification of the async recovery
-
   - test:
       name: Change Mon weight for Mgr
       polarion-id: CEPH-83588304
       module: test_mon_mgr_weight.py
       desc: Verify Mgr stability when mon-weight is modified
+
+# below test has been moved from: tier-2_rados_test-slow-op-requests.yaml
+  - test:
+      name: Limit slow request details to cluster log
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool1
+              pg_num: 64
+              rados_write_duration: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+          - create_pool:
+              pool_name: pool2
+              pg_num: 128
+              rados_write_duration: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+          - create_pool:
+              pool_name: pool3
+              pg_num: 256
+              rados_write_duration: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+        delete_pools:
+          - pool1
+          - pool2
+          - pool3
 
 # PG log limit parameter cannot be unset,
 # this test should always run at the last

--- a/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -174,43 +174,6 @@ tests:
       polarion-id: CEPH-83583664
       desc: libcephsqlite reopens database connection upon blocklisting
 
-# below test has been moved from: tier-2_rados_test-slow-op-requests.yaml
-  - test:
-      name: Limit slow request details to cluster log
-      module: test_slow_op_requests.py
-      desc: Limit slow request details to cluster log
-      polarion-id: CEPH-83574884
-      config:
-        create_pools:
-          - create_pool:
-              pool_name: pool1
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool2
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-          - create_pool:
-              pool_name: pool3
-              pg_num: 64
-              rados_write_duration: 1000
-              byte_size: 1024
-              pool_type: replicated
-              osd_max_backfills: 16
-              osd_recovery_max_active: 16
-        delete_pools:
-          - pool1
-          - pool2
-          - pool3
-
 # below tests have been moved from: tier-3_rados-recovery_tests.yaml
 # commented until a definite method to
 # trigger Async recovery is found
@@ -233,6 +196,46 @@ tests:
       polarion-id: CEPH-83588304
       module: test_mon_mgr_weight.py
       desc: Verify Mgr stability when mon-weight is modified
+
+# below test has been moved from: tier-2_rados_test-slow-op-requests.yaml
+  - test:
+      name: Limit slow request details to cluster log
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool1
+              pg_num: 64
+              rados_write_duration: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+          - create_pool:
+              pool_name: pool2
+              pg_num: 128
+              rados_write_duration: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+          - create_pool:
+              pool_name: pool3
+              pg_num: 256
+              rados_write_duration: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+        delete_pools:
+          - pool1
+          - pool2
+          - pool3
 
 # PG log limit parameter cannot be unset,
 # this test should always run at the last


### PR DESCRIPTION
Slow ops requests are found in MON log during OSD flapping, current test workflow was designed to organically create this scenario.
Once exec_command module was fixed to honour the input timeout provided and enhanced to dynamically control its run time, the test started failing as radosbench would never succeed within the calculated timeout

Test cases modified:
- `tests/rados/test_slow_op_requests.py`

Test suites modified:
- `suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml`
- `suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml` 

Logs:
Reef - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-4M406P/
Squid - http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9.5/Test/19.2.0-92/227/tier-3_rados_cidr_blocklisting/

Signed-off-by: Harsh Kumar <hakumar@redhat.com>