### PR TITLE
Added new GW CLIs for 8.1

### DIFF
--- a/ceph/nvmegw_cli/gateway.py
+++ b/ceph/nvmegw_cli/gateway.py
@@ -16,14 +16,17 @@ class Gateway(ExecuteCommandMixin):
     def mtls(self, value):
         self._mtls = value
 
+    def get_log_level(self, **kwargs):
+        return self.run_nvme_cli("get_log_level", **kwargs)
+
     def info(self, **kwargs):
         return self.run_nvme_cli("info", **kwargs)
 
-    def version(self, **kwargs):
-        return self.run_nvme_cli("version", **kwargs)
+    def listener_info(self, **kwargs):
+        return self.run_nvme_cli("listener_info", **kwargs)
 
     def set_log_level(self, **kwargs):
         return self.run_nvme_cli("set_log_level", **kwargs)
 
-    def get_log_level(self, **kwargs):
-        return self.run_nvme_cli("get_log_level", **kwargs)
+    def version(self, **kwargs):
+        return self.run_nvme_cli("version", **kwargs)

--- a/ceph/nvmegw_cli/namespace.py
+++ b/ceph/nvmegw_cli/namespace.py
@@ -38,7 +38,7 @@ class Namespace(ExecuteCommandMixin):
         """Delete a namespace from a subsystem."""
         return self.run_nvme_cli("del", **kwargs)
 
-    def delete_host(self, **kwargs):
+    def del_host(self, **kwargs):
         """Delete host from a namespace."""
         return self.run_nvme_cli("del_host", **kwargs)
 

--- a/suites/squid/nvmeof/tier-2_8-1_nvmeof_gateway_operations.yaml
+++ b/suites/squid/nvmeof/tier-2_8-1_nvmeof_gateway_operations.yaml
@@ -1,0 +1,738 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: conf/squid/nvmeof/ceph_nvmeof_sanity.yaml
+# Inventory: conf/inventory/rhel-9.5-server-x86_64-xlarge.yaml
+
+tests:
+# Set up the cluster
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node10
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  #  Configure Ceph NVMeoF gateway
+  #  Configure Initiators
+  #  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool application enable rbd rbd
+          - config:
+              command: shell
+              args:
+                - rbd create -s 1G image1
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                    - node5
+                    - node6
+              pos_args:
+                - rbd
+                - gw-group1
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node6
+        pool: rbd
+        port: 5500
+        gw_group: gw-group1
+        steps:
+          - config:
+              service: gateway
+              command: version         # gateway Version
+              base_cmd_args:
+                format: json
+                output: log
+          - config:
+              service: gateway
+              command: info             # gateway info
+          - config:
+              service: loglevel
+              command: get
+              base_cmd_args:
+                format: json
+                output: stdio
+          - config:
+              service: loglevel
+              command: set
+              base_cmd_args:
+                format: json
+                output: stdio
+              args:
+                level: error
+                print: error
+          - config:
+              service: loglevel
+              command: disable
+              base_cmd_args:
+                format: json
+                output: stdio
+          - config:
+              service: subsystem
+              command: add              # Subsystem add with groupName
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                serial-number: 1
+              validate:
+                omap: true
+          - config:
+              service: subsystem
+              command: add              # Subsystem add without groupName
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                serial-number: 2
+                no-group-append: true
+              validate:
+                omap: true
+          - config:
+              service: gateway
+              command: info             # gateway info
+          - config:
+              service: subsystem
+              command: list             # Subsystem list
+              base_cmd_args:
+                format: json
+          - config:
+              service: connection
+              command: list             # Subsystem connection list
+              base_cmd_args:
+                format: json
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: listener
+              command: add                # Listener add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host-name: node6
+                trsvcid: 5001
+                traddr: node6
+              validate:
+                omap: true
+              base_cmd_args:
+                format: json
+          - config:
+              service: listener
+              command: list               # Listener list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: host
+              command: add              # add Host access
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host: '"*"'
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: list             # List access hosts
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: gateway
+              command: listener_info             # List ana states for subsystem
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image1
+                rbd-pool: rbd
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image2
+                rbd-pool: rbd
+                nsid: 2
+                rbd-create-image: true
+                size: 10G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image3
+                rbd-pool: rbd
+                nsid: 3
+                load-balancing-group: 1
+                rbd-create-image: true
+                size: 1G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add with trash-image enabled
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image4
+                rbd-pool: rbd
+                nsid: 4
+                load-balancing-group: 2
+                rbd-create-image: true
+                size: 1G
+                rbd-trash-image-on-delete: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list using nsid
+              args:
+                nsid: 4
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list for all subsystems
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+                rw-ios-per-second: 10
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+                rw-ios-per-second: 20
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: resize              # Namespace resize
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 2
+                size: 15G
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 3
+                load-balancing-group: 2
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 4
+                load-balancing-group: 1
+          - config:
+              service: namespace
+              command: list             # namespace list using subsystem NQN
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list using nsid
+              args:
+                nsid: 4
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list for all subsystems
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: get_io_stats             # namespace get_io_stats
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 2
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 3
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 4
+                i-am-sure: true
+              validate:
+                omap: true
+          - config:
+              service: listener
+              command: delete             # listener del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host-name: node6
+                trsvcid: 5001
+                traddr: node6
+              validate:
+                omap: true
+          - config:
+              service: subsystem
+              command: delete           # subsystem delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+              validate:
+                omap: true
+          - config:
+              service: gateway
+              command: info
+          - config:
+              service: connection
+              command: list             # Subsystem connection list
+              base_cmd_args:
+                format: json
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: listener
+              command: add                # Listener add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host-name: node6
+                trsvcid: 5001
+                traddr: node6
+              validate:
+                omap: true
+              base_cmd_args:
+                format: json
+          - config:
+              service: listener
+              command: list               # Listener list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: host
+              command: add              # add Host access
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host: '"*"'
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: list             # List access hosts
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: gateway
+              command: listener_info             # List ana states for subsystem
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image1
+                rbd-pool: rbd
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image5
+                rbd-pool: rbd
+                nsid: 2
+                rbd-create-image: true
+                size: 10G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image3
+                rbd-pool: rbd
+                nsid: 3
+                load-balancing-group: 1
+                rbd-create-image: true
+                size: 1G
+                no-auto-visible: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image4
+                rbd-pool: rbd
+                nsid: 4
+                load-balancing-group: 2
+                rbd-create-image: true
+                size: 1G
+                no-auto-visible: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: list             # namespace list using subsystem NQN
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list using nsid
+              args:
+                nsid: 4
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list for all subsystems
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: add_host             # namespace add_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080b
+          - config:
+              service: namespace
+              command: add_host             # namespace add_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080c
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+                rw-ios-per-second: 10
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+                rw-ios-per-second: 20
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: resize              # Namespace resize
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 2
+                size: 15G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                load-balancing-group: 2
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                load-balancing-group: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: get_io_stats             # namespace get_io_stats
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+          - config:
+              service: namespace
+              command: del_host             # namespace del_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080b
+          - config:
+              service: namespace
+              command: del_host             # namespace del_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080c
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                auto-visible: 'yes'
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                auto-visible: 'yes'
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+                auto-visible: 'no'
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 2
+                auto-visible: 'no'
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 2
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                i-am-sure: true
+              validate:
+                omap: true
+          - config:
+              service: listener
+              command: delete             # listener del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host-name: node6
+                trsvcid: 5001
+                traddr: node6
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: delete           # access host del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host: '"*"'
+              validate:
+                omap: true
+          - config:
+              service: subsystem
+              command: delete           # subsystem delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              validate:
+                omap: true
+          - config:
+              service: gateway
+              command: info
+          - config:
+              service: version          # CLI Version
+              command: version
+              base_cmd_args:
+                format: json
+                output: log
+      desc: Manage NVMeoF Subsystem entities
+      destroy-cluster: false
+      module: test_nvme_cli.py
+      name: Manage nvmeof gateway entities
+      polarion-id: CEPH-83575783
+
+  - test:
+      abort-on-fail: true
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.rbd.gw-group1
+           verify: true
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-cluster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: NVMeoF Gateway deployment using cephadm
+      do-not-skip-tc: true
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Delete nvmeof gateway pre-reqs

