### PR TITLE
Added codeowners for NVMe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@ iscsi/              @Manohar-Murthy @HaruChebrolu
 
 # for NVMe-oF
 nvmeof/             @Manohar-Murthy @HaruChebrolu
+ceph/nvmegw_cli     @Manohar-Murthy @HaruChebrolu
 
 # for RADOS
 rados/              @neha-gangadhar @pdhiran


### PR DESCRIPTION
# Description

Updated codeowners for NVMe (ceph/nvmegw_cli folder)
