### PR TITLE
[RBD-Mirror] rbd mirror common test suites

### DIFF
--- a/suites/squid/common/regression/2way_rbd_mirror.yaml
+++ b/suites/squid/common/regression/2way_rbd_mirror.yaml
@@ -1,0 +1,220 @@
+# Conf file : conf/squid/common/ms_2way_9node_1client_rh.yaml
+# deployment: suites/squid/common/sanity/ms_2way_deploy-and-configure.yaml
+tests:
+  - test:
+      name: Mirroring of cloned image
+      module: test_rbd_clone_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+      polarion-id: CEPH-9521
+      desc: Testing mirroring of cloned image
+
+  - test:
+      name: Mirroring from journal to snapshot
+      module: test_rbd_mirror_journal_to_snap.py
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              mode: "image"
+              size: "2G"
+            ec_pool_config:
+              mode: "image"
+              size: "2G"
+      polarion-id: CEPH-83573618
+      desc: Testing journal mirroring to snapshot mirroring
+
+  - test:
+      name: Attempt expanding or shrinking secondary image
+      module: test_expand_or_shrink_img_at_secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            ec_pool_config:
+              imagesize: 2G
+              io-total: 200M
+            rep_pool_config:
+              imagesize: 2G
+              io-total: 200M
+      polarion-id: CEPH-9500
+      desc: Verify that resizing secondary image fails
+
+  - test:
+      name: test image meta operations sync to secondary
+      module: test_rbd_image_meta_mirroring.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            key: ping
+            value: pong
+      polarion-id: CEPH-9524
+      desc: Verify removal of image meta gets mirrored
+
+  - test:
+      name: Image shrink in primary cluster
+      module: test_rbd_mirror_shrink_image_primary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            journal:
+              ec_pool_config:
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                size: 2G
+                io_total: 10
+            snapshot:
+              ec_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+              rep_pool_config:
+                mode: image
+                mirrormode: snapshot
+                size: 2G
+                io_total: 10
+      polarion-id: CEPH-9499
+      desc: Verify image size at secondary when image shrink at primary cluster
+
+  - test:
+      name: Test to change of mirror pool replica size
+      module: test_rbd_mirror_replica_count.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io_total: 200M
+      polarion-id: CEPH-9518
+      desc: Verify changing mirror pool replica size shouldn't affect mirroring with IO
+
+  - test:
+      name: Testing snapshot based mirroring of cloned images
+      module: test_rbd_mirror_cloned_image.py
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              mode: image
+              mirrormode: snapshot
+              imagesize: 2G
+              io_total: 200M
+            ec_pool_config:
+              mode: image
+              mirrormode: snapshot
+              imagesize: 2G
+              io_total: 200M
+      polarion-id: CEPH-83576099
+      desc: Verify enabling snapshot based mirroring of cloned image is not supported
+
+  - test:
+      desc: Validate the mirror pool status reflects accordingly
+      name: Test to verify changing and Reseting peer client ID
+      module: test_rbd_mirror_peer_id.py
+      polarion-id: CEPH-83590607
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              mode: image
+              mirrormode: snapshot
+              imagesize: 2G
+              io_total: 100M
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              mode: image
+              mirrormode: snapshot
+              imagesize: 2G
+              io_total: 100M
+
+  - test:
+      name: test-image-delete-from-primary-site
+      module: test-image-delete-primary-site.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-9501
+      desc: Verify that image deleted at primary site updated at secondary
+
+  - test:
+      name: test mirror on image having snap and clone after restoring from trash
+      module: test_mirror_move_primary_trash_restore.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-11417
+      desc: Verify that image is restore and mirroring is intact
+
+  - test:
+      name: test image delete from secondary after promote and demote
+      module: test-image-delete-from-secondary.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            repeat_count: 1
+      polarion-id: CEPH-83574741
+      desc: Verify that deleting primary image also delete the secondary image
+
+  - test:
+      name: Test to verify snapshot based rbd mirror related metrics
+      module: test_rbd_mirror_snapshot_metrics.py
+      clusters:
+        ceph-rbd2:
+          config:
+            mode: image
+            mirrormode: snapshot
+      polarion-id: CEPH-83575565
+      desc: Validate rbd mirror daemon related snapshot based metrics
+
+  - test:
+      abort-on-fail: True
+      desc: Verify snapshot based mirroring cannot be enabled at pool mode
+      name: Test validating neg scenario snapshot mirroring in pool mode
+      module: test_snapshot_mirroring_on_pool_negative.py
+      polarion-id: CEPH-83573617
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 1
+              mode: pool
+              mirrormode: snapshot
+            ec_pool_config:
+              num_pools: 1
+              num_images: 1
+              mode: pool
+              mirrormode: snapshot
+
+  - test:
+      abort-on-fail: True
+      desc: Verify image expand/shrink/remove from mirroring cluster
+      name: Verify image operations from primary and secondary cluster
+      module: test_image_operations_on_snap_mirroring.py
+      polarion-id: CEPH-83574857
+      clusters:
+        ceph-rbd1:
+          config:
+            rep_pool_config:
+              num_pools: 1
+              num_images: 10
+              mode: image
+              mirrormode: snapshot
+            ec_pool_config:
+              num_pools: 1
+              num_images: 10
+              mode: image
+              mirrormode: snapshot

