### PR TITLE
[RADOS] Create common test suites for serial execution

### DIFF
--- a/suites/squid/common/regression/rados/rados_3-AZ-Cluster.yaml
+++ b/suites/squid/common/regression/rados/rados_3-AZ-Cluster.yaml
@@ -1,0 +1,84 @@
+# 3 AZ cluster deployment tests
+# Conf: conf/squid/common/9node-1client-availability-zone.yaml
+# Deployment: suites/squid/common/regression/AZ_cluster_deploy_and_configure.yaml
+tests:
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Enable Stretch mode on pools
+      module: pool_tests.py
+      polarion-id: CEPH-83609796
+      config:
+        enable_3AZ_stretch_pools:
+          pool_name: test-pool-11
+          stretch_bucket: datacenter
+          rule_name: 3az_rule
+      desc: Enable 3 AZ stretch mode on all pools of the cluster
+
+  - test:
+      name: Upgrade ceph cluster
+      desc: Upgrade cluster to latest version and check health warn
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83609797
+      config:
+        verify_warning: false
+        verify_daemons: true
+        verify_cluster_usage: false
+      abort-on-fail: true
+
+  - test:
+      name: Enable Stretch mode on pool post upgrade
+      module: pool_tests.py
+      polarion-id: CEPH-83609796
+      config:
+        enable_3AZ_stretch_pools:
+          pool_name: test-pool-12
+          stretch_bucket: datacenter
+          rule_name: 3az_rule
+          pool_list:
+            - test-pool-12
+      desc: Enable 3 AZ stretch mode on new pools of the cluster post upgrade
+
+  - test:
+      name: Site-down Scenarios
+      module: test_stretch_n_az_site_down_scenarios.py
+      polarion-id: CEPH-83609869
+      config:
+        pool_name: test_stretch_pool6
+        stretch_bucket: datacenter
+        rule_name: 3az_rule
+      desc: Test stretch site down scenarios in 3 AZ cluster
+
+  - test:
+      name: Maintenance mode Scenarios
+      module: test_stretch_n_az_site_down_scenarios.py
+      polarion-id: CEPH-83609871
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        rule_name: 3az_rule
+        scenarios_to_run:
+          - scenario-8
+          - scenario-9
+          - scenario-10
+      desc: Test stretch site maintenance mode scenarios in 3 AZ cluster
+
+  - test:
+      name: Netsplit Scenarios data-data sites
+      module: test_stretch_n-az_netsplit_scenarios.py
+      polarion-id: CEPH-83609870
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        netsplit_site_1: DC1
+        netsplit_site_2: DC3
+        delete_pool: true
+        rule_name: 3az_rule
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
+      comments: Bugzilla for feature 2318936, 2316900

