### PR TITLE
cephci integration: CEPH-83575113

### DIFF
--- a/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
+++ b/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
@@ -366,3 +366,33 @@ tests:
             module: push_cosbench_workload.py
             name: push cosbench cleanup workload from secondary
             polarion-id: CEPH-83575074
+
+  - test:
+      name: upload of objects
+      desc: upload of objects
+      clusters:
+        ceph-pri:
+          config:
+            controllers:
+              - mero003
+            drivers:
+              - mero003
+              - mero004
+            bucket_prefix: reg-cosbench-bkt-downup-
+            number_of_buckets: 1
+            number_of_objects: 2000000
+      desc: upload 2M object to regular bucket
+      module: push_cosbench_workload.py
+      name: upload 2M object to regular bucket
+      polarion-id: CEPH-83575113
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_sync_post_destruptive_services.py
+            config-file-name: test_sync_consistent_post_service_down_up.yaml
+      desc: Test sync consistent post RGW service down and bringing it up
+      module: sanity_rgw_multisite.py
+      name: Test sync consistent post RGW service down and bringing it up
+      polarion-id: CEPH-83575113


### PR DESCRIPTION
# Description

cephci integration: CEPH-83575113

pass log with extensa setup: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-3FMVGR/
since mero baremetal cluster is in bad state, due to mero001 node being inaccessible

currently not going with parallel execution of IO and testcase , since with parallel.py module seen an issue with
consideration of cluster when two testcases are executed in parallel.

i.e, as per this PR's requirement
IO should be done from primary cluster, and service down/up should be done from secondary cluster.
when we tried this using parallel module.

both the scenarios are happening in primary cluster.
it doesn't consider ceph-sec for second testcase.



Testing needs to be done, depends on baremetal cluster

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