--- a/suites/squid/common/sanity/rbd_mirror.yaml
+++ b/suites/squid/common/sanity/rbd_mirror.yaml
@@ -1,0 +1,81 @@
+# Conf file : conf/squid/common/ms_2way_9node_1client_rh.yaml
+# deployment: suites/squid/common/sanity/ms_2way_deploy-and-configure.yaml
+tests:
+
+# Tests from - suites/squid/rbd/tier-1_rbd_mirror.yaml
+  - test:
+      name: test_rbd_mirror
+      module: test_rbd_mirror.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+            resize_to: 5G
+      polarion-id: CEPH-83573332
+      desc: Create RBD mirrored image in pools  and run IOs
+  - test:
+      name: test_rbd_mirror_image
+      module: test_rbd_mirror_image.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-83573619,CEPH-83573620
+      desc: Create RBD mirrored images and run IOs
+  - test:
+      name: test_rbd_mirror_rename_image
+      module: test_rbd_mirror_rename_image.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-83573614
+      desc: Rename primary image and check on secondary for this change
+  - test:
+      name: test_rbd_mirror_daemon_status
+      module: test_rbd_mirror_daemon_status.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            io-total: 200M
+      polarion-id: CEPH-83573760
+      desc: Verify rbd mirror and daemon status on cluster
+
+# Tests from - suites/squid/rbd/tier-2_rbd_mirror_snapshot_regression.yaml
+  - test:
+      name: test_rbd_mirror_snapshot_pool
+      module: test_rbd_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            ec_pool_config:
+              mirrormode: snapshot
+              mode: image
+            rep_pool_config:
+              mirrormode: snapshot
+              mode: image
+            snapshot_schedule_level: "pool"
+      polarion-id: CEPH-83575375
+      desc: Create snapshot based RBD mirrored pools, schedule snapshots at pool level and verify
+
+  - test:
+      name: test_rbd_mirror_snapshot_cluster
+      module: test_rbd_mirror_snapshot.py
+      clusters:
+        ceph-rbd1:
+          config:
+            imagesize: 2G
+            ec_pool_config:
+              mirrormode: snapshot
+              mode: image
+            rep_pool_config:
+              mirrormode: snapshot
+              mode: image
+            snapshot_schedule_level: "cluster"
+      polarion-id: CEPH-83575376
+      desc: Create snapshot based RBD mirrored pools, schedule snapshots at cluster level and verify

--- a/suites/squid/rbd/tier-2_rbd_cache_scenarios.yaml
+++ b/suites/squid/rbd/tier-2_rbd_cache_scenarios.yaml
@@ -91,7 +91,7 @@ tests:
         sudo: true
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
-          - "dnf install rbd-nbd -y"
+          - "dnf install rbd-nbd -y --nogpgcheck"
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rbd/tier-2_rbd_encryption.yaml
+++ b/suites/squid/rbd/tier-2_rbd_encryption.yaml
@@ -80,7 +80,7 @@ tests:
         sudo: true
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
-          - "dnf install rbd-nbd -y"
+          - "dnf install rbd-nbd -y --nogpgcheck"
 
   - test:
       desc: Encrypt & decrypt file using same keys and different keys

--- a/suites/squid/rbd/tier-3_rbd_operations.yaml
+++ b/suites/squid/rbd/tier-3_rbd_operations.yaml
@@ -70,7 +70,7 @@ tests:
         sudo: true
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
-          - "dnf install rbd-nbd -y"
+          - "dnf install rbd-nbd -y --nogpgcheck"
 
   - test:
       desc: Run all image operations in scale

--- a/suites/squid/rbd/tier-3_rbd_persistent_write_back_cache.yaml
+++ b/suites/squid/rbd/tier-3_rbd_persistent_write_back_cache.yaml
@@ -77,7 +77,7 @@ tests:
         sudo: true
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
-          - "dnf install rbd-nbd -y"
+          - "dnf install rbd-nbd -y --nogpgcheck"
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rbd/tier-3_rbd_snap_operations.yaml
+++ b/suites/squid/rbd/tier-3_rbd_snap_operations.yaml
@@ -79,7 +79,7 @@ tests:
         sudo: true
         commands:
           - "rm -rf /etc/yum.repos.d/epel*"
-          - "dnf install rbd-nbd -y"
+          - "dnf install rbd-nbd -y --nogpgcheck"
 
   - test:
       desc: Run all image snap operations in scale

--- a/tests/rbd/test_rbd_immutable_cache.py
+++ b/tests/rbd/test_rbd_immutable_cache.py
@@ -72,7 +72,7 @@ def configure_immutable_cache(rbd_obj, client_node, user_name):
 
         # Install ceph-immutable-object-cache package
         client_node.exec_command(
-            cmd="dnf install ceph-immutable-object-cache -y", sudo=True
+            cmd="dnf install ceph-immutable-object-cache -y --nogpgcheck", sudo=True
         )
 
         # Generate keyring and create keyring file


### PR DESCRIPTION
# Description

Added common sanity and regression tests for rbd mirror.

RBD Baremetal runs getting failed with package issue on`gpgcheck` failure,
hence added `--nogpgcheck` on package installaion.

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
