### PR TITLE
update the registry when custom-config flags set for insecure and ibm-build

### DIFF
--- a/pipeline/scripts/interop/test-ceph-features.sh
+++ b/pipeline/scripts/interop/test-ceph-features.sh
@@ -98,6 +98,7 @@ for suite in "${!TEST_SUITES[@]}" ; do
       --skip-subscription \
       --rhbuild ${RHCS_VERSION} \
       --platform ${CEPH_PLATFORM} \
+      --custom-config insecure-registry=true \
       --build ${BUILD_TYPE} \
       --suite ${TEST_SUITE} \
       --global-conf ${TEST_CONFIG} \

--- a/utility/utils.py
+++ b/utility/utils.py
@@ -2482,3 +2482,36 @@ def get_registry_info(registry):
         raise KeyError(
             "CephCI configuration yaml file does not have 'registries' section"
         )
+
+
+def is_unsecured_registry(test_data):
+    """
+    Returns a boolean based on custom config values set for 'insecure-registry' and 'ibm-build'
+
+    Args:
+        test_data (dict): The test data containing configuration.
+
+    Returns:
+        bool: if build is RH and 'insecure-registry' is set to True  function returns True else returns False.
+    """
+
+    if "custom-config" in test_data and isinstance(test_data["custom-config"], list):
+        ibm_build_value = None
+        insecure_registry_value = False  # Default to False if not found
+
+        for config in test_data["custom-config"]:
+            key, value = config.split("=")
+
+            # Check for the 'ibm-build' key
+            if key == "ibm-build":
+                ibm_build_value = value.strip().lower() in ("true", "yes")
+
+            # Check for the 'insecure-registry' key
+            if key == "insecure-registry":
+                insecure_registry_value = value.strip().lower() in ("true", "yes")
+
+        # If 'ibm-build' is not set or False and 'insecure-registry' is True, return True
+        if ibm_build_value is None or not ibm_build_value:
+            return insecure_registry_value  # Return boolean value for insecure-registry
+
+    return False  # Default return value if conditions are not met


### PR DESCRIPTION
# Description

Update the RH build registry file when insecure-registry flag set to true.

Log:  
[setup_pre-requisites_0.log](https://github.com/user-attachments/files/19055980/setup_pre-requisites_0.log)


<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
