### PR TITLE
Updated rados upgrade paths to include n, n-1 & n-2 paths in all releases

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-brownfield.yaml
@@ -158,6 +158,10 @@ tests:
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
 
   - test:

--- a/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -19,7 +19,8 @@ tests:
         base_cmd_args:
           verbose: true
         args:
-          custom_repo: "cdn"
+          rhcs-version: 5.3
+          release: rc
           mon-ip: node1
           orphan-initial-daemons: true
           skip-monitoring-stack: true

--- a/suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -27,6 +27,8 @@ tests:
                 registry-url: registry.redhat.io
                 mon-ip: node1
                 allow-fqdn-hostname: true
+                rhcs-version: 6.1
+                release: rc
           - config:
               command: add_hosts
               service: host
@@ -108,6 +110,17 @@ tests:
       config:
         log_to_file: true
       desc: Change config options to enable logging to file
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: true
+      abort-on-fail: true
 
   - test:
       name: EC Pool Recovery Improvement

--- a/suites/quincy/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-brownfield.yaml
@@ -158,7 +158,12 @@ tests:
       desc: Upgrade cluster to latest version and check health warn
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
+      config:
+        verify_warning: true
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
+      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
 
   - test:
       name: "verify fix: obj snap and pool snap deletion"

--- a/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -19,7 +19,7 @@ tests:
         verify_cluster_health: true
         steps:
           - config:
-              rhcs-version: 7.0
+              rhcs-version: 7.1
               release: rc
               command: bootstrap
               orphan-initial-daemons: true

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -242,7 +242,7 @@ tests:
         verify_daemons: true
         verify_cluster_usage: true
       abort-on-fail: true
-      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
+      comments: "upgrade bug from 5.x to 7.x wrt warning : 2243570"
 
   # Running basic rbd and rgw tests after upgrade
   - test:

--- a/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -21,7 +21,7 @@ tests:
         verify_cluster_health: true
         steps:
           - config:
-              rhcs-version: 7.0
+              rhcs-version: 6.1
               release: rc
               command: bootstrap
               orphan-initial-daemons: true
@@ -116,18 +116,16 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
-      name: Upgrade cluster to latest 8.x ceph version
-      desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       config:
-        command: start
-        service: upgrade
-        base_cmd_args:
-          verbose: true
-        verify_cluster_health: true
-      destroy-cluster: false
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: true
       abort-on-fail: true
+      comments: "upgrade bug from 6.x to 7.x wrt warning : 2243570"
 
   - test:
       name: EC Pool Recovery Improvement

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -236,7 +236,7 @@ tests:
       module: test_upgrade_warn.py
       polarion-id: CEPH-83574934
       config:
-        verify_warning: true
+        verify_warning: false
         verify_daemons: true
         verify_cluster_usage: true
       abort-on-fail: true


### PR DESCRIPTION
Updated upgrade paths in rados suites. Paths covered : 

Pacific :
5.3 z5 -> 5.x latest
5.3 CDN -> 5.x latest

Quincy:
5.3 z6 -> 6.x latest
5.3 CDN -> 6.x latest
6.1 CDN -> 6.x latest

Reef:
6.1 CDN -> 7.x latest
5.3 CDN -> 7.x latest
7.1 CDN -> 7.x latest

Squid:
7.1 z1 -> 8.x latest
6.1 CDN -> 8.x latest
8.0 CDN -> 8.x latest