### PR TITLE
Disabling WIP as a required check

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - base=main
       - branch-protection-review-decision=approved
       - "check-success=tox (3.9.18)"
-      - check-success=WIP
     actions:
       merge:
         method: merge


### PR DESCRIPTION
# Description

WIP currently is down resulting in PR's being queued for merge. We are disabling this check till the app comes online.
