### PR TITLE
Qos test cases for cluster level

### DIFF
--- a/cli/ceph/nfs/cluster/cluster.py
+++ b/cli/ceph/nfs/cluster/cluster.py
@@ -1,3 +1,5 @@
+import json
+
 from cli import Cli
 
 from .qos import Qos
@@ -39,3 +41,19 @@ class Cluster(Cli):
         if isinstance(out, tuple):
             return out[0].strip()
         return out
+
+    def ls(self):
+        """
+        List the NFS clusters and return as a Python list
+        """
+        cmd = f"{self.base_cmd} ls"
+        out = self.execute(sudo=True, cmd=cmd)
+
+        # Extract stdout if tuple (output, err)
+        stdout = out[0].strip() if isinstance(out, tuple) else str(out).strip()
+
+        try:
+            # Parse JSON output to Python list
+            return json.loads(stdout)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse cluster list. Output: {stdout}") from e

--- a/cli/ceph/nfs/cluster/qos.py
+++ b/cli/ceph/nfs/cluster/qos.py
@@ -24,27 +24,70 @@ class Qos(Cli):
             return out
 
     def enable(
-        self, cluster_id: str, qos_type: str, operation="bandwidth_control", **kwargs
-    ):
+        self,
+        cluster_id: str,
+        qos_type: str,
+        operation: str = "bandwidth_control",
+        **kwargs,
+    ) -> str:
+        """Enable QoS controls for an NFS cluster.
+
+        Args:
+            cluster_id: NFS cluster identifier
+            qos_type: QoS type (PerShare/PerClient/PerShare-PerClient)
+            operation: Operation type (default: bandwidth_control)
+            **kwargs: Required parameters based on qos_type:
+                - PerShare: Either (max_export_write_bw + max_export_read_bw)
+                            OR max_export_combined_bw
+                - PerClient: Either (max_client_write_bw + max_client_read_bw)
+                             OR max_client_combined_bw
+                - PerShare-PerClient: Combination of PerShare AND PerClient requirements
+
+        Returns:
+            Command execution output
+
+        Raises:
+            ValueError: For missing/invalid parameters or qos_type
         """
-        nfs_name = nfs cluster name
-        export = export
-        operation = "bandwidth_control"
-        max_export_read_bw : required  - pass in kwargs
-        max_export_read_bw : required  - pass in kwargs
-        """
-        if qos_type == "PerShare" and (
-            "max_export_write_bw" not in kwargs or "max_export_read_bw" not in kwargs
-        ):
-            raise Exception(
-                'For "PerShare" - kwargs "max_export_write_bw" and "max_export_read_bw" required'
-                + ', example - max_export_write_bw = "10MB"'
-            )
-        cmd = f"{self.base_cmd} enable {operation} {cluster_id} {qos_type} {build_cmd_from_args(**kwargs)}"
-        out = self.execute(sudo=True, cmd=cmd)
-        if isinstance(out, tuple):
-            return out[0].strip()
-        return out
+        # Validate qos_type
+        params = []
+
+        # Handle Export (PerShare) parameters
+        if qos_type in ["PerShare", "PerShare_PerClient"]:
+            if "max_export_combined_bw" in kwargs:
+                params.append(
+                    f"--max_export_combined_bw {kwargs['max_export_combined_bw']}"
+                )
+            else:
+                params.extend(
+                    [
+                        f"--max_export_write_bw {kwargs['max_export_write_bw']}",
+                        f"--max_export_read_bw {kwargs['max_export_read_bw']}",
+                    ]
+                )
+
+        # Handle Client (PerClient) parameters
+        if qos_type in ["PerClient", "PerShare_PerClient"]:
+            if "max_client_combined_bw" in kwargs:
+                params.append(
+                    f"--max_client_combined_bw {kwargs['max_client_combined_bw']}"
+                )
+            else:
+                params.extend(
+                    [
+                        f"--max_client_write_bw {kwargs['max_client_write_bw']}",
+                        f"--max_client_read_bw {kwargs['max_client_read_bw']}",
+                    ]
+                )
+
+        # Build and execute command
+        cmd = (
+            f"{self.base_cmd} enable {operation} {cluster_id} {qos_type} "
+            f"{' '.join(params)}"
+        )
+        result = self.execute(sudo=True, cmd=cmd)
+
+        return result[0].strip() if isinstance(result, tuple) else result
 
     def disable(self, cluster_id, operation="bandwidth_control", **kwargs):
         """

