### PR TITLE
NVMe regression suites simplification

### DIFF
--- a/suites/squid/common/regression/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
+++ b/suites/squid/common/regression/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
@@ -1,0 +1,646 @@
+# Ceph-NVMeoF GWgroup with HA Test suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml or later version
+
+tests:
+# Non-mtls HA tests with different NQNs in GWgroup sequential
+  - test:
+      abort-on-fail: false
+      config:
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                             # Configure gatewayGroups
+          - gw_group: group1
+            gw_nodes:
+              - node16
+              - node17
+            subsystems:                       # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode1
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node16
+              - nqn: nqn.2016-06.io.spdk:cnode2
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node17
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node16
+              - tool: daemon
+                nodes: node17
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node18
+          - gw_group: group2
+            gw_nodes:
+              - node14
+              - node15
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode3
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node14
+              - nqn: nqn.2016-06.io.spdk:cnode4
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node15
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node14
+              - tool: daemon
+                nodes: node15
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node19
+          - gw_group: group3
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode5
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node10
+              - nqn: nqn.2016-06.io.spdk:cnode6
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node11
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node20
+          - gw_group: group4
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode7
+                no-group-append: True
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node12
+              - tool: daemon
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node21
+      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback with different NQN's
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA different NQN's without mtls
+      polarion-id: CEPH-83595701
+
+# mtls HA tests with same NQNs in GWgroup sequential
+  - test:
+      abort-on-fail: false
+      config:
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd1
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                             # Configure gatewayGroups
+          - gw_group: group1
+            mtls: true
+            gw_nodes:
+              - node16
+              - node17
+            subsystems:                       # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node16
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node17
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node16
+              - tool: daemon
+                nodes: node17
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node18
+          - gw_group: group2
+            mtls: true
+            gw_nodes:
+              - node14
+              - node15
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node14
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node15
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node14
+              - tool: daemon
+                nodes: node15
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node19
+          - gw_group: group3
+            mtls: true
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node20
+          - gw_group: group4
+            mtls: true
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node12
+              - tool: daemon
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node21
+      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback with mtls and same NQN's
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA with mtls and same NQN's
+      polarion-id: CEPH-83598264
+
+  - test:
+      abort-on-fail: false
+      config:
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd10
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd10
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                             # Configure gatewayGroups
+          - gw_group: group1
+            mtls: true
+            gw_nodes:
+              - node16
+              - node17
+            subsystems:                       # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node16
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node17
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node16
+              - tool: daemon
+                nodes: node17
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node18
+          - gw_group: group2
+            mtls: true
+            gw_nodes:
+              - node14
+              - node15
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node14
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node15
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node14
+              - tool: daemon
+                nodes: node15
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node19
+          - gw_group: group3
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node20
+          - gw_group: group4
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                # Failure induction
+              - tool: systemctl
+                nodes: node12
+              - tool: daemon
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node21
+      desc: NVMeoF 4-GWgroups with 2 gateways HA failover-failback with mtls and without mtls
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA with and without mtls
+      polarion-id: CEPH-83598266
+
+# non-mtls HA tests with same NQNs in GWgroup parallel
+  - test:
+      abort-on-fail: false
+      config:
+        parallel: true
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd3
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd3
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                                     # Configure gatewayGroups
+          - gw_group: group1
+            gw_nodes:
+              - node16
+              - node17
+            subsystems:                                # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node16
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node17
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node16
+              - tool: daemon
+                nodes: node17
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node18
+          - gw_group: group2
+            gw_nodes:
+              - node14
+              - node15
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node14
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node14
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node14
+              - tool: daemon
+                nodes: node15
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node19
+          - gw_group: group3
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node20
+          - gw_group: group4
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node12
+              - tool: daemon
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node21
+      desc: NVMeoF 4-GWgroups with 2 gateways HA in parallel
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA in parallel
+      polarion-id: CEPH-83598254
+
+# non-mtls HA tests with different pools sequential
+  - test:
+      abort-on-fail: false
+      config:
+        parallel: true
+        install: true                           # Run SPDK with all pre-requisites
+        rbd_pool: rbd3
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd3
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_groups:                                     # Configure gatewayGroups
+          - gw_group: group1
+            rbd_pool: rbd10
+            gw_nodes:
+              - node16
+              - node17
+            subsystems:                                # Configure subsystems with all sub-entities
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node16
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node16, node17]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node17
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node16
+              - tool: daemon
+                nodes: node17
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node18
+          - gw_group: group2
+            rbd_pool: rbd11
+            gw_nodes:
+              - node14
+              - node15
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node14
+              - nqn: nqn.2016-06.io.spdk:cnode17
+                listener_port: 4420
+                listeners: [node14, node15]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+                    lb_group: node15
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node14
+              - tool: daemon
+                nodes: node15
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node19
+          - gw_group: group3
+            rbd_pool: rbd12
+            gw_nodes:
+              - node10
+              - node11
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node10, node11]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                   # Failure induction
+              - tool: systemctl
+                nodes: node10
+              - tool: daemon
+                nodes: node11
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node20
+          - gw_group: group4
+            rbd_pool: rbd13
+            gw_nodes:
+              - node12
+              - node13
+            subsystems:
+              - nqn: nqn.2016-06.io.spdk:cnode16
+                listener_port: 4420
+                listeners: [node12, node13]
+                allow_host: "*"
+                bdevs:
+                  - count: 2
+                    size: 4G
+            fault-injection-methods:                   # Failure induction
+              - tool: maintanence_mode
+                nodes: node12
+              - tool: power_on_off
+                nodes: node13
+            initiators:                                # Configure Initiators with all pre-req
+              - nqn: connect-all
+                listener_port: 4420
+                node: node21
+      desc: Configure NVMeoF 4-GWgroups with 2 gateways HA with different pools
+      destroy-cluster: false
+      module: test_nvmeof_gwgroup.py
+      name: Configure NVMeoF 4-GWgroups with 2 gateways HA with different pools
+      polarion-id: CEPH-83598688

