### PR TITLE
CEPH-83609785: Test to verify OSD failure recovery due to corruption in allocator file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,8 @@ iscsi/              @Manohar-Murthy @HaruChebrolu
 nvmeof/             @Manohar-Murthy @HaruChebrolu
 
 # for RADOS
-rados/              @neha-gangadhar @pdhiran
+rados/				             @neha-gangadhar @pdhiran
+utility/generate_frag_objs.py	             @neha-gangadhar @pdhiran
 
 # for FS
 cephfs/             @neha-gangadhar @AmarnatReddy @Manimaran-MM

--- a/ceph/rados/bluestoretool_workflows.py
+++ b/ceph/rados/bluestoretool_workflows.py
@@ -16,6 +16,7 @@ Module to perform specific functionalities of ceph-bluestore-tool.
  - ceph-bluestore-tool reshard --path osd path --sharding new sharding [ --sharding-ctrl control string ]
  - ceph-bluestore-tool show-sharding --path osd path
  - ceph-bluestore-tool bluefs-stats --path osd path
+ - ceph-bluestore-tool bluefs-log-dump --path osd path
 """
 
 from typing import Dict
@@ -315,11 +316,22 @@ class BluestoreToolWorkflows:
         return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
 
     def show_bluefs_stats(self, osd_id: int):
-        """
+        """Module to fetch the o/p of CBT bluefs-stats
         Args:
-            osd_id:
+            osd_id: OSD ID for which cbt will be executed
         Returns:
             Returns the output of cbt bluefs-stats cmd
         """
         _cmd = "ceph-bluestore-tool bluefs-stats"
+        return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)
+
+    def get_bluefs_log_dump(self, osd_id: int):
+        """Module to fetch the bluefs_log_dump
+        e.g. - cephadm shell --name osd.7 -- ceph-bluestore-tool --path /var/lib/ceph/osd/ceph-7 bluefs-log-dump
+        Args:
+            osd_id: OSD ID for which cbt will be executed
+        Returns:
+            the output of cbt bluefs-log-dump cmd
+        """
+        _cmd = "ceph-bluestore-tool bluefs-log-dump"
         return self.run_cbt_command(cmd=_cmd, osd_id=osd_id)

--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -18,6 +18,8 @@ from collections import namedtuple
 
 from ceph.ceph_admin import CephAdmin
 from ceph.parallel import parallel
+from ceph.rados import utils as osd_utils
+from tests.rados.rados_test_util import wait_for_device_rados
 from utility import utils
 from utility.log import Log
 
@@ -1907,9 +1909,11 @@ class RadosOrchestrator:
             f"ceph orch ps --daemon_type {daemon_type} "
             f"--daemon_id {daemon_id} --refresh"
         )
-        orch_ps_out = self.run_ceph_command(cmd=cmd_)[0]
+        orch_ps_out = self.run_ceph_command(cmd=cmd_)
         log.debug(orch_ps_out)