--- a/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
+++ b/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
@@ -1,0 +1,738 @@
+# Suite is to be used to verify the EC 2+2 and EC 8+6 with MSR config on 4 nodes
+# conf: conf/squid/rados/5node-1client-ecpool-replica1.yaml
+# Deployment: suites/squid/common/regression/ecpool-replica1-deploy-and-configure.yaml
+tests:
+
+  - test:
+      name: Configure email alerts
+      module: rados_prep.py
+      polarion-id: CEPH-83574472
+      config:
+        email_alerts:
+          smtp_host: smtp.corp.redhat.com
+          smtp_sender: ceph-iad2-c01-lab.mgr@redhat.com
+          smtp_port: 25
+          interval: 10
+          smtp_destination:
+            - pdhiran@redhat.com
+          smtp_from_name: EC 8+6@4 MSR rules cluster alerts
+      desc: Configure email alerts on ceph cluster
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Set configs for 4 node cluster
+      desc: Set configs for 4 node cluster
+      module: test_cephadm.py
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph
+                - config
+                - set
+                - mon
+                - mon_osd_down_out_subtree_limit
+                - host
+
+  - test:
+      name: EC pool 2+2@4 LC
+      module: test_four_node_ecpool.py
+      polarion-id: CEPH-83575858
+      config:
+        ec_pool:
+          profile_name: ec22_profile
+          pool_name: test_ec_pool
+          k: 2
+          m: 2
+          force: true
+          plugin: jerasure
+          crush-failure-domain: host
+        remove_host: true
+        delete_pools:
+          - test_ec_pool
+      desc: 2+2@4 EC pool life cycle with serviceability scenarios
+
+  - test:
+      name: EC 2+2 Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          pool_name: ec_pool_recovery
+          k: 2
+          m: 2
+          pg_num: 32
+          plugin: jerasure
+          crush-failure-domain: host
+          max_objs: 500
+          rados_read_duration: 50
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+
+  - test:
+      name: EC 2+2 pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          pool_name: ec_pool_overwrite
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 2
+          m: 2
+          plugin: jerasure
+          crush-failure-domain: host
+          max_objs: 500
+          rados_read_duration: 30
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec_pool_overwrite
+          - re_pool_overwrite
+      desc: EC pool with Overwrites & create RBD pool
+
+  - test:
+      name: EC pool 8+6@4 with MSR LC
+      module: test_ec_86.py
+      polarion-id: CEPH-83590733
+      config:
+        profile_name: ec86_0
+        pool_name: ec86_pool0
+        k: 8
+        m: 6
+        force: true
+        plugin: jerasure
+        create_rule: false
+        modify_threshold: true
+        pre_create_rule: false
+        crush-failure-domain: host
+        change_subtree_limit: host
+        crush-osds-per-failure-domain: 4
+        crush-num-failure-domains: 4
+        delete_pools:
+          - ec86_pool0
+      desc: 8+6@4 MSR EC pool life cycle with serviceability scenarios
+      comments: "Bug with OSD down scenario 2305520"
+
+  - test:
+      name: Upgrade cluster to latest 8.x ceph version
+      desc: Upgrade cluster to latest version
+      module: test_cephadm_upgrade.py
+      polarion-id: CEPH-83573791,CEPH-83573790
+      config:
+        command: start
+        service: upgrade
+        base_cmd_args:
+          verbose: true
+        verify_cluster_health: true
+      destroy-cluster: false
+
+  - test:
+      name: EC 8+6 Pool Recovery Improvement
+      module: pool_tests.py
+      polarion-id: CEPH-83573852
+      config:
+        ec_pool_recovery_improvement:
+          create: true
+          profile_name: ec86_1
+          pool_name: ec86_pool1
+          k: 8
+          m: 6
+          pg_num: 32
+          plugin: jerasure
+          create_rule: false
+          crush-osds-per-failure-domain: 4
+          crush-num-failure-domains: 4
+          crush-failure-domain: host
+          max_objs: 500
+          rados_read_duration: 50
+          osd_max_backfills: 16
+          osd_recovery_max_active: 16
+          delete_pool: true
+      desc: Verify Recovery of EC pool with only "k" shards available
+      comments: "Bug with OSD down scenario 2305520"
+
+  - test:
+      name: EC 8+6 pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec86_2
+          pool_name: ec86_pool2
+          pg_num: 64
+          k: 8
+          m: 6
+          create_rule: false
+          crush-osds-per-failure-domain: 4
+          crush-num-failure-domains: 4
+          plugin: jerasure
+          crush-failure-domain: host
+          disable_pg_autoscale: true
+          max_objs: 500
+          rados_read_duration: 30
+        set_pool_configs:
+          pool_name: ec86_pool2
+          configurations:
+            pg_num: 32
+            pgp_num: 32
+            pg_autoscale_mode: 'on'
+            compression_mode: force
+            compression_algorithm: snappy
+        delete_pools:
+          - ec86_pool2
+      desc: Create, modify & delete EC pools and run IO
+
+  - test:
+      name: EC 8+6 pool with Overwrites
+      module: rados_prep.py
+      polarion-id: CEPH-83571730
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec86_3
+          pool_name: ec86_pool3
+          app_name: rbd
+          pg_num: 32
+          erasure_code_use_overwrites: "true"
+          k: 8
+          m: 6
+          create_rule: false
+          crush-osds-per-failure-domain: 4
+          crush-num-failure-domains: 4
+          plugin: jerasure
+          crush-failure-domain: host
+          max_objs: 500
+          rados_read_duration: 30
+          test_overwrites_pool: true
+          metadata_pool: re_pool_overwrite
+          image_name: image_ec_pool
+          image_size: 100M
+        delete_pools:
+          - ec86_pool3
+          - re_pool_overwrite
+      comments: "RBD support RFE : 2305966"
+      desc: EC pool with Overwrites & create RBD pool
+
+  - test:
+      name: Inconsistent objects in EC 8+6 pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec86_4
+          pool_name: ec86_pool4
+          pg_num: 1
+          k: 8
+          m: 6
+          create_rule: false
+          crush-failure-domain: host
+          crush-osds-per-failure-domain: 4
+          crush-num-failure-domains: 4
+          plugin: jerasure
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec86_pool4
+
+  - test:
+      name: Compression test - EC 8+6 pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
+      config:
+        Compression_tests:
+          pool_type: erasure
+          pool_config:
+            pool-1: ec86_pool5
+            pool-2: ec86_pool6
+            max_objs: 2000
+            byte_size: 10KB
+            pg_num: 32
+            k: 8
+            m: 6
+            create_rule: false
+            crush-osds-per-failure-domain: 4
+            crush-num-failure-domains: 4
+            plugin: jerasure
+            crush-failure-domain: host
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.7
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on erasure coded pools
+
+  - test:
+      name: Autoscaler test - EC 2+2 pool target size ratio
+      module: pool_tests.py
+      polarion-id: CEPH-83573424
+      config:
+        verify_pool_target_ratio:
+          configurations:
+            pool-1:
+              profile_name: ec22_7
+              pool_name: ec22_pool7
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              target_size_ratio: 0.8
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+  - test:
+      name: Inconsistent objects in EC 2+2 pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          profile_name: ec22_4
+          pool_name: ec22_pool4
+          pg_num: 1
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+          crush-failure-domain: host
+        inconsistent_obj_count: 4
+        delete_pool:
+          - ec22_pool4
+
+  - test:
+      name: Compression test - EC 2+2 pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
+      config:
+        Compression_tests:
+          pool_type: erasure
+          pool_config:
+            pool-1: ec22_pool5
+            pool-2: ec22_pool6
+            max_objs: 2000
+            byte_size: 10KB
+            pg_num: 32
+            k: 2
+            m: 2
+            plugin: jerasure
+            crush-failure-domain: host
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.7
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on erasure coded pools
+
+  - test:
+      name: Verify premerge PGS during PG split for EC 2+2
+      module: test_pg_split.py
+      desc: Verify if there are premerge PGs when split is in progress
+      polarion-id: CEPH-83573526
+      config:
+        create_pools:
+          - create_pool:
+              check_premerge_pgs: true
+              profile_name: ec22_8
+              pool_name: ec22_pool8
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec22_pool8
+
+  - test:
+      name: Verify premerge PGS during PG split for EC 8+6
+      module: test_pg_split.py
+      desc: Verify if there are premerge PGs when split is in progress
+      polarion-id: CEPH-83573526
+      config:
+        create_pools:
+          - create_pool:
+              check_premerge_pgs: true
+              profile_name: ec86_8
+              pool_name: ec86_pool8
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-failure-domain: host
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+        delete_pools:
+          - ec86_pool8
+
+  - test:
+      name: Verify PG split and merge with network delay for EC 8+6
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              profile_name: ec86_9
+              pool_name: ec86_pool9
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-failure-domain: host
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+        add_network_delay: true
+        delete_pools:
+          - ec86_pool9
+
+  - test:
+      name: Verify scrub logs for EC 8+6
+      module: test_scrub_log.py
+      polarion-id: CEPH-83575403
+      config:
+        # After the implementation of BZ#2320860 set the verify_log to true
+        verify_log: false
+        pool_configs:
+            - type: erasure
+              conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Verify that scrub & deep-scrub logs are captured in OSD logs
+
+  - test:
+      name: Verify PG split and merge with network delay for EC 2+2
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              profile_name: ec22_9
+              pool_name: ec22_pool9
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: erasure
+              k: 2
+              m: 2
+              crush-failure-domain: host
+              plugin: jerasure
+        add_network_delay: true
+        delete_pools:
+          - ec22_pool9
+
+  - test:
+      name: Verify scrub logs EC 2+2
+      module: test_scrub_log.py
+      polarion-id: CEPH-83575403
+      config:
+        # After the implementation of BZ#2320860 set the verify_log to true
+        verify_log: false
+        pool_configs:
+            - type: erasure
+              conf: sample-pool-5
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Verify that scrub & deep-scrub logs are captured in OSD logs
+
+  - test:
+      name: Autoscaler test - EC 8+6 pool target size ratio
+      module: pool_tests.py
+      polarion-id: CEPH-83573424
+      config:
+        verify_pool_target_ratio:
+          configurations:
+            pool-1:
+              profile_name: ec86_10
+              pool_name: ec86_pool10
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              target_size_ratio: 0.8
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+  - test:
+      name: Autoscaler test - EC 8+6 pool pg_num_min
+      module: pool_tests.py
+      polarion-id: CEPH-83573425
+      config:
+        verify_pg_num_min:
+          configurations:
+            pool-1:
+              profile_name: ec86_11
+              pool_name: ec86_pool11
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              pg_num_min: 16
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+
+  - test:
+      name: client pg access
+      module: test_client_pg_access.py
+      polarion-id: CEPH-83571713
+      config:
+        verify_client_pg_access:
+          num_snapshots: 20
+          configurations:
+            pool-1:
+              profile_name: ec86_12
+              pool_name: ec86_pool12
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              disable_pg_autoscale: true
+      desc: many clients clients accessing same PG with bluestore as backend
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-2. RE -> EC 8+6
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-3
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-3. EC 8+6 -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-4
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-4. Ec 8+6 -> EC 8+6
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-5
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-3. EC 2+2 -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-6
+        pool-2-conf: sample-pool-5
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-4. Ec 2+2 -> EC 2+2
+
+# Blocked due to BZ 2172795. Bugzilla fixed.
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: erasure
+              conf: sample-pool-3
+          pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
+  - test:
+      name: Scrub enhancement for EC 8+6
+      module: test_scrub_enhancement.py
+      desc: Verify scrub enhancement feature
+      polarion-id: CEPH-83575885
+      config:
+        create_pools:
+          - create_pool:
+              pg_num: 1
+              pg_num_max: 1
+              profile_name: ec86_13
+              pool_name: ec86_pool13
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool13
+
+  - test:
+      name: Limit slow request details to cluster log for EC 8+6
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        create_pools:
+          - create_pool:
+              profile_name: ec86_14
+              pool_name: ec86_pool14
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              pg_num: 64
+              max_objs: 5000
+              byte_size: 1024
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+        delete_pools:
+          - ec86_pool14
+
+# to be run only where OSDs are directly created on top of disks.
+# user created LVM based OSDs cannot run the below test
+  - test:
+      name: Robust rebalancing - in progress osd replacement for EC 8+6
+      module: test_osd_inprogress_rebalance.py
+      desc: Add osd while data migration from the pools are in progress
+      polarion-id: CEPH-9228
+      abort-on-fail: true
+      config:
+        create_pools:
+          - create_pool:
+              create: true
+              profile_name: ec86_15
+              pool_name: ec86_pool15
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+              rados_put: true
+          - create_pool:
+              create: true
+              profile_name: ec86_16
+              pool_name: ec86_pool16
+              pool_type: erasure
+              k: 8
+              m: 6
+              create_rule: false
+              crush-osds-per-failure-domain: 4
+              crush-num-failure-domains: 4
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec86_pool15
+          - ec86_pool16
+
+  - test:
+      name: Robust rebalancing - in progress osd replacement for EC 2+2
+      module: test_osd_inprogress_rebalance.py
+      desc: Add osd while data migration from the pools are in progress
+      polarion-id: CEPH-9228
+      abort-on-fail: true
+      config:
+        create_pools:
+          - create_pool:
+              create: true
+              profile_name: ec22_15
+              pool_name: ec22_pool15
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+              rados_put: true
+          - create_pool:
+              create: true
+              profile_name: ec22_16
+              pool_name: ec22_pool16
+              pool_type: erasure
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec22_pool15
+          - ec22_pool16

