### PR TITLE
Capturing the Cli commands

### DIFF
--- a/utility/cephci-commands-results.py
+++ b/utility/cephci-commands-results.py
@@ -1,72 +1,8 @@
-"""
-This script is designed to process local log files, extract specific command outputs,
-and save them in structured JSON format.
-It ensures efficient log parsing, prevents duplicate storage, and organizes outputs based on subcomponents.
-
-### **Features:**
-1. **Recursive Log Retrieval:**
-   - The script scans the specified directory to find .log files for processing.
-
-2. **Command Extraction:**
-   - Identifies and extracts radosgw-admin commands from log files.
-   - Parses corresponding command outputs and structures them in JSON format.
-
-3. **Output Storage:**
-   - Saves extracted data into organized JSON files based on subcommands.
-   - Ensures no duplicate entries using hash-based validation.
-
-4. **Automatic Directory & File Handling:**
-   - Creates necessary directories and JSON files if they don't exist.
-   - Organizes extracted outputs by subcomponent filters.
-
-5. **Duplicate Detection:**
-   - Computes SHA-256 hashes for command outputs to prevent redundant storage.
-
-6. **Error Handling:**
-   - Manages file I/O operations and JSON parsing errors gracefully.
-
-### **How the Script Works:**
-1. **Fetching Log Files:**
-   - The get_log_files_from_directory function scans the given directory and collects all .log files.
-
-2. **Processing Log Files:**
-   - The process_log_file function reads each .log file, extracts radosgw-admin commands, and processes outputs.
-
-3. **Command Extraction & Deduplication:**
-   - The extract_radosgw_admin_commands function:
-     - Identifies radosgw-admin commands within log lines.
-     - Extracts and reconstructs command outputs.
-     - Uses SHA-256 hashes to detect and prevent duplicate entries.
-
-4. **Saving Outputs:**
-   - The save_to_remote function:
-     - Creates the required directory structure.
-     - Saves extracted command outputs into JSON files categorized by subcommands.
-     - Checks for duplicates before appending new entries.
-
-5. **Execution Flow:**
-   - The run function:
-     - Retrieves .log files from the specified directory.
-     - Processes each file, extracting relevant commands and saving outputs.
-
-### **Key Functions:**
-- get_log_files_from_directory(directory): Retrieves all .log files from a directory.
-- process_log_file(file_path, subcomponent_filter, output_directory): Processes each log file for command extraction.
-- extract_radosgw_admin_commands(log_lines): Extracts radosgw-admin commands and reconstructs outputs.
-- compute_output_hash(output): Computes a unique SHA-256 hash for deduplication.
-- save_to_remote(command, output, subcomponent_filter, output_directory): Saves as JSON files.
-- run(log_directory, subcomponent_filter, output_directory): Orchestrates log file processing and output storage.
-
-### **Folder Structure:**
-The script organizes extracted outputs into the specified output directory as follows:
-
-"""
-
 import hashlib
 import json
 import os
 import re