--- a/suites/squid/common/regression/tier-2_8-1_nvmeof_gateway_operations.yaml
+++ b/suites/squid/common/regression/tier-2_8-1_nvmeof_gateway_operations.yaml
@@ -1,0 +1,693 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# Inventory: conf/inventory/rhel-9.5-server-x86_64-xlarge.yaml
+
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - ceph osd pool application enable rbd rbd
+          - config:
+              command: shell
+              args:
+                - rbd create -s 1G image1
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                    - node14
+                    - node15
+              pos_args:
+                - rbd
+                - gw-group1
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy nvmeof gateway
+
+  - test:
+      abort-on-fail: false
+      config:
+        node: node14
+        pool: rbd
+        port: 5500
+        gw_group: gw-group1
+        steps:
+          - config:
+              service: gateway
+              command: version         # gateway Version
+              base_cmd_args:
+                format: json
+                output: log
+          - config:
+              service: gateway
+              command: info             # gateway info
+          - config:
+              service: loglevel
+              command: get
+              base_cmd_args:
+                format: json
+                output: stdio
+          - config:
+              service: loglevel
+              command: set
+              base_cmd_args:
+                format: json
+                output: stdio
+              args:
+                level: error
+                print: error
+          - config:
+              service: loglevel
+              command: disable
+              base_cmd_args:
+                format: json
+                output: stdio
+          - config:
+              service: subsystem
+              command: add              # Subsystem add with groupName
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1
+                serial-number: 1
+              validate:
+                omap: true
+          - config:
+              service: subsystem
+              command: add              # Subsystem add without groupName
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                serial-number: 2
+                no-group-append: true
+              validate:
+                omap: true
+          - config:
+              service: gateway
+              command: info             # gateway info
+          - config:
+              service: subsystem
+              command: list             # Subsystem list
+              base_cmd_args:
+                format: json
+          - config:
+              service: connection
+              command: list             # Subsystem connection list
+              base_cmd_args:
+                format: json
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: listener
+              command: add                # Listener add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host-name: node14
+                trsvcid: 5001
+                traddr: node14
+              validate:
+                omap: true
+              base_cmd_args:
+                format: json
+          - config:
+              service: listener
+              command: list               # Listener list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: gateway
+              command: listener_info             # List ana states for subsystem
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: listener
+              command: delete             # listener del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host-name: node14
+                trsvcid: 5001
+                traddr: node14
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: add              # add Host access
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                host: '"*"'
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: list             # List access hosts
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image1
+                rbd-pool: rbd
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image2
+                rbd-pool: rbd
+                nsid: 2
+                rbd-create-image: true
+                size: 10G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image3
+                rbd-pool: rbd
+                nsid: 3
+                load-balancing-group: 1
+                rbd-create-image: true
+                size: 1G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add with trash-image enabled
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                rbd-image: image4
+                rbd-pool: rbd
+                nsid: 4
+                load-balancing-group: 2
+                rbd-create-image: true
+                size: 1G
+                rbd-trash-image-on-delete: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: list             # namespace list per subsystem NQN
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list using nsid
+              args:
+                nsid: 4
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list for all subsystems
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+                rw-ios-per-second: 150
+                rw-megabytes-per-second: 19
+                r-megabytes-per-second: 19
+                w-megabytes-per-second: 19
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+                rw-ios-per-second: 200
+                rw-megabytes-per-second: 59
+                r-megabytes-per-second: 59
+                w-megabytes-per-second: 59
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: resize              # Namespace resize
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 2
+                size: 15G
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 3
+                load-balancing-group: 2
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 4
+                load-balancing-group: 1
+          - config:
+              service: namespace
+              command: list             # namespace list using subsystem NQN
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: get_io_stats             # namespace get_io_stats
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 2
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 3
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+                nsid: 4
+                i-am-sure: true
+              validate:
+                omap: true
+          - config:
+              service: subsystem
+              command: delete           # subsystem delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode2
+              validate:
+                omap: true
+          - config:
+              service: gateway
+              command: info
+          - config:
+              service: connection
+              command: list             # Subsystem connection list
+              base_cmd_args:
+                format: json
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: listener
+              command: add                # Listener add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host-name: node14
+                trsvcid: 5001
+                traddr: node14
+              validate:
+                omap: true
+              base_cmd_args:
+                format: json
+          - config:
+              service: listener
+              command: list               # Listener list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: host
+              command: add              # add Host access
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host: '"*"'
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: list             # List access hosts
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: gateway
+              command: listener_info             # List ana states for subsystem
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image1
+                rbd-pool: rbd
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image5
+                rbd-pool: rbd
+                nsid: 2
+                rbd-create-image: true
+                size: 10G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image3
+                rbd-pool: rbd
+                nsid: 3
+                load-balancing-group: 1
+                rbd-create-image: true
+                size: 1G
+                no-auto-visible: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image4
+                rbd-pool: rbd
+                nsid: 4
+                load-balancing-group: 2
+                rbd-create-image: true
+                size: 1G
+                no-auto-visible: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: add              # Namespace add with trash-image enabled
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                rbd-image: image6
+                rbd-pool: rbd
+                nsid: 5
+                rbd-create-image: true
+                size: 1G
+                rbd-trash-image-on-delete: true
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: list             # namespace list using subsystem NQN
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list using nsid
+              args:
+                nsid: 4
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: list             # namespace list for all subsystems
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: add_host             # namespace add_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080b
+          - config:
+              service: namespace
+              command: add_host             # namespace add_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080c
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+                rw-ios-per-second: 150
+                rw-megabytes-per-second: 19
+                r-megabytes-per-second: 19
+                w-megabytes-per-second: 19
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: set_qos             # namespace set_qos
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+                rw-ios-per-second: 200
+                rw-megabytes-per-second: 59
+                r-megabytes-per-second: 59
+                w-megabytes-per-second: 59
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: resize              # Namespace resize
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 2
+                size: 15G
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                load-balancing-group: 2
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: change_load_balancing_group              # Namespace change_load_balancing_group
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                load-balancing-group: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: get_io_stats             # namespace get_io_stats
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+          - config:
+              service: namespace
+              command: del_host             # namespace del_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080b
+          - config:
+              service: namespace
+              command: del_host             # namespace del_host
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                host: nqn.2014-08.org.nvmexpress:uuid:7c1c2d62-2ad0-4181-ae79-8e780a6a080c
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+                auto-visible: 'yes'
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+                auto-visible: 'yes'
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+                auto-visible: 'no'
+          - config:
+              service: namespace
+              command: change_visibility              # Namespace change_visibility
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 2
+                auto-visible: 'no'
+          - config:
+              service: namespace
+              command: list             # namespace list
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              base_cmd_args:
+                format: json
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 1
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 2
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 3
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 4
+              validate:
+                omap: true
+          - config:
+              service: namespace
+              command: delete           # namespace delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                nsid: 5
+                i-am-sure: true
+              validate:
+                omap: true
+          - config:
+              service: listener
+              command: delete             # listener del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host-name: node14
+                trsvcid: 5001
+                traddr: node14
+              validate:
+                omap: true
+          - config:
+              service: host
+              command: delete           # access host del
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+                host: '"*"'
+              validate:
+                omap: true
+          - config:
+              service: subsystem
+              command: delete           # subsystem delete
+              args:
+                subsystem: nqn.2016-06.io.spdk:cnode1.gw-group1
+              validate:
+                omap: true
+          - config:
+              service: gateway
+              command: info
+          - config:
+              service: version          # CLI Version
+              command: version
+              base_cmd_args:
+                format: json
+                output: log
+      desc: Manage NVMeoF Subsystem entities
+      destroy-cluster: false
+      module: test_nvme_cli.py
+      name: Manage nvmeof gateway entities
+      polarion-id: CEPH-83575783
+
+  - test:
+      abort-on-fail: true
+      config:
+         command: remove
+         service: nvmeof
+         args:
+           service_name: nvmeof.rbd.gw-group1
+           verify: true
+      desc: NVMeoF Gateway deployment using cephadm
+      destroy-cluster: false
+      module: test_orch.py
+      name: Delete nvmeof gateway
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+      desc: NVMeoF Gateway deployment using cephadm
+      do-not-skip-tc: true
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Delete nvmeof gateway pre-reqs

