### PR TITLE
[RGW] Including Upgrade suites of RGW for 8.1

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_archive_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -1,4 +1,4 @@
-#upgrade multisite with archive zone to latest 7.1(GA) to 8x
+#upgrade multisite with archive zone to latest 8.0(GA) to 8x
 #conf file: rgw_ms_archive.yaml
 tests:
 
@@ -20,7 +20,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 7.1
+                    rhcs-version: 8.0
                     release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
@@ -49,6 +49,21 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "secondary.rgw.buckets.data rgw"
+                  command: shell
               - config:
                   command: apply
                   service: rgw
@@ -58,6 +73,18 @@ tests:
                     placement:
                       nodes:
                         - node5
+              # - config:
+              #     command: apply_spec
+              #     service: orch
+              #     specs:
+              #       - service_type: rgw
+              #         service_id: shared.pri
+              #         placement:
+              #           nodes:
+              #             - node5
+              #         spec:
+              #           ssl: true
+              #           rgw_frontend_ssl_certificate: create-cert
         ceph-sec:
           config:
             verify_cluster_health: true
@@ -66,7 +93,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 7.1
+                    rhcs-version: 8.0
                     release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
@@ -95,6 +122,21 @@ tests:
                   service: osd
                   args:
                     all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "secondary.rgw.buckets.data rgw"
+                  command: shell
               - config:
                   command: apply
                   service: rgw
@@ -104,6 +146,18 @@ tests:
                     placement:
                       nodes:
                         - node5
+              # - config:
+              #     command: apply_spec
+              #     service: orch
+              #     specs:
+              #       - service_type: rgw
+              #         service_id: shared.sec
+              #         placement:
+              #           nodes:
+              #             - node5
+              #         spec:
+              #           ssl: true
+              #           rgw_frontend_ssl_certificate: create-cert
         ceph-arc:
           config:
             verify_cluster_health: true
@@ -112,7 +166,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 7.1
+                    rhcs-version: 8.0
                     release: rc
                     registry-url: registry.redhat.io
                     mon-ip: node1
@@ -142,6 +196,21 @@ tests:
                   args:
                     all-available-devices: true
               - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "secondary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
                   command: apply
                   service: rgw
                   pos_args:
@@ -150,6 +219,18 @@ tests:
                     placement:
                       nodes:
                         - node5
+              # - config:
+              #     command: apply_spec
+              #     service: orch
+              #     specs:
+              #       - service_type: rgw
+              #         service_id: shared.arc
+              #         placement:
+              #           nodes:
+              #             - node5
+              #         spec:
+              #           ssl: true
+              #           rgw_frontend_ssl_certificate: create-cert
       desc: RHCS cluster deployment using cephadm.
       polarion-id: CEPH-83573386
       destroy-cluster: false
@@ -308,6 +389,42 @@ tests:
       clusters:
         ceph-pri:
           config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-ter:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
+      name: Test NFS cluster and export create
+      desc: Test NFS cluster and export create
+      polarion-id: CEPH-83574597
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets.yaml
             verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
@@ -320,38 +437,99 @@ tests:
       clusters:
         ceph-pri:
           config:
-            script-name: test_versioning_with_objects.py
-            config-file-name: test_versioning_objects_enable.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-      name: enabling bucket versioning and uploading objects on secondary
-      polarion-id: CEPH-10652 # also applies to CEPH-14261 and CEPH-9222
-      desc: test_versioning_objects_enable on secondary
-      module: sanity_rgw_multisite.py
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-sec:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-arc:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.sec rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.shared.sec rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart rgw.shared.sec"
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.pri rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.shared.pri rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart rgw.shared.pri"
+        ceph-arc:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.shared.arc rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.shared.arc rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart rgw.shared.arc"
+      desc: Setting vault configs for sse-s3 on multisite archive
+      module: exec.py
+      name: set sse-s3 vault configs on multisite
 
   - test:
       clusters:
         ceph-pri:
           config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-      desc: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+      desc: test multipart+encrypt object access at the archive site
+      polarion-id: CEPH-83573390
       module: sanity_rgw_multisite.py
-      name: Create bucket for Testing dynamic resharding brownfield scenario after upgrade
-      polarion-id: CEPH-83574736
+      name: test multipart+encrypt object access at the archive site
 
   - test:
       clusters:
         ceph-pri:
           config:
