### PR TITLE
[TFA] config file modified to run on haproxy, but node is not configured

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_sw_qat.yaml
+++ b/suites/squid/rgw/tier-1_rgw_sw_qat.yaml
@@ -78,6 +78,17 @@ tests:
   - test:
       abort-on-fail: true
       config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
+      abort-on-fail: true
+      config:
         install:
           - agent
         run-on-rgw: true
@@ -107,6 +118,7 @@ tests:
       polarion-id: CEPH-11350
       module: sanity_rgw.py
       config:
+        run-on-haproxy: true
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
 
@@ -118,6 +130,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
+        run-on-haproxy: true
 
   - test:
       name: compresstion_with_Zlib_type
@@ -127,6 +140,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+        run-on-haproxy: true
 
   - test:
       config:


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/RHCEPHQE-18548
[TFA] config files of testcase is modified to run on haproxy, but node is not configured with the same
due to that endpoint port was not as expected
issue log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-YL6POL/compresstion_with_zstd_type_0.log


with haproxy configuration : 
  http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-EVAXSZ/ 
rerun passed : http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-L5QKJH/ 

for sse s3 issue created separate ticket : https://issues.redhat.com/browse/RHCEPHQE-18594 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
