### PR TITLE
Cephci Integration of CEPH-83574448

### DIFF
--- a/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
+++ b/suites/squid/rgw/baremetal/mero_scale_rgw_multi_site.yaml
@@ -448,6 +448,7 @@ tests:
             name: sync error check in secondary
             polarion-id: CEPH-83572752
 
+# Please keep below(distruptive) testcases at the end of the suites only
   - test:
       clusters:
         ceph-pri:
@@ -475,3 +476,31 @@ tests:
       module: sanity_rgw_multisite.py
       name: Test sync consistent post RGW service down and bringing it up
       polarion-id: CEPH-83575113
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            controllers:
+              - mero003
+            drivers:
+              - mero003
+              - mero004
+            bucket_prefix: reg-cosbench-bkt-reboot-
+            number_of_buckets: 1
+            number_of_objects: 1000000
+      desc: upload 1M object to regular bucket
+      module: push_cosbench_workload.py
+      name: Test upload 1M object to regular bucket
+      polarion-id: CEPH-83574448
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_sync_post_destruptive_services.py
+            config-file-name: test_sync_consistent_with_node_reboot.yaml
+      desc: sync consistent post RGW sync node reboot
+      module: sanity_rgw_multisite.py
+      name: Test sync consistent post RGW sync node reboot
+      polarion-id: CEPH-83574448


### PR DESCRIPTION
# Description

cephci integration of CEPH-83574448: Verify node reboot during sync
Log with extensa baremetal setup: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-NTVBEZ/

dependent on: https://github.com/red-hat-storage/ceph-qe-scripts/pull/697
Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
