### PR TITLE
Automate CEPH-83609782 - Test E2E NS masking at scale

### DIFF
--- a/suites/squid/nvmeof/tier-3_8-1-nvmeof_1-group_4-gw_scale.yaml
+++ b/suites/squid/nvmeof/tier-3_8-1-nvmeof_1-group_4-gw_scale.yaml
@@ -1,0 +1,218 @@
+# Scale test suite including all new features from 8.1
+# 1 GW group with 4 GWs and 128 subsystems with 20 namespaces each and 5 initiator nodes
+# Test conf at rhos-d conf/squid/nvmeof/ceph_nvmeof_ns-masking-5_client.yaml
+# Bare Metal conf TBD
+tests:
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node8
+          - node9
+          - node10
+          - node11
+          - node12
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_pool
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node4
+                  - node5
+                  - node6
+                  - node7
+              pos_args:
+                - nvmeof_pool
+                - group1
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+      desc: deploy NVMeoF service for GW group 1
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 1
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 128
+                max-namespaces: 1024
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 128
+                port: 4420
+                group: group1
+                nodes:
+                  - node4
+                  - node5
+                  - node6
+                  - node7
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 128
+                group: group1
+      desc: GW group with 4 GWs and 128 subsystems
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Configure subsystems
+      polarion-id: CEPH-83595512                     # This can be replaced with In band authentication functionality at scale
+
+  - test:
+      abort-on-fail: true
+      config:
+        nodes:
+          - node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 128
+                namespaces: 2560
+                pool: rbd
+                image_size: 1T
+                no-auto-visible: true
+                group: group1
+          - config:
+              command: add_host
+              args:
+                subsystems: 128
+                namespaces: 2560
+                initiators:
+                  - node8
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+          - config:
+              command: del_host
+              args:
+                subsystems: 128
+                namespaces: 2560
+                initiators:
+                  - node8
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 128
+                namespaces: 2560
+                auto-visible: 'yes'
+                group: group1
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 128
+                namespaces: 2560
+                auto-visible: 'no'
+                group: group1
+        initiators:
+          - node8
+          - node9
+          - node10
+          - node11
+          - node12
+      desc: e2e NS masking on 2560 namespaces 128 subsystems and 5 initiators
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Test E2E nvmeof namespace masking at scale
+      polarion-id: CEPH-83609782


### PR DESCRIPTION
Automate CEPH-83609782 - Test E2E NS masking at scale
Enabled a test suite to incorporate all Features in single GW group at scale

- Provision to  include In-band at scale before NS masking runs
- NS masking is included