--- a/suites/squid/common/regression/rados/rados_bluestore.yaml
+++ b/suites/squid/common/regression/rados/rados_bluestore.yaml
@@ -1,0 +1,195 @@
+# Suite contains basic tier-2 rados tests around bluestore feature
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+tests:
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: BlueStore Checksum algorithms
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571646
+      config:
+        checksums:
+          - none
+          - crc32c
+          - crc32c_16
+          - crc32c_8
+          - xxhash32
+          - xxhash64
+      desc: Verify the different applicable BlueStore Checksum algorithms
+
+  - test:
+      name: BlueStore cache size tuning
+      module: test_bluestore_configs.py
+      polarion-id: CEPH-83571675
+      config:
+        bluestore_cache: true
+      desc: Verify tuning of BlueStore cache size for HDDs and SSDs
+
+  - test:
+      name: BlueStore Superblock redundancy
+      module: test_bluestore_superblock.py
+      polarion-id: CEPH-83590892
+      desc: Verify OSD recovery when Bluestore superblock is corrupted
+
+  - test:
+      name: OSD Superblock redundancy
+      module: test_osd_superblock.py
+      polarion-id: CEPH-83593841
+      desc: Verify OSD recovery when OSD superblock is corrupted
+
+  - test:
+      name: Bluefs DB utilization
+      desc: DB utilization is under check - bluefs files are not inflated
+      module: test_bluefs_space.py
+      polarion-id: CEPH-83600867
+      config:
+        omap_config:
+          pool_name: re_pool_bluefs_db
+          pg_num: 1
+          pg_num_max: 1
+          obj_start: 0
+          obj_end: 15
+          normal_objs: 400
+          num_keys_obj: 200001
+
+  - test:
+      name: OMAP feature
+      desc: Testing omap features
+      module: test_scrub_omap.py
+      polarion-id: CEPH-83572661
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Test
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 200
+            num_keys_obj: 300000
+        verify_cluster_health: true
+
+  - test:
+      name: Omap creations on objects
+      module: test_omap_entries.py
+      polarion-id: CEPH-83571702
+      config:
+        # Pool created to  verify the Bug#2249003
+        crash_config:
+          pool_name: re_pool_crash
+        # EC pool config is commented out because omaps can be written only on RE pools
+        omap_config:
+          small_omap:
+            pool_name: re_pool_small_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: false
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200000
+          large_omap:
+            pool_name: re_pool_large_omap
+            pg_num: 1
+            pg_num_max: 1
+            large_warn: true
+            obj_start: 0
+            obj_end: 5
+            normal_objs: 400
+            num_keys_obj: 200001
+      desc: Large number of omap creation on objects and OSD resiliency
+
+  - test:
+      name: Database reopening by libcephsqlite
+      module: test_libcephsqlite.py
+      polarion-id: CEPH-83583664
+      desc: libcephsqlite reopens database connection upon blocklisting
+
+  - test:
+      name: Change Mon weight for Mgr
+      polarion-id: CEPH-83588304
+      module: test_mon_mgr_weight.py
+      desc: Verify Mgr stability when mon-weight is modified
+
+  - test:
+      name: Ceph MSGRV2 paramter check in 8.x
+      desc: MSGRV2 parameter check in 8.x
+      polarion-id: CEPH-83574890
+      module: test_config_parameter_chk.py
+      config:
+        scenario: msgrv2_6x
+        ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
+  - test:
+      name: Mclock sleep parameter check
+      desc: Mclock sleep parameter check
+      polarion-id: CEPH-83574903
+      module: test_config_parameter_chk.py
+      config:
+        scenario: mclock_sleep
+        ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
+  - test:
+      name: Mclock default,reservation,limit and weight parameter check
+      desc: Mclock default,reservation,limit and weight parameter check
+      polarion-id: CEPH-83574902
+      module: test_config_parameter_chk.py
+      config:
+        scenario: mclock_chg_chk
+        ini-file: conf/squid/rados/test-confs/rados_config_parameters.ini
+
+  - test:
+      name: Check RocksDB compression default value
+      desc: Check that RocksDB compression value is kLZ4Compression
+      polarion-id: CEPH-83582326
+      module: test_config_parameter_chk.py
+      config:
+        scenario: rocksdb_compression
+
+  - test:
+      name: Ceph Volume utility zap test with destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id:
+      desc: verify ceph-volume lvm zap functionality with destroy flag
+      config:
+        zap_with_destroy_flag: true
+
+  - test:
+      name: Ceph Volume utility zap test without destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id:
+      desc: verify ceph-volume lvm zap functionality without destroy flag
+      config:
+        zap_without_destroy_flag: true
+
+  - test:
+      name: ceph-bluestore-tool utility
+      module: test_bluestoretool_workflows.py
+      polarion-id: CEPH-83571692
+      desc: Verify ceph-bluestore-tool functionalities
+
+  - test:
+      name: ceph-objectstore-tool utility
+      module: test_objectstoretool_workflows.py
+      polarion-id: CEPH-83581811
+      desc: Verify ceph-objectstore-tool functionalities
+
+  - test:
+      name: Test ceph osd command arguments
+      desc: Provide invalid values as argument to different ceph osd commands
+      module: test_osd_args.py
+      polarion-id: CEPH-10417
+      config:
+        cmd_list:
+          - "reweight-by-pg"
+          - "reweight-by-utilization"
+          - "test-reweight-by-pg"
+          - "test-reweight-by-utilization"