-
+from collections import defaultdict
 from docopt import docopt
 
 DOC = """
@@ -85,193 +21,136 @@ Options:
 
 
 def compute_output_hash(output):
-    """
-    Computes a SHA-256 hash for the given output data.
-    Args:
-        output (dict): The output data to hash.
-    Returns:
-        str: The computed hash value as a hexadecimal string.
-    """
-    return hashlib.sha256(
-        json.dumps(output, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    """Compute SHA-256 hash for output data."""
+    return hashlib.sha256(json.dumps(output, sort_keys=True).encode()).hexdigest()
 
 
 def clean_log_line(line):
-    """
-    Cleans log lines by removing timestamps and log level prefixes.
-    Args:
-        line (str): A single line from the log file.
-    Returns:
-        str or None: The cleaned log line or None if empty.
-    """
-    line = re.sub(
-        r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - cephci - ceph:\d+ - (INFO|DEBUG|ERROR) -\s*",
-        "",
-        line,
-    ).strip()
-    line = re.sub(
-        r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} (INFO|DEBUG|ERROR):?\s*", "", line
-    ).strip()
-    return line if line else None
+    """Clean log line from timestamps and prefixes."""
+    return re.sub(
+        r"^\d{4}-\d{2}-\d{2}.*?(INFO|DEBUG|ERROR)[:\s-]*", 
+        "", 
+        line
+    ).strip() or None
 
 
 def reconstruct_json(lines):
-    """
-    Reconstructs JSON data from cleaned log lines.
-    Args:
-        lines (list): A list of cleaned log lines.
-    Returns:
-        dict or list: The reconstructed JSON data if valid, otherwise a list of cleaned lines.
-    """
-    cleaned_lines = [clean_log_line(line) for line in lines if clean_log_line(line)]
+    """Try to parse cleaned lines as JSON or return raw lines."""
     try:
-        return json.loads("\n".join(cleaned_lines))
+        return json.loads("\n".join(lines))
     except json.JSONDecodeError:
-        return cleaned_lines
+        return lines
+
+def load_existing_hashes(output_dir):
+    """Preload existing hashes from output JSON files."""
+    hashes = set()
+    base_dir = os.path.join(output_dir, "cephci-commands-results")
+    if not os.path.exists(base_dir):
+        return hashes
+        
+    for fname in os.listdir(base_dir):
+        if fname.endswith("_outputs.json"):
+            try:
+                with open(os.path.join(base_dir, fname), "r") as f:
+                    data = json.load(f)
+                    hashes.update(e["output_hash"] for e in data.get("outputs", []))
+            except Exception:
+                pass
+    return hashes
+
+def process_log_file(file_path, existing_hashes):
+    """Streaming log processor yielding new command outputs."""
+    current_command, output_lines = None, []
+    
+    with open(file_path, "r") as f:
+        for line in f:
+            cleaned = clean_log_line(line)
+            if not cleaned:
+                continue
+
+            if match := re.search(r"(radosgw-admin\s+[\w-]+)", cleaned):
+                if current_command:
+                    output = reconstruct_json(output_lines)
+                    output_hash = compute_output_hash(output)
+                    if output_hash not in existing_hashes:
+                        existing_hashes.add(output_hash)
+                        subcommand_match = re.match(r"radosgw-admin\s+([\w-]+)", current_command)
+                        if subcommand_match:
+                            yield {
+                                "command": current_command,
+                                "output": output,
+                                "hash": output_hash,
+                                "subcommand": subcommand_match.group(1)
+                            }
+                
+                current_command = match.group(0).strip()
+                output_lines = []
+            else:
+                output_lines.append(cleaned)
+
+        if current_command and output_lines:
+            output = reconstruct_json(output_lines)
+            output_hash = compute_output_hash(output)
+            if output_hash not in existing_hashes:
+                existing_hashes.add(output_hash)
+                subcommand_match = re.match(r"radosgw-admin\s+([\w-]+)", current_command)
+                if subcommand_match:
+                    yield {
+                        "command": current_command,
+                        "output": output,
+                        "hash": output_hash,
+                        "subcommand": subcommand_match.group(1)
+                    }
 
 
-def extract_radosgw_admin_commands(log_lines):
-    """
-    Extracts `radosgw-admin` commands and their corresponding outputs from log files.
-    Args:
-        log_lines (list): A list of log file lines.
-    Returns:
-        dict: Extracted commands and their outputs, preventing duplicates using SHA-256 hashes.
-    """
-    results, existing_hashes = [], set()
-    current_command, current_output_lines = None, []
-
-    for line in log_lines:
-        cleaned_line = clean_log_line(line)
-        if not cleaned_line:
-            continue
-
-        cmd_match = re.search(r"(?:sudo )?radosgw-admin[^;\n]+", cleaned_line)
-        if cmd_match:
-            if current_command and current_output_lines:
-                output = reconstruct_json(current_output_lines)
-                output_hash = compute_output_hash(output)
-                if output_hash not in existing_hashes:
-                    results.append(
-                        {
-                            "command": current_command,
-                            "output": output,
-                            "output_hash": output_hash,
-                        }
-                    )
-                    existing_hashes.add(output_hash)
-            current_command, current_output_lines = cmd_match.group(0).strip(), []
-        else:
-            current_output_lines.append(cleaned_line)
-
-    return {"outputs": results}
-
-
-def save_to_remote(command, output, subcomponent_filter, output_directory):
-    """
-    Saves extracted command outputs to structured JSON files, avoiding duplicates.
-    Args:
-        command (str): The extracted `radosgw-admin` command.
-        output (dict): The parsed output of the command.
-        subcomponent_filter (str): The specified subcomponent filter.
-        output_directory (str): The directory where JSON files will be saved.
-    """
-    output_hash = compute_output_hash(output)
-    base_dir = os.path.join(output_directory, "cephci-commands-results")
+def run(log_dir, _, output_dir):
+    """Main processing workflow with batched writes."""
+    existing_hashes = load_existing_hashes(output_dir)
+    buffers = defaultdict(list)
+    
+    for log_file in get_log_files(log_dir):
+        for entry in process_log_file(log_file, existing_hashes):
+            buffers[entry["subcommand"]].append(entry)
+    
+    # Batch write all results
+    base_dir = os.path.join(output_dir, "cephci-commands-results")
     os.makedirs(base_dir, exist_ok=True)
-
-    subcommand_match = re.search(r"radosgw-admin (\w+)", command)
-    if subcommand_match:
-        subcommand = subcommand_match.group(1)
-        file_path = os.path.join(base_dir, f"{subcommand}_outputs.json")
-
-        try:
-            if not os.path.exists(file_path):
-                with open(file_path, "w") as file:
-                    json.dump({"outputs": []}, file)
-            with open(file_path, "r") as file:
-                data = json.load(file)
-            if not any(
-                entry["output_hash"] == output_hash for entry in data["outputs"]
-            ):
-                data["outputs"].append(
-                    {"command": command, "output": output, "output_hash": output_hash}
-                )
-                with open(file_path, "w") as file:
-                    json.dump(data, file, indent=4)
-        except Exception as e:
-            print(f"Error saving file: {e}")
+    
+    for subcmd, entries in buffers.items():
+        fpath = os.path.join(base_dir, f"{subcmd}_outputs.json")
+        existing = []
+        
+        if os.path.exists(fpath):
+            with open(fpath, "r") as f:
+                existing = json.load(f).get("outputs", [])
+        
+        new_entries = [
+            {"command": e["command"], "output": e["output"], "output_hash": e["hash"]}
+            for e in entries
+        ]
+        
+        with open(fpath, "w") as f:
+            json.dump(
+                {"outputs": existing + new_entries},
+                f,
+                indent=2
+            )
 
 
-def get_log_files_from_directory(directory):
-    """
-    Retrieves all `.log` files from a given directory.
-    Args:
-        directory (str): The directory to scan.
-    Returns:
-        list: List of file paths to `.log` files.
-    """
-    if not isinstance(directory, str):
-        raise TypeError("Expected a string path for directory")
+def get_log_files(directory):
+    """Get all .log files recursively from directory."""
     return [
-        os.path.join(root, file)
+        os.path.join(root, f)
         for root, _, files in os.walk(directory)
-        for file in files
-        if file.endswith(".log")
+        for f in files
+        if f.endswith(".log")
     ]
 
 
-def process_log_file(file_path, subcomponent_filter, output_directory, chunk_size=1000):
-    """
-    Processes a single log file in chunks for command extraction and saves the outputs.
-    Args:
-        file_path (str): The path to the log file.
-        subcomponent_filter (str): The subcomponent filter.
-        output_directory (str): The directory where extracted data will be saved.
-    """
-    try:
-        with open(file_path, "r") as file:
-            buffer = []
-            for line in file:
-                buffer.append(line)
-                if len(buffer) >= chunk_size:
-                    extracted_data = extract_radosgw_admin_commands(buffer)
-                    for entry in extracted_data["outputs"]:
-                        save_to_remote(
-                            entry["command"],
-                            entry["output"],
-                            subcomponent_filter,
-                            output_directory,
-                        )
-                    buffer = []
-            if buffer:
-                extracted_data = extract_radosgw_admin_commands(buffer)
-                for entry in extracted_data["outputs"]:
-                    save_to_remote(
-                        entry["command"],
-                        entry["output"],
-                        subcomponent_filter,
-                        output_directory,
-                    )
-    except Exception as e:
-        print(f"Failed {file_path}: {e}")
-
-
-def run(log_directory, subcomponent_filter, output_directory):
-    """
-    Orchestrates log file processing and output storage.
-    Args:
-        log_directory (str): Directory containing log files.
-        subcomponent_filter (str): Subcomponent filter for logs.
-        output_directory (str): Directory for storing extracted JSON files.
-    """
-    log_files = get_log_files_from_directory(log_directory)
-    for file_path in log_files:
-        process_log_file(file_path, subcomponent_filter, output_directory)
-    print("Successfully stored cephcli commands")
-
-
 if __name__ == "__main__":
-    arguments = docopt(DOC)
-    run(arguments["--logdir"], arguments["--filter"], arguments["--outdir"])
+    args = docopt(DOC)
+    run(
+        args["--logdir"],
+        args["--filter"],
+        args["--outdir"]
+    )

--- a/utility/cephci-commands-results.py
+++ b/utility/cephci-commands-results.py
@@ -1,8 +1,72 @@
+"""
+This script is designed to process local log files, extract specific command outputs,
+and save them in structured JSON format.
+It ensures efficient log parsing, prevents duplicate storage, and organizes outputs based on subcomponents.
+
+### **Features:**
+1. **Recursive Log Retrieval:**
+   - The script scans the specified directory to find .log files for processing.
+
+2. **Command Extraction:**
+   - Identifies and extracts radosgw-admin commands from log files.
+   - Parses corresponding command outputs and structures them in JSON format.
+
+3. **Output Storage:**
+   - Saves extracted data into organized JSON files based on subcommands.
+   - Ensures no duplicate entries using hash-based validation.
+
+4. **Automatic Directory & File Handling:**
+   - Creates necessary directories and JSON files if they don't exist.
+   - Organizes extracted outputs by subcomponent filters.
+
+5. **Duplicate Detection:**
+   - Computes SHA-256 hashes for command outputs to prevent redundant storage.
+
+6. **Error Handling:**
+   - Manages file I/O operations and JSON parsing errors gracefully.
+
+### **How the Script Works:**
+1. **Fetching Log Files:**
+   - The get_log_files_from_directory function scans the given directory and collects all .log files.
+
+2. **Processing Log Files:**
+   - The process_log_file function reads each .log file, extracts radosgw-admin commands, and processes outputs.
+
+3. **Command Extraction & Deduplication:**
+   - The extract_radosgw_admin_commands function:
+     - Identifies radosgw-admin commands within log lines.
+     - Extracts and reconstructs command outputs.
+     - Uses SHA-256 hashes to detect and prevent duplicate entries.
+
+4. **Saving Outputs:**
+   - The save_to_remote function:
+     - Creates the required directory structure.
+     - Saves extracted command outputs into JSON files categorized by subcommands.
+     - Checks for duplicates before appending new entries.
+
+5. **Execution Flow:**
+   - The run function:
+     - Retrieves .log files from the specified directory.
+     - Processes each file, extracting relevant commands and saving outputs.
+
+### **Key Functions:**
+- get_log_files_from_directory(directory): Retrieves all .log files from a directory.
+- process_log_file(file_path, subcomponent_filter, output_directory): Processes each log file for command extraction.
+- extract_radosgw_admin_commands(log_lines): Extracts radosgw-admin commands and reconstructs outputs.
+- compute_output_hash(output): Computes a unique SHA-256 hash for deduplication.
+- save_to_remote(command, output, subcomponent_filter, output_directory): Saves as JSON files.
+- run(log_directory, subcomponent_filter, output_directory): Orchestrates log file processing and output storage.
+
+### **Folder Structure:**
+The script organizes extracted outputs into the specified output directory as follows:
+
+"""
+
 import hashlib
 import json
 import os
 import re
-from collections import defaultdict
+
 from docopt import docopt
 
 DOC = """