--- a/suites/squid/nvmeof/tier-2_8-1_nvmeof_gateway_operations.yaml
+++ b/suites/squid/nvmeof/tier-2_8-1_nvmeof_gateway_operations.yaml
@@ -191,6 +191,21 @@ tests:
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode2
           - config:
+              service: gateway
+              command: listener_info             # List ana states for subsystem
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: listener
+              command: delete             # listener del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host-name: node6
+                trsvcid: 5001
+                traddr: node6
+              validate:
+                omap: true
+          - config:
               service: host
               command: add              # add Host access
               args:
@@ -201,11 +216,6 @@ tests:
           - config:
               service: host
               command: list             # List access hosts
-              args:
-                subsystem: nqn.2016-06.io.spdk:cnode2
-          - config:
-              service: gateway
-              command: listener_info             # List ana states for subsystem
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode2
           - config:
@@ -259,7 +269,7 @@ tests:
                 omap: true
           - config:
               service: namespace
-              command: list             # namespace list
+              command: list             # namespace list per subsystem NQN
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode2
               base_cmd_args:
@@ -324,18 +334,6 @@ tests:
                 format: json
           - config:
               service: namespace
-              command: list             # namespace list using nsid
-              args:
-                nsid: 4
-              base_cmd_args:
-                format: json
-          - config:
-              service: namespace
-              command: list             # namespace list for all subsystems
-              base_cmd_args:
-                format: json
-          - config:
-              service: namespace
               command: get_io_stats             # namespace get_io_stats
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode2
@@ -371,16 +369,6 @@ tests:
                 subsystem: nqn.2016-06.io.spdk:cnode2
                 nsid: 4
                 i-am-sure: true
-              validate:
-                omap: true
-          - config:
-              service: listener
-              command: delete             # listener del
-              args:
-                subsystem: nqn.2016-06.io.spdk:cnode2
-                host-name: node6
-                trsvcid: 5001
-                traddr: node6
               validate:
                 omap: true
           - config:
@@ -487,6 +475,19 @@ tests:
                 omap: true
           - config:
               service: namespace
+              command: add              # Namespace add with trash-image enabled
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image6
+                rbd-pool: rbd
+                nsid: 5
+                rbd-create-image: true
+                size: 1G
+                rbd-trash-image-on-delete: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
               command: list             # namespace list using subsystem NQN
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
@@ -662,6 +663,14 @@ tests:
               args:
                 subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
                 nsid: 4
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 5
                 i-am-sure: true
               validate:
                 omap: true


### PR DESCRIPTION
Added new GW CLIs for 8.1 as per 
https://jsw.ibm.com/browse/ISCE-1423
logs: http://magna002.ceph.redhat.com/ceph-qe-logs/hchebrol/cephci-run-DGTI05/

Note: The success logs were retrieved when we tried to do operations prior to listener delete 
Once https://github.com/ceph/ceph-nvmeof/issues/1162 gets fixed, this suite can be run without any errors

# Description

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [x] Implement the test script and perform test runs
- [x] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