-            script-name: test_Mbuckets_with_Nobjects.py
-            config-file-name: test_multisite_manual_resharding_brownfield.yaml
-            verify-io-on-site: ["ceph-pri", "ceph-sec", "ceph-arc"]
-      desc: Create bucket for Testing manual resharding brownfield scenario after upgrade
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_s3_bucket_enc_multipart_download_archive_site.yaml
+      desc: test multipart+encrypt object access at the archive site
+      polarion-id: CEPH-83573390
       module: sanity_rgw_multisite.py
-      name: Create bucket for Testing manual resharding brownfield scenario after upgrade
-      polarion-id: CEPH-83574735
+      name: test multipart+encrypt object access at the archive site
 
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: ../s3cmd/test_s3cmd.py
+            config-file-name: ../../s3cmd/multisite_configs/test_s3cmd.yaml
+            run-on-haproxy: true
+      desc: Upload 5000 objects via s3cmd to test full sync at archive
+      polarion-id: CEPH-83575917
+      module: sanity_rgw_multisite.py
+      name: Upload 5000 objects via s3cmd to test full sync at archive
 
 # Performing cluster upgrade
 
@@ -401,6 +579,17 @@ tests:
             script-name: test_multisite_bucket_granular_sync_policy.py
             config-file-name: test_multisite_granular_bucketsync_archive_symmetrical.yaml
             timeout: 5500