@@ -21,136 +85,193 @@ Options:
 
 
 def compute_output_hash(output):
-    """Compute SHA-256 hash for output data."""
-    return hashlib.sha256(json.dumps(output, sort_keys=True).encode()).hexdigest()
+    """
+    Computes a SHA-256 hash for the given output data.
+    Args:
+        output (dict): The output data to hash.
+    Returns:
+        str: The computed hash value as a hexadecimal string.
+    """
+    return hashlib.sha256(
+        json.dumps(output, sort_keys=True).encode("utf-8")
+    ).hexdigest()
 
 
 def clean_log_line(line):
-    """Clean log line from timestamps and prefixes."""
-    return re.sub(
-        r"^\d{4}-\d{2}-\d{2}.*?(INFO|DEBUG|ERROR)[:\s-]*", 
-        "", 
-        line
-    ).strip() or None
+    """
+    Cleans log lines by removing timestamps and log level prefixes.
+    Args:
+        line (str): A single line from the log file.
+    Returns:
+        str or None: The cleaned log line or None if empty.
+    """
+    line = re.sub(
+        r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - cephci - ceph:\d+ - (INFO|DEBUG|ERROR) -\s*",
+        "",
+        line,
+    ).strip()
+    line = re.sub(
+        r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} (INFO|DEBUG|ERROR):?\s*", "", line
+    ).strip()
+    return line if line else None
 
 
 def reconstruct_json(lines):