--- a/suites/squid/nfs/tier0-nfs-ganesha.yaml
+++ b/suites/squid/nfs/tier0-nfs-ganesha.yaml
@@ -310,3 +310,22 @@ tests:
       config:
         nfs_version: 4.1
         clients: 1
+
+  - test:
+      name: Qos enablement on Cluster level with nfs service restart
+      module: test_nfs_qos_on_cluster_level_enablement.py
+      desc: Verify qos [Pershare,PerClient, PerShare-Perclient] enablement on cluster level
+      polarion-id: CEPH-83611390
+      abort-on-fail: false
+      config:
+        cephfs_volume : cephfs
+        cluster_name : cephfs-nfs
+        max_export_write_bw : 10MB
+        max_export_read_bw : 10MB
+        max_client_write_bw : 10MB
+        max_client_read_bw: 10MB
+        qos_type :
+          - PerShare
+          - PerClient
+          - PerShare_PerClient
+        operation : restart

--- a/tests/nfs/test_nfs_qos_on_cluster_level_enablement.py
+++ b/tests/nfs/test_nfs_qos_on_cluster_level_enablement.py
@@ -1,0 +1,159 @@
+import json
+from time import sleep
+
+from cli.ceph.ceph import Ceph
+from cli.exceptions import ConfigError, OperationFailedError
+from utility.log import Log
+
+log = Log(__name__)
+
+
+def validate_qos_operation(
+    operation_key: str, qos_type: str, cluster_name: str, qos_data: dict
+) -> None:
+    """Validate QoS operation result and handle logging."""
+    expected_key = "qos_type" if operation_key == "enable" else None
+    success = (
+        (expected_key in qos_data)
+        if operation_key == "enable"
+        else (expected_key not in qos_data)
+    )
+
+    log_message = (
+        f"QoS {qos_type} {operation_key}d for cluster {cluster_name}. Current state: {qos_data}"
+        if success
+        else f"QoS {qos_type} failed to {operation_key} for cluster {cluster_name}. State: {qos_data}"
+    )
+
+    log.info(log_message) if success else log.error(log_message)
+
+    if not success:
+        raise RuntimeError(log_message)
+
+
+def enable_disable_qos_for_cluster(
+    enable_flag: bool,
+    ceph_cluster_nfs_obj,
+    cluster_name: str,
+    qos_type: str = None,
+    **qos_parameters,
+) -> None:
+    # Common validation
+    if enable_flag and not qos_type:
+        raise ValueError("qos_type is required when enabling QoS")
+
+    operation_key = "enable" if enable_flag else "disable"
+
+    try:
+        if enable_flag:
+            ceph_cluster_nfs_obj.qos.enable(
+                cluster_id=cluster_name, qos_type=qos_type, **qos_parameters
+            )
+        else:
+            ceph_cluster_nfs_obj.qos.disable(cluster_id=cluster_name)
+
+        qos_data = ceph_cluster_nfs_obj.qos.get(cluster_id=cluster_name)
+        validate_qos_operation(
+            operation_key=operation_key,
+            qos_type=qos_type,
+            cluster_name=cluster_name,
+            qos_data=qos_data,
+        )
+
+    except Exception as e:
+        raise RuntimeError(
+            f"QoS {operation_key} failed for cluster {cluster_name}"
+        ) from e
+
+
+def run(ceph_cluster, **kw):
+    """Verify QoS operations on NFS cluster"""
+    config = kw.get("config")
+    clients = ceph_cluster.get_nodes("client")
+    nfs_nodes = ceph_cluster.get_nodes("nfs")
+    cluster_name = config["cluster_name"]
+    operation = config.get("operation", None)
+
+    if not nfs_nodes:
+        raise OperationFailedError("No NFS nodes found in cluster")
+
+    nfs_node = nfs_nodes[0]
+    qos_type = config.get("qos_type", [])
+    ceph_nfs_client = Ceph(clients[0]).nfs
+
+    try:
+        # Create NFS cluster
+        ceph_nfs_client.cluster.create(
+            name=cluster_name, nfs_server=nfs_node.hostname, ha=False
+        )
+        sleep(3)
+
+        # Get cluster name reliably
+        clusters = ceph_nfs_client.cluster.ls()
+        if not clusters:
+            raise OperationFailedError("No NFS clusters found")
+        cluster_name_created = clusters[0]
+        if cluster_name_created != cluster_name:
+            raise OperationFailedError("NFS cluster was not created as user parameter")
+
+        # Process QoS operations
+        for qos in qos_type:
+            # Enable QoS with parameters
+            enable_disable_qos_for_cluster(
+                enable_flag=True,
+                ceph_cluster_nfs_obj=ceph_nfs_client.cluster,
+                cluster_name=cluster_name,
+                qos_type=qos,
+                **{
+                    k: config[k]
+                    for k in [
+                        "max_export_write_bw",
+                        "max_export_read_bw",
+                        "max_client_write_bw",
+                        "max_client_read_bw",
+                    ]
+                    if k in config
+                },
+            )
+
+            if operation == "restart":
+                # Get nfs service name
+                data = json.loads(Ceph(nfs_node).orch.ls(format="json"))
+                [service_name] = [
+                    x["service_name"]
+                    for x in data
+                    if x.get("service_id") == cluster_name
+                ]
+
+                # restart the service
+                Ceph(nfs_node).orch.restart(service_name)
+                if cluster_name not in [x["service_name"] for x in data]:
+                    sleep(1)
+
+                # validate if QOS data persists after cluster restart
+                qos_data_after_restart = ceph_nfs_client.cluster.qos.get(
+                    cluster_id=cluster_name
+                )
+                if qos_data_after_restart["qos_type"] == qos:
+                    log.info(
+                        f"Qos data for {qos} persists even after the nfs cluster restarted"
+                    )
+                else:
+                    raise OperationFailedError(
+                        f"Qos data for {qos} did not persists after the nfs cluster restarted"
+                    )
+
+            # Disable QoS
+            enable_disable_qos_for_cluster(
+                enable_flag=False,
+                ceph_cluster_nfs_obj=ceph_nfs_client.cluster,
+                cluster_name=cluster_name,
+            )
+        return 0
+    except (ConfigError, OperationFailedError, RuntimeError) as e:
+        log.error(f"Test failed: {e}")
+        return 1
+    finally:
+        log.info("Cleanup in progress <Finally block>")
+        log.debug(f"deleting NFS cluster {cluster_name}")
+        ceph_nfs_client.cluster.delete(cluster_name)


### PR DESCRIPTION
# Description

QOS [Quality of service] - New-Feature

Covers the following test cases

- Verify that the nfs cluster qos enable bandwidth_control <PerShare_PerClient > command enables QoS for the Ceph cluster
- Verify that the nfs cluster qos enable bandwidth_control <PerShare > command enables QoS for the Ceph cluster
- Verify that the nfs cluster qos enable bandwidth_control <PerClient > command enables QoS for the Ceph cluster
- Restart the NFS server and verify that global QoS settings persist <PerShare_PerClient >
- Restart the NFS server and verify that global QoS settings persist <PerShare >
- Restart the NFS server and verify that global QoS settings persist <PerClient >

logs : http://magna002.ceph.redhat.com/ceph-qe-logs/hacharya/qos_part1_cluster_level/