--- a/suites/squid/common/regression/rados/rados_bugfixes.yaml
+++ b/suites/squid/common/regression/rados/rados_bugfixes.yaml
@@ -1,0 +1,128 @@
+# Suite contains  tier-2 rados bug verification automation
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+# Bugs:
+#     1. https://bugzilla.redhat.com/show_bug.cgi?id=2233800
+#     2. https://bugzilla.redhat.com/show_bug.cgi?id=1900127
+#     3. https://bugzilla.redhat.com/show_bug.cgi?id=2229651
+#     4. https://bugzilla.redhat.com/show_bug.cgi?id=2011756
+#     5. https://bugzilla.redhat.com/show_bug.cgi?id=2264053
+#     6. https://bugzilla.redhat.com/show_bug.cgi?id=2264054
+#     7. https://bugzilla.redhat.com/show_bug.cgi?id=2264052
+#     8. https://bugzilla.redhat.com/show_bug.cgi?id=2260306
+#     9. https://bugzilla.redhat.com/show_bug.cgi?id=2237038
+#     10.https://bugzilla.redhat.com/show_bug.cgi?id=1892173
+#     11.https://bugzilla.redhat.com/show_bug.cgi?id=2174954
+#     12.https://bugzilla.redhat.com/show_bug.cgi?id=2151501
+#     13.https://bugzilla.redhat.com/show_bug.cgi?id=2315595
+#     14.https://bugzilla.redhat.com/show_bug.cgi?id=2326179
+#     15.https://bugzilla.redhat.com/show_bug.cgi?id=2213766
+#===============================================================================================
+# RHOS-d run duration: 330 mins
+tests:
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verification of the Mon ballooning
+      module: test_rados_ballooning_client.py
+      polarion-id: CEPH-83584004
+      desc: Verify MON ballooning client
+
+# moved prior to Inconsistent object test due to chances of an OSD being down
+  - test:
+      name: OSD restart when bluefs_shared_alloc_size is lower than bluestore_min_alloc_size
+      module: test_bug_fixes.py
+      config:
+        lower_bluefs_shared_alloc_size: true
+      polarion-id: CEPH-83591092
+      desc: verify OSD resiliency when 'bluefs_shared_alloc_size' is below 'bluestore_min_alloc_size'
+
+  - test:
+      name: Verification the recovery flag functionality
+      desc: Verify the pg_num and recovery status
+      module: test_norecovery_flag_functionality.py
+      polarion-id: CEPH-83591783
+      config:
+        replicated_pool:
+          create: true
+          pool_name: recovery_pool
+      delete_pool:
+        - recovery_pool
+
+  - test:
+      name: Inconsistent objects in  EC pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in EC pool
+      module: test_osd_ecpool_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        ec_pool:
+          create: true
+          pool_name: ecpool
+          pg_num: 1
+          k: 2
+          m: 2
+          plugin: jerasure
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - ecpool
+      comments: Active bugs 2277111,2335727 and 2335762
+
+  - test:
+      name: Inconsistent objects in replicated pool functionality check
+      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+      module: test_osd_replicated_inconsistency_scenario.py
+      polarion-id: CEPH-83586175
+      config:
+        replicated_pool:
+          create: true
+          pool_name: replicated_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        inconsistent_obj_count: 4
+        debug_enable: False
+        delete_pool:
+          - replicated_pool
+      comments: Active bug 2316244
+
+  - test:
+      name: Verification of ceph config show & get
+      module: test_bug_fixes.py
+      config:
+        test-config-show-get: true
+      polarion-id: CEPH-83590689
+      desc: Verify ceph config show & get outputs
+
+  - test:
+      name: Verification of Slow OSD heartbeat
+      module: test_bug_fixes.py
+      config:
+        slow-osd-heartbeat: true
+      polarion-id: CEPH-83590688
+      desc: Generate Slow OSD heartbeats by inducing network delay
+
+  - test:
+      name: Client connection over v1 port
+      module: test_v1client.py
+      polarion-id: CEPH-83594645
+      desc: Ensure client connection over v1 port does not crash
+
+  - test:
+      name: Mon connection scores testing
+      desc: Verification of mon connection scores in different scenarios
+      module: test_mon_connection_scores.py
+      polarion-id: CEPH-83602911
+      comments: Active bug 2151501
+
+  - test:
+      name: Verify config values via cephadm-ansible
+      module: test_cephadm_ansible.py
+      polarion-id: CEPH-83602686
+      desc: Ensure configuration values are accessible via cephadm-ansible module

--- a/suites/squid/common/regression/rados/rados_location-stretch-mode.yaml
+++ b/suites/squid/common/regression/rados/rados_location-stretch-mode.yaml
@@ -1,0 +1,260 @@
+# Stretch mode tests performing site down scenarios
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+# This test case is Openstack only and should be executed an the end in serial single suite
+# execution pipeline
+
+tests:
+
+# serviceability tests to be run at the end of regression run
+# and before stretch mode tests
+  - test:
+      name: Mute ceph health alerts
+      polarion-id: CEPH-83573854
+      module: mute_alerts.py
+      desc: Mute health alerts
+
+  - test:
+      name: Replacement of a failed OSD host
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-9408
+      config:
+        osd_host_fail: True
+      desc: Replacement of a failed OSD host with a healthy host
+
+  - test:
+      name: mon replacement test
+      polarion-id: CEPH-9407
+      module: test_mon_addition_removal.py
+      desc: Replace a Healthy Mon with a new MON
+
+  - test:
+      name: mon system tests
+      polarion-id: CEPH-9388
+      module: test_mon_system_operations.py
+      desc: Performing system tests with mon daemons
+
+# beginning of stretch-mode tests
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Deploy stretch Cluster
+      module: test_deploy_stretch_cluster_baremetal.py
+      polarion-id: CEPH-83573621
+      config:
+        stretch_rule_name: "stretch_rule"
+        site1:
+          name: "DC1"
+          hosts: ["node2", "node3", "node4", "node5", "node6"]
+        site2:
+          name: "DC2"
+          hosts: ["node7", "node8", "node9", "node10", "node11"]
+        site3:
+          name: "DC3"
+          hosts: ["node1"]
+      desc: Enables connectivity mode, deploys cluster with Stretch rule with tiebreaker node
+      abort-on-fail: true
+
+  - test:
+      name: Mon election strategies in stretch mode
+      polarion-id: CEPH-83573627
+      module: test_election_strategies.py
+      config:
+        stretch_mode: True
+      desc: Run Mon election strategies workflow for a stretch cluster
+
+  - test:
+      name: rbd-io
+      module: rbd_faster_exports.py
+      polarion-id: CEPH-83574972
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: rbd_rep_pool
+          image: rbd_rep_image
+          size: 10G
+        io-total: 100M
+      desc: Perform export during read/write,resizing,flattening,lock operations
+
+  - test:
+      name: rgw sanity tests
+      module: sanity_rgw.py
+      config:
+        script-name: test_multitenant_user_access.py
+        config-file-name: test_multitenant_access.yaml
+        timeout: 300
+      desc: Perform rgw tests
+
+  - test:
+      abort-on-fail: false
+      desc: "cephfs basic operations"
+      module: cephfs_basic_tests.py
+      name: cephfs-basics
+      polarion-id: "CEPH-11293"
+
+  - test:
+      name: nfs-ganesha_with_cephfs
+      module: nfs-ganesha_basics.py
+      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
+      polarion-id: CEPH-83574439
+      abort-on-fail: false
+
+  - test:
+      name: Verify stretch Cluster
+      module: stretch_cluster.py
+      polarion-id: CEPH-83573630
+      config:
+        verify_forced_recovery: true
+        osd_max_backfills: 16
+        osd_recovery_max_active: 16
+        max_objs: 1000
+      desc: Verify forced recovery and healthy on a stretch configured cluster
+
+  - test:
+      name: test stretch Cluster site down with delay - Data site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83571705
+      config:
+        pool_name: test_stretch_pool9
+        shutdown_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        add_network_delay: true
+      desc: Test the cluster when we have only 1 of 2 DC's surviving with network delay
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site down - tiebreaker site
+      module: test_stretch_site_down.py
+      polarion-id: CEPH-83574974
+      config:
+        pool_name: test_stretch_pool5
+        shutdown_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is shut down
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster maintenance mode - tiebreaker site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool2
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is moved to maintenance mode
+      abort-on-fail: true
+
+  - test:
+      name: test stretch Cluster site reboot - Data site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool3
+        affected_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the data site is rebooted
+
+  - test:
+      name: test stretch Cluster site reboot - tiebreaker site
+      module: test_stretch_site_reboot.py
+      polarion-id: CEPH-83574977
+      config:
+        pool_name: test_stretch_pool4
+        affected_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the tiebreaker site is rebooted
+
+  - test:
+      name: Mon replacement on Data site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool5
+        replacement_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        add_mon_without_location: true
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - Data site
+
+  - test:
+      name: Mon replacement on tiebreaker site
+      module: test_stretch_mon_replacements.py
+      polarion-id: CEPH-83574971
+      config:
+        pool_name: test_stretch_pool6
+        replacement_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster mon replacement - tiebreaker site
+
+  - test:
+      name: Netsplit Scenarios data-data sites
+      module: test_stretch_netsplit_scenarios.py
+      polarion-id: CEPH-83574979
+      config:
+        pool_name: test_stretch_pool8
+        netsplit_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster netsplit scenario between data sites
+      comments: Active bug with netsplit scenarios - 2318975
+
+  - test:
+      name: Netsplit Scenarios data-tiebreaker sites
+      module: test_stretch_netsplit_scenarios.py
+      polarion-id: CEPH-83574979
+      config:
+        pool_name: test_stretch_pool7
+        netsplit_site: tiebreaker
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster netsplit scenario between data site and tiebreaker site
+
+  - test:
+      name: test stretch Cluster maintenance mode - data site
+      module: test_stretch_site_maintenance_modes.py
+      polarion-id: CEPH-83574976
+      config:
+        pool_name: test_stretch_pool1
+        affected_site: DC1
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test the cluster when the Data site is moved to maintenance mode
+
+  - test:
+      name: Negative scenarios - post-deployment
+      module: test_stretch_negative_scenarios.py
+      polarion-id: CEPH-83584499
+      config:
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+      desc: Perform post-deployment negative tests on stretch mode
+
+  - test:
+      name: OSD and host replacement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+      desc: Test stretch Cluster osd and Host replacement
+
+# PG log limit parameter cannot be unset,
+# this test should always run at the last
+  - test:
+      name: Limit PG log size
+      polarion-id: CEPH-83573252
+      module: test_pg_log_limit.py
+      desc: Verify PG log growth limit using pglog_hardlimit flag