-    """Try to parse cleaned lines as JSON or return raw lines."""
+    """
+    Reconstructs JSON data from cleaned log lines.
+    Args:
+        lines (list): A list of cleaned log lines.
+    Returns:
+        dict or list: The reconstructed JSON data if valid, otherwise a list of cleaned lines.
+    """
+    cleaned_lines = [clean_log_line(line) for line in lines if clean_log_line(line)]
     try:
-        return json.loads("\n".join(lines))
+        return json.loads("\n".join(cleaned_lines))
     except json.JSONDecodeError:
-        return lines
-
-def load_existing_hashes(output_dir):
-    """Preload existing hashes from output JSON files."""
-    hashes = set()
-    base_dir = os.path.join(output_dir, "cephci-commands-results")
-    if not os.path.exists(base_dir):
-        return hashes
-        
-    for fname in os.listdir(base_dir):
-        if fname.endswith("_outputs.json"):
-            try:
-                with open(os.path.join(base_dir, fname), "r") as f:
-                    data = json.load(f)
-                    hashes.update(e["output_hash"] for e in data.get("outputs", []))
-            except Exception:
-                pass
-    return hashes
-
-def process_log_file(file_path, existing_hashes):
-    """Streaming log processor yielding new command outputs."""
-    current_command, output_lines = None, []
-    
-    with open(file_path, "r") as f:
-        for line in f:
-            cleaned = clean_log_line(line)
-            if not cleaned:
-                continue
-
-            if match := re.search(r"(radosgw-admin\s+[\w-]+)", cleaned):
-                if current_command:
-                    output = reconstruct_json(output_lines)
-                    output_hash = compute_output_hash(output)
-                    if output_hash not in existing_hashes:
-                        existing_hashes.add(output_hash)
-                        subcommand_match = re.match(r"radosgw-admin\s+([\w-]+)", current_command)
-                        if subcommand_match:
-                            yield {
-                                "command": current_command,
-                                "output": output,
-                                "hash": output_hash,
-                                "subcommand": subcommand_match.group(1)
-                            }
-                
-                current_command = match.group(0).strip()
-                output_lines = []
-            else:
-                output_lines.append(cleaned)
-
-        if current_command and output_lines:
-            output = reconstruct_json(output_lines)
-            output_hash = compute_output_hash(output)
-            if output_hash not in existing_hashes:
-                existing_hashes.add(output_hash)
-                subcommand_match = re.match(r"radosgw-admin\s+([\w-]+)", current_command)
-                if subcommand_match:
-                    yield {
-                        "command": current_command,
-                        "output": output,
-                        "hash": output_hash,
-                        "subcommand": subcommand_match.group(1)
-                    }
+        return cleaned_lines
 
 
-def run(log_dir, _, output_dir):
-    """Main processing workflow with batched writes."""
-    existing_hashes = load_existing_hashes(output_dir)
-    buffers = defaultdict(list)
-    
-    for log_file in get_log_files(log_dir):
-        for entry in process_log_file(log_file, existing_hashes):
-            buffers[entry["subcommand"]].append(entry)
-    
-    # Batch write all results
-    base_dir = os.path.join(output_dir, "cephci-commands-results")
+def extract_radosgw_admin_commands(log_lines):
+    """
+    Extracts `radosgw-admin` commands and their corresponding outputs from log files.
+    Args:
+        log_lines (list): A list of log file lines.
+    Returns:
+        dict: Extracted commands and their outputs, preventing duplicates using SHA-256 hashes.
+    """
+    results, existing_hashes = [], set()
+    current_command, current_output_lines = None, []
+
+    for line in log_lines:
+        cleaned_line = clean_log_line(line)
+        if not cleaned_line:
+            continue
+
+        cmd_match = re.search(r"(?:sudo )?radosgw-admin[^;\n]+", cleaned_line)
+        if cmd_match:
+            if current_command and current_output_lines:
+                output = reconstruct_json(current_output_lines)
+                output_hash = compute_output_hash(output)
+                if output_hash not in existing_hashes:
+                    results.append(
+                        {
+                            "command": current_command,
+                            "output": output,
+                            "output_hash": output_hash,
+                        }
+                    )
+                    existing_hashes.add(output_hash)
+            current_command, current_output_lines = cmd_match.group(0).strip(), []
+        else:
+            current_output_lines.append(cleaned_line)
+
+    return {"outputs": results}
+
+
+def save_to_remote(command, output, subcomponent_filter, output_directory):
+    """
+    Saves extracted command outputs to structured JSON files, avoiding duplicates.
+    Args:
+        command (str): The extracted `radosgw-admin` command.
+        output (dict): The parsed output of the command.
+        subcomponent_filter (str): The specified subcomponent filter.
+        output_directory (str): The directory where JSON files will be saved.
+    """
+    output_hash = compute_output_hash(output)
+    base_dir = os.path.join(output_directory, "cephci-commands-results")
     os.makedirs(base_dir, exist_ok=True)
