### PR TITLE
Fixes test failures in s3tests for cross_account with email as grantee

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_extended.yaml
@@ -234,6 +234,8 @@ tests:
         commands:
           - "radosgw-admin account create --account-id RGW22222222222222222 --account-name Account2 --email account2@ceph.com"
           - "radosgw-admin account create --account-id RGW11111111111111111 --account-name Account1  --email account1@ceph.com"
+          - "radosgw-admin user create --account-id RGW11111111111111111 --uid testacct1root --account-root --display-name 'Account1Root' --access-key  AAAAAAAAAAAAAAAAAAaa --secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - "radosgw-admin user create --account-id RGW22222222222222222 --uid testacct2root --account-root --display-name 'Account2Root' --access-key BBBBBBBBBBBBBBBBBBbb --secret bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
           - "radosgw-admin zone modify --enable-feature notification_v2"
           - "radosgw-admin zonegroup modify --enable-feature notification_v2"
           - "ceph orch restart rgw.rgw.1"

--- a/suites/squid/rgw/tier-2_ssl_rgw_ecpool_test.yaml
+++ b/suites/squid/rgw/tier-2_ssl_rgw_ecpool_test.yaml
@@ -186,6 +186,8 @@ tests:
         commands:
           - "radosgw-admin account create --account-id RGW22222222222222222 --account-name Account2 --email account2@ceph.com"
           - "radosgw-admin account create --account-id RGW11111111111111111 --account-name Account1  --email account1@ceph.com"
+          - "radosgw-admin user create --account-id RGW11111111111111111 --uid testacct1root --account-root --display-name 'Account1Root' --access-key  AAAAAAAAAAAAAAAAAAaa --secret aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          - "radosgw-admin user create --account-id RGW22222222222222222 --uid testacct2root --account-root --display-name 'Account2Root' --access-key BBBBBBBBBBBBBBBBBBbb --secret bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
           - "radosgw-admin zone modify --enable-feature notification_v2"
           - "radosgw-admin zonegroup modify --enable-feature notification_v2"
           - "ceph orch restart rgw.rgw.ssl"
@@ -193,7 +195,6 @@ tests:
       module: exec.py
       name: Create 2 rgw accounts
       polarian-id: CEPH-83591683
-
 
   - test:
       abort-on-fail: false

--- a/tests/rgw/test_s3.py
+++ b/tests/rgw/test_s3.py
@@ -93,20 +93,18 @@ KC_REALM = {{ data.webidentity.realm }}
 S3CONF_ACC = """
 {%- if data.iamroot %}
 [iam root]
-display_name = {{ data.iamroot.name }}
-user_id = {{ data.iamroot.account_id }}
-access_key = {{ data.iamroot.access_key }}
-secret_key = {{ data.iamroot.secret_key }}
-email = {{ data.iamroot.email }}
+access_key = AAAAAAAAAAAAAAAAAAaa
+secret_key = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+user_id = RGW11111111111111111
+email = account1@ceph.com
 {% endif %}
 
 {%- if data.iamrootalt %}
 [iam alt root]
-display_name = {{ data.iamrootalt.name }}
-user_id = {{ data.iamrootalt.account_id }}
-access_key = {{ data.iamrootalt.access_key }}
-secret_key = {{ data.iamrootalt.secret_key }}
-email = {{ data.iamrootalt.email }}
+access_key = BBBBBBBBBBBBBBBBBBbb
+secret_key = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+user_id = RGW22222222222222222
+email = account2@ceph.com
 {% endif %}
 """
 


### PR DESCRIPTION
**# Description**

Fixes test failures in s3tests for cross_account_access with email as grantee

Failed TFA logs http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Regression/19.2.0-113/rgw/87/tier-2_rgw_regression_extended/execute_s3tests_0.log

**Failures that will get fixed with the PR**
- FAILED s3tests_boto3/functional/test_iam.py::test_cross_account_bucket_acl_user_policy_grant_account_email
- FAILED s3tests_boto3/functional/test_iam.py::test_cross_account_user_policy_bucket_acl_grant_account_email

**Passed log** 
http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-0BQIYQ
s3tests_boto3/functional/test_iam.py::test_cross_account_bucket_acl_user_policy_grant_account_email 
2025-03-19 13:33:22,493 - cephci - ceph:1186 - DEBUG - PASSED [ 16%]

s3tests_boto3/functional/test_iam.py::test_cross_account_user_policy_bucket_acl_grant_account_email 
2025-03-19 13:33:23,879 - cephci - ceph:1186 - DEBUG - PASSED [ 16%]


**Please note :** 
The s3select tests 'test_schema_definition' and 'test_alias_cyclic_refernce testcases' are failing with EventStreamError since the PR in s3tests has been reverted yesterday 
Refer https://github.com/ceph/s3-tests/commit/140bf6e61c162569e7eb1c58e5bfff80f30cb5de