--- a/suites/squid/common/regression/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
+++ b/suites/squid/common/regression/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
@@ -1,0 +1,253 @@
+# Ceph-NVMeoF HA with a single gatewaygroup for n-1 node failures
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml or later version
+
+tests:
+# 8GW HA 4-subsystems multinode(7/8) Failover and failback parallely using systemctl and daemon
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node10
+          - node11
+          - node12
+          - node13
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node19
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes:
+              - node10
+              - node11
+              - node12
+              - node13
+              - node14
+              - node15
+              - node16
+          - tool: systemctl
+            nodes:
+              - node10
+              - node11
+              - node12
+              - node13
+              - node14
+              - node16
+              - node17
+      desc: 8GW 1GWgroup HA 4-subsystems multinode 7/8 Failover and failback parallely
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail parallel
+      polarion-id: CEPH-83595555
+
+# 8GW HA 4-subsystems multinode(7/8) Failover and failback parallely using power off|on and maintanence_mode
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd2
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd2
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node10
+          - node11
+          - node12
+          - node13
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node18
+        fault-injection-methods:                # Failure induction
+          - tool: maintanence_mode
+            nodes:
+              - node10
+              - node11
+              - node13
+              - node14
+              - node15
+              - node16
+              - node17
+          - tool: power_on_off
+            nodes:
+              - node10
+              - node11
+              - node12
+              - node13
+              - node14
+              - node15
+              - node17
+      desc: 8GW 1GWgroup HA 4-subsystems multinode 7/8 Failover and failback using poweronoff
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail using poweronoff
+      polarion-id: CEPH-83595555
+
+# 8GW HA 4-subsystems multinode(7/8) Failover and failback parallely using redeploy
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd3
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd3
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node10
+          - node11
+          - node12
+          - node13
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node14
+        fault-injection-methods:                # Failure induction
+          - tool: daemon_redeploy
+            nodes:
+              - node10
+              - node11
+              - node12
+              - node14
+              - node15
+              - node16
+              - node17
+      desc: 8GW 1GWgroup HA 4-subsystems multinode 7/8 Failover and failback using redeploy
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail using redeploy
+      polarion-id: CEPH-83595545

