### PR TITLE
CephCI Integration PR for Ratelimit division test

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/squid/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -296,6 +296,16 @@ tests:
       comments: known issue BZ 2301986
 
   - test:
+      name: Test Ratelimit Division
+      desc: Test Ratelimit Division
+      polarion-id: CEPH-83574917
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_rate_limit.py
+        config-file-name: ../../s3cmd/configs/test_ratelimit_split.yaml
+      comments: known issue BZ 2349530
+
+  - test:
       name: Test ratelimit on bucket owner change
       desc: Test ratelimit on bucket owner change
       polarion-id: CEPH-83574920


### PR DESCRIPTION
Polarion ID : CEPH-83574917
[ceph-qe-scripts PR ](https://github.com/red-hat-storage/ceph-qe-scripts/pull/684)  
Steps:
1. Set the rate limit for a bucket.
2. Add a rgw daemon to the cluster , the rate limit should be halved.

Known issue : BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2349530

Fail log  : http://magna002.ceph.redhat.com/cephci-jenkins/tchandra/cephci-run-PRYWCG/
