### PR TITLE
reverting ceph-qe-scripts cleanup code in cephadm_upgrade

### DIFF
--- a/tests/cephadm/test_cephadm_upgrade.py
+++ b/tests/cephadm/test_cephadm_upgrade.py
@@ -44,17 +44,6 @@ def run(ceph_cluster, **kwargs) -> int:
     verify_image = bool(config.get("verify_cluster_health", False))
     orch = Orch(cluster=ceph_cluster, **config)
 
-    # Clean up the ceph-qe-scripts to prepare for the execution of RGW singlesite and multisite test suites.
-    cleanup_dir = "/home/cephuser/"
-    cleanup_dir_cmd = (
-        f"find {cleanup_dir} -type d \\( "
-        f"-name rgw-tests -o -name rgw-ms-tests -o -name venv \\) "
-        f"-exec rm -r {{}} +"
-    )
-
-    for node in ceph_cluster.get_nodes():
-        node.exec_command(sudo=True, cmd=cleanup_dir_cmd, check_ec=False)
-
     client = ceph_cluster.get_nodes(role="client")[0]
     clients = ceph_cluster.get_nodes(role="client")
     executor = None


### PR DESCRIPTION
as discussed with Obanna and rgw team, raised this PR to revert the changes merged in this PR: https://github.com/red-hat-storage/cephci/pull/4438/files

```
the initial requirement is to only cleanup ceph-qe-scripts at the start of the baremetal run. But not to re-clone the repo. but the solution given is to remove it at the upgrade step. We accepted it as we thought the next test after upgrade will re-clone the repo.
But later we found that the very next test after upgrade is not cloning the repo. It’s cloning the repo in the first test of the suite where we set-env in the test config of a suite. We missed this while reviewing the PR.

also with cleanup in the upgrade test we suspect few more issues..
1. pre upgrade tests will run on some version of ceph-qe-scripts and post upgrade tests will run on the latest ceph-qe-scripts which may cause failures
 
2. we create few other files inside the local repo which are required for other tests later in the suite. Like rgw/v2/lib/user_details.json. if we delete and re-clone, those files will be lost..
 
So we decided it’s better if we cleanup/update ceph-qe-scripts repo even before the tests execution start only for BareMetal suites. We will brainstorm on this and we will create a ticket later.
```

upgrade suites failure logs:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Upgrade/19.2.0-90/64/

# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