--- a/suites/squid/common/regression/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
+++ b/suites/squid/common/regression/tier-2_nvmeof_1gwgroup_8gwnodes_loadbalancing_tests.yaml
@@ -1,0 +1,140 @@
+# Ceph-NVMeoF scaledown with a single gatewaygroup for n-1 node failures
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml or later version
+
+tests:
+# 1 GWgroup 4GW 4-subsystems scaledown 2 nodes -> scaleup 2 nodes
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd2
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd2
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node14, node15, node16, node17]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node14, node15, node16, node17]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node14, node15, node16, node17]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node14, node15, node16, node17]
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node14
+        load_balancing:
+          - scale_down: ["node14", "node15"]             # scale down
+          - scale_up: ["node14", "node15"]               # scale up
+          - scale_up: ["node10", "node11"]               # scale up new nodes
+      desc: 4GW 1GWgroup namespace load balancing
+      destroy-cluster: false
+      module: test_ceph_nvmeof_loadbalancing.py
+      name: NVMeoF 4GW 1GWgroup namespaces load balancing
+      polarion-id: CEPH-83598717
+
+# 1 GWgroup 8GW 4-subsystems scaledown from 8 - 2 nodes and scaleup from 2-8 nodes
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd2
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd2
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node16
+          - node17
+          - node14
+          - node15
+          - node10
+          - node11
+          - node12
+          - node13
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 8G
+            listener_port: 4420
+            listeners: [node16, node17, node14, node15, node10, node11, node12, node13]
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node14
+        load_balancing:
+          - scale_down: [node16, node17, node14, node15, node10, node11]             # scale down
+          - scale_up: [node16, node17, node14, node15, node10, node11]                # scale up
+      desc: 8GW 1GWgroup namespaces load balancing
+      destroy-cluster: false
+      module: test_ceph_nvmeof_loadbalancing.py
+      name: NVMeoF 8-GW 1GWgroup namespaces load balancing
+      polarion-id: CEPH-83598716