--- a/suites/squid/common/regression/rados/rados_osd-rebalance-recovery.yaml
+++ b/suites/squid/common/regression/rados/rados_osd-rebalance-recovery.yaml
@@ -1,0 +1,358 @@
+# Suite contains tests related to osd re-balance upon OSD addition / removal
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+
+tests:
+
+  - test:
+      name: osd_memory_target param set at OSD level
+      module: test_osd_memory_target.py
+      desc: Verification of osd_memory_target parameter set at OSD level
+      polarion-id: CEPH-83580882
+      config:
+        osd_level: true
+
+  - test:
+      name: osd_memory_target param set at host level
+      module: test_osd_memory_target.py
+      desc: Verification of osd_memory_target parameter set at host level
+      polarion-id: CEPH-83580881
+      config:
+        host_level: true
+
+  - test:
+      name: ObjectStore block stats verification
+      module: test_objectstore_block.py
+      desc: Reduce data from an object and verify the decrease in blocks
+      polarion-id: CEPH-83571714
+      config:
+        create_pool: true
+        pool_name: test-objectstore
+        write_iteration: 3
+        delete_pool: true
+
+  - test:
+      name: concurrent and parallel IOPS on an object
+      desc: Perform concurrent and parallel IOPs on one object
+      module: test_object_ops.py
+      config:
+        obj_sizes:
+          - 45
+          - 80
+          - 23
+          - 107
+      polarion-id: CEPH-83571710
+
+  - test:
+      name: Inconsistent OSD epoch
+      desc: list-inconsistent requires the correct epoch
+      module: test_inconsistency_osd_epoch.py
+      polarion-id: CEPH-9947
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool_name: test_pool_4
+            pool_type: replicated
+          omap_config:
+            obj_start: 0
+            obj_end: 50
+            num_keys_obj: 100
+        delete_pool: true
+
+  - test:
+      name: Verification of dump scrub parameters
+      desc: Verification of forced and scheduled time flags
+      module: test_scrub_parameters.py
+      polarion-id: CEPH-83593830
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_rp_pool
+          pg_num: 1
+        ec_pool:
+          pool_name: scrub_ec_pool
+          k: 2
+          m: 2
+          pg_num: 1
+          plugin: jerasure
+
+  - test:
+      name: OSD behaviour when marked Out
+      module: pool_tests.py
+      polarion-id: CEPH-83591786
+      config:
+        Verify_osd_in_out_behaviour: true
+      desc: Verify OSD behaviour when it is marked in and out of cluster
+
+  - test:
+      name: OSD addition on an unavailable disk
+      desc: Add new OSD on an pre-occupied OSD disk
+      module: test_add_new_osd.py
+      polarion-id: CEPH-83574780
+
+  - test:
+      name: replacement of OSD
+      module: test_osd_replacement.py
+      polarion-id: CEPH-83572702
+      desc: Replace an OSD by retaining its ID
+
+  - test:
+      name: Robust rebalancing in ecpool - osd replacement
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration in ec pool
+      polarion-id: CEPH-9212
+      config:
+        create_pools:
+          - create_pool:
+              create: true
+              pool_name: ec_pool_9212
+              pool_type: erasure
+              rados_put: true
+              pg_num: 32
+              pgp_num: 32
+              k: 3
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+        delete_pools:
+          - ec_pool_9212
+
+  - test:
+      name: Taking snaps during rebalance
+      module: test_osd_rebalance_snap.py
+      desc: Taking snaps while data migration is in progress
+      polarion-id: CEPH-9235
+      config:
+        create_pools:
+          - create_pool:
+              snapshot: true
+              num_snaps: 2
+              pool_name: repool_1
+              pg_num: 1
+              rados_put: true
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+
+        delete_pools:
+          - repool_1
+
+  - test:
+      name: Robust rebalancing - osd replacement
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration
+      polarion-id: CEPH-9205
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool_p1
+              pg_num: 64
+              max_objs: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+        delete_pools:
+          - pool_p1
+
+  - test:
+      name: Robust rebalancing - in progress osd replacement
+      module: test_osd_inprogress_rebalance.py
+      desc: Add osd while data migration from the pools are in progress
+      polarion-id: CEPH-9228
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: repool_1
+              pg_num: 32
+              rados_put: true
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              pool_name: repool_2
+              pg_num: 32
+              pool_type: replicated
+              size: 2
+              min_size: 2
+              rados_put: true
+              byte_size: 1024
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              create: true
+              pool_name: ercpool_1
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 3
+              plugin: jerasure
+              rados_put: true
+          - create_pool:
+              create: true
+              pool_name: ercpool_2
+              pool_type: erasure
+              rados_put: true
+              pg_num: 32
+              pgp_num: 32
+              k: 8
+              m: 4
+              plugin: jerasure
+
+        delete_pools:
+          - repool_1
+          - repool_2
+          - ercpool_1
+          - ercpool_2
+
+  - test:
+      name: Robust rebalancing - osd replacement with many pools
+      module: test_osd_rebalance.py
+      desc: Remove and add osd to verify data migration from the pools which have different replica and pg count
+      polarion-id: CEPH-9210
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 32
+              max_objs: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 32
+              pool_type: replicated
+              size: 2
+              min_size: 2
+              max_objs: 500
+              byte_size: 1024
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 500
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              disable_pg_autoscale: true
+          - create_pool:
+              create: true
+              pool_name: ecpool_1
+              pool_type: erasure
+              pg_num: 32
+              k: 4
+              m: 2
+              plugin: jerasure
+              max_objs: 500
+              rados_read_duration: 30
+          - create_pool:
+              create: true
+              pool_name: ecpool_2
+              pool_type: erasure
+              pg_num: 32
+              k: 4
+              m: 2
+              l: 3
+              plugin: lrc
+              max_objs: 500
+              rados_read_duration: 30
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_1
+          - ecpool_2
+
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+  - test:
+      name: Cluster behaviour when OSDs are full
+      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
+      module: test_osd_full.py
+      polarion-id: CEPH-83571715
+      config:
+        pg_autoscaling:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool_3
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
+  - test:
+      name: ceph osd df stats
+      module: test_osd_df.py
+      desc: Mark osd out and inspect stats change in ceph osd df
+      polarion-id: CEPH-10787
+      config:
+        run_iteration: 3
+        create_pool: true
+        pool_name: test-osd-df
+        write_iteration: 10
+        delete_pool: true
+
+  - test:
+      name: OSD compaction with failures
+      module: test_osd_compaction.py
+      polarion-id: CEPH-11681
+      config:
+        omap_config:
+          pool_name: re_pool_large_omap
+          large_warn: true
+          obj_start: 0
+          obj_end: 5
+          normal_objs: 400
+          num_keys_obj: 200001
+        bench_config:
+          pool_name: re_pool_bench
+          pg_num: 128
+          pgp_num: 128
+      desc: Perform OSD compaction with & without failures
+
+  - test:
+      name: Failure recovery on Replicated & EC
+      module: test_pool_osd_recovery.py
+      polarion-id: CEPH-11032
+      config:
+        pool_configs:
+          - type: replicated
+            conf: sample-pool-2
+          - type: erasure
+            conf: sample-pool-2
+          - type: replicated
+            conf: sample-pool-1
+          - type: erasure
+            conf: sample-pool-1
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+        remove_host : node13
+      desc: Failure recovery on Replicated & EC pools upon OSD changes
+
+  - test:
+      name: pg rebalancing upon addition of new OSD
+      desc: Test PG rebalancing upon addition of new OSDs when Cluster is in full state
+      module: test_osd_full.py
+      polarion-id: CEPH-9232
+      config:
+        osd_addition:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
+  - test:
+      name: crash warning upon daemon crash
+      module: test_crash_daemon.py
+      polarion-id: CEPH-83573855
+      desc: Verify crash warning in ceph health upon crashing a daemon
+      comments: Active BZ-2253394

