### PR TITLE
[Fix] do_rados_put method numeric suffix

### DIFF
--- a/ceph/rados/pool_workflows.py
+++ b/ceph/rados/pool_workflows.py
@@ -228,14 +228,12 @@ class PoolFunctions:
 
         for i in range(nobj):
             log.info(f"running command on {client.hostname}")
-            if nobj > 1:
-                obj_name = f"{obj_name}-{i}"
+            if obj_name is None:
+                _obj_name = f"obj{i}" if nobj > 1 else "obj"
+            else:
+                _obj_name = f"{obj_name}-{i}" if nobj > 1 else obj_name
 
-            put_cmd = (
-                f"rados put -p {pool} obj{i} {infile}"
-                if obj_name is None
-                else f"rados put -p {pool} {obj_name} {infile}"
-            )
+            put_cmd = f"rados put -p {pool} {_obj_name} {infile}"
             if offset:
                 put_cmd = f"{put_cmd} --offset {offset}"
             try:


### PR DESCRIPTION
# Description
PR to fix do_rados_put() numeric suffix error

`2025-03-20 10:57:58,626 - cephci - pool_workflows:230 - INFO - running command on ceph-vipin-81-v634tv-node7
2025-03-20 10:57:58,906 - cephci - ceph:1576 - INFO - Execute rados put -p compression_test-QLYY compression_test-QLYY-999I-0 /tmp/sdata.txt on 10.0.66.70
2025-03-20 10:58:00,247 - cephci - ceph:1606 - INFO - Execution of rados put -p compression_test-QLYY compression_test-QLYY-999I-0 /tmp/sdata.txt on 10.0.66.70 took 1.340163 seconds
2025-03-20 10:58:00,248 - cephci - pool_workflows:230 - INFO - running command on ceph-vipin-81-v634tv-node7
2025-03-20 10:58:00,527 - cephci - ceph:1576 - INFO - Execute rados put -p compression_test-QLYY compression_test-QLYY-999I-0-1 /tmp/sdata.txt on 10.0.66.70
2025-03-20 10:58:01,809 - cephci - ceph:1606 - INFO - Execution of rados put -p compression_test-QLYY compression_test-QLYY-999I-0-1 /tmp/sdata.txt on 10.0.66.70 took 1.28135 seconds
2025-03-20 10:58:01,810 - cephci - pool_workflows:230 - INFO - running command on ceph-vipin-81-v634tv-node7`

Pass logs:- http://magna002.ceph.redhat.com/ceph-qe-logs/vips/tfa-fix-do-reados-put/logs_cbt_spillover_25_03_20_13_22_49/Verify_degraded_pool_behaviour_at_min_size_0.log 

Pass logs for different scenarios of rados put:- http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_cbt_spillover_25_03_20_17_03_35/Scenarios_for_do_rados_put_method_0.log 

1. pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=10, obj_name="test-obj-1") 
2. pool_obj.do_rados_put(client=client_node, pool=pool_name, obj_name="test-obj-2")
3. pool_obj.do_rados_put(client=client_node, pool=pool_name)
4. pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=200, timeout=50)
5. pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=200, offset=10)
6. pool_obj.do_rados_put(client=client_node, pool=pool_name, nobj=10, offset=10, obj_name="test-obj") 


Note: Failure in "Compression test - replicated pool" in pass logs is not related since rados put command is not getting executed. 

Pass log with tests `test_pool_snap.py` and `test_pool_snap.py`
- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-F10GHK/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