Test runs failed due to rhos-d instability, but we will use same suite to test on Bare Metal
[cephci-run-GBP63Z.zip](https://github.com/user-attachments/files/19318598/cephci-run-GBP63Z.zip)

```
2025-03-18 11:38:05,323 - cephci - execute:57 - INFO - ERROR - None,
OUTPUT - {
    "error_message": "Success",
    "subsystem_nqn": "nqn.2016-06.io.spdk:cnode3.group1",
    "namespaces": [
        {
            "nsid": 20,
            "bdev_name": "bdev_f02a3edc-e9ea-4ecb-a558-74deba0648a5",
            "rbd_image_name": "PKEM-image20",
            "rbd_pool_name": "rbd",
            "load_balancing_group": 1,
            "block_size": 512,
            "rbd_image_size": "1099511627776",
            "uuid": "f02a3edc-e9ea-4ecb-a558-74deba0648a5",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode3.group1",
            "trash_image": false,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": false,
            "hosts": []
        }
    ],
    "status": 0
}

2025-03-18 11:38:05,323 - cephci - test_ceph_nvmeof_ns_masking:72 - INFO - False
2025-03-18 11:38:05,323 - cephci - ha:1002 - INFO - add
2025-03-18 11:38:05,323 - cephci - ha:1004 - INFO - Validated - **Namespace 20** has correct visibility: False
2025-03-18 11:38:05,323 - cephci - test_ceph_nvmeof_ns_masking:34 - INFO - Subsystem **4/128**
2025-03-18 11:38:05,324 - cephci - ceph:1576 - INFO - Execute rbd create rbd/LGV2-image1 --size 1T on 10.0.65.151
2025-03-18 11:38:06,326 - cephci - ceph:1606 - INFO - Execution of rbd create rbd/LGV2-image1 --size 1T on 10.0.65.151 took 1.002709 seconds
2025-03-18 11:38:06,327 - cephci - rbd_utils:107 - INFO - Command execution complete
2025-03-18 11:38:06,327 - cephci - test_ceph_nvmeof_ns_masking:40 - INFO - Creating image LGV2-image1/2560
2025-03-18 11:38:06,327 - cephci - execute:33 - INFO - NVMe CLI command : namespace add
2025-03-18 11:38:06,328 - cephci - ceph:1576 - INFO - Execute podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image1 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible  on 10.0.67.0
2025-03-18 11:38:09,663 - cephci - ceph:1606 - INFO - Execution of podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image1 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible  on 10.0.67.0 took 3.33471 seconds
2025-03-18 11:38:09,664 - cephci - ceph:1682 - INFO -
Command:    podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image1 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible
Duration:   3.33471 seconds
Exit Code:  0
Stderr:      {
    "error_message": "Success",
    "nsid": 1,
    "status": 0
}

2025-03-18 11:38:09,664 - cephci - execute:57 - INFO - ERROR - None,
OUTPUT - {
    "error_message": "Success",
    "nsid": 1,
    "status": 0
}

2025-03-18 11:38:09,664 - cephci - execute:33 - INFO - NVMe CLI command : namespace list
2025-03-18 11:38:09,705 - cephci - ceph:1576 - INFO - Execute podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace list  --nsid 1 --subsystem nqn.2016-06.io.spdk:cnode4.group1 on 10.0.67.0
2025-03-18 11:38:12,968 - cephci - ceph:1606 - INFO - Execution of podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace list  --nsid 1 --subsystem nqn.2016-06.io.spdk:cnode4.group1 on 10.0.67.0 took 3.262734 seconds
2025-03-18 11:38:12,969 - cephci - ceph:1682 - INFO -
Command:    podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace list  --nsid 1 --subsystem nqn.2016-06.io.spdk:cnode4.group1
Duration:   3.262734 seconds
2025-03-18 11:38:12,969 - cephci - execute:57 - INFO - ERROR - None,
OUTPUT - {
    "error_message": "Success",
    "subsystem_nqn": "nqn.2016-06.io.spdk:cnode4.group1",
    "namespaces": [
        {
            "nsid": 1,
            "bdev_name": "bdev_748bc474-3d8a-42df-bf0e-b3354b6cf1c7",
            "rbd_image_name": "LGV2-image1",
            "rbd_pool_name": "rbd",
            "load_balancing_group": 4,
            "block_size": 512,
            "rbd_image_size": "1099511627776",
            "uuid": "748bc474-3d8a-42df-bf0e-b3354b6cf1c7",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode4.group1",
            "trash_image": false,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": false,
            "hosts": []
        }
    ],
    "status": 0
}

2025-03-18 11:38:12,969 - cephci - test_ceph_nvmeof_ns_masking:72 - INFO - False
2025-03-18 11:38:12,969 - cephci - ha:1002 - INFO - add
2025-03-18 11:38:12,969 - cephci - ha:1004 - INFO - Validated - Namespace 1 has correct visibility: False
.
.
.
2025-03-18 11:38:53,138 - cephci - execute:57 - INFO - ERROR - None,
OUTPUT - {
    "error_message": "Success",
    "subsystem_nqn": "nqn.2016-06.io.spdk:cnode4.group1",
    "namespaces": [
        {
            "nsid": 4,
            "bdev_name": "bdev_dd9053e5-907b-494a-af6c-cccb0aee3aa5",
            "rbd_image_name": "LGV2-image4",
            "rbd_pool_name": "rbd",
            "load_balancing_group": 1,
            "block_size": 512,
            "rbd_image_size": "1099511627776",
            "uuid": "dd9053e5-907b-494a-af6c-cccb0aee3aa5",
            "ns_subsystem_nqn": "nqn.2016-06.io.spdk:cnode4.group1",
            "trash_image": false,
            "rw_ios_per_second": "0",
            "rw_mbytes_per_second": "0",
            "r_mbytes_per_second": "0",
            "w_mbytes_per_second": "0",
            "auto_visible": false,
            "hosts": []
        }
    ],
    "status": 0
}

2025-03-18 11:38:53,138 - cephci - test_ceph_nvmeof_ns_masking:72 - INFO - False
2025-03-18 11:38:53,138 - cephci - ha:1002 - INFO - add
2025-03-18 11:38:53,138 - cephci - ha:1004 - INFO - Validated - Namespace 4 has correct visibility: False
2025-03-18 11:38:53,139 - cephci - ceph:1576 - INFO - Execute rbd create rbd/LGV2-image5 --size 1T on 10.0.65.151
2025-03-18 11:38:54,142 - cephci - ceph:1606 - INFO - Execution of rbd create rbd/LGV2-image5 --size 1T on 10.0.65.151 took 1.002981 seconds
2025-03-18 11:38:54,142 - cephci - rbd_utils:107 - INFO - Command execution complete
2025-03-18 11:38:54,142 - cephci - test_ceph_nvmeof_ns_masking:40 - INFO - Creating image LGV2-image5/2560
2025-03-18 11:38:54,142 - cephci - execute:33 - INFO - NVMe CLI command : namespace add
2025-03-18 11:38:54,152 - cephci - ceph:1576 - INFO - Execute podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image5 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible  on 10.0.67.0
2025-03-18 11:38:58,269 - cephci - ceph:1606 - INFO - Execution of podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image5 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible  on 10.0.67.0 took 4.116487 seconds
2025-03-18 11:38:58,269 - cephci - ceph:1682 - INFO -
Command:    podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image5 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible
Duration:   4.116487 seconds
Exit Code:  108
Stderr:      {
    "status": 108,
    "error_message": "Gateway is going down",    ----> RHOS-d issues
    "nsid": 0
}

2025-03-18 11:38:58,269 - cephci - test_ceph_nvmeof_ns_masking:318 - ERROR - podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image5 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible  returned {
    "status": 108,
    "error_message": "Gateway is going down",
    "nsid": 0
}
 and code 108 on 10.0.67.0
Traceback (most recent call last):
  File "/root/scale_ns/cephci/tests/nvmeof/test_ceph_nvmeof_ns_masking.py", line 309, in run
    add_namespaces(cfg, command, hostnqn_dict, rbd_obj, ha)
  File "/root/scale_ns/cephci/tests/nvmeof/test_ceph_nvmeof_ns_masking.py", line 55, in add_namespaces
    _, namespaces_response = nvmegwcli.namespace.add(**config)
  File "/root/scale_ns/cephci/ceph/nvmegw_cli/namespace.py", line 23, in add
    return self.run_nvme_cli("add", **kwargs)
  File "/root/scale_ns/cephci/ceph/nvmegw_cli/execute.py", line 56, in run_nvme_cli
    err, out = self.node.exec_command(cmd=command, sudo=True, pretty_print=True)
  File "/root/scale_ns/cephci/ceph/ceph.py", line 1700, in exec_command
    raise CommandFailed(
ceph.ceph.CommandFailed: podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image LGV2-image5 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode4.group1 --no-auto-visible  returned {
    "status": 108,
    "error_message": "Gateway is going down",
    "nsid": 0
}

```

