### PR TITLE
Fetch build artifacts correctly when input platform is rhel-9.x

### DIFF
--- a/utility/utils.py
+++ b/utility/utils.py
@@ -1486,7 +1486,8 @@ def fetch_build_artifacts(build, ceph_version, platform, upstream_build=None):
 
         registry, image_name = container_image.split(":")[0].split("/", 1)
         image_tag = container_image.split(":")[-1]
-        base_url = build_info["composes"][platform]
+        _plat = platform.split(".")[0]
+        base_url = build_info["composes"][_plat]
         return base_url, registry, image_name, image_tag
     except Exception as e:
         raise TestSetupFailure(f"Could not fetch build details of : {e}")


### PR DESCRIPTION
During local runs, we generally provide `rhel-9` or rhel-8` as the input to the `--platform` flag in run.py
This value is then used by the method `fetch_build_artifacts` in `utility/utils.py` to obtain the correct image and build details from the recipe file store in magna.

It was recently observed that [Jenkins test executor ](https://jenkins-csb-rhgsocs3x-ocs3xstage.dno.corp.redhat.com/view/Executor/job/qe-squid-test-executor-openstack/) requires us to choose the the RHEL OS Version from a pre-defined list where all the entries are in the format - `rhel-9.x`

This does not sit well with out current recipe file yaml keys as the platform there only contains `rhel-9` or `rhel-8`
```
latest:
  composes:
    rhel-9: http://download-01.beak-001.prod.ia<----omitted----->
  ceph-version: 19.2.1-52
  repository: registry-proxy.engine<------omitted----->
  bvt: NotExecuted
```

Due to this discrepancy, Jenkins test executor was not able to fetch the correct build image when input RHEL OS Version was rhel-9.5

Proposed fix ignores the minor rhel version and considers only the major version to align with magna recipe file yaml entries.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>