--- a/suites/squid/common/regression/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/squid/common/regression/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -1,0 +1,883 @@
+# Basic Ceph-NvmeoF sanity Test suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+  # NVMe 4-GW HA Test with mTLS configuration
+  - test:
+      name: NVMe Service deployment with spec
+      desc: NVMe services with mTLS deployment using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83594617
+      abort-on-fail: false
+      config:
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+          - config:
+              command: apply_spec
+              service: orch
+              validate-spec-services: true
+              specs:
+                - service_type: nvmeof
+                  service_id: rbd.group1
+                  mtls: true
+                  placement:
+                    nodes:
+                      - node6
+                      - node7
+                  spec:
+                    pool: rbd
+                    group: group1
+                    enable_auth: true                     # boolean as string
+          - config:
+              command: shell
+              args:
+                - ceph orch rm nvmeof.rbd.group1
+          - config:
+              command: shell
+              args:              # sleep to get all services deployed
+                - sleep
+                - "60"
+          - config:
+              command: shell
+              args:
+                - ceph config set mon mon_allow_pool_delete true
+          - config:
+              command: shell
+              args:
+                - ceph osd pool rm rbd rbd --yes-i-really-really-mean-it
+          - config:
+              command: shell
+              args:              # sleep to get all services deployed
+                - sleep
+                - "60"
+
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true
+        mtls: true
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            - count: 2
+              size: 5G
+              lb_group: node15
+            - count: 2
+              size: 5G
+              lb_group: node16
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node18
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node15
+          - tool: systemctl
+            nodes: node16
+      desc: NVMe 4-GW HA test Failover-Failback
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW HA test with mTLS configuration
+      polarion-id: CEPH-83594616
+
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        gw_group: gw_group1
+        test_case: CEPH-83595464
+        rep_pool_config:
+          pool: rbd
+        install: true
+        mtls: true
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            - count: 2
+              size: 5G
+              lb_group: node15
+            - count: 2
+              size: 5G
+              lb_group: node16
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node19
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node17
+      desc: Switch NVMeoF with mTLS to Non-mTLS configuration
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Switch NVMeoF with mTLS to Non-mTLS configuration
+      polarion-id: CEPH-83595464
+
+  # Non-mTLS Tests
+  # NVMe 4-GW Single node failure(s)
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            - count: 2
+              size: 5G
+              lb_group: node15
+            - count: 2
+              size: 5G
+              lb_group: node16
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node22
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes: node17
+          - tool: systemctl
+            nodes: node14
+      desc: 4GW HA test Single subsystem systemctl Failure
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW HA test Single failure
+      polarion-id: CEPH-83589016
+
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node15
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node16
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node21
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes: node14
+          - tool: daemon
+            nodes: node17
+      desc: 4GW HA test 4 subsystes Single daemon Failure
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW HA test Single failure with daemon failure
+      polarion-id: CEPH-83589010
+
+# 4GW HA Single-sub multinode Failover and failback parallely via ceph orchestrator daemon
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            - count: 2
+              size: 5G
+              lb_group: node15
+            - count: 2
+              size: 5G
+              lb_group: node16
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node20
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes:
+              - node14
+              - node16
+          - tool: daemon
+            nodes:
+              - node15
+              - node17
+      desc: Single-sub multinode Failover-failback via ceph daemon orchestrator
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: NVMeoF 4-GW Test HA multinode fail parallel via orchestrator
+      polarion-id: CEPH-83589019
+
+  # 4GW Multi node sequential failover-failback
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            - count: 2
+              size: 5G
+              lb_group: node15
+            - count: 2
+              size: 5G
+              lb_group: node16
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node19
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes:
+              - node14
+              - node15
+          - tool: systemctl
+            nodes:
+              - node16
+              - node17
+      desc: 4GW HA test Single multinode sequential Failure
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA multi node sequential failure
+      polarion-id: CEPH-83591997
+
+# 4GW HA 2-subsystems multinode Failover and failback parallely
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            - count: 2
+              size: 5G
+              lb_group: node15
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node16
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node18
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes:
+              - node14
+              - node17
+          - tool: systemctl
+            nodes:
+              - node15
+              - node16
+      desc: 4GW HA 2-subsystems multinode Failover and failback parallely
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 2-sub multinode fail parallel
+      polarion-id: CEPH-83591996
+
+# 4GW HA 4-subsystems multinode Failover and failback parallely
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node15
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node16
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node19
+        fault-injection-methods:                # Failure induction
+          - tool: systemctl
+            nodes:
+              - node15
+              - node16
+          - tool: systemctl
+            nodes:
+              - node14
+              - node17
+      desc: 4GW HA 4-subsystems multinode Failover and failback parallely
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub multinode fail parallel
+      polarion-id: CEPH-83591995
+
+# 4GW HA 4-subsystems multinode Failover and failback parallely
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node15
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node16
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node20
+        fault-injection-methods:                # Failure induction
+          - tool: daemon
+            nodes:
+              - node14
+              - node15
+              - node16
+          - tool: daemon
+            nodes:
+              - node14
+              - node15
+              - node17
+      desc: 4GW HA 4-subsystems multinode Failover and failback parallely
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub n-1 node fail parallel
+      polarion-id: CEPH-83589021
+
+# 4GW HA 4-subsystems node Failover and failback using power off|on
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node15
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node16
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node19
+        fault-injection-methods:                # Failure induction
+          - tool: power_on_off
+            nodes:
+              - node15
+          - tool: power_on_off
+            nodes:
+              - node16
+      desc: 4GW HA 4-subsystems Failover and failback using node power on off
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub fail using node power on off
+      polarion-id: CEPH-83589012
+
+# 4GW HA 4-subsystems node Failover and failback using maintanence_mode
+  - test:
+      abort-on-fail: false
+      config:
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - pool
+          - gateway
+          - initiators
+        gw_nodes:
+          - node14
+          - node15
+          - node16
+          - node17
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node14
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node15
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node16
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 1
+            bdevs:
+            - count: 2
+              size: 5G
+              lb_group: node17
+            listener_port: 4420
+            listeners:
+              - node14
+              - node15
+              - node16
+              - node17
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - nqn: connect-all
+            listener_port: 4420
+            node: node22
+        fault-injection-methods:                # Failure induction
+          - tool: maintanence_mode
+            nodes:
+              - node16
+          - tool: maintanence_mode
+            nodes:
+              - node17
+      desc: 4GW HA 4-subsystems Failover and failback using node maintanence_mode
+      destroy-cluster: false
+      module: test_ceph_nvmeof_high_availability.py
+      name: Test NVMeoF 4-GW HA 4-sub fail using node maintanence_mode
+      polarion-id: CEPH-83589020