+
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ms_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -1,0 +1,594 @@
+# Test suite for evaluating RGW ssl-multi-site upgrade scenario.
+#
+# This suite deploys a single realm (India) spanning across two RHCS clusters. It has a
+# zonegroup (shared) which also spans across the clusters. There exists a master (pri)
+# and secondary (sec) zones within this group. The master zone is part of the pri
+# cluster whereas the sec zone is part of the sec datacenter (cluster).
+
+# conf : conf/squid/rgw/rgw_multisite.yaml
+tests:
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: install vm pre-requsites
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 8.0
+                    release: rc
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create primary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "primary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.pri
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+              # - config:
+              #     command: apply_spec
+              #     service: orch
+              #     specs:
+              #       - service_type: rgw
+              #         service_id: shared.pri
+              #         placement:
+              #           nodes:
+              #             - node5
+              #         spec:
+              #           ssl: true
+              #           rgw_frontend_ssl_certificate: create-cert
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: bootstrap
+                  service: cephadm
+                  args:
+                    rhcs-version: 8.0
+                    release: rc
+                    registry-url: registry.redhat.io
+                    mon-ip: node1
+                    orphan-initial-daemons: true
+                    initial-dashboard-password: admin@123
+                    dashboard-password-noupdate: true
+              - config:
+                  command: add_hosts
+                  service: host
+                  args:
+                    attach_ip_address: true
+                    labels: apply-all-labels
+              - config:
+                  command: apply
+                  service: mgr
+                  args:
+                    placement:
+                      label: mgr
+              - config:
+                  command: apply
+                  service: mon
+                  args:
+                    placement:
+                      label: mon
+              - config:
+                  command: apply
+                  service: osd
+                  args:
+                    all-available-devices: true
+              - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec01 k=4 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create secondary.rgw.buckets.data 32 32"
+                    - "erasure rgwec01"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "secondary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
+                  command: apply
+                  service: rgw
+                  pos_args:
+                    - shared.sec
+                  args:
+                    placement:
+                      nodes:
+                        - node5
+              # - config:
+              #     command: apply_spec
+              #     service: orch
+              #     specs:
+              #       - service_type: rgw
+              #         service_id: shared.sec
+              #         placement:
+              #           nodes:
+              #             - node5
+              #         spec:
+              #           ssl: true
+              #           rgw_frontend_ssl_certificate: create-cert
+      desc: RHCS-ssl multisite cluster deployment using cephadm.
+      polarion-id: CEPH-83575222
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+        ceph-sec:
+          config:
+            verify_cluster_health: true
+            steps:
+              - config:
+                  command: apply_spec
+                  service: orch
+                  validate-spec-services: true
+                  specs:
+                    - service_type: prometheus
+                      placement:
+                        count: 1
+                        nodes:
+                          - node1
+                    - service_type: grafana
+                      placement:
+                        nodes:
+                          - node1
+                    - service_type: alertmanager
+                      placement:
+                        count: 1
+                    - service_type: node-exporter
+                      placement:
+                        host_pattern: "*"
+                    - service_type: crash
+                      placement:
+                        host_pattern: "*"
+      name: Monitoring Services deployment
+      desc: Add monitoring services using spec file.
+      module: test_cephadm.py
+      polarion-id: CEPH-83574727
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+        ceph-sec:
+          config:
+            command: add
+            id: client.1
+            node: node6
+            install_packages:
+              - ceph-common
+            copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "radosgw-admin realm create --rgw-realm india --default"
+              - "radosgw-admin zonegroup create --rgw-realm india --rgw-zonegroup shared --endpoints https://{node_ip:node5} --master --default"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --endpoints https://{node_ip:node5} --master --default"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "radosgw-admin user create --uid=repuser --display_name='Replication user' --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --rgw-realm india --system"
+              - "radosgw-admin zone modify --rgw-realm india --rgw-zonegroup shared --rgw-zone primary --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_zone primary"
+              - "ceph config set client.rgw rgw_verify_ssl False"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
+              - "ceph orch restart {service_name:shared.pri}"
+        ceph-sec:
+          config:
+            commands:
+              - "sleep 120"
+              - "radosgw-admin realm pull --rgw-realm india --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d --default"
+              - "radosgw-admin period pull --url https://{node_ip:ceph-pri#node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin zone create --rgw-realm india --rgw-zonegroup shared --rgw-zone secondary --endpoints https://{node_ip:node5} --access-key 21e86bce636c3aa0 --secret cf764951f1fdde5d"
+              - "radosgw-admin period update --rgw-realm india --commit"
+              - "ceph config set client.rgw rgw_verify_ssl False"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_verify_ssl False"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_realm india"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zonegroup shared"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_zone secondary"
+              - "ceph orch restart {service_name:shared.sec}"
+              - "sleep 120"
+      desc: Setting up RGW multisite replication environment
+      module: exec.py
+      name: setup multisite
+      polarion-id: CEPH-10362
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph versions"
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: get shared realm info on primary
+
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph versions"
+              - "radosgw-admin sync status"
+              - "ceph -s"
+              - "radosgw-admin realm list"
+              - "radosgw-admin zonegroup list"
+              - "radosgw-admin zone list"
+      desc: Retrieve the configured environment details
+      polarion-id: CEPH-83575227
+      module: exec.py
+      name: get shared realm info on secondary
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: user_create.py
+            config-file-name: non_tenanted_user.yaml
+            copy-user-info-to-site: ceph-sec
+      desc: create non-tenanted user
+      module: sanity_rgw_multisite.py
+      name: create non-tenanted user
+      polarion-id: CEPH-83575199
+      abort-on-fail: true
+
+  - test:
+      clusters:
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  # HAPROXY for ssl rgw
+  # - test:
+  #     clusters:
+  #       ceph-sec:
+  #         config:
+  #           haproxy_clients:
+  #             - node6
+  #           rgw_endpoints:
+  #             - node5:443
+  #       ceph-pri:
+  #         config:
+  #           haproxy_clients:
+  #             - node6
+  #           rgw_endpoints:
+  #             - node5:443
+  #     desc: "Configure HAproxy"
+  #     module: haproxy.py
+  #     name: "Configure HAproxy"
+
+  # Baseline tests before upgrade
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_multisite_dynamic_resharding_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
+      desc: Create bucket for Testing dynamic resharding brownfield scenario pre upgrade
+      module: sanity_rgw_multisite.py
+      name: Create bucket for Testing dynamic resharding brownfield scenario pre upgrade
+      polarion-id: CEPH-83574736
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            config-file-name: test_multisite_manual_resharding_brownfield.yaml
+            verify-io-on-site: ["ceph-pri", "ceph-sec"]
+      desc: Create bucket for Testing manual resharding brownfield scenario pre upgrade
+      module: sanity_rgw_multisite.py
+      name: Create bucket for Testing manual resharding brownfield scenario pre upgrade
+      polarion-id: CEPH-83574735
+
+  - test:
+      name: S3CMD object download on primary pre upgarde
+      desc: S3CMD object download or GET pre upgarde
+      polarion-id: CEPH-83575477
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../s3cmd/test_s3cmd.py
+            config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+            monitor-consistency-bucket-stats: true
+            run-on-haproxy: true
+
+  - test:
+      name: enable compression on primary pre upgarde
+      desc: test_Mbuckets_with_Nobjects_compression on primary pre upgarde
+      polarion-id: CEPH-11350
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-sec"]
+            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+        ceph-sec:
+          config:
+            install:
+              - agent
+            run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-sec:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.sec} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.sec}"
+        ceph-pri:
+          config:
+            cephadm: true
+            commands:
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_require_ssl false"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_backend vault"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_addr http://127.0.0.1:8100"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_auth agent"
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_prefix /v1/transit "
+              - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_crypt_sse_s3_vault_secret_engine transit"
+              - "ceph orch restart {service_name:shared.pri}"
+      desc: Setting vault configs for sse-s3 on multisite
+      module: exec.py
+      name: set sse-s3 vault configs on multisite
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload.yaml
+      desc: test_sse_kms_kmip_gklm_per_bucket_encryption_multipart_object_upload pre upgarde
+      module: sanity_rgw_multisite.py
+      name:  pre upgarde test encryption with multipart
+      polarion-id: CEPH-83592485
+
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml
+
+ # Performing cluster upgrade
+
+  - test:
+      abort-on-fail: true
+      desc: Multisite upgrade
+      module: test_cephadm_upgrade.py
+      name: multisite ceph upgrade
+      polarion-id: CEPH-83574647
+      clusters:
+        ceph-pri:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+        ceph-sec:
+          config:
+            command: start
+            service: upgrade
+            verify_cluster_health: true
+
+  - test:
+      name: Buckets and Objects test
+      desc: test_Mbuckets_with_Nobjects_download on secondary
+      polarion-id: CEPH-14237
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+
+  - test:
+      name: Granular multisite sync policy group transition
+      desc: Test multisite sync policy group transition
+      polarion-id: CEPH-83575133
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_multisite_sync_policy.py
+            config-file-name: test_sync_policy_state_change.yaml
+
+  - test:
+      name: S3CMD object download on secondary post upgarde
+      desc: S3CMD object download or GET post upgarde
+      polarion-id: CEPH-83575477
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: ../s3cmd/test_s3cmd.py
+            config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+            monitor-consistency-bucket-stats: true
+            run-on-haproxy: true
+
+  - test:
+      name: enable compression on secondary post upgrade
+      desc: test_Mbuckets_with_Nobjects_compression on secondary post upgrade
+      polarion-id: CEPH-11350
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-sec:
+          config:
+            script-name: test_Mbuckets_with_Nobjects.py
+            verify-io-on-site: ["ceph-pri"]
+            config-file-name: test_Mbuckets_with_Nobjects_compression.yaml
+
+  - test:
+      clusters:
+        ceph-pri:
+          config:
+            script-name: test_sse_s3_kms_with_vault.py
+            config-file-name: test_sse_kms_kmip_gklm_per_object.yaml
+      desc: test_sse_kms_kmip_gklm_per_object post upgrade
+      module: sanity_rgw_multisite.py
+      name: test_sse_kms_kmip_gklm_per_object post upgrade
+      polarion-id: CEPH-83592485
+
+  - test:
+      name: Test NFS cluster and export create
+      desc: Test NFS cluster and export create
+      polarion-id: CEPH-83574597
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            run-on-rgw: true
+            script-name: ../nfs_ganesha/nfs_cluster.py
+            config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml

