### PR TITLE
Log filter add support for filtering tuple

### DIFF
--- a/utility/log.py
+++ b/utility/log.py
@@ -187,9 +187,11 @@ class SensitiveLogFilter(logging.Filter):
         """Redact values in the iterator."""
         for i, v in enumerate(data):
             if isinstance(v, list):
-                data[i] = self.redact_list(v)
+                self.redact_list(data[i])
             elif isinstance(v, dict):
-                data[i] = self.redact_dict(v)
+                self.redact_dict(data[i])
+            elif isinstance(v, tuple):
+                data[i] = self.redact(v)
             elif isinstance(v, (str, bytearray, bytes)):
                 data[i] = self.redact_str(v)
 
@@ -202,6 +204,8 @@ class SensitiveLogFilter(logging.Filter):
                 self.redact_dict(data[_key])
             elif isinstance(data[_key], list):
                 self.redact_list(data[_key])
+            elif isinstance(data[_key], tuple):
+                data[_key] = self.redact(data[_key])
             elif isinstance(data[_key], (str, bytearray, bytes)):
                 data[_key] = self.redact_str(data[_key])
 


### PR DESCRIPTION
# Description

Tuple data structure was not supported when it was found as part of `list` or `dict`. In this commit, we are know processing it so that sensitive data can also be masked.

- [x] Review the automation design
- [x] Unit testing

