### PR TITLE
Move to a supported Ubuntu runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   tox:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 5
       matrix:
@@ -12,9 +12,9 @@ jobs:
         - '3.9.18'
         - '3.8.15'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
# Description

Ubuntu 20.4 is unsupported from April, 2025. Hence, we are moving to a newer version of the runners to help with gatechecks.

- [x] Review the automation design
- [x] Unit testing (automated runner)