--- a/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_80GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_ssl_ecpool_80GA_to_8x_latest.yaml
@@ -1,0 +1,273 @@
+#Objective: Testing single site ssl setup upgrade from RHCS 8.0 G.A latest to 8.x latest build
+#platform : RHEL-9
+#conf: conf/squid/rgw/tier-0_rgw.yaml
+
+tests:
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: Setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                rhcs-version: 8.0
+                release: rc
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              args:
+                - "ceph osd erasure-code-profile set rgwecprofile01 k=4 m=2"
+                - "crush-failure-domain=host crush-device-class=hdd"
+              command: shell
+          - config:
+              args:
+                - "ceph osd pool create default.rgw.buckets.data 32 32"
+                - "erasure rgwecprofile01"
+              command: shell
+          - config:
+              args:
+                - "ceph osd pool create default.rgw.buckets.index 32 32"
+              command: shell
+          - config:
+              args:
+                - "ceph osd pool application enable"
+                - "default.rgw.buckets.data rgw"
+              command: shell
+          - config:
+              args:
+                - "ceph osd pool application enable"
+                - "default.rgw.buckets.index rgw"
+              command: shell
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+          # - config:
+          #     command: apply_spec
+          #     service: orch
+          #     specs:
+          #       - service_type: rgw
+          #         service_id: rgw.ssl
+          #         placement:
+          #           nodes:
+          #             - node7
+          #         spec:
+          #           ssl: true
+          #           rgw_frontend_ssl_certificate: create-cert
+      desc: bootstrap and deployment services with label placements.
+      polarion-id: CEPH-83573777
+      destroy-cluster: false
+      module: test_cephadm.py
+      name: Deploy RHCS-ssl cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      destroy-cluster: false
+      module: test_client.py
+      name: Configure client
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
+      abort-on-fail: true
+      config:
+        install:
+          - agent
+        run-on-rgw: true
+      desc: Setup and configure vault agent
+      destroy-cluster: false
+      module: install_vault.py
+      name: configure vault agent
+      polarion-id: CEPH-83575226
+
+  - test:
+      name: Manual Resharding tests pre upgrade
+      desc: Resharding test - manual
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
+
+  - test:
+      name: Dynamic Resharding tests with version pre upgrade
+      desc: Resharding test - dynamic
+      polarion-id: CEPH-83571740
+      module: sanity_rgw.py
+      config:
+        script-name: test_dynamic_bucket_resharding.py
+        config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
+
+  - test:
+      name: S3CMD small and multipart object download pre upgrade
+      desc: S3CMD small and multipart object download or GET
+      polarion-id: CEPH-83575477
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
+
+  - test:
+      name: compression_with_zstd_type pre upgrade
+      desc: test compression with zstd type pre upgrade
+      polarion-id: CEPH-11350
+      module: sanity_rgw.py
+      config:
+        run-on-haproxy: true
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_normal_object_upload.yaml
+      desc: test sse-s3 per bucket encryption pre upgrade
+      module: sanity_rgw.py
+      name: sse-s3 per bucket encryption test pre upgrade
+      polarion-id: CEPH-83574615 # CEPH-83574617, CEPH-83575151
+
+  - test:
+      name: Test NFS cluster and export create
+      desc: Test NFS cluster and export create
+      polarion-id: CEPH-83574597
+      module: sanity_rgw.py
+      config:
+        run-on-rgw: true
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_cluster.yaml
+
+  # upgrade cluster
+  - test:
+      name: Parallel run
+      desc: RGW upgarde and IO parallelly.
+      module: test_parallel.py
+      parallel:
+        - test:
+            desc: test to create "M" no of buckets and "N" no of objects with download
+            module: sanity_rgw.py
+            name: Test download with M buckets with N objects
+            polarion-id: CEPH-14237
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+              run-on-haproxy: true
+        - test:
+            name: Upgrade cluster to latest 8.x ceph version
+            desc: Upgrade cluster to latest version
+            module: test_cephadm_upgrade.py
+            polarion-id: CEPH-83573791
+            abort-on-fail: true
+            verify_cluster_health: true
+            config:
+              command: start
+              service: upgrade
+              base_cmd_args:
+                verbose: true
+
+# Post Upgrade tests
+
+  - test:
+      desc: Retrieve the versions of the cluster
+      module: exec.py
+      name: post upgrade gather version
+      polarion-id: CEPH-83575200
+      config:
+        cephadm: true
+        commands:
+          - "ceph versions"
+
+  - test:
+      name: S3CMD small and multipart object download post upgrade
+      desc: S3CMD small and multipart object download or GET
+      polarion-id: CEPH-83575477
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
+
+  - test:
+      config:
+        script-name: test_sse_s3_kms_with_vault.py
+        config-file-name: test_sse_s3_per_bucket_encryption_multipart_object_upload.yaml
+      module: sanity_rgw.py
+      desc: test sse-s3 per bucket encryption with multipart post upgrade
+      name: test sse-s3 per bucket encryption with multipart post upgrade
+      polarion-id: CEPH-83575155
+
+  - test:
+      name: compresstion_with_zstd_type post upgarde
+      desc: test compresstion with zstd type post upgarde
+      polarion-id: CEPH-11350
+      module: sanity_rgw.py
+      config:
+        run-on-haproxy: true
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
+
+  - test:
+      name: NFS export delete
+      desc: NFS cluster and exports delete
+      polarion-id: CEPH-83574600 # also covers CEPH-83574601
+      module: sanity_rgw.py
+      config:
+        script-name: ../nfs_ganesha/nfs_cluster.py
+        config-file-name: ../../nfs_ganesha/config/nfs_cluster_delete.yaml


### PR DESCRIPTION
# Description
Including upgrade path to 8.1
1 IBM and 3 RH suites, as of now there is an issue with haproxy + ssl. We have ticket for that (http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-9CAU7G/ )
So cluster build with non-ssl rgw haproxy + ecpool

https://issues.redhat.com/browse/RHCEPHQE-18441 

logs with ssl:
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-U9X20I/ 
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-9CAU7G/
http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-2CIAHM/


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
