### PR TITLE
Updating the rados upgrade workflows

### DIFF
--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -115,13 +115,7 @@ tests:
           - config:
               command: shell
               args: # arguments to ceph orch
-                - ceph
-                - osd
-                - pool
-                - set
-                - cephfs.cephfs.data
-                - bulk
-                - false
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
 
   - test:
       name: RGW Service deployment

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -114,13 +114,7 @@ tests:
           - config:
               command: shell
               args: # arguments to ceph orch
-                - ceph
-                - osd
-                - pool
-                - set
-                - cephfs.cephfs.data
-                - bulk
-                - false
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
 
   - test:
       name: RGW Service deployment

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -115,13 +115,7 @@ tests:
           - config:
               command: shell
               args: # arguments to ceph orch
-                - ceph
-                - osd
-                - pool
-                - set
-                - cephfs.cephfs.data
-                - bulk
-                - false
+                - "ceph osd pool set cephfs.cephfs.data bulk false"
 
   - test:
       name: RGW Service deployment


### PR DESCRIPTION
  Test to Upgrade the ceph cluster to the latest version, with few RADOS checks
    1. check if the warning "OSD_UPGRADE_FINISHED" is generated when "require_osd_release" does not match
    the current release during upgrades.
    2. Check if the cluster usage is same before & after upgrade
    3. Check if MAX_AVAIL is calculated correctly for all the pools before and after upgrade
    4. Check if all the daemons on the cluster are present post upgrade
    5. Check if there were inactive PGs, causing data unavailability during the upgrade process