--- a/suites/squid/common/regression/tier-2_nvmeof_e2e_ns-masking.yaml
+++ b/suites/squid/common/regression/tier-2_nvmeof_e2e_ns-masking.yaml
@@ -1,0 +1,151 @@
+# Test Suite to test namespace masking feature from 8.1
+# 1 GW group with 4 GWs and 5 subsystems with 10 namespaces each. 5 initiator nodes
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_pool
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node14
+                  - node15
+                  - node16
+                  - node17
+              pos_args:
+                - nvmeof_pool
+                - group1
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+      desc: deploy NVMeoF service for GW group 1
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 1
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node14
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 5
+                max-namespaces: 1024
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 5
+                port: 4420
+                group: group1
+                nodes:
+                  - node14
+                  - node15
+                  - node16
+                  - node17
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 5
+                group: group1
+      desc: GW group with 4 GWs and 5 subsystems
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Configure subsystems
+      polarion-id: CEPH-83595512
+
+  - test:
+      abort-on-fail: true
+      config:
+        nodes:
+          - node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 5
+                namespaces: 50
+                pool: rbd
+                image_size: 1T
+                no-auto-visible: true
+                group: group1
+          - config:
+              command: add_host
+              args:
+                subsystems: 5
+                namespaces: 50
+                initiators:
+                  - node18
+                  - node19
+                  - node20
+                  - node21
+                  - node22
+                group: group1
+          - config:
+              command: del_host
+              args:
+                subsystems: 5
+                namespaces: 50
+                initiators:
+                  - node18
+                  - node19
+                  - node20
+                  - node21
+                  - node22
+                group: group1
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 5
+                namespaces: 50
+                auto-visible: 'yes'
+                group: group1
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 5
+                namespaces: 50
+                auto-visible: 'no'
+                group: group1
+        initiators:
+          - node18
+          - node19
+          - node20
+          - node21
+          - node22
+      desc: e2e NS masking on 50 namespaces and 5 initiators
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Test E2E nvmeof namespace masking
+      polarion-id: CEPH-83609777