*Log snippet*
```
(venv) psathyan@magna002:~/src/cephci$ python utest_log.py
2025-03-05 04:24:48,149 - cephci - log:125 - INFO - Test logfile: /tmp/unit_testing.log
2025-03-05 04:24:48,149 - cephci - utest_log:6 - INFO - Welcome
2025-03-05 04:24:48,150 - cephci - utest_log:9 - INFO - There is some password <masked>
2025-03-05 04:24:48,151 - cephci - utest_log:93 - INFO - {'name': 'testuser', 'password': '<masked>', 'age': 10, 'tuple': ('some value', 'Has password <masked>', True, False), 'list': ['password <masked>', 'you got it', 'check', True], 'dict': {'access-key': '<masked>', 'passwd': '<masked>', 'pass': 'True', 'node': {'passwd': '<masked>', 'user': 'nested dict node'}}}
2025-03-05 04:24:48,151 - cephci - utest_log:96 - INFO - value not modified
2025-03-05 04:24:48,151 - cephci - utest_log:104 - INFO - Tuple value not modified
====================
2025-03-05 04:24:48,151 - cephci - utest_log:107 - INFO - [{'test': {'name': 'Test M buckets with N objects', 'desc': "Test to create 'M' no of buckets and 'N' no of objects", 'polarion-id': 'CEPH-9789', 'module': 'sanity_rgw.py', 'config': {'script-name': 'test_Mbuckets_with_Nobjects.py', 'config-file-name': 'test_Mbuckets_with_Nobjects.yaml', 'timeout': 300}}}, {'test': {'name': 'Run RBD tier-0 operations', 'desc': 'Run RBD tier-0 operations', 'polarion-id': 'CEPH-83575401', 'module': 'rbd_tier0.py', 'config': {'ec-pool-k-m': '2,1', 'ec-pool-only': False, 'ec_pool_config': {'pool': 'rbd_pool', 'data_pool': 'rbd_ec_pool', 'ec_profile': 'rbd_ec_profile', 'image': 'rbd_image', 'image_thick_provision': 'rbd_thick_image', 'snap_thick_provision': 'rbd_thick_snap', 'clone_thick_provision': 'rbd_thick_clone', 'thick_size': '2G', 'size': '10G', 'snap': 'rbd_ec_pool_snap', 'clone': 'rbd_ec_pool_clone'}, 'rep_pool_config': {'pool': 'rbd_rep_pool', 'image': 'rbd_rep_image', 'image_thick_provision': 'rbd_rep_thick_image', 'snap_thick_provision': 'rbd_rep_thick_snap', 'clone_thick_provision': 'rbd_rep_thick_clone', 'thick_size': '2G', 'size': '10G', 'snap': 'rbd_rep_pool_snap', 'clone': 'rbd_rep_pool_clone'}, 'operations': {'map': True, 'io': True, 'nounmap': False}}}}, {'test': {'name': 'cephfs-basics', 'desc': 'CephFS basic operations', 'polarion-id': 'CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295', 'module': 'cephfs_basic_tests.py'}}]
[{'test': {'name': 'Test M buckets with N objects', 'desc': "Test to create 'M' no of buckets and 'N' no of objects", 'polarion-id': 'CEPH-9789', 'module': 'sanity_rgw.py', 'config': {'script-name': 'test_Mbuckets_with_Nobjects.py', 'config-file-name': 'test_Mbuckets_with_Nobjects.yaml', 'timeout': 300}}}, {'test': {'name': 'Run RBD tier-0 operations', 'desc': 'Run RBD tier-0 operations', 'polarion-id': 'CEPH-83575401', 'module': 'rbd_tier0.py', 'config': {'ec-pool-k-m': '2,1', 'ec-pool-only': False, 'ec_pool_config': {'pool': 'rbd_pool', 'data_pool': 'rbd_ec_pool', 'ec_profile': 'rbd_ec_profile', 'image': 'rbd_image', 'image_thick_provision': 'rbd_thick_image', 'snap_thick_provision': 'rbd_thick_snap', 'clone_thick_provision': 'rbd_thick_clone', 'thick_size': '2G', 'size': '10G', 'snap': 'rbd_ec_pool_snap', 'clone': 'rbd_ec_pool_clone'}, 'rep_pool_config': {'pool': 'rbd_rep_pool', 'image': 'rbd_rep_image', 'image_thick_provision': 'rbd_rep_thick_image', 'snap_thick_provision': 'rbd_rep_thick_snap', 'clone_thick_provision': 'rbd_rep_thick_clone', 'thick_size': '2G', 'size': '10G', 'snap': 'rbd_rep_pool_snap', 'clone': 'rbd_rep_pool_clone'}, 'operations': {'map': True, 'io': True, 'nounmap': False}}}}, {'test': {'name': 'cephfs-basics', 'desc': 'CephFS basic operations', 'polarion-id': 'CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295', 'module': 'cephfs_basic_tests.py'}}]
(venv) psathyan@magna002:~/src/cephci$ cat utest_log.py
from utility.log import Log

log = Log()
log.configure_logger('unit_testing', '/tmp', False)

log.info("Welcome")

test_data = "There is some password x"
log.info(test_data)

test_dict = {
    "name": "testuser",
    "password": "Should be masked",
    "age": 10,
    "tuple": ('some value', 'Has password something', True, False),
    "list": ['password x', 'you got it', 'check', True],
    "dict": {
        "access-key": "xxxxxx",
        "passwd": "Should be masked",
        "pass": "True",
        "node": {
            "passwd": "Should be masked",
            "user": "nested dict node"
            },
        },
    }

test_a = [
  {
    "test": {
      "name": "Test M buckets with N objects",
      "desc": "Test to create 'M' no of buckets and 'N' no of objects",
      "polarion-id": "CEPH-9789",
      "module": "sanity_rgw.py",
      "config": {
        "script-name": "test_Mbuckets_with_Nobjects.py",
        "config-file-name": "test_Mbuckets_with_Nobjects.yaml",
        "timeout": 300
      }
    }
  },
  {
    "test": {
      "name": "Run RBD tier-0 operations",
      "desc": "Run RBD tier-0 operations",
      "polarion-id": "CEPH-83575401",
      "module": "rbd_tier0.py",
      "config": {
        "ec-pool-k-m": "2,1",
        "ec-pool-only": False,
        "ec_pool_config": {
          "pool": "rbd_pool",
          "data_pool": "rbd_ec_pool",
          "ec_profile": "rbd_ec_profile",
          "image": "rbd_image",
          "image_thick_provision": "rbd_thick_image",
          "snap_thick_provision": "rbd_thick_snap",
          "clone_thick_provision": "rbd_thick_clone",
          "thick_size": "2G",
          "size": "10G",
          "snap": "rbd_ec_pool_snap",
          "clone": "rbd_ec_pool_clone"
        },
        "rep_pool_config": {
          "pool": "rbd_rep_pool",
          "image": "rbd_rep_image",
          "image_thick_provision": "rbd_rep_thick_image",
          "snap_thick_provision": "rbd_rep_thick_snap",
          "clone_thick_provision": "rbd_rep_thick_clone",
          "thick_size": "2G",
          "size": "10G",
          "snap": "rbd_rep_pool_snap",
          "clone": "rbd_rep_pool_clone"
        },
        "operations": {
          "map": True,
          "io": True,
          "nounmap": False
        }
      }
    }
  },
  {
    "test": {
      "name": "cephfs-basics",
      "desc": "CephFS basic operations",
      "polarion-id": "CEPH-11293,CEPH-11296,CEPH-11297,CEPH-11295",
      "module": "cephfs_basic_tests.py"
    }
  }
]

log.info(test_dict)

if test_dict['list'][0] == 'password x':
    log.info("value not modified")
else:
    print(test_dict['list'][0])
    log.error('Dict value got modified')

if test_dict['tuple'][1] != 'Has password something':
    log.error("Data manipulated")
else:
    log.info("Tuple value not modified")

print("="*20)
log.info(test_a)
print(test_a)
```