### PR TITLE
Fix manipulation during log filtering

### DIFF
--- a/utility/log.py
+++ b/utility/log.py
@@ -2,6 +2,7 @@ import logging
 import logging.handlers
 import os
 import re
+from copy import deepcopy
 from typing import Dict
 
 from .config import TestMetaData
@@ -223,12 +224,14 @@ class SensitiveLogFilter(logging.Filter):
         excluded fields.
         """
         if isinstance(msg, dict):
-            self.redact_dict(msg)
-            return msg
+            data = deepcopy(msg)
+            self.redact_dict(data)
+            return data
 
         if isinstance(msg, list):
-            self.redact_list(msg)
-            return msg
+            data = deepcopy(msg)
+            self.redact_list(data)
+            return data
 
         if isinstance(msg, tuple):
             return tuple(self.redact(arg) for arg in msg)


### PR DESCRIPTION
# Description

SensitiveLogFilter was manipulating mutable data types via shallow reference. This leads to tainted value being set to the variable that was processed.

Invariably causing a modification of the vaules. This commit fixes this issue.

- [x] Review the automation design
- [x] Unit testing

*Logs*
[Magna](http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-DAMXSX/)

```
(venv) psathyan@magna002:~/src/cephci$ python utest_log.py
2025-03-05 03:19:01,180 - cephci - log:125 - INFO - Test logfile: /tmp/unit_testing.log
2025-03-05 03:19:01,181 - cephci - utest_log:6 - INFO - Welcome
2025-03-05 03:19:01,182 - cephci - utest_log:9 - INFO - There is some password <masked>
2025-03-05 03:19:01,182 - cephci - utest_log:19 - INFO - {'name': 'testuser', 'password': '<masked>', 'age': 10, 'tuple': ('some value', True, False), 'list': ['password <masked>', 'you got it', 'check', True]}
2025-03-05 03:19:01,182 - cephci - utest_log:22 - INFO - value not modified
(venv) psathyan@magna002:~/src/cephci$ cat utest_log.py
from utility.log import Log

log = Log()
log.configure_logger('unit_testing', '/tmp', False)

log.info("Welcome")

test_data = "There is some password x"
log.info(test_data)

test_dict = {
    "name": "testuser",
    "password": "Should be masked",
    "age": 10,
    "tuple": ('some value', True, False),
    "list": ['password x', 'you got it', 'check', True]
    }

log.info(test_dict)

if test_dict['list'][0] == 'password x':
    log.info("value not modified")
 ```