### PR TITLE
[RHCEPHQE-18647]: Migrate Loop TC to System test

### DIFF
--- a/suites/quincy/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/quincy/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -314,12 +314,6 @@ tests:
       desc: File system life cycle
       abort-on-fail: false
   - test:
-      name: Test fs volume creation, run IO & deletion in loop for 5 times
-      module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
-      polarion-id: CEPH-83604070
-      desc: Test fs volume creation, run IO & deletion in loop for 5 times
-      abort-on-fail: false
-  - test:
       abort-on-fail: true
       desc: "test cephfs nfs export path"
       module: cephfs_nfs.nfs_export_path.py

--- a/suites/reef/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/reef/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -465,12 +465,6 @@ tests:
       desc: File system life cycle
       abort-on-fail: false
   - test:
-      name: Test fs volume creation, run IO & deletion in loop for 5 times
-      module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
-      polarion-id: CEPH-83604070
-      desc: Test fs volume creation, run IO & deletion in loop for 5 times
-      abort-on-fail: false
-  - test:
       name: volume related scenarios(delete,rename)
       module: cephfs_vol_management.cephfs_vol_mgmt_volume_scenarios.py
       polarion-id: CEPH-83603354

--- a/suites/squid/cephfs/regression_suite.yaml
+++ b/suites/squid/cephfs/regression_suite.yaml
@@ -298,12 +298,6 @@ tests:
       desc: File system life cycle
       abort-on-fail: false
   - test:
-      name: Test fs volume creation, run IO & deletion in loop for 5 times
-      module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
-      polarion-id: CEPH-83604070
-      desc: Test fs volume creation, run IO & deletion in loop for 5 times
-      abort-on-fail: false
-  - test:
       name: CephFS Volume Operations
       module: cephfs_vol_management.cephfs_vol_mgmt_test_volume.py
       polarion-id: CEPH-83604097

--- a/suites/squid/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
+++ b/suites/squid/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
@@ -465,12 +465,6 @@ tests:
       desc: File system life cycle
       abort-on-fail: false
   - test:
-      name: Test fs volume creation, run IO & deletion in loop for 5 times
-      module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
-      polarion-id: CEPH-83604070
-      desc: Test fs volume creation, run IO & deletion in loop for 5 times
-      abort-on-fail: false
-  - test:
       name: CephFS Volume Operations
       module: cephfs_vol_management.cephfs_vol_mgmt_test_volume.py
       polarion-id: CEPH-83604097

--- a/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
+++ b/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
@@ -301,7 +301,7 @@ tests:
             desc: System monitor
             module: cephfs_system.cephfs_systest_monitor.py
             name: "CephFS System monitor"
-        - 
+        -
           test:
             name: Test fs volume creation, run IO & deletion in loop for 5 times
             module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py

--- a/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
+++ b/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
@@ -308,6 +308,8 @@ tests:
             polarion-id: CEPH-83604070
             desc: Test fs volume creation, run IO & deletion in loop for 5 times
             abort-on-fail: false
+            config:
+              iteration_cnt : 5
       desc: Running all System test workflows in parallel
       abort-on-fail: false
   -

--- a/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
+++ b/suites/squid/cephfs/tier-3_cephfs_system_test.yaml
@@ -301,6 +301,13 @@ tests:
             desc: System monitor
             module: cephfs_system.cephfs_systest_monitor.py
             name: "CephFS System monitor"
+        - 
+          test:
+            name: Test fs volume creation, run IO & deletion in loop for 5 times
+            module: cephfs_vol_management.cephfs_vol_mgmt_fs_create_delete_loop.py
+            polarion-id: CEPH-83604070
+            desc: Test fs volume creation, run IO & deletion in loop for 5 times
+            abort-on-fail: false
       desc: Running all System test workflows in parallel
       abort-on-fail: false
   -

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1122,6 +1122,7 @@ class FsUtils(object):
             *args:
                 umount : if this argument is passed this will unmounts all the devices
             **kwargs:
+                retain_keyring(default: False) : if this argument is set to True, it will not remove the keyring file
 
         Returns:
             0 if all the clean up is passed
@@ -1146,16 +1147,19 @@ class FsUtils(object):
                 client.exec_command(sudo=True, cmd=cmd)
                 log.info("Removing mounting directory:")
                 client.exec_command(sudo=True, cmd=f"rmdir {mounting_dir}")