-    
-    for subcmd, entries in buffers.items():
-        fpath = os.path.join(base_dir, f"{subcmd}_outputs.json")
-        existing = []
-        
-        if os.path.exists(fpath):
-            with open(fpath, "r") as f:
-                existing = json.load(f).get("outputs", [])
-        
-        new_entries = [
-            {"command": e["command"], "output": e["output"], "output_hash": e["hash"]}
-            for e in entries
-        ]
-        
-        with open(fpath, "w") as f:
-            json.dump(
-                {"outputs": existing + new_entries},
-                f,
-                indent=2
-            )
+
+    subcommand_match = re.search(r"radosgw-admin (\w+)", command)
+    if subcommand_match:
+        subcommand = subcommand_match.group(1)
+        file_path = os.path.join(base_dir, f"{subcommand}_outputs.json")
+
+        try:
+            if not os.path.exists(file_path):
+                with open(file_path, "w") as file:
+                    json.dump({"outputs": []}, file)
+            with open(file_path, "r") as file:
+                data = json.load(file)
+            if not any(
+                entry["output_hash"] == output_hash for entry in data["outputs"]
+            ):
+                data["outputs"].append(
+                    {"command": command, "output": output, "output_hash": output_hash}
+                )
+                with open(file_path, "w") as file:
+                    json.dump(data, file, indent=4)
+        except Exception as e:
+            print(f"Error saving file: {e}")
 
 
-def get_log_files(directory):
-    """Get all .log files recursively from directory."""
+def get_log_files_from_directory(directory):
+    """
+    Retrieves all `.log` files from a given directory.
+    Args:
+        directory (str): The directory to scan.
+    Returns:
+        list: List of file paths to `.log` files.
+    """
+    if not isinstance(directory, str):
+        raise TypeError("Expected a string path for directory")
     return [
-        os.path.join(root, f)
+        os.path.join(root, file)
         for root, _, files in os.walk(directory)
-        for f in files
-        if f.endswith(".log")
+        for file in files
+        if file.endswith(".log")
     ]
 
 
