### PR TITLE
integrating hotfix bz tests: rgw crash with kafka topic name compare

### DIFF
--- a/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-bucket-notifications.yaml
@@ -334,6 +334,18 @@ tests:
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
         timeout: 300
 
+  # this test is destructive, pls add the testcases above this
+  - test:
+      name: test if rgw crashes with kafka broker configured with acl authorizer
+      desc: test if rgw crashes with kafka topic name compare, with kafka broker configured with acl authorizer
+      polarion-id: CEPH-83607419
+      module: sanity_rgw.py
+      comments: Known issue BZ-2337418
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
+
   - test:
       name: check-ceph-health
       module: exec.py

--- a/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -210,6 +210,18 @@ tests:
         script-name: test_bucket_notifications.py
         config-file-name: test_empty_bucket_notification_kafka_broker.yaml
 
+  # this test is destructive, pls add the testcases above this
+  - test:
+      name: test if rgw crashes with kafka broker configured with acl authorizer
+      desc: test if rgw crashes with kafka topic name compare, with kafka broker configured with acl authorizer
+      polarion-id: CEPH-83607419
+      module: sanity_rgw.py
+      comments: Known issue BZ-2337418
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
+
   - test:
       name: check-ceph-health
       module: exec.py

--- a/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -338,6 +338,19 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_multipart_transition_notifications.yaml
 
+
+  # this test is destructive, pls add the testcases above this
+  - test:
+      name: test if rgw crashes with kafka broker configured with acl authorizer
+      desc: test if rgw crashes with kafka topic name compare, with kafka broker configured with acl authorizer
+      polarion-id: CEPH-83607419
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
+
+
   - test:
       name: check-ceph-health
       module: exec.py

--- a/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_bucket_notifications.yaml
@@ -339,6 +339,18 @@ tests:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_multipart_transition_notifications.yaml
 
+
+  # this test is destructive, pls add the testcases above this
+  - test:
+      name: test if rgw crashes with kafka broker configured with acl authorizer
+      desc: test if rgw crashes with kafka topic name compare, with kafka broker configured with acl authorizer
+      polarion-id: CEPH-83607419
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: test_bucket_notifications.py
+        config-file-name: test_bucket_notification_kafka_broker_multipart_with_kafka_acl_config_set.yaml
+
   - test:
       name: check-ceph-health
       module: exec.py


### PR DESCRIPTION
# Description

depends on ceph-qe-scripts PR: https://github.com/red-hat-storage/ceph-qe-scripts/pull/681

hotfix bz: https://bugzilla.redhat.com/show_bug.cgi?id=2337265
polarion: [CEPH-83607419 : segfault in kafka topic name compare operator overload](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83607419)

pass logs:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_MOD_kafka_topic_name_crash/cephci-run-DOUZYZ/

pass logs for existing config:
http://magna002.ceph.redhat.com/cephci-jenkins/hsm/PR_MOD_kafka_topic_name_crash/cephci-run-ND4QAA/



Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