-                log.info("Removing keyring file:")
-                client.exec_command(
-                    sudo=True,
-                    cmd=f"rm -rf /etc/ceph/ceph.client.{kwargs.get('client_name', client.node.hostname)}.keyring",
-                )
-                log.info("Removing permissions:")
-                client.exec_command(
-                    sudo=True,
-                    cmd=f"ceph auth del client.{kwargs.get('client_name', client.node.hostname)}",
-                )
+
+                # If retain_keyring is not set, remove the keyring file and permissions
+                if not kwargs.get("retain_keyring", False):
+                    log.info("Removing keyring file:")
+                    client.exec_command(
+                        sudo=True,
+                        cmd=f"rm -rf /etc/ceph/ceph.client.{kwargs.get('client_name', client.node.hostname)}.keyring",
+                    )
+                    log.info("Removing permissions:")
+                    client.exec_command(
+                        sudo=True,
+                        cmd=f"ceph auth del client.{kwargs.get('client_name', client.node.hostname)}",
+                    )
                 client.exec_command(
                     cmd="find /home/cephuser -type f -not -name 'authorized_keys' "
                     " -name 'Crefi' -name 'smallfile' -delete",

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -38,7 +38,6 @@ def run(ceph_cluster, **kw):
     fs_io = FSIO(ceph_cluster)
     config = kw.get("config")
     clients = ceph_cluster.get_ceph_objects("client")
-    build = config.get("build", config.get("rhbuild"))
 
     log.info("checking Pre-requisites")
     if not clients:

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -93,8 +93,8 @@ def run(ceph_cluster, **kw):
         },
     ]
 
-    # Run the FS lifecycle for 2 iteration
-    for i in range(1, 3):
+    # Run the FS lifecycle for 5 iteration
+    for i in range(1, 6):
         log.info(
             "\n"
             "\n---------------***************---------------"
@@ -102,9 +102,11 @@ def run(ceph_cluster, **kw):
             "\n---------------***************---------------"
         )
         try:
-            fs_util.prepare_clients(clients, build)
-            fs_util.auth_list(clients)
-            client1 = clients[0]
+            # fs_util.prepare_clients(clients, build)
+
+            # Set recreate to False, since the clients are already created as part of system test
+            fs_util.auth_list(clients, recreate=False)
+            client1 = clients[1]
 
             # Creation of FS
             fs_util.create_fs(client1, fs_name)
@@ -518,7 +520,10 @@ def run(ceph_cluster, **kw):
                 fuse_mount_dir_pgsql,
             ]:
                 fs_util.client_clean_up(
-                    "umount", fuse_clients=[client1], mounting_dir=mount_dir
+                    "umount",
+                    fuse_clients=[client1],
+                    mounting_dir=mount_dir,
+                    retain_keyring=True,
                 )
 
             for mount_dir in [
@@ -527,7 +532,10 @@ def run(ceph_cluster, **kw):
                 kernel_mount_dir_pgsql,
             ]:
                 fs_util.client_clean_up(
-                    "umount", kernel_clients=[client1], mounting_dir=mount_dir
+                    "umount",
+                    kernel_clients=[client1],
+                    mounting_dir=mount_dir,
+                    retain_keyring=True,
                 )
 
             client1.exec_command(sudo=True, cmd=f"rm -rf {nfs_mounting_dir}/*")

--- a/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
+++ b/tests/cephfs/cephfs_vol_management/cephfs_vol_mgmt_fs_create_delete_loop.py
@@ -92,8 +92,9 @@ def run(ceph_cluster, **kw):
         },
     ]
 
-    # Run the FS lifecycle for 5 iteration
-    for i in range(1, 6):
+    # Run the FS lifecycle based on config values else defaults between 5-10
+    iteration_cnt = config.get("iteration_cnt", random.randrange(5, 11))
+    for i in range(1, iteration_cnt + 1):
         log.info(
             "\n"
             "\n---------------***************---------------"


### PR DESCRIPTION
# Description

Moving the functional TC "FS Lifecycle" to System Test suite due to its continuous failure caused by the network load.

## Changes

- Added to the parallel execution of system test workflow
   - suites/squid/cephfs/tier-3_cephfs_system_test.yaml
- Included additional flag in the lib to avoid re-creating the auth, since the parallel run may be impacted
   - tests/cephfs/cephfs_utilsV1.py
- Removed the existing placeholder from the suite file
   - suites/quincy/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
   - suites/reef/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml
   - suites/squid/cephfs/regression_suite.yaml
   - suites/squid/cephfs/tier-2_file-dir-lay_vol-mgmt_nfs.yaml

## Logs
- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-18647-2/


<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