--- a/suites/squid/common/regression/tier-2_nvmeof_functional_Regression.yaml
+++ b/suites/squid/common/regression/tier-2_nvmeof_functional_Regression.yaml
@@ -1,0 +1,262 @@
+# configfile: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+tests:
+#  Perform Data Integrity tests
+  - test:
+      abort-on-fail: true
+      config:
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+        gw_node: node14
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode1
+            serial: 1
+            bdevs:
+              count: 1
+              size: 5G
+            listener_port: 5001
+            allow_host: "*"
+        initiators:                              # Configure Initiators with all pre-req
+            subnqn: nqn.2016-06.io.spdk:cnode1
+            listener_port: 5001
+            node: node18
+      desc: Perform Data integrity test over NVMEoF targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_data_integrity.py
+      name: Test to perform Data Integrity test over NVMe-OF targets
+      polarion-id: CEPH-83576094
+
+#  Run IO on NVMe Targets
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node15
+        rbd_pool: rbd
+        gw_group: gw_group2
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+          - disconnect_all
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode2
+            serial: 2
+            bdevs:
+              count: 1
+              size: 5G
+            listener_port: 5002
+            allow_host: "*"
+        initiators:                            # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode2
+            listener_port: 5002
+            node: node19
+      desc: E2E-Test NVMEoF Gateway collocated with OSD node and Run IOs on targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Basic E2E-Test Ceph NVMEoF GW sanity test collocated with OSD node
+      polarion-id: CEPH-83575442
+
+#  GW deployment collocation with Mon_MGR nodes
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node13
+        rbd_pool: rbd
+        gw_group: 1group
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+          - disconnect_all
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode6
+            serial: 1
+            bdevs:
+              count: 1
+              size: 5G
+            listener_port: 5006
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode6
+            listener_port: 5006
+            node: node19
+      desc: E2E-Test NVMEoF Gateway collocated with MON-MGR node and Run IOs on targets
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Basic E2E-Test Ceph NVMEoF GW sanity test collocated with MON-MGR node
+      polarion-id: CEPH-83575443
+
+# Run IOs using multiple-initiators against multi-subsystems based NVMe-OF targets using fio tool
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: group
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+          - disconnect_all
+        subsystems:                             # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode3
+            serial: 3
+            bdevs:
+              count: 1
+              size: 5G
+            listener_port: 5003
+            allow_host: "*"
+          - nqn: nqn.2016-06.io.spdk:cnode4
+            serial: 4
+            bdevs:
+              count: 1
+              size: 5G
+            listener_port: 5004
+            allow_host: "*"
+        initiators:                             # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode3
+            listener_port: 5003
+            node: node19
+          - subnqn: nqn.2016-06.io.spdk:cnode4
+            listener_port: 5004
+            node: node11
+      desc: Perform IOs on multi-subsystems with Multiple-Initiators
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to run IOs using multiple-initiators against multi-subsystems
+      polarion-id: CEPH-83575789
+
+#  Multiple gateways deployment in the cluster
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node15                       # Deploying multiple gateways on the cluster
+        rbd_pool: rbd
+        gw_group: gw__group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        install: true                           # Run SPDK with all pre-requisites
+        cleanup:
+          - subsystems
+          - initiators
+          - pool
+          - gateway
+          - disconnect_all
+        subsystems: # Configure subsystems with all sub-entities
+          - nqn: nqn.2016-06.io.spdk:cnode5
+            serial: 1
+            bdevs:
+              count: 1
+              size: 5G
+            listener_port: 5005
+            allow_host: "*"
+        initiators: # Configure Initiators with all pre-req
+          - subnqn: nqn.2016-06.io.spdk:cnode5
+            listener_port: 5005
+            node: node20
+      desc: Deploy multiple NVMEoF Gateway on the cluster
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway.py
+      name: Test to Deploy multiple NVMEoF Gateway on the cluster
+      polarion-id: CEPH-83576112
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node21
+        operation: CEPH-83575812
+      desc: Test remove RBD image used as NVMe namespace
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Remove-image ops on NVMe Namespace
+      polarion-id: CEPH-83575812
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group2
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node19
+        operation: CEPH-83575467
+      desc: Perform restart and validate the gateway entities
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Perform restart of NVMeOF gateway
+      polarion-id: CEPH-83575467
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node22
+        operation: CEPH-83575813
+      desc: Perform RBD operations shrink and expand on images.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: RBD operations shrink and expand on images
+      polarion-id: CEPH-83575813
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node17
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node21
+        operation: CEPH-83575455
+      desc: Validate Host accessibility via nvme-cli commands.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Validate Host accessibility to NVMe namespaces
+      polarion-id: CEPH-83575455