--- a/suites/squid/common/regression/rados/rados_pg-split-merge.yaml
+++ b/suites/squid/common/regression/rados/rados_pg-split-merge.yaml
@@ -1,0 +1,242 @@
+# Suite contains tests related pg split and merge scenario
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+
+tests:
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Test Reads Balancer
+      module: test_reads_balancer.py
+      desc: Testing reads balancer online tool functionality in RHCS
+      polarion-id: CEPH-83576078
+      config:
+        negative_scenarios: true
+        online_command_verification: true
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 30
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_1
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_1
+
+  - test:
+      name: Test Reads Balancer
+      module: test_reads_balancer.py
+      desc: Testing reads balancer offline tool functionality in RHCS
+      polarion-id: CEPH-83576079
+      config:
+        offline_command_verification: true
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 30
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_2
+
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+  - test:
+      name: verify mon parameter 'mon_pg_warn_max_object_skew'
+      polarion-id: CEPH-83575440
+      module: test_mon_pg_warn.py
+      desc: verify auto-increment of 'mon_pg_warn_max_object_skew' MON parameter
+
+  - test:
+      name: Verify PG split and merge
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging
+      polarion-id: CEPH-11674
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool1
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool1
+
+  - test:
+      name: Verify restart osd during PG split
+      module: test_pg_split.py
+      desc: Verify restart osd when PG split in progress
+      polarion-id: CEPH-11667
+      config:
+        create_pools:
+          - create_pool:
+              restart_osd: true
+              pool_name: pool2
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool2
+
+  - test:
+      name: Verify PG split and merge with network delay
+      module: test_pg_split.py
+      desc: Verify PG splitting and merging with network delay
+      polarion-id: CEPH-83571705
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool5
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        add_network_delay: true
+        delete_pools:
+          - pool5
+
+  - test:
+      name: Verify delete object during PG split
+      module: test_pg_split.py
+      desc: Verify delete object when PG split in progress
+      polarion-id: CEPH-11671
+      config:
+        create_pools:
+          - create_pool:
+              del_obj: true
+              pool_name: pool3
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              objs_to_del: 20
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool3
+
+  - test:
+      name: Verify add remove osd during PG split
+      module: test_pg_split.py
+      desc: Verify osd removal and addition when PG split in progress
+      polarion-id: CEPH-11677
+      config:
+        create_pools:
+          - create_pool:
+              remove_add_osd: true
+              pool_name: pool4
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool4
+
+  - test:
+      name: Verify premerge PGS during PG split
+      module: test_pg_split.py
+      desc: Verify if there are premerge PGs when split is in progress
+      polarion-id: CEPH-83573526
+      config:
+        create_pools:
+          - create_pool:
+              check_premerge_pgs: true
+              pool_name: pool3
+              pg_num: 32
+              rados_put: true
+              num_objs: 200
+              byte_size: 1024
+              pool_type: replicated
+        delete_pools:
+          - pool3
+
+  - test:
+      name: client pg access
+      module: test_client_pg_access.py
+      polarion-id: CEPH-83571713
+      config:
+        verify_client_pg_access:
+          num_snapshots: 20
+          configurations:
+            pool-1:
+              pool_name: ec_pool_4
+              pool_type: erasure
+              pg_num: 1
+              k: 8
+              m: 3
+              disable_pg_autoscale: true
+            pool-2:
+              pool_type: replicated
+              pool_name: re_pool_4
+              pg_num: 1
+              disable_pg_autoscale: true
+      desc: many clients clients accessing same PG with bluestore as backend

