### PR TITLE
Rados TFA issue fixes

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1349,7 +1349,7 @@ class RadosOrchestrator:
         if yes_i_mean_it:
             cmd = cmd + " --yes-i-really-mean-it "
 
-        log.debug(f"Final command to create EC pool : {cmd}")
+        log.debug(f"Final command to create EC Profile : {cmd}")
         try:
             self.run_ceph_command(cmd=cmd)
             time.sleep(5)
@@ -1365,7 +1365,8 @@ class RadosOrchestrator:
             return False
 
         cmd = f"ceph osd erasure-code-profile get {profile_name}"
-        log.info(self.node.shell([cmd]))
+        log.info("Profile created : \n %s", self.run_ceph_command(cmd=cmd))
+        log.debug("EC profile created. Proceeding to create pool")
 
         # Creating the Crush rule for the profile created
         if create_rule:

--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -124,10 +124,10 @@ class PoolFunctions:
             f"Writing {(obj_end - obj_start) * num_keys_obj} Key pairs"
             f" to increase the omap entries on pool {pool_name}"
         )
-        script_loc = "https://raw.githubusercontent.com/red-hat-storage/cephci/master/utility/generate_omap_entries.py"
+        lx = "https://raw.githubusercontent.com/red-hat-storage/cephci/refs/heads/main/utility/generate_omap_entries.py"
         client_node.exec_command(
             sudo=True,
-            cmd=f"curl -k {script_loc} -O",
+            cmd=f"curl -k {lx} -O",
         )
         # Setup Script pre-requisites : docopt
         client_node.exec_command(
@@ -770,6 +770,7 @@ class PoolFunctions:
         test_pg_split = kwargs.get("test_pg_split")
         test_pg_merge = kwargs.get("test_pg_merge")
         modify_threshold = kwargs.get("modify_threshold", False)
+        threshold_val = kwargs.get("threshold_val", 1.3)
         timeout = kwargs.get("timeout", 14000)
 
         if overwrite_recovery_threads:
@@ -785,6 +786,7 @@ class PoolFunctions:
             self.rados_obj.set_pool_property(
                 pool=pool, props="pg_autoscale_mode", value="on"
             )
+            time.sleep(10)
 
         init_pg_count = self.rados_obj.get_pool_property(pool=pool, props="pg_num")[
             "pg_num"
@@ -841,7 +843,7 @@ class PoolFunctions:
                         log.info(
                             "Param passed to modify the threshold set. Changing it to 1.3 from 3."
                         )
-                        self.modify_autoscale_threshold(threshold=1.3)
+                        self.modify_autoscale_threshold(threshold=threshold_val)
                         time.sleep(60)
                     else:
                         no_count_change = True

--- a/suites/pacific/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/pacific/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -83,68 +83,70 @@ tests:
       abort-on-fail: true
 
 
+
   - test:
-      name: Configure clients
-      desc: Configures multiple client nodes on cluster
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Configure client 1
-            desc: Configures client.1 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.1                      # client Id (<type>.<Id>)
-              nodes:
-                  - node15:
-                      release: 5
-                  - node7:
-                      release: 5
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 2
-            desc: Configures client.2 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.2                     # client Id (<type>.<Id>)
-              nodes:
-                - node16:
-                    release: 5
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps: # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 3
-            desc: Configures client admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.3                      # client Id (<type>.<Id>)
-              node: node17                       # client node
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
+      name: Configure client 1
+      desc: Configures client.1 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node15:
+              release: 5
+          - node7:
+              release: 5
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 2
+      desc: Configures client.2 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2                     # client Id (<type>.<Id>)
+        nodes:
+          - node16:
+              release: 5
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 3
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3                      # client Id (<type>.<Id>)
+        node: node17                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
 
   - test:
       name: Enable logging to file

--- a/suites/quincy/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/quincy/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -1,7 +1,7 @@
 # Suite contains tests related to CIDR blocklisting of ceph clients
 # This is Openstack only test suite.
 # conf: 13-node-cluster-4-clients.yaml
-
+# RHOS-d run duration: 50 mins + 50 min (slow_ops) + 20 min (recovery_tests)
 tests:
   - test:
       name: setup install pre-requisistes
@@ -82,69 +82,68 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
 
+  - test:
+      name: Configure client 1
+      desc: Configures client.1 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node15:
+              release: 6
+          - node7:
+              release: 6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
 
   - test:
-      name: Configure clients
-      desc: Configures multiple client nodes on cluster
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Configure client 1
-            desc: Configures client.1 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.1                      # client Id (<type>.<Id>)
-              nodes:
-                  - node15:
-                      release: 5
-                  - node7:
-                      release: 5
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 2
-            desc: Configures client.2 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.2                     # client Id (<type>.<Id>)
-              nodes:
-                - node16:
-                    release: 6
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps: # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 3
-            desc: Configures client admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.3                      # client Id (<type>.<Id>)
-              node: node17                       # client node
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
+      name: Configure client 2
+      desc: Configures client.2 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2                     # client Id (<type>.<Id>)
+        nodes:
+          - node16:
+              release: 7
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 3
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3                      # client Id (<type>.<Id>)
+        node: node17                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
 
   - test:
       name: Enable logging to file
@@ -165,7 +164,7 @@ tests:
           pool-2:
             type: replicated
             conf: sample-pool-2
-        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+        pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
       desc: CIDR Blocklisting of ceph rbd clients
 
   - test:

--- a/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -76,6 +76,17 @@ tests:
                   service_id: cephfs
                   placement:
                     label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs.cephfs.data
+                - bulk
+                - false
 
   - test:
       name: RGW Service deployment
@@ -98,6 +109,7 @@ tests:
       desc: Configures client admin node on cluster
       module: test_client.py
       polarion-id:  CEPH-83573758
+      abort-on-fail: true
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
@@ -147,6 +159,7 @@ tests:
       name: EC pool 2=2@4 LC
       module: test_four_node_ecpool.py
       polarion-id: CEPH-83575858
+      abort-on-fail: true
       config:
         ec_pool:
           profile_name: ec22_profile

--- a/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -82,69 +82,68 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
 
+  - test:
+      name: Configure client 1
+      desc: Configures client.1 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node15:
+              release: 6
+          - node7:
+              release: 6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
 
   - test:
-      name: Configure clients
-      desc: Configures multiple client nodes on cluster
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Configure client 1
-            desc: Configures client.1 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.1                      # client Id (<type>.<Id>)
-              nodes:
-                  - node15:
-                      release: 6
-                  - node7:
-                      release: 6
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 2
-            desc: Configures client.2 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.2                     # client Id (<type>.<Id>)
-              nodes:
-                - node16:
-                    release: 7
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps: # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 3
-            desc: Configures client admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.3                      # client Id (<type>.<Id>)
-              node: node17                       # client node
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
+      name: Configure client 2
+      desc: Configures client.2 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2                     # client Id (<type>.<Id>)
+        nodes:
+          - node16:
+              release: 7
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 3
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3                      # client Id (<type>.<Id>)
+        node: node17                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
 
   - test:
       name: Enable logging to file
@@ -165,7 +164,7 @@ tests:
           pool-2:
             type: replicated
             conf: sample-pool-2
-        pool_configs_path: "conf/pacific/rados/test-confs/pool-configurations.yaml"
+        pool_configs_path: "conf/reef/rados/test-confs/pool-configurations.yaml"
       desc: CIDR Blocklisting of ceph rbd clients
 
   - test:
@@ -190,6 +189,7 @@ tests:
 #                pool_name: async_recover
 #                pg_num: 16
 #          desc: Verification of the async recovery
+
   - test:
       name: Change Mon weight for Mgr
       polarion-id: CEPH-83588304

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -22,6 +22,8 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
+                rhcs-version: 7.1
+                release: rc
 
   - test:
       name: Add host
@@ -109,6 +111,17 @@ tests:
                   service_id: cephfs
                   placement:
                     label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs.cephfs.data
+                - bulk
+                - false
 
   - test:
       name: RGW Service deployment
@@ -130,6 +143,7 @@ tests:
       name: Configure client admin
       desc: Configures client admin node on cluster
       module: test_client.py
+      abort-on-fail: true
       polarion-id:  CEPH-83573758
       config:
         command: add
@@ -180,6 +194,7 @@ tests:
       name: EC pool 2=2@4 LC
       module: test_four_node_ecpool.py
       polarion-id: CEPH-83575858
+      abort-on-fail: true
       config:
         ec_pool:
           profile_name: ec22_profile
@@ -192,7 +207,7 @@ tests:
         remove_host: true
         delete_pools:
           - test_ec_pool
-      desc: 2+2@4 EC pool life cycle with serviceability scenarios
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
 
   - test:
       name: EC Pool Recovery Improvement

--- a/suites/squid/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/squid/rados/tier-2-rados-basic-regression.yaml
@@ -399,8 +399,6 @@ tests:
       polarion-id: CEPH-83573478
       desc: Config sources - Verify config source changes and reset config
 
-# Commenting until bug fix : https://bugzilla.redhat.com/show_bug.cgi?id=2252788
-# Other issues with noautoscale flag listed here : https://bugzilla.redhat.com/show_bug.cgi?id=2283358
 # RHOS-d run duration: 8 mins
   - test:
       name: autoscaler flags
@@ -411,7 +409,6 @@ tests:
         create_ec_pool: true
         create_re_pool: true
       desc: verify autoscaler flags functionality
-      comments: active Bugs 2252788, 2283358
 
 # RHOS-d run duration: 1 min
 # env: VM + BM

--- a/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -82,69 +82,68 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
 
+  - test:
+      name: Configure client 1
+      desc: Configures client.1 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1                      # client Id (<type>.<Id>)
+        nodes:
+          - node15:
+              release: 6
+          - node7:
+              release: 6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
 
   - test:
-      name: Configure clients
-      desc: Configures multiple client nodes on cluster
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Configure client 1
-            desc: Configures client.1 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.1                      # client Id (<type>.<Id>)
-              nodes:
-                  - node15:
-                      release: 6
-                  - node7:
-                      release: 6
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 2
-            desc: Configures client.2 admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.2                     # client Id (<type>.<Id>)
-              nodes:
-                - node16:
-                    release: 7
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps: # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
-        - test:
-            name: Configure client 3
-            desc: Configures client admin node on cluster
-            module: test_client.py
-            polarion-id:
-            config:
-              command: add
-              id: client.3                      # client Id (<type>.<Id>)
-              node: node17                       # client node
-              install_packages:
-                - ceph-common
-              copy_admin_keyring: true          # Copy admin keyring to node
-              caps:                             # authorize client capabilities
-                mon: "allow *"
-                osd: "allow *"
-                mds: "allow *"
-                mgr: "allow *"
+      name: Configure client 2
+      desc: Configures client.2 admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.2                     # client Id (<type>.<Id>)
+        nodes:
+          - node16:
+              release: 7
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
+
+  - test:
+      name: Configure client 3
+      desc: Configures client admin node on cluster
+      module: test_client.py
+      polarion-id:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.3                      # client Id (<type>.<Id>)
+        node: node17                       # client node
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true          # Copy admin keyring to node
+        caps: # authorize client capabilities
+          mon: "allow *"
+          osd: "allow *"
+          mds: "allow *"
+          mgr: "allow *"
 
   - test:
       name: Enable logging to file

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -22,6 +22,8 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
+                rhcs-version: 8.0
+                release: rc
 
   - test:
       name: Add host
@@ -108,6 +110,17 @@ tests:
                   service_id: cephfs
                   placement:
                     label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs.cephfs.data
+                - bulk
+                - false
 
   - test:
       name: RGW Service deployment

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -22,6 +22,8 @@ tests:
                 verbose: true
               args:
                 mon-ip: node1
+                rhcs-version: 8.0
+                release: rc
 
   - test:
       name: Add host
@@ -109,6 +111,17 @@ tests:
                   service_id: cephfs
                   placement:
                     label: mds
+          # Adding below WA to set bulk flag to false until bug fix : 2308623
+          - config:
+              command: shell
+              args: # arguments to ceph orch
+                - ceph
+                - osd
+                - pool
+                - set
+                - cephfs.cephfs.data
+                - bulk
+                - false
 
   - test:
       name: RGW Service deployment
@@ -131,6 +144,7 @@ tests:
       desc: Configures client admin node on cluster
       module: test_client.py
       polarion-id:  CEPH-83573758
+      abort-on-fail: true
       config:
         command: add
         id: client.1                      # client Id (<type>.<Id>)
@@ -180,6 +194,7 @@ tests:
       name: EC pool 2=2@4 LC
       module: test_four_node_ecpool.py
       polarion-id: CEPH-83575858
+      abort-on-fail: true
       config:
         ec_pool:
           profile_name: ec22_profile
@@ -192,7 +207,7 @@ tests:
         remove_host: true
         delete_pools:
           - test_ec_pool
-      desc: 2+2@4 EC pool life cycle with serviceability scenarios
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios with upgrade
 
   - test:
       name: EC Pool Recovery Improvement

--- a/tests/rados/test_pg_autoscale_flag.py
+++ b/tests/rados/test_pg_autoscale_flag.py
@@ -102,7 +102,10 @@ def run(ceph_cluster, **kw):
                     f"Pg autoscaler mode still on for pool : {entry['pool_name']}"
                 )
                 # tbd: Uncomment the below exception upon bug fix: https://bugzilla.redhat.com/show_bug.cgi?id=2252788
-                # raise Exception("PG autoscaler mode still on error")
+                raise Exception(
+                    "PG autoscaler mode still on error. fixed only in squid"
+                    "Open bug : https://bugzilla.redhat.com/show_bug.cgi?id=2252788. "
+                )
         log.debug(
             "All the pools have the autoscaler mode changed from default on. pass"
         )

--- a/tests/rados/test_stretch_n-az_netsplit_scenarios.py
+++ b/tests/rados/test_stretch_n-az_netsplit_scenarios.py
@@ -231,7 +231,7 @@ def run(ceph_cluster, **kw):
                 "Observed that just IP tables flush did not work to bring back the nodes to cluster."
                 f"rebooting the nodes post testing. Rebooting node : {host.hostname}"
             )
-            host.exec_command(sudo=True, cmd="reboot")
+            host.exec_command(sudo=True, cmd="reboot", check_ec=False)
         log.debug("Sleeping for 30 seconds...")
         time.sleep(30)
 
@@ -257,7 +257,7 @@ def run(ceph_cluster, **kw):
                 "Observed that just IP tables flush did not work to bring back the nodes to cluster."
                 f"rebooting the nodes post testing. Rebooting node : {host.hostname}"
             )
-            host.exec_command(sudo=True, cmd="reboot")
+            host.exec_command(sudo=True, cmd="reboot", check_ec=False)
 
         rados_obj.rados_pool_cleanup()
 


### PR DESCRIPTION
1. Fixed the git curl link for omap entry generation 
2. Updated the client deployment workflow for CIDR tests
3. Updated write method in EC 8+6 MSR tests, in a bid to reduce run time
4. Updated -ve scenario condition in Online reads balancer
5. Uncommented test exception in PG autoscaler tests. ( fixed in squid with rebase )
6. Removed command execution status check in netsplit scenarios for Reboots.
7. Added Upgrade paths for 2+2 & 8+6 MSR pool tests. 
8. Removed the bulk flag on the CephFS data pool until bug fix : 2308623 for 4 node suites