### PR TITLE
[TFA] - Enhance do_rados_put() to support writing single object without appending numeric suffixes

### DIFF
--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -228,10 +228,13 @@ class PoolFunctions:
 
         for i in range(nobj):
             log.info(f"running command on {client.hostname}")
+            if nobj > 1:
+                obj_name = f"{obj_name}-{i}"
+
             put_cmd = (
                 f"rados put -p {pool} obj{i} {infile}"
                 if obj_name is None
-                else f"rados put -p {pool} {obj_name}-{i} {infile}"
+                else f"rados put -p {pool} {obj_name} {infile}"
             )
             if offset:
                 put_cmd = f"{put_cmd} --offset {offset}"

--- a/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
+++ b/suites/squid/rados/tier-2_rados_test_cot_cbt.yaml
@@ -190,6 +190,7 @@ tests:
       config:
         non-collocated: true
       desc: Verify ceph-bluestore-tool functionalities for non-collocated OSDs
+      comments: regression Bug in 8.1 - 2309610
 
   - test:
       name: cbt utility bluefs spillover

--- a/suites/squid/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/squid/rados/tier-2_rados_trim_tests.yaml
@@ -189,3 +189,4 @@ tests:
           pg_num: 128
           pgp_num: 128
       desc: Perform OSD compaction with & without failures
+      comments: regression Bug in 8.1 - 2351352


### PR DESCRIPTION
# Description

Enhance do_rados_put() to support writing single object without appending numeric suffixes 
Test case affected :- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-26/rados/80/tier-2_rados_test-osd-rebalance/ObjectStore_block_stats_verification_0.log 

`2025-03-10 21:54:30,865 - cephci - test_objectstore_block:110 - INFO - Verify the block size, total size and number of blocks after write operation
2025-03-10 21:54:30,865 - cephci - test_objectstore_block:114 - INFO - 4096 == 4096
2025-03-10 21:54:30,865 - cephci - test_objectstore_block:116 - INFO - 8388608 == 12582912
2025-03-10 21:54:30,865 - cephci - test_objectstore_block:139 - INFO - ^FAIL`

Task:- https://issues.redhat.com/browse/RHCEPHQE-18476 

Pass logs:- http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_osd_rebalance_25_03_17_11_08_45/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