--- a/suites/squid/common/regression/rados/rados_pool-functionalities.yaml
+++ b/suites/squid/common/regression/rados/rados_pool-functionalities.yaml
@@ -1,0 +1,594 @@
+# Suite contains tests to verify and test ceph pools
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+tests:
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verify pool behaviour at min_size
+      module: pool_tests.py
+      polarion-id: CEPH-9167
+      config:
+        Verify_pool_min_size_behaviour:
+          pool_name: test-pool-3
+      desc: Verify that Clients can read and write data into pools with min_size OSDs
+
+  - test:
+      name: Replicated pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      config:
+        replicated_pool:
+          pool_name: test_re_pool
+          pg_num: 32
+          byte_size: 200KB
+          max_objs: 1000
+          rados_read_duration: 100
+      desc: Create replicated pools and run IO
+
+  - test:
+      name: EC pool LC
+      module: rados_prep.py
+      polarion-id: CEPH-83571632
+      desc: Create EC pools and run IO
+      config:
+        ec_pool:
+          pool_name: test_ec_pool
+          pg_num: 32
+          k: 8
+          byte_size: 200KB
+          m: 3
+          plugin: jerasure
+          max_objs: 1000
+          rados_read_duration: 100
+        replicated_pool:
+          pool_name: delete_pool
+          pg_num: 32
+          byte_size: 1024
+          max_objs: 2000
+          rados_read_duration: 10
+
+  - test:
+      name: Autoscaler test - pool target size ratio
+      module: pool_tests.py
+      polarion-id: CEPH-83573424
+      config:
+        verify_pool_target_ratio:
+          configurations:
+            pool-1:
+              pool_name: ec_pool_1
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              plugin: jerasure
+              crush-failure-domain: host
+              target_size_ratio: 0.8
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+            pool-2:
+              pool_type: replicated
+              pool_name: re_pool_1
+              pg_num: 32
+              target_size_ratio: 0.8
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
+
+  - test:
+      name: Verify Ceph df stats
+      desc: Verify Ceph df stats after creating and deleting objects from a pool
+      module: test_cephdf.py
+      polarion-id: CEPH-83571666
+      config:
+        verify_cephdf_stats:
+          create_pool: true
+          pool_name: test-ceph-df
+          obj_nums:
+            - 5
+            - 20
+            - 50
+          delete_pool: true
+      destroy-cluster: false
+
+  - test:
+      name: Mon target for PG num
+      module: pool_tests.py
+      polarion-id: CEPH-83573423
+      desc: Verification of mon_target_pg_per_osd option globally
+      config:
+        verify_mon_target_pg_per_osd:
+          section: "global"
+          name: "mon_target_pg_per_osd"
+          value: "150"
+
+  - test:
+      name: Autoscaler test - pool pg_num_min
+      module: pool_tests.py
+      polarion-id: CEPH-83573425
+      config:
+        verify_pg_num_min:
+          configurations:
+            pool-1:
+              pool_name: ec_pool_2
+              pool_type: erasure
+              pg_num: 32
+              k: 8
+              m: 3
+              plugin: jerasure
+              crush-failure-domain: host
+              pg_num_min: 16
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+            pool-2:
+              pool_type: replicated
+              pool_name: re_pool_2
+              pg_num: 64
+              pg_num_min: 32
+              max_objs: 500
+              rados_read_duration: 50
+              delete_pool: true
+      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-2
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-1. RE -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: replicated
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-1
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-2. RE -> EC
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: replicated
+        pool-1-conf: sample-pool-3
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-3. EC -> RE
+
+  - test:
+      name: Migrate data bw pools.
+      module: test_data_migration_bw_pools.py
+      polarion-id: CEPH-83574768
+      config:
+        pool-1-type: erasure
+        pool-2-type: erasure
+        pool-1-conf: sample-pool-2
+        pool-2-conf: sample-pool-3
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Migrating data between different pools. Scenario-4. Ec -> EC
+
+  - test:
+      name: Pg autoscaler bulk flag
+      module: pool_tests.py
+      polarion-id: CEPH-83573412
+      desc: Ceph PG autoscaler bulk flag tests
+      config:
+        test_autoscaler_bulk_feature: true
+        pool_name: test_bulk_features
+        delete_pool: true
+
+  - test:
+      name: PG number maximum limit check
+      module: pool_tests.py
+      desc: Check the pg_num maximut limit is <=128
+      polarion-id: CEPH-83574909
+      config:
+        verify_pg_num_limit:
+          pool_name: pool_num_chk
+          delete_pool: true
+
+  - test:
+      name: OSD min-alloc size and fragmentation checks
+      module: rados_prep.py
+      polarion-id: CEPH-83573808
+      config:
+        Verify_osd_alloc_size:
+          allocation_size: 4096
+      desc: Verify the minimum allocation size for OSDs along with fragmentation scores.
+
+  - test:
+      name: Compression test - replicated pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571673
+      config:
+        Compression_tests:
+          verify_compression_ratio_set: true          # TC : CEPH-83571672
+          pool_type: replicated
+          pool_config:
+            pool-1: test_compression_repool-1
+            pool-2: test_compression_repool-2
+            max_objs: 1000
+            byte_size: 400KB
+            pg_num: 32
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.6
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on replicated pools
+
+# Blocked due to BZ 2172795. Bugzilla fixed.
+  - test:
+      name: Verify cluster behaviour during PG autoscaler warn
+      module: pool_tests.py
+      polarion-id:  CEPH-83573413
+      config:
+        verify_pool_warnings:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+
+  - test:
+      name: Verify autoscaler scales up pool to pg_num_min
+      module: pool_tests.py
+      polarion-id:  CEPH-83592793
+      config:
+        verify_pool_min_pg_count:
+          pool_configs:
+            - type: replicated
+              conf: sample-pool-1
+            - type: erasure
+              conf: sample-pool-2
+          pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Verify if PG Autoascler will autoscale pools to pg_num_min size
+
+  - test:
+      name: Verify degraded pool behaviour at min_size
+      module: pool_tests.py
+      polarion-id: CEPH-9185
+      config:
+        Verify_degraded_pool_min_size_behaviour:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: pool_degraded_test
+              pg_num: 1
+              disable_pg_autoscale: true
+      desc: On a degraded cluster verify that clients can read and write data into pools with min_size OSDs
+      abort-on-fail: false
+
+# Pool scale down tests commented until fix for 2302230
+  - test:
+      name: Test Online Reads Balancer Upmap-read
+      module: test_online_reads_balancer.py
+      desc: Testing Online reads balancer tool via balancer module | upmap-read
+      polarion-id: CEPH-83590731
+      config:
+        balancer_mode: upmap-read
+        negative_scenarios: true
+        scale_up: true
+        scale_down: false
+        create_pools:
+          - create_pool:
+              pool_name: rpool_1
+              pg_num: 64
+              byte_size: 256
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 30
+          - create_pool:
+              pool_name: rpool_2
+              pg_num: 128
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+          - create_pool:
+              pool_name: rpool_3
+              pg_num: 32
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+              pool_type: replicated
+          - create_pool:
+              create: true
+              pool_name: ecpool_test_2
+              pool_type: erasure
+              pg_num: 32
+              k: 2
+              m: 2
+              max_objs: 500
+              rados_read_duration: 30
+              byte_size: 256
+        delete_pools:
+          - rpool_1
+          - rpool_2
+          - rpool_3
+          - ecpool_test_2
+
+  - test:
+      name: Inconsistent object pg check
+      desc: Inconsistent object pg check
+      module: test_osd_inconsistency_pg.py
+      polarion-id: CEPH-9924
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: Inconsistent object pg check using pool snapshot for RE pools
+      desc: Inconsistent object pg check using pool snapshot for RE pools
+      module: test_osd_snap_inconsistency_pg.py
+      polarion-id: CEPH-9942
+      config:
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_snap_pool_re
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: Inconsistent object secondary pg check using pool snapshot
+      desc: Inconsistent object pg check using pool snapshot for RE pools for secondary OSD in PG
+      module: test_osd_snap_inconsistency_pg.py
+      polarion-id: CEPH-83571452
+      config:
+        test_secondary: true
+        verify_osd_omap_entries:
+          configurations:
+            pool-1:
+              pool_name: Inconsistent_snap_pool
+              pool_type: replicated
+              pg_num: 1
+          omap_config:
+            obj_start: 0
+            obj_end: 5
+            num_keys_obj: 10
+        delete_pool: true
+
+  - test:
+      name: Compression test - EC pool
+      module: pool_tests.py
+      polarion-id: CEPH-83571674
+      config:
+        Compression_tests:
+          pool_type: erasure
+          pool_config:
+            pool-1: test_compression_ecpool-1
+            pool-2: test_compression_ecpool-2
+            max_objs: 2000
+            byte_size: 10KB
+            pg_num: 32
+            k: 2
+            m: 2
+            plugin: jerasure
+            crush-failure-domain: host
+          compression_config:
+            compression_mode: aggressive
+            compression_algorithm: snappy
+            compression_required_ratio: 0.7
+            compression_min_blob_size: 1B
+            byte_size: 10KB
+      desc: Verification of the effect of compression on erasure coded pools
+
+  - test:
+      name: Automatic trimming of Mon DB
+      module: customer_scenarios.py
+      polarion-id: CEPH-83574466
+      config:
+        mondb_trim_config:
+          paxos_service_trim_min: 10
+          paxos_service_trim_max: 100
+          osd_op_complaint_time: 0.000001
+          osd_max_backfills: 10
+          osd_recovery_max_active: 10
+      desc: Verification of mon DB trimming during various cluster operations
+
+  - test:
+      name: Automatic trimming of osdmaps
+      desc: check for periodic trimming of osdmaps
+      module: test_osdmap_trim.py
+      polarion-id: CEPH-10046
+
+  - test:
+      name: Trimming of onodes
+      desc: check for the onode trimming in the cluster
+      module: test_osd_onode_trimming.py
+      polarion-id: CEPH-83575269
+
+  - test:
+      name: CIDR Blocklisting.
+      module: test_cidr_blocklisting.py
+      polarion-id: CEPH-83575008
+      config:
+        pool_configs:
+          pool-1:
+            type: replicated
+            conf: sample-pool-1
+          pool-2:
+            type: replicated
+            conf: sample-pool-2
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: CIDR Blocklisting of ceph rbd clients
+
+# below test has been moved from: tier-2_rados_test-slow-op-requests.yaml
+  - test:
+      name: Limit slow request details to cluster log
+      module: test_slow_op_requests.py
+      desc: Limit slow request details to cluster log
+      polarion-id: CEPH-83574884
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: pool1
+              pg_num: 64
+              max_objs: 5000
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+          - create_pool:
+              pool_name: pool2
+              pg_num: 128
+              max_objs: 5000
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+          - create_pool:
+              pool_name: pool3
+              pg_num: 256
+              max_objs: 5000
+              byte_size: 1024
+              pool_type: replicated
+              osd_max_backfills: 16
+              osd_recovery_max_active: 16
+              check_ec: False
+        delete_pools:
+          - pool1
+          - pool2
+          - pool3
+
+  - test:
+      name: Verify Ceph df MAX_AVAIL
+      desc: MAX_AVAIL value should not change to 0 upon addition of OSD with weight 0
+      module: test_cephdf.py
+      polarion-id: CEPH-10312
+      config:
+        verify_cephdf_max_avail:
+          create_pool: true
+          pool_name: test-max-avail
+          obj_nums: 5
+          delete_pool: true
+
+# commented due to active bug: https://bugzilla.redhat.com/show_bug.cgi?id=2316351
+  - test:
+      name: Verify MAX_AVAIL variance with OSD size change
+      desc: MAX_AVAIL value update correctly when OSD size changes
+      module: test_cephdf.py
+      polarion-id: CEPH-83595780
+      config:
+        cephdf_max_avail_osd_expand: true
+
+  - test:
+      name: Verify MAX_AVAIL variance when OSDs are removed
+      desc: MAX_AVAIL value update correctly when OSDs are removed
+      module: test_cephdf.py
+      polarion-id: CEPH-83604474
+      config:
+        cephdf_max_avail_osd_rm: true
+      comments: bug to be fixed - BZ-2275995
+
+  - test:
+      name: Compression algorithms - modes
+      module: rados_prep.py
+      polarion-id: CEPH-83571670
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 100
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 500
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Enable/disable different compression modes.
+
+  - test:
+      name: Compression algorithm tuneables
+      module: rados_prep.py
+      polarion-id: CEPH-83571671
+      config:
+        replicated_pool:
+          create: true
+          pool_name: re_pool_compress
+          pg_num: 32
+          max_objs: 100
+          rados_read_duration: 10
+        enable_compression:
+          pool_name: re_pool_compress
+          max_objs: 500
+          rados_read_duration: 50
+          configurations:
+            - config-1:
+                compression_mode: force
+                compression_algorithm: snappy
+                compression_required_ratio: 0.3
+                compression_min_blob_size: 1B
+                byte_size: 10KB
+            - config-2:
+                compression_mode: passive
+                compression_algorithm: zlib
+                compression_required_ratio: 0.7
+                compression_min_blob_size: 10B
+                byte_size: 100KB
+            - config-3:
+                compression_mode: aggressive
+                compression_algorithm: zstd
+                compression_required_ratio: 0.5
+                compression_min_blob_size: 1KB
+                byte_size: 100KB
+      desc: Verify and alter different compression tunables.

