### PR TITLE
RHCEPHQE-18630 | [RADOS] Ensure OSD removal method is time bound

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -1907,9 +1907,11 @@ class RadosOrchestrator:
             f"ceph orch ps --daemon_type {daemon_type} "
             f"--daemon_id {daemon_id} --refresh"
         )
-        orch_ps_out = self.run_ceph_command(cmd=cmd_)[0]
+        orch_ps_out = self.run_ceph_command(cmd=cmd_)
         log.debug(orch_ps_out)
-        return orch_ps_out["status"], orch_ps_out["status_desc"] if orch_ps_out else ()
+        return orch_ps_out[0]["status"], (
+            orch_ps_out[0]["status_desc"] if orch_ps_out else ()
+        )
 
     def daemon_check_post_tests(
         self, pre_test_orch_ps: dict, pre_crash_report: list = None

--- a/ceph/rados/utils.py
+++ b/ceph/rados/utils.py
@@ -195,24 +195,31 @@ def set_osd_in(
     return ret_val
 
 
-def osd_remove(ceph_cluster, osd_id, zap=False, force=False):
+def osd_remove(ceph_cluster, osd_id, **kwargs):
     """
     osd remove
     Args:
         ceph_cluster: ceph cluster
         osd_id: osd id
-        zap: flag to control zapping of device
-        force: flag to remove the OSD forcefully
+        valid inputs for keyword argument dict:
+            - zap(bool): flag to control zapping of device
+            - force(bool): flag to remove the OSD forcefully
+            - timeout(int): time to wait for OSD removal
+            - interval(int): retry interval wait time
+            - validate(bool): flag to control OSD removal validation
     """
     config = {"command": "rm", "service": "osd", "pos_args": [osd_id]}
     cmd_args = {}
-    if zap:
+    if kwargs.get("zap"):
         cmd_args["zap"] = True
         cmd_args["force"] = True
-    if force:
+    if kwargs.get("force"):
         cmd_args["force"] = True
     if bool(cmd_args):
         config["base_cmd_args"] = cmd_args
+    config["timeout"] = kwargs.get("timeout", 1800)
+    config["interval"] = kwargs.get("interval", 120)
+    config["validate"] = kwargs.get("validate", True)
     log.info(f"Executing OSD {config.pop('command')} service")
     osd = OSD(cluster=ceph_cluster, **config)
     osd.rm(config)


### PR DESCRIPTION
Jira tracker: [RHCEPHQE-18630](https://issues.redhat.com/browse/RHCEPHQE-18630)

Recently CephFS found and reported that current implementation of OSD removal triggers an infinite loop with no time boundary to drain OSD daemons and it only exits when OSD drain and removal has been successfull

This is a concerning test workflow as we already have bugs where cluster has been reported as stuck during backfill and recovery for more than 24 hours.
Refer: [BZ-2265371](https://bugzilla.redhat.com/show_bug.cgi?id=2265371)

With the code changes in the PR, the following are being addressed:
- Enhance the rm method implementation in `ceph_admin/osd.py` to not use While True loop but rather use a time bound while loop
- Allow users to control the retry interval instead of hard coding it to 2 secs


Jira tracker: [RHCEPHQE-18524](https://issues.redhat.com/browse/RHCEPHQE-18524)
The existing method to check daemon status was now being utilized to ascertain if the drain and removal of an OSD daemon was complete, it was expected that when an OSD daemon is no longer present in the cluster, the output of `ceph orch ps --daemon-type osd --daemon-id <osd-ID>` would return an empty list. Consequently, the method was still trying to fetch the contents from an empty list. Fix has been provided to address this false failure and ensure that method attempts to extract data only from a non-empty list.

Signed-off-by: Harsh Kumar <hakumar@redhat.com>
