### PR TITLE
[TFA] Rearranging Restart rgw service of primary fixed the failover issue

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -337,8 +337,9 @@ tests:
             commands:
               - "radosgw-admin realm pull --rgw-realm india --url http://{node_ip:ceph-sec#node5}:80 --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
               - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --master --default"
-              - "radosgw-admin period update --rgw-realm india --commit"
               - "ceph orch restart {service_name:shared.pri}"
+              - "sleep 30"
+              - "radosgw-admin period update --rgw-realm india --commit"
               - "sleep 120"
       desc: RGW multisite failback
       module: exec.py


### PR DESCRIPTION
# Description
tier-2_rgw_ms_failover_failback: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-109/rgw/85/tier-2_rgw_ms_failover_failback/Failback_to_primary_0.log 

rearranged retstart command no issue seen log: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-Y0Z72A/  

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