+def process_log_file(file_path, subcomponent_filter, output_directory, chunk_size=1000):
+    """
+    Processes a single log file in chunks for command extraction and saves the outputs.
+    Args:
+        file_path (str): The path to the log file.
+        subcomponent_filter (str): The subcomponent filter.
+        output_directory (str): The directory where extracted data will be saved.
+    """
+    try:
+        with open(file_path, "r") as file:
+            buffer = []
+            for line in file:
+                buffer.append(line)
+                if len(buffer) >= chunk_size:
+                    extracted_data = extract_radosgw_admin_commands(buffer)
+                    for entry in extracted_data["outputs"]:
+                        save_to_remote(
+                            entry["command"],
+                            entry["output"],
+                            subcomponent_filter,
+                            output_directory,
+                        )
+                    buffer = []
+            if buffer:
+                extracted_data = extract_radosgw_admin_commands(buffer)
+                for entry in extracted_data["outputs"]:
+                    save_to_remote(
+                        entry["command"],
+                        entry["output"],
+                        subcomponent_filter,
+                        output_directory,
+                    )
+    except Exception as e:
+        print(f"Failed {file_path}: {e}")
+
+
+def run(log_directory, subcomponent_filter, output_directory):
+    """
+    Orchestrates log file processing and output storage.
+    Args:
+        log_directory (str): Directory containing log files.
+        subcomponent_filter (str): Subcomponent filter for logs.
+        output_directory (str): Directory for storing extracted JSON files.
+    """
+    log_files = get_log_files_from_directory(log_directory)
+    for file_path in log_files:
+        process_log_file(file_path, subcomponent_filter, output_directory)
+    print("Successfully stored cephcli commands")
+
+
 if __name__ == "__main__":
-    args = docopt(DOC)
-    run(
-        args["--logdir"],
-        args["--filter"],
-        args["--outdir"]
-    )
+    arguments = docopt(DOC)
+    run(arguments["--logdir"], arguments["--filter"], arguments["--outdir"])