--- a/suites/squid/common/regression/rados/rados_replica1.yaml
+++ b/suites/squid/common/regression/rados/rados_replica1.yaml
@@ -1,0 +1,23 @@
+# Suite contains tests for replica-1 non-resilient pool
+# conf: conf/squid/rados/5node-1client-ecpool-replica1.yaml
+# Deployment: suites/squid/common/regression/ecpool-replica1-deploy-and-configure.yaml
+
+tests:
+
+  - test:
+      name: replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83575297
+      config:
+       replica-1: true
+      desc: Test replica-1 non-resilient pools
+
+# test should run in succession with previous test(replica-1 non-resilient pools)
+# as it needs replica-1 pools to be present on the cluster
+  - test:
+      name: EIO flag on replica-1 non-resilient pools
+      module: test_replica1.py
+      polarion-id: CEPH-83582009, CEPH-83582010
+      config:
+        eio: true
+      desc: Test EIO flag on replica-1 non-resilient pools

--- a/suites/squid/common/regression/rados/rados_scrubbing.yaml
+++ b/suites/squid/common/regression/rados/rados_scrubbing.yaml
@@ -1,0 +1,199 @@
+# Suite contains tests around scrubbing process
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+tests:
+
+  - test:
+      name: Enable logging to file
+      module: rados_prep.py
+      config:
+        log_to_file: true
+      desc: Change config options to enable logging to file
+
+  - test:
+      name: Verify scrub logs
+      module: test_scrub_log.py
+      polarion-id: CEPH-83575403
+      config:
+        # After the implementation of BZ#2320860 set the verify_log to true
+        verify_log: false
+        pool_configs:
+            - type: replicated
+              conf: sample-pool-2
+            - type: erasure
+              conf: sample-pool-2
+        pool_configs_path: "conf/squid/rados/test-confs/pool-configurations.yaml"
+      desc: Verify that scrub & deep-scrub logs are captured in OSD logs
+
+  - test:
+      name: verify scrub chunk max
+      polarion-id: CEPH-10792
+      module: test_scrub_chunk_max.py
+      config:
+        delete_pool: true
+      desc: Scrub Chunk max validation
+  - test:
+      name: Scrub enhancement
+      module: test_scrub_enhancement.py
+      desc: Verify scrub enhancement feature
+      polarion-id: CEPH-83575885
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scrub_pool
+              pg_num: 1
+              pg_num_max: 1
+              pool_type: replicated
+        delete_pools:
+          - scrub_pool
+  - test:
+      name: CPU and Memory check during scheduled scrub
+      module: test_scrub_cpu_memory_usage.py
+      desc: Verify CPU and Memory check during scheduled scrub
+      polarion-id: CEPH-9369
+      config:
+        create_pools:
+          - create_pool:
+              pool_name: scheduled_scrub
+              pg_num: 32
+              pg_num_min: 32
+              pool_type: replicated
+              max_objs: 500
+              rados_read_duration: 120
+              byte_size: 1KB
+        delete_pools:
+          - scheduled_scrub
+
+  - test:
+      name: Preempt scrub messages checks
+      desc: Checking preempt messages in the OSDs
+      module: test_rados_preempt_scrub.py
+      polarion-id: CEPH-83572916
+      config:
+        pool_name: preempt_pool
+        pg_num: 1
+        delete_pool: true
+
+  - test:
+      name: Default scheduled scrub
+      polarion-id: CEPH-9361
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "default"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin Time = End Time
+      polarion-id: CEPH-9362
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "begin_end_time_equal"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin time > End time
+      polarion-id: CEPH-9363
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "beginTime gt endTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin Time >End time<current
+      polarion-id: CEPH-9365
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "beginTime gt endTime lt currentTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Begin Time & End time > current
+      polarion-id: CEPH-9368
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "beginTime and endTime gt currentTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Decrease scrub time
+      polarion-id: CEPH-9371
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "decreaseTime"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Unsetting scrubbing
+      polarion-id: CEPH-9374
+      module: scheduled_scrub_scenarios.py
+      desc: Scheduled scrub validation
+      config:
+        replicated_pool:
+          create: true
+          pool_name: scrub_pool
+          pg_num: 1
+          disable_pg_autoscale: true
+        scenario: "unsetScrub"
+        debug_enable: False
+      delete_pools:
+        - scrub_pool
+
+  - test:
+      name: Verification of the scrub and deep-scrub time check
+      desc: BZ#2292517deep scrub taking too long under mclock I/O scheduler
+      module: test_scrub_deepscrub_timecheck.py
+      polarion-id: CEPH-83605026
+      config:
+        pool_name: scrub_pool
+        pg_num: 1
+        pg_num_max: 1
+      delete_pool:
+        - scrub_pool


### PR DESCRIPTION
# Description

Jira tracker: [RHCEPHQE-18391](https://issues.redhat.com/browse/RHCEPHQE-18391)

Ask is to add test suites in common directory for serial execution using new pipeline

Test suites for `13-node-4-client` conf:
- suites/squid/common/regression/rados/rados_bluestore.yaml
- suites/squid/common/regression/rados/rados_bugfixes.yaml
- suites/squid/common/regression/rados/rados_osd-rebalance-recovery.yaml
- suites/squid/common/regression/rados/rados_pg-split-merge.yaml
- suites/squid/common/regression/rados/rados_pool-functionalities.yaml
- suites/squid/common/regression/rados/rados_scrubbing.yaml 
- suites/squid/common/regression/rados/rados_location-stretch-mode.yaml

Test suites for `9node-1client-availability-zone.yaml` conf:
- suites/squid/common/regression/rados/rados_3-AZ-Cluster.yaml

Test suites for `5node-1client-ecpool-replica1.yaml` conf: 
- suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
- suites/squid/common/regression/rados/rados_replica1.yaml


Signed-off-by: Harsh Kumar <hakumar@redhat.com>



