### PR TITLE
Automate CEPH-83609783 - Test namespace masking limit per GW group

### DIFF
--- a/suites/squid/nvmeof/tier-3_ns-mask_gw-group_limit.yaml
+++ b/suites/squid/nvmeof/tier-3_ns-mask_gw-group_limit.yaml
@@ -1,0 +1,218 @@
+# Test Suite to test limit of namespace that can be masked per GW group and subsystem
+# Current global lmit proposed is 1000 namespaces can be restrictive per GW group
+# 1 GW group with 4 GWs and 1 subsystems with 1005 namespaces. 5 initiator nodes
+# Test conf at conf/squid/nvmeof/ceph_nvmeof_ns-masking-5_client.yaml
+tests:
+  - test:
+      abort-on-fail: true
+      module: install_prereq.py
+      name: install ceph pre-requisites
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                mon-ip: node1
+                registry-url: registry.redhat.io
+                allow-fqdn-hostname: true
+                log-to-file: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: mgr
+              args:
+                placement:
+                  label: mgr
+          - config:
+              command: apply
+              service: mon
+              args:
+                placement:
+                  label: mon
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+      desc: RHCS cluster deployment using cephadm
+      destroy-clster: false
+      module: test_cephadm.py
+      name: deploy cluster
+
+#  Test cases to be executed
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        nodes:
+          - node8
+          - node9
+          - node10
+          - node11
+          - node12
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Setup client on NVMEoF gateway
+      destroy-cluster: false
+      module: test_client.py
+      name: configure Ceph client for NVMe tests
+      polarion-id: CEPH-83573758
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create nvmeof_pool
+          - config:
+              command: shell
+              args:
+                - rbd pool init nvmeof_pool
+          - config:
+              command: apply
+              service: nvmeof
+              args:
+                placement:
+                  nodes:
+                  - node4
+                  - node5
+                  - node6
+                  - node7
+              pos_args:
+                - nvmeof_pool
+                - group1
+          - config:
+              command: shell
+              args:
+                - ceph osd pool create rbd
+          - config:
+              command: shell
+              args:
+                - rbd pool init rbd
+      desc: deploy NVMeoF service for GW group 1
+      destroy-cluster: false
+      do-not-skip-tc: true
+      module: test_cephadm.py
+      name: deploy NVMeoF service for GW group 1
+      polarion-id: CEPH-83595696
+
+  - test:
+      abort-on-fail: true
+      config:
+        node: node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        steps:
+          - config:
+              service: subsystem
+              command: add
+              args:
+                subsystems: 1
+                max-namespaces: 1500
+          - config:
+              service: listener
+              command: add
+              args:
+                subsystems: 1
+                port: 4420
+                group: group1
+                nodes:
+                  - node4
+                  - node5
+                  - node6
+                  - node7
+          - config:
+              service: host
+              command: add
+              args:
+                subsystems: 1
+                group: group1
+      desc: GW group with 4 GWs and 5 subsystems
+      destroy-cluster: false
+      module: test_ceph_nvmeof_gateway_sub_scale.py
+      name: Configure subsystems
+      polarion-id: CEPH-83595512
+
+  - test:
+      abort-on-fail: true
+      config:
+        nodes:
+          - node4
+        rbd_pool: rbd
+        do_not_create_image: true
+        rep-pool-only: true
+        service: namespace
+        steps:
+          - config:
+              command: add
+              args:
+                subsystems: 1
+                namespaces: 1005
+                pool: rbd
+                image_size: 1T
+                no-auto-visible: true
+                group: group1
+          - config:
+              command: add_host
+              args:
+                subsystems: 1
+                namespaces: 1005
+                initiators:
+                  - node8
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+          - config:
+              command: del_host
+              args:
+                subsystems: 1
+                namespaces: 1005
+                initiators:
+                  - node8
+                  - node9
+                  - node10
+                  - node11
+                  - node12
+                group: group1
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 1
+                namespaces: 1005
+                auto-visible: 'yes'
+                group: group1
+          - config:
+              command: change_visibility
+              args:
+                subsystems: 1
+                namespaces: 1005
+                auto-visible: 'no'
+                group: group1
+        initiators:
+          - node8
+          - node9
+          - node10
+          - node11
+          - node12
+      desc: e2e NS masking on 1005 namespaces and 1 subsystem
+      destroy-cluster: false
+      module: test_ceph_nvmeof_ns_masking.py
+      name: Test namespace masking limit per GW group
+      polarion-id: CEPH-83609783


### PR DESCRIPTION
Test Suite to test limit of namespaces that can be masked per GW group and subsystem(both are validated)

- Current global lmit proposed is 1000 namespaces can be restrictive per GW group
- 1 GW group with 4 GWs and 1 subsystems with 1005 namespaces. 5 initiator nodes

Logs - 

test failed as GW node went offline - plan to run this on XL instance
ceph-new-te3r0g-node4            10.0.67.0    mds,osd,nvmeof-gw         Offline

[cephci-run-8ZZKVE.zip](https://github.com/user-attachments/files/19368713/cephci-run-8ZZKVE.zip)
[cephci-run-WHYZOW.zip](https://github.com/user-attachments/files/19369855/cephci-run-WHYZOW.zip)


```
2025-03-20 13:47:49,945 - cephci - test_ceph_nvmeof_ns_masking:34 - INFO - Subsystem 1/1   -----> Only 1 subsystem
2025-03-20 13:47:49,949 - cephci - ceph:1576 - INFO - Execute rbd create rbd/QYPD-image1 --size 1T on 10.0.65.151
2025-03-20 13:47:50,952 - cephci - ceph:1606 - INFO - Execution of rbd create rbd/QYPD-image1 --size 1T on 10.0.65.151 took 1.003371 seconds
2025-03-20 13:47:50,953 - cephci - rbd_utils:107 - INFO - Command execution complete
2025-03-20 13:47:50,953 - cephci - test_ceph_nvmeof_ns_masking:40 - INFO - Creating image QYPD-image1/1005
2025-03-20 13:47:50,953 - cephci - execute:33 - INFO - NVMe CLI command : namespace add
2025-03-20 13:47:50,953 - cephci - ceph:1576 - INFO - Execute podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image QYPD-image1 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode1.group1 --no-auto-visible  on 10.0.67.0
2025-03-20 13:47:53,106 - cephci - ceph:1606 - INFO - Execution of podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image QYPD-image1 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode1.group1 --no-auto-visible  on 10.0.67.0 took 2.152813 seconds
2025-03-20 13:47:53,107 - cephci - ceph:1682 - INFO -
Command:    podman run --quiet --rm  quay.io/ceph/nvmeof-cli:latest  --format json --server-address 10.0.67.0 --server-port 5500 namespace add  --rbd-image QYPD-image1 --rbd-pool rbd --subsystem nqn.2016-06.io.spdk:cnode1.group1 --no-auto-visible
Duration:   2.152813 seconds
Exit Code:  0
Stderr:      {
    "error_message": "Success",
    "nsid": 1,
    "status": 0
}

2025-03-20 13:47:53,107 - cephci - execute:57 - INFO - ERROR - None,
OUTPUT - {
    "error_message": "Success",
    "nsid": 1,
    "status": 0
}



```