--- a/suites/squid/common/regression/tier-3_nvmeof_bdev_fio_operations.yaml
+++ b/suites/squid/common/regression/tier-3_nvmeof_bdev_fio_operations.yaml
@@ -1,0 +1,40 @@
+# NVMeoTCP functional regression tests suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml or later version
+
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node14
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node19
+        operation: CEPH-83576084
+      desc: Delete-recreate bdev in loop and rediscover namespace
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Delete-recreate bdev namespace
+      polarion-id: CEPH-83576084
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group2
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node18
+        operation: CEPH-83575814
+      desc: Perform cluster operations when  IO operations between NVMeOF target NVMe-OF initiator are in progress.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Perform cluster operations when  IO operations are in progress.
+      polarion-id: CEPH-83575814

--- a/suites/squid/common/regression/tier-3_nvmeof_restart_operations.yaml
+++ b/suites/squid/common/regression/tier-3_nvmeof_restart_operations.yaml
@@ -1,0 +1,42 @@
+# NVMeoTCP functional regression tests suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml
+
+tests:
+
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node19
+        operation: CEPH-83576087
+      desc: Perform reboot on initiator node and validate the namespaces.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Reboot client node and check NVMe namespaces
+      polarion-id: CEPH-83576087
+
+  # Reboot GW node
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node19
+        operation: CEPH-83576093
+      desc: Perform reboot on GW node and validate the namespaces.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Reboot GW node and check NVMe namespaces
+      polarion-id: CEPH-83576093

--- a/suites/squid/common/regression/tier-4_nvmeof_namespace_operations.yaml
+++ b/suites/squid/common/regression/tier-4_nvmeof_namespace_operations.yaml
@@ -1,0 +1,22 @@
+# NVMeoTCP functional regression tests suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+# Inventory: conf/inventory/rhel-9.3-server-x86_64-xlarge.yaml or later version
+
+tests:
+  - test:
+      abort-on-fail: true
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node20
+        operation: CEPH-83576085
+      desc: Perform map and unmap NVMe namespaces in loop
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: Map-Unmap NVMe namespaces continuously
+      polarion-id: CEPH-83576085

--- a/suites/squid/common/regression/tier-4_nvmeof_neg_tests.yaml
+++ b/suites/squid/common/regression/tier-4_nvmeof_neg_tests.yaml
@@ -1,0 +1,57 @@
+# Basic Ceph-NVMeOF Negative cases Test suite
+# cluster configuration file: suites/squid/common/regression/nvme-single-site-deploy-and-configure.yaml
+
+tests:
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node16
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node20
+        operation: CEPH-83581753
+      desc: set QoS for namespace in subsystem with invalid values and args
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: set QoS for namespace in subsystem with invalid values and args.
+      polarion-id: CEPH-83581753
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node14
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node19
+        operation: CEPH-83581945
+      desc: set QoS for namespace in subsystem without mandatory values and args
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: set QoS for namespace in subsystem without mandatory values and args.
+      polarion-id: CEPH-83581945
+
+  - test:
+      abort-on-fail: false
+      config:
+        gw_node: node15
+        rbd_pool: rbd
+        gw_group: gw_group1
+        do_not_create_image: true
+        rep-pool-only: true
+        rep_pool_config:
+          pool: rbd
+        initiator_node: node18
+        operation: CEPH-83581755
+      desc: set QoS for multiple namespace in a single go.
+      destroy-cluster: false
+      module: test_ceph_nvmeof_neg_tests.py
+      name: set QoS for multiple namespace in a single go.
+      polarion-id: CEPH-83581755


### PR DESCRIPTION
- Adding all NVMe test suites under simplification and compaction process.
- Removing install-prereq and deployment from current suites.
- Identify the test suite flow doesn't be bottleneck for next suite
- need to ensure proper cleanup.
- update test case configs w.r.t new cluster config