### PR TITLE
[Fix] Update service_name with service_id.

### DIFF
--- a/suites/quincy/ceph_volume/tier2-ceph-volume-lvm.yaml
+++ b/suites/quincy/ceph_volume/tier2-ceph-volume-lvm.yaml
@@ -82,7 +82,7 @@ tests:
       config:
         specs:
           service_type: osd
-          service_id: osd.3
+          service_id: osd
           placement:
             hosts:
               - node0

--- a/suites/quincy/ceph_volume/tier2-ceph-volume-non-collocated.yaml
+++ b/suites/quincy/ceph_volume/tier2-ceph-volume-non-collocated.yaml
@@ -83,7 +83,7 @@ tests:
       config:
         specs:
           service_type: osd
-          service_id: osd.3
+          service_id: osd
           placement:
             hosts:
               - node0

--- a/suites/quincy/ceph_volume/tier2-ceph-volume-redeploy.yaml
+++ b/suites/quincy/ceph_volume/tier2-ceph-volume-redeploy.yaml
@@ -83,7 +83,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             hosts:
               - node0
@@ -103,7 +103,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             hosts:
               - node0
@@ -123,7 +123,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             label: "osd"
           spec:
@@ -140,7 +140,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_sdd
+          service_id: osd_sdd
           placement:
             label: "osd"
           crush_device_class: ssd

--- a/suites/reef/ceph_volume/tier2-ceph-volume-lvm.yaml
+++ b/suites/reef/ceph_volume/tier2-ceph-volume-lvm.yaml
@@ -82,7 +82,7 @@ tests:
       config:
         specs:
           service_type: osd
-          service_id: osd.3
+          service_id: osd
           placement:
             hosts:
               - node0

--- a/suites/reef/ceph_volume/tier2-ceph-volume-non-collocated.yaml
+++ b/suites/reef/ceph_volume/tier2-ceph-volume-non-collocated.yaml
@@ -83,7 +83,7 @@ tests:
       config:
         specs:
           service_type: osd
-          service_id: osd.3
+          service_id: osd
           placement:
             hosts:
               - node0

--- a/suites/reef/ceph_volume/tier2-ceph-volume-redeploy.yaml
+++ b/suites/reef/ceph_volume/tier2-ceph-volume-redeploy.yaml
@@ -83,7 +83,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             hosts:
               - node0
@@ -103,7 +103,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             hosts:
               - node0
@@ -123,7 +123,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             label: "osd"
           spec:
@@ -140,7 +140,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_sdd
+          service_id: osd_sdd
           placement:
             label: "osd"
           crush_device_class: ssd

--- a/suites/squid/ceph_volume/tier2-ceph-volume-lvm.yaml
+++ b/suites/squid/ceph_volume/tier2-ceph-volume-lvm.yaml
@@ -82,7 +82,7 @@ tests:
       config:
         specs:
           service_type: osd
-          service_id: osd.3
+          service_id: osd
           placement:
             hosts:
               - node0

--- a/suites/squid/ceph_volume/tier2-ceph-volume-non-collocated.yaml
+++ b/suites/squid/ceph_volume/tier2-ceph-volume-non-collocated.yaml
@@ -83,7 +83,7 @@ tests:
       config:
         specs:
           service_type: osd
-          service_id: osd.3
+          service_id: osd
           placement:
             hosts:
               - node0

--- a/suites/squid/ceph_volume/tier2-ceph-volume-redeploy.yaml
+++ b/suites/squid/ceph_volume/tier2-ceph-volume-redeploy.yaml
@@ -83,7 +83,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             hosts:
               - node0
@@ -103,7 +103,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             hosts:
               - node0
@@ -123,7 +123,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_hdd
+          service_id: osd_hdd
           placement:
             label: "osd"
           spec:
@@ -140,7 +140,7 @@ tests:
       config:
         spec:
           service_type: osd
-          service_name: osd_sdd
+          service_id: osd_sdd
           placement:
             label: "osd"
           crush_device_class: ssd


### PR DESCRIPTION
Recent fix in production doesn't allow service_name in service spec. Development has changed service_name with service_id which leading to fail exisiting test cases.

Logs:
http://magna002.ceph.redhat.com/cephci-jenkins/aramteke/ceph-volume/cephci-run-2XEXW0/
http://magna002.ceph.redhat.com/cephci-jenkins/aramteke/ceph-volume/cephci-run-IBAIBD/
http://magna002.ceph.redhat.com/cephci-jenkins/aramteke/ceph-volume/cephci-run-CBNH9I/