### PR TITLE
[Tier-3] [rgw-ms] CEPH-83575304 - Tweak num_shards to 32 and test bi-directional sync workload

### DIFF
--- a/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
+++ b/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
@@ -251,7 +251,49 @@ tests:
       desc: create versioned bucket in primary
       module: sanity_rgw_multisite.py
       name: create versioned bucket in primary
-      polarion-id: CEPH-83575073
+      polarion-id: CEPH-83575073 # CEPH-83575304
+
+  - test:
+      name: parallel manually resharding bucket to 32 number of shards
+      desc: parallel manually resharding bucket to 32 number of shards
+      module: test_parallel.py
+      parallel:
+        - test:
+            clusters:
+              ceph-sec:
+                config:
+                  cephadm: true
+                  commands:
+                    - "radosgw-admin bucket stats --bucket cosbench01-bkt-1"
+            desc: check bucket stats of bucket on secondary
+            name: check bucket stats of bucket on secondary
+            module: exec.py
+            polarion-id: CEPH-83575304
+        - test:
+            clusters:
+              ceph-pri:
+                config:
+                  cephadm: true
+                  commands:
+                    - "radosgw-admin bucket stats --bucket cosbench01-bkt-1"
+                    - "radosgw-admin bucket reshard --bucket cosbench01-bkt-1 --num-shards=32"
+                    - "radosgw-admin bucket stats --bucket cosbench01-bkt-1"
+            desc: manually reshard bucket to 32 on primary
+            name: manually reshard bucket to 32 on primary
+            module: exec.py
+            polarion-id: CEPH-83575304
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin bucket stats --bucket cosbench01-bkt-1"
+      desc: check bucket stats of bucket cosbench01-bkt-1 on secondary
+      name: check bucket stats of bucket cosbench01-bkt-1 on secondary
+      polarion-id: CEPH-83575304
+      module: exec.py
 
   - test:
       name: Parallel upload of objects to versioned bucket
@@ -275,7 +317,7 @@ tests:
             desc: initiate cosbench push workload from primary
             module: push_cosbench_workload.py
             name: push cosbench push workload from primary
-            polarion-id: CEPH-83575073
+            polarion-id: CEPH-83575073 # CEPH-83575304
         - test:
             clusters:
               ceph-sec:
@@ -293,7 +335,7 @@ tests:
             desc: initiate cosbench push workload from secondary
             module: push_cosbench_workload.py
             name: push cosbench push workload from secondary
-            polarion-id: CEPH-83575073
+            polarion-id: CEPH-83575073 # CEPH-83575304
 
   - test:
       clusters:
@@ -313,7 +355,7 @@ tests:
       desc: initiate cosbench fill workload for versioned bucket
       name: push cosbench fill workload for versioned bucket
       module: push_cosbench_workload.py
-      polarion-id: CEPH-83575077
+      polarion-id: CEPH-83575077 # CEPH-83575304
 
   - test:
       clusters:
@@ -348,7 +390,7 @@ tests:
             desc: initiate cosbench cleanup workload from primary
             module: push_cosbench_workload.py
             name: push cosbench cleanup workload from primary
-            polarion-id: CEPH-83575074
+            polarion-id: CEPH-83575074 # CEPH-83575304
         - test:
             clusters:
               ceph-sec:
@@ -365,7 +407,20 @@ tests:
             desc: initiate cosbench cleanup workload from secondary
             module: push_cosbench_workload.py
             name: push cosbench cleanup workload from secondary
-            polarion-id: CEPH-83575074
+            polarion-id: CEPH-83575074 # CEPH-83575304
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin bucket rm --bucket cosbench01-bkt-1 --purge-data"
+              - "radosgw-admin bucket list"
+      desc: remove bucket cosbench01-bkt-1 from primary
+      module: exec.py
+      name: remove bucket cosbench01-bkt-1
+      polarion-id: CEPH-83575304
 
   - test:
       name: Parallel sync error check

--- a/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
@@ -198,4 +198,4 @@ tests:
         cephadm: true
         commands:
           - "radosgw-admin bucket rm --bucket test-bucket-1 --purge-data"
-          - "radosgw-admin test-bucket-1 list"
+          - "radosgw-admin bucket list"


### PR DESCRIPTION
# Description
log : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-YYTCHE/ 
manually reshard bucket to 32 then initiate bidirectional workload 
included deletion of bucket as well 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
