### PR TITLE
Remove TC CEPH-83607707 from quincy suite

### DIFF
--- a/suites/quincy/rgw/tier-1-extn_rgw.yaml
+++ b/suites/quincy/rgw/tier-1-extn_rgw.yaml
@@ -338,12 +338,3 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bi_put_with_incomplete_multipart_upload.yaml
-
-  - test:
-      name: Test swift bulk upload with tar format
-      desc: Test swift bulk upload with tar format
-      polarion-id: CEPH-83607707
-      module: sanity_rgw.py
-      config:
-        script-name: test_swift_bulk_upload.py
-        config-file-name: test_swift_bulk_upload.yaml


### PR DESCRIPTION
# Description
Removing TC:CEPH-83607707: Test swift bulk upload with tar format
We have known issue [RGW]:GET on swift container displays X-Container-Object-Count, X-Container-Bytes-Used, X-Container-Bytes-Used-Actual as 0 even though object present in a container. (BZ2346223)
which is targeted to reef: 7.1z4 release.

Now we are seeing same failure(issue): with 6.1z9 build as well, since there is no upcoming release planned for 6.1 series.
and this issue not a blocker,

we are removing Test case from quincy suite to avoid FAIL entry in quincy TFA pipeline.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