--- a/utility/cephci-commands-results.py
+++ b/utility/cephci-commands-results.py
@@ -1,0 +1,277 @@
+"""
+This script is designed to process local log files, extract specific command outputs,
+and save them in structured JSON format.
+It ensures efficient log parsing, prevents duplicate storage, and organizes outputs based on subcomponents.
+
+### **Features:**
+1. **Recursive Log Retrieval:**
+   - The script scans the specified directory to find .log files for processing.
+
+2. **Command Extraction:**
+   - Identifies and extracts radosgw-admin commands from log files.
+   - Parses corresponding command outputs and structures them in JSON format.
+
+3. **Output Storage:**
+   - Saves extracted data into organized JSON files based on subcommands.
+   - Ensures no duplicate entries using hash-based validation.
+
+4. **Automatic Directory & File Handling:**
+   - Creates necessary directories and JSON files if they don't exist.
+   - Organizes extracted outputs by subcomponent filters.
+
+5. **Duplicate Detection:**
+   - Computes SHA-256 hashes for command outputs to prevent redundant storage.
+
+6. **Error Handling:**
+   - Manages file I/O operations and JSON parsing errors gracefully.
+
+### **How the Script Works:**
+1. **Fetching Log Files:**
+   - The get_log_files_from_directory function scans the given directory and collects all .log files.
+
+2. **Processing Log Files:**
+   - The process_log_file function reads each .log file, extracts radosgw-admin commands, and processes outputs.
+
+3. **Command Extraction & Deduplication:**
+   - The extract_radosgw_admin_commands function:
+     - Identifies radosgw-admin commands within log lines.
+     - Extracts and reconstructs command outputs.
+     - Uses SHA-256 hashes to detect and prevent duplicate entries.
+
+4. **Saving Outputs:**
+   - The save_to_remote function:
+     - Creates the required directory structure.
+     - Saves extracted command outputs into JSON files categorized by subcommands.
+     - Checks for duplicates before appending new entries.
+
+5. **Execution Flow:**
+   - The run function:
+     - Retrieves .log files from the specified directory.
+     - Processes each file, extracting relevant commands and saving outputs.
+
+### **Key Functions:**
+- get_log_files_from_directory(directory): Retrieves all .log files from a directory.
+- process_log_file(file_path, subcomponent_filter, output_directory): Processes each log file for command extraction.
+- extract_radosgw_admin_commands(log_lines): Extracts radosgw-admin commands and reconstructs outputs.
+- compute_output_hash(output): Computes a unique SHA-256 hash for deduplication.
+- save_to_remote(command, output, subcomponent_filter, output_directory): Saves as JSON files.
+- run(log_directory, subcomponent_filter, output_directory): Orchestrates log file processing and output storage.
+
+### **Folder Structure:**
+The script organizes extracted outputs into the specified output directory as follows:
+
+"""
+
+import hashlib
+import json
+import os
+import re
+
+from docopt import docopt
+
+DOC = """
+Standard script to fetch and process log files from a given directory.
+
+Usage:
+    subcommands.py --logdir <log_directory> --filter <subcomponent_filter> --outdir <output_directory>
+    subcommands.py (-h | --help)
+
+Options:
+    -h --help                      Show this help message
+    --logdir <log_directory>       Directory containing log files
+    --filter <subcomponent_filter> Filter logs by subcomponent (e.g., rgw, rbd, rados)
+    --outdir <output_directory>    Directory where output JSON files will be stored
+"""
+
+
+def compute_output_hash(output):
+    """
+    Computes a SHA-256 hash for the given output data.
+    Args:
+        output (dict): The output data to hash.
+    Returns:
+        str: The computed hash value as a hexadecimal string.
+    """
+    return hashlib.sha256(
+        json.dumps(output, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def clean_log_line(line):
+    """
+    Cleans log lines by removing timestamps and log level prefixes.
+    Args:
+        line (str): A single line from the log file.
+    Returns:
+        str or None: The cleaned log line or None if empty.
+    """
+    line = re.sub(
+        r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} - cephci - ceph:\d+ - (INFO|DEBUG|ERROR) -\s*",
+        "",
+        line,
+    ).strip()
+    line = re.sub(
+        r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} (INFO|DEBUG|ERROR):?\s*", "", line
+    ).strip()
+    return line if line else None
+
+
+def reconstruct_json(lines):
+    """
+    Reconstructs JSON data from cleaned log lines.
+    Args:
+        lines (list): A list of cleaned log lines.
+    Returns:
+        dict or list: The reconstructed JSON data if valid, otherwise a list of cleaned lines.
+    """
+    cleaned_lines = [clean_log_line(line) for line in lines if clean_log_line(line)]
+    try:
+        return json.loads("\n".join(cleaned_lines))
+    except json.JSONDecodeError:
+        return cleaned_lines
+
+
+def extract_radosgw_admin_commands(log_lines):
+    """
+    Extracts `radosgw-admin` commands and their corresponding outputs from log files.
+    Args:
+        log_lines (list): A list of log file lines.
+    Returns:
+        dict: Extracted commands and their outputs, preventing duplicates using SHA-256 hashes.
+    """
+    results, existing_hashes = [], set()
+    current_command, current_output_lines = None, []
+
+    for line in log_lines:
+        cleaned_line = clean_log_line(line)
+        if not cleaned_line:
+            continue
+
+        cmd_match = re.search(r"(?:sudo )?radosgw-admin[^;\n]+", cleaned_line)
+        if cmd_match:
+            if current_command and current_output_lines:
+                output = reconstruct_json(current_output_lines)
+                output_hash = compute_output_hash(output)
+                if output_hash not in existing_hashes:
+                    results.append(
+                        {
+                            "command": current_command,
+                            "output": output,
+                            "output_hash": output_hash,
+                        }
+                    )
+                    existing_hashes.add(output_hash)
+            current_command, current_output_lines = cmd_match.group(0).strip(), []
+        else:
+            current_output_lines.append(cleaned_line)
+
+    return {"outputs": results}
+
+
+def save_to_remote(command, output, subcomponent_filter, output_directory):
+    """
+    Saves extracted command outputs to structured JSON files, avoiding duplicates.
+    Args:
+        command (str): The extracted `radosgw-admin` command.
+        output (dict): The parsed output of the command.
+        subcomponent_filter (str): The specified subcomponent filter.
+        output_directory (str): The directory where JSON files will be saved.
+    """
+    output_hash = compute_output_hash(output)
+    base_dir = os.path.join(output_directory, "cephci-commands-results")
+    os.makedirs(base_dir, exist_ok=True)
+
+    subcommand_match = re.search(r"radosgw-admin (\w+)", command)
+    if subcommand_match:
+        subcommand = subcommand_match.group(1)
+        file_path = os.path.join(base_dir, f"{subcommand}_outputs.json")
+
+        try:
+            if not os.path.exists(file_path):
+                with open(file_path, "w") as file:
+                    json.dump({"outputs": []}, file)
+            with open(file_path, "r") as file:
+                data = json.load(file)
+            if not any(
+                entry["output_hash"] == output_hash for entry in data["outputs"]
+            ):
+                data["outputs"].append(
+                    {"command": command, "output": output, "output_hash": output_hash}
+                )
+                with open(file_path, "w") as file:
+                    json.dump(data, file, indent=4)
+        except Exception as e:
+            print(f"Error saving file: {e}")
+
+
+def get_log_files_from_directory(directory):
+    """
+    Retrieves all `.log` files from a given directory.
+    Args:
+        directory (str): The directory to scan.
+    Returns:
+        list: List of file paths to `.log` files.
+    """
+    if not isinstance(directory, str):
+        raise TypeError("Expected a string path for directory")
+    return [
+        os.path.join(root, file)
+        for root, _, files in os.walk(directory)
+        for file in files
+        if file.endswith(".log")
+    ]
+
+
+def process_log_file(file_path, subcomponent_filter, output_directory, chunk_size=1000):
+    """
+    Processes a single log file in chunks for command extraction and saves the outputs.
+    Args:
+        file_path (str): The path to the log file.
+        subcomponent_filter (str): The subcomponent filter.
+        output_directory (str): The directory where extracted data will be saved.
+    """
+    try:
+        with open(file_path, "r") as file:
+            buffer = []
+            for line in file:
+                buffer.append(line)
+                if len(buffer) >= chunk_size:
+                    extracted_data = extract_radosgw_admin_commands(buffer)
+                    for entry in extracted_data["outputs"]:
+                        save_to_remote(
+                            entry["command"],
+                            entry["output"],
+                            subcomponent_filter,
+                            output_directory,
+                        )
+                    buffer = []
+            if buffer:
+                extracted_data = extract_radosgw_admin_commands(buffer)
+                for entry in extracted_data["outputs"]:
+                    save_to_remote(
+                        entry["command"],
+                        entry["output"],
+                        subcomponent_filter,
+                        output_directory,
+                    )
+    except Exception as e:
+        print(f"Failed {file_path}: {e}")
+
+
+def run(log_directory, subcomponent_filter, output_directory):
+    """
+    Orchestrates log file processing and output storage.
+    Args:
+        log_directory (str): Directory containing log files.
+        subcomponent_filter (str): Subcomponent filter for logs.
+        output_directory (str): Directory for storing extracted JSON files.
+    """
+    log_files = get_log_files_from_directory(log_directory)
+    for file_path in log_files:
+        process_log_file(file_path, subcomponent_filter, output_directory)
+    print("Successfully stored cephcli commands")
+
+
+if __name__ == "__main__":
+    arguments = docopt(DOC)
+    run(arguments["--logdir"], arguments["--filter"], arguments["--outdir"])