-        return orch_ps_out["status"], orch_ps_out["status_desc"] if orch_ps_out else ()
+        return orch_ps_out[0]["status"], (
+            orch_ps_out[0]["status_desc"] if orch_ps_out else ()
+        )
 
     def daemon_check_post_tests(
         self, pre_test_orch_ps: dict, pre_crash_report: list = None
@@ -4445,6 +4449,11 @@ EOF"""
              False, if unmanaged flag is not set
         """
 
+        # the command "orch set-unmanaged" is not available below Reef
+        if self.rhbuild and self.rhbuild.split(".")[0] < "7":
+            return self.set_service_managed_type(
+                service_type=service_type, unmanaged=True
+            )
         cmd_set_unmanaged_flag = f"ceph orch set-unmanaged {service_name}"
         self.client.exec_command(sudo=True, cmd=cmd_set_unmanaged_flag)
         base_cmd = "ceph orch ls"
@@ -4472,6 +4481,11 @@ EOF"""
             False, if unmanaged flag is not unset
         """
 
+        # the command "orch set-managed" is not available below Reef
+        if self.rhbuild and self.rhbuild.split(".")[0] < "7":
+            return self.set_service_managed_type(
+                service_type=service_type, unmanaged=False
+            )
         cmd_set_managed_flag = f"ceph orch set-managed {service_name}"
         self.client.exec_command(sudo=True, cmd=cmd_set_managed_flag)
         base_cmd = "ceph orch ls"
@@ -4697,18 +4711,18 @@ EOF"""
 
         cmd_export = f"ceph orch ls {service_type} --export"
         out = self.run_ceph_command(cmd=cmd_export, client_exec=True)
-        for osd_service in out:
+        for _service in out:
             if unmanaged:
                 log.debug(
-                    f"Setting the {service_type} service as unmanaged by cephadm. current status : {out}"
+                    f"Setting the {_service} service as unmanaged by cephadm. current status : {out}"
                 )
-                osd_service["unmanaged"] = "true"
+                _service["unmanaged"] = True
             else:
                 log.debug(
-                    f"Setting the {service_type} service as unmanaged by cephadm. current status : {out}"
+                    f"Setting the {_service} service as managed by cephadm. current status : {out}"
                 )
-                osd_service["unmanaged"] = "false"
-            json_out = json.dumps(osd_service)
+                _service.pop("unmanaged", "key not found")
+            json_out = json.dumps(_service)
             # Adding the spec rules into the file
             cmd = f"echo '{json_out}' > {file_name}"
             self.client.exec_command(cmd=cmd, sudo=True)
@@ -4718,8 +4732,8 @@ EOF"""
             self.client.exec_command(cmd=apply_cmd, sudo=True)
             time.sleep(10)
         out = self.list_orch_services(service_type=service_type, export=True)
-        for osd_service in out:
-            status = osd_service.get("unmanaged", False)
+        for _service in out:
+            status = _service.get("unmanaged", False)
             if status == "false":
                 unmanaged_check = False
             else:
@@ -4727,7 +4741,7 @@ EOF"""
 
             if unmanaged_check != unmanaged:
                 log.error(
-                    f"{service_type} Service with {osd_service['service_id']}not unmanaged={unmanaged} state. Fail"
+                    f"{service_type} Service with {_service['service_id']}not unmanaged={unmanaged} state. Fail"
                 )
                 return False
         log.info(f" All {service_type} Service in unmanaged={unmanaged} state. Pass")
@@ -4883,3 +4897,38 @@ EOF"""
         else:
             log.error(f"The {label} not added to the {host_name} node ")
             return False
+
+    def switch_osd_device_type(self, osd_id: str, rota_val: int, redeploy: bool = True):
+        """
+        Method to fake the OSD underlying device class by changing the
+        queue/rotational value in /sys/block/<device> and re-deploy OSD
+        Args:
+            osd_id: ID of the OSD
+            rota_val: underlying device type's rotational value (0 / 1)
+            redeploy: flag to control redeployment of OSD
+        Returns:
+            None if pass | raise exception if failure
+        """
+        # find the osd device from metadata
+        osd_metadata = self.get_daemon_metadata(daemon_type="osd", daemon_id=osd_id)
+
+        # get osd device path and OSD host
+        osd_device = osd_metadata["devices"]
+        osd_host = self.fetch_host_node(daemon_type="osd", daemon_id=osd_id)
+
+        _cmd = f"echo {rota_val} > /sys/block/{osd_device}/queue/rotational"
+        osd_host.exec_command(cmd=_cmd, sudo=True)
+
+        if redeploy:
+            # re-deploy the input OSD
+            osd_utils.set_osd_out(self.ceph_cluster, osd_id=osd_id)
+            osd_utils.osd_remove(self.ceph_cluster, osd_id=osd_id, zap=True, force=True)
+
+            # set OSD service to managed
+            self.set_service_managed_type(service_type="osd", unmanaged=False)
+
+            # wait for OSD to be re-deployed
+            if not wait_for_device_rados(host=osd_host, osd_id=osd_id, action="add"):
+                _err = f"OSD {osd_id} did not get redeployed within timeout"
+                log.error(_err)
+                raise Exception(_err)

--- a/suites/reef/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/reef/rados/tier-2_rados_test-brownfield.yaml
@@ -154,6 +154,20 @@ tests:
         issue_reproduction: true
 
   - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           issue_reproduction: true
+        pool_config:
+           pool_name: osd-alloc-pool
+           pg_num: 1
+           pg_num_max: 1
+           pool_type: replicated
+
+  - test:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
       module: test_cephadm_upgrade.py
@@ -166,6 +180,15 @@ tests:
         verify_cluster_health: true
       destroy-cluster: false
       abort-on-fail: true
+
+  - test:
+      name: "verify fix-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+          verify_fix: true
 
   - test:
       name: "verify fix-obj snap and pool snap deletion"

--- a/suites/squid/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/squid/rados/tier-2_rados_test-brownfield.yaml
@@ -146,7 +146,6 @@ tests:
       polarion-id: CEPH-83574439
       abort-on-fail: false
 
-# commented until fix merged in Squid: #2326892 - Issue fixed
   - test:
       name: "issue repro-obj snap and pool snap deletion"
       module: test_pool_snap.py
@@ -154,6 +153,21 @@ tests:
       polarion-id: CEPH-83602685
       config:
         issue_reproduction: true
+
+  - test:
+      name: "issue repro-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+           issue_reproduction: true
+        pool_config:
+           pool_name: osd-alloc-pool
+           pg_num: 1
+           pg_num_max: 1
+           pool_type: replicated
+      comments: "8.1 bug-2338097"
 
   - test:
       name: Upgrade cluster to latest 8.x ceph version
@@ -169,7 +183,15 @@ tests:
       destroy-cluster: false
       abort-on-fail: true
 
-# commented until fix merged in Squid: #2326892 - Issue fixed
+  - test:
+      name: "verify fix-osd recovery with allocator file corruption"
+      module: test_osd_crashes.py
+      desc: failed osd recovery due to allocator file corruption during upgrade
+      polarion-id: CEPH-83609785
+      config:
+        verify_allocator_corruption:
+          verify_fix: true
+
   - test:
       name: "verify fix-obj snap and pool snap deletion"
       module: test_pool_snap.py

--- a/tests/rados/test_osd_crashes.py
+++ b/tests/rados/test_osd_crashes.py
@@ -1,0 +1,272 @@
+"""
+This file contains various tests/ validations related to OSD crashes
+Tests included:
+1. Bug 2335317 - multiple OSDs crashing while replaying bluefs -- ceph_assert(delta.offset == fnode.allocated)
+"""
+
+import time
+
+from ceph.ceph_admin import CephAdmin
+from ceph.rados.bluestoretool_workflows import BluestoreToolWorkflows
+from ceph.rados.core_workflows import RadosOrchestrator
+from tests.rados.monitor_configurations import MonConfigMethods
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def run(ceph_cluster, **kw):
+    """
+    Performs tests related to OSD crashes
+    Returns:
+        1 -> Fail, 0 -> Pass
+    """
+    log.info(run.__doc__)
+    config = kw["config"]
+    cephadm = CephAdmin(cluster=ceph_cluster, **config)
+    rados_obj = RadosOrchestrator(node=cephadm)
+    mon_obj = MonConfigMethods(rados_obj=rados_obj)
+    bluestore_obj = BluestoreToolWorkflows(node=cephadm)
+    client_node = ceph_cluster.get_nodes(role="client")[0]
+
+    if config.get("verify_allocator_corruption"):
+        desc = (
+            "\n#CEPH-83609785 \n"
+            "Bugzilla trackers -\n"
+            "7.1: BZ-2335317 \n"
+            "8.0: BZ-2338096 \n"
+            "8.1: BZ-2338097 \n"
+            "This test is to verify whether OSDs deployed with NCB allocator file"
+            "face corruption during subsequent restarts and upgrades \n"
+            "1. Create a pool with single PG \n"
+            "2. Obtain the acting set of the created pool \n"
+            "3. Re-deploy the OSDs part of acting set after faking their underlying disk as non-rotational \n"
+            "4. Check the current value of bluestore_allocation_from_file \n"
+            "5. Check the current value of osd_fast_shutdown \n"
+            "6. Check existence of Allocator NCB file in Bluefs files List \n"
+            "7. Use fragmentation python script to write first set of fragmented objects \n"
+            "8. Stop primary OSD using systemctl and verify that the last "
+            "file saved during shutdown is allocator file(ino 27) \n"
+            "9. Use fragmentation python script to write second set of fragmented objects \n"
+            "10. Stop primary OSD using systemctl and verify the "
+            "increase in number of extents for allocator file(ino 27) \n"
+            "11. Use fragmentation python script to write third set of fragmented objects \n"
+            "12. Stop primary OSD using systemctl and verify the "
+            "increase in number of extents for allocator file(ino 27) \n"
+            "13. Remove around 10K fragmented objects  at different offsets \n"
+            "14. Stop primary OSD using systemctl and verify the "
+            "increase in number of extents for allocator file(ino 27) \n"
+            "15. Upgrade the cluster and ensure cluster Health is OK \n"
+        )
+
+        log.info(desc)
+        _config = config.get("verify_allocator_corruption")
+        pool_cfg = config.get("pool_config", {})
+        pool_name = pool_cfg.get("pool_name", "osd-alloc-pool")
+
+        try:
+            if _config.get("issue_reproduction"):
+                log.info(
+                    "\n \n Running test to reproduce OSD crash in case of Allocator File corruption"
+                )
+                log.debug("Creating pool with given config")
+                # create pool with given config
+                assert rados_obj.create_pool(**pool_cfg), "Pool creation failed"
+
+                # get acting set of created pool
+                acting_set = rados_obj.get_pg_acting_set(pool_name=pool_name)
+                prim_osd = acting_set[0]
+                log.debug("Acting set for pool %s : %s" % (pool_name, acting_set))
+
+                # for each OSD in acting set, change the underlying disk type
+                for _osd in acting_set:
+                    rados_obj.switch_osd_device_type(osd_id=_osd, rota_val=0)
+                time.sleep(5)
+
+                # ensure acting set is same as before
+                new_acting_set = rados_obj.get_pg_acting_set(pool_name=pool_name)
+                log.debug(
+                    "Acting set for pool %s after switching OSD device class: %s"
+                    % (pool_name, new_acting_set)
+                )
+                assert acting_set == new_acting_set, "Acting set has changed"
+
+                log.debug(
+                    "Checking current value of bluestore_allocation_from_file & osd_fast_shutdown"
+                )
+                assert mon_obj.show_config(
+                    daemon="osd", id=prim_osd, param="bluestore_allocation_from_file"
+                ), "bluestore_allocation_from_file is not true"
+                assert mon_obj.show_config(
+                    daemon="osd", id=prim_osd, param="osd_fast_shutdown"
+                ), "osd_fast_shutdown is not true"
+
+                # check for existence of NCB allocator file
+                # this file exists only for non-rotational OSDs
+                # and is created during deployment
+                log.debug(
+                    "Check existence of NCB allocator file for SSD OSDs: %s"
+                    % acting_set
+                )
+                for _osd in acting_set:
+                    _cmd = f"ceph tell osd.{_osd} bluefs files list"
+                    out = rados_obj.run_ceph_command(cmd=_cmd, client_exec=True)
+                    assert (
+                        "ALLOCATOR" in out[0]["name"]
+                    ), f"ALLOCATOR file not found for OSD {_osd}"
+
+                log.debug("Fetching script to generate fragmented objects")
+                # pull script to write fragmented objects
+                script_loc = (
+                    "https://raw.githubusercontent.com/red-hat-storage/cephci/"
+                    "main/utility/generate_frag_objs.py"
+                )
+                client_node.exec_command(
+                    sudo=True,
+                    cmd=f"curl -k {script_loc} -O",
+                )
+                # Setup Script pre-requisites : docopt
+                client_node.exec_command(
+                    sudo=True, cmd="pip3 install docopt", long_running=True
+                )
+
+                ino_lines = []
+                obj_sizes = [4, 8, 12]
+                log.debug("Writing fragmented objects to the pool %s" % pool_name)
+                for size in obj_sizes:
+                    # index is calculated to verify extent count
+                    # and to check the number of objects written to the pool
+                    # each iteration is supposed to add 5K objects to the pool
+                    index = obj_sizes.index(size) + 1
+                    _exp_objs = index * 5000
+                    cmd_options = f"--pool {pool_name} --create 10000 --remove 0 --size $((1024*{size}))"
+                    _cmd = f"python3 generate_frag_objs.py {cmd_options}"
+
+                    out, err = client_node.exec_command(sudo=True, cmd=_cmd)
+                    log.debug(out + err)
+
+                    # smart wait to let objects show up in cephdf
+                    if not rados_obj.verify_pool_stats(
+                        pool_name=pool_name, exp_objs=_exp_objs
+                    ):
+                        log.error("Objects in the pool are not as expected.")
+                        raise Exception("Objects in the pool are not as expected.")
+
+                    log.debug(
+                        "Verify increase in extents in bluefs-log-dump "
+                        "file ino 27 after addition of fragmented objects"
+                    )
+                    out = bluestore_obj.get_bluefs_log_dump(osd_id=prim_osd)
+                    log.info("Output of ceph-bluestore-tool bluefs-log-dump: \n")
+                    log.info(out)
+
+                    for line in out.splitlines():
+                        if "op_file_update  file(ino 27" in line:
+                            assert (
+                                f"{10000 * index} extents" in line
+                            ), "expected extents not found"
+                            ino_lines.append(line)
+
+                rm_obj_sizes = [12, 8]
+                log.debug("Removing fragmented objects from the pool %s" % pool_name)
+                for size in rm_obj_sizes:
+                    _exp_objs = _exp_objs - 5000
+                    cmd_options = f"--pool {pool_name} --create 0 --remove 10000 --size $((1024*{size}))"
+                    _cmd = f"python3 generate_frag_objs.py {cmd_options}"
+                    out, err = client_node.exec_command(sudo=True, cmd=_cmd)
+                    log.debug(out + err)
+
+                    if not rados_obj.verify_pool_stats(
+                        pool_name=pool_name, exp_objs=_exp_objs
+                    ):
+                        log.error("Objects in the pool are not as expected.")
+                        raise Exception("Objects in the pool are not as expected.")
+
+                log.debug(
+                    "Verify increase in extents in bluefs-log-dump "
+                    "file ino 27 after removal of fragmented objects"
+                )
+                out = bluestore_obj.get_bluefs_log_dump(osd_id=prim_osd)
+                log.info("Output of ceph-bluestore-tool bluefs-log-dump: \n")
+                log.info(out)
+                for line in out.splitlines():
+                    if "op_file_update  file(ino 27" in line:
+                        assert (
+                            f"{10000 * (index+1)} extents" in line
+                        ), "expected extents not found"
+                        ino_lines.append(line)
+                log.info("Relevant log lines from bluefs_log_dump \n \n")
+                log.info(ino_lines)
+
+                # to-do: add validation to check ceph assert during OSD restart when upgrading to RHCS 7.1z2
+                # currently not possible as two-step upgrade is not supported with framework
+            if _config.get("verify_fix"):
+                # now that cluster has been upgraded to the fixed build, ensure all OSDs are UP
+                # and cluster is in HEALTH OK State.
+                # Ensure OSD in question has recovered successfully
+                log.info(desc)
+                log.info(
+                    "\n \n Running test to verify OSD recovery in case of Allocator File corruption"
+                )
+                log.info(
+                    "now that cluster has been upgraded to the fixed build, ensure all OSDs are UP"
+                    "and cluster is in HEALTH OK State.\n"
+                    "Ensure OSD in question has recovered successfully"
+                )
+
+                # rationale: fetch the list of all OSDs that belong to device class 'ssd'
+                log.debug("Getting the list of SSD device class OSDs on the cluster")
+                ssd_osd_list = rados_obj.run_ceph_command(
+                    cmd="ceph osd crush class ls-osd ssd", client_exec=True
+                )
+                # all the ssd OSDs should be up
+                log.debug("Ensuring all SSD OSDs are UP")
+                for _osd in ssd_osd_list:
+                    osd_status, status_desc = rados_obj.get_daemon_status(
+                        daemon_type="osd", daemon_id=_osd
+                    )
+                    log.info(
+                        "OSD.%s - osd_status: %s, status_desc: %s"
+                        % (_osd, osd_status, status_desc)
+                    )
+                    assert osd_status == 1, f"OSD.{_osd} is in down state"
+
+                cluster_health = rados_obj.run_ceph_command(
+                    cmd="ceph health detail", client_exec=True
+                )
+                log.info("Cluster health: \n\n %s" % cluster_health)
+                assert (
+                    "HEALTH_OK" in cluster_health["status"]
+                ), "Cluster not in Healthy state post upgrade"
+
+                log.info(
+                    "Verification completed around recovery of failed OSD due"
+                    " to corruption in Allocator file during upgrade"
+                )
+        except Exception as e:
+            log.error(f"Failed with exception: {e.__doc__}")
+            log.exception(e)
+            return 1
+        finally:
+            log.info(
+                "\n \n ************** Execution of finally block begins here *************** \n \n"
+            )
+
+            rados_obj.change_recovery_flags(action="unset")
+            if _config.get("verify_fix"):
+                rados_obj.delete_pool(pool=pool_name)
+                # restore modified OSDs
+                ssd_osd_list = rados_obj.run_ceph_command(
+                    cmd="ceph osd crush class ls-osd ssd", client_exec=True
+                )
+                if ssd_osd_list:
+                    for osd_id in ssd_osd_list:
+                        rados_obj.switch_osd_device_type(osd_id=osd_id, rota_val=1)
+                        time.sleep(5)
+            # log cluster health
+            rados_obj.log_cluster_health()
+            # check for crashes after test execution
+            if rados_obj.check_crash_status():
+                log.error("Test failed due to crash at the end of test")
+                return 1
+        return 0

--- a/utility/generate_frag_objs.py
+++ b/utility/generate_frag_objs.py
@@ -1,0 +1,77 @@
+# module can be used to generate fragmented objects on replicated pool only
+# support for EC pool may be added later
+# !/usr/bin/env python
+from __future__ import print_function
+
+import sys
+
+from docopt import docopt
+from rados import Rados
+
+doc = """
+Usage:
+  generate_frag_objs.py --pool <pool_name> --create <object_count> --remove <object_count> --size <each_object_size>
+
+Options:
+  --pool <name>      Name of the pool where the omap entries need to be generated
+  --create <num>       Start point/count to create objects
+  --remove <num>       Start point/count to create objects
+  --size <num>       Number of kw pairs to be created for each object
+
+"""
+
+
+def run(args):
+    pool = args["--pool"]
+    create = int(args["--create"])
+    remove = int(args["--remove"])
+    size = int(args["--size"])
+    data = bytes(size)
+    with Rados(conffile="") as cluster:
+        with cluster.open_ioctx(pool) as ioctx:
+            prefix = "filler_" + str(size) + "_"
+            for i in range(0, create):
+                ioctx.write(prefix + str(i), data, 0)
+                print(
+                    "create",
+                    i,
+                    "of",
+                    create,
+                    "objects",
+                    end="\r",
+                )
+                sys.stdout.flush()
+            for i in range(0, create, 2):
+                ioctx.remove_object(prefix + str(i))
+                print(
+                    "removed - fragment",
+                    int(i / 2),
+                    "of",
+                    int(create / 2),
+                    "objects",
+                    end="\r",
+                )
+                sys.stdout.flush()
+            for i in range(0, remove, 2):
+                ioctx.remove_object(prefix + str(i + 1))
+                print(
+                    "removed - defragment",
+                    int(i / 2),
+                    "of",
+                    int(remove / 2),
+                    "objects",
+                    end="\r",
+                )
+                sys.stdout.flush()
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    args = docopt(doc)
+    try:
+        run(args)
+    except Exception as err:
+        print(
+            f"Exception hit while creating/removing objects on the given pool.\n error : {err} "
+        )
+        exit(1)


### PR DESCRIPTION
# Description

[CEPH-83609785](https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83609785): Tier 4 test to reproduce customer scenario where consecutive orderly shutdowns caused a corruption in Allocator NCB file resulting in OSD crash during upgrades.
The direct cause of the bug is desynchronization between `bluefs_fnode_t::extents` and `bluefs_fnode_t::extents_index`.

When `bluefs_fnode_t::extents` and `bluefs_fnode_t::extents_index` are out of sync, function `bluefs_fnode_t::seek()` does not work properly.

Jira tracker: [RHCEPHQE-17777](https://issues.redhat.com/browse/RHCEPHQE-17777)
Bugzilla trackers: 
- 7.1: [BZ-2335317](https://bugzilla.redhat.com/show_bug.cgi?id=2335317)
- 8.0: [BZ-2338096](https://bugzilla.redhat.com/show_bug.cgi?id=2338096)
- 8.1: [BZ-2338097](https://bugzilla.redhat.com/show_bug.cgi?id=2338097)

Test suites modified:
- `suites/reef/rados/tier-2_rados_test-brownfield.yaml`
- `suites/squid/rados/tier-2_rados_test-brownfield.yaml`

Test modules added:
- `tests/rados/test_osd_crashes.py`
- `utility/generate_frag_objs.py`

Logs - 
- Reef: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YSPZ6Q/
- Squid: http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1PT8K7/ 

Signed-off-by: Harsh Kumar <hakumar@redhat.com>

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