--- a/utility/rgw_command_extractor.py
+++ b/utility/rgw_command_extractor.py
@@ -178,7 +178,7 @@ def save_to_remote(command, output, subcomponent_filter, output_directory):
         output_directory (str): The directory where JSON files will be saved.
     """
     output_hash = compute_output_hash(output)
-    base_dir = os.path.join(output_directory, "cephci-commands-results")
+    base_dir = os.path.join(output_directory, "rgw_command_extractor")
     os.makedirs(base_dir, exist_ok=True)
 
     subcommand_match = re.search(r"radosgw-admin (\w+)", command)

--- a/utility/rgw_command_extractor.py
+++ b/utility/rgw_command_extractor.py
@@ -78,8 +78,8 @@ DOC = """
 Standard script to fetch and process log files from a given directory.
 
 Usage:
-    subcommands.py --logdir <log_directory> --filter <subcomponent_filter> --outdir <output_directory>
-    subcommands.py (-h | --help)
+    rgw_command_extractor.py --logdir <log_directory> --filter <subcomponent_filter> --outdir <output_directory>
+    rgw_command_extractor.py (-h | --help)
 
 Options:
     -h --help                      Show this help message

--- a/utility/rgw_command_extractor.py
+++ b/utility/rgw_command_extractor.py
@@ -72,6 +72,7 @@ import hashlib
 import json
 import os
 import re
+
 from docopt import docopt
 
 DOC = """


### PR DESCRIPTION
# Description

I have added subcommands.py to the utility files, similar to how the sos report is handled. This file is responsible for capturing the output of CLI commands (radosgw-admin) and storing them in JSON format. It helps extract, process, and save command outputs efficiently for further analysis.
i have executed and it is saving in the log directory
the log link :http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9.5/Test/19.2.0-98/267/tier-1_rgw/

the output is assed by the following
output stored:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9.5/Test/19.2.0-98/267/tier-1_rgw/cephci-commands-results/