### PR TITLE
[RBD] rbd regression test suites for common deployment

### DIFF
--- a/suites/squid/common/regression/rbd/tier-2_rbd_group.yaml
+++ b/suites/squid/common/regression/rbd/tier-2_rbd_group.yaml
@@ -1,0 +1,149 @@
+# Suite contains tier-2 RBD Group feature related tests
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+tests:
+  - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd -y"
+
+  - test:
+      desc: Run group creation and image add, IO
+      module: test_rbd_groups_image_usecase.py
+      name: RBD group create and image add
+      polarion-id: CEPH-83585132
+      config:
+        group: image_group
+        rep_pool_config:
+          rbd_pool:
+            rbd_image1_group:
+              size: 4G
+            rbd_image2_group:
+              size: 4G
+        ec_pool_config:
+          rbd_ec_pool1:
+            data_pool: rbd_ec_pool
+            rbd_ec_image1_group:
+              size: 4G
+            rbd_ec_image2_group:
+              size: 4G
+        fio:
+          size: 100M
+
+  - test:
+      desc: Cloning an image from a Group Snapshot
+      module: test_rbd_groups_image_clone.py
+      name: RBD group image clone create and delete
+      polarion-id: CEPH-83594298
+      config:
+        group: group1
+        group_snap: group_snap
+        user_snap: user_snap
+        rep_pool_config:
+          rbd_pool:
+            rbd_image_group:
+              size: 4G
+        ec_pool_config:
+          rbd_ec_pool:
+            data_pool: rbd_ec_data_pool
+            rbd_ec_image_group:
+              size: 4G
+        fio:
+          size: 100M
+
+  - test:
+      desc: Run group snap creation and rollback
+      module: test_rbd_group_snapshot_usecase.py
+      name: RBD group snap creation and rollback
+      polarion-id: CEPH-83588302
+      config:
+        group: image_group
+        snap: group_snap
+        rep_pool_config:
+          rbd_pool:
+            rbd_image1_group:
+              size: 4G
+            rbd_image2_group:
+              size: 4G
+        ec_pool_config:
+          rbd_ec_pool1:
+            data_pool: rbd_ec_pool
+            rbd_ec_image1_group:
+              size: 4G
+            rbd_ec_image2_group:
+              size: 4G
+        fio:
+          size: 100M
+
+  - test:
+      desc: Creating group snapshot, clone, snap rollback from pool namespace
+      config:
+        group: image_group
+        snap: group_snap
+        rep_pool_config:
+          num_pools: 1
+          do_not_create_image: true
+        ec_pool_config:
+          num_pools: 1
+          do_not_create_image: true
+        io:
+          io-type: write
+          io-size: 1G
+          io-threads: 16
+          io-pattern: rand
+      module: test_rbd_group_snapshot_on_pool_namespace.py
+      name: Test group snapshot, clone, rollback from pool namespace
+      polarion-id: CEPH-83594337
+
+  - test:
+      desc: Verify cloning and flattening a group snapshot
+      config:
+        group: image_group
+        snap: group_snap
+        rep_pool_config:
+          num_pools: 1
+          num_images: 1
+        ec_pool_config:
+          num_pools: 1
+          num_images: 1
+        fio:
+          size: 100M
+      module: test_rbd_clone_flatten_group_snapshot.py
+      name: Test cloning and flattening group snapshot
+      polarion-id: CEPH-83594299
+
+  - test:
+      desc: Verify group snapshot rollback not allowed if memberships dont match
+      config:
+        group: test_group
+        snap: test_snap
+        rep_pool_config:
+          num_pools: 2
+          num_images: 1
+        ec_pool_config:
+          num_pools: 2
+          num_images: 1
+        fio:
+          size: 10M
+      module: test_rbd_disallow_group_snapshot_rollback.py
+      name: Disallow Group Snapshot Rollback if Memberships Don't Match
+      polarion-id: CEPH-83594544
+
+  - test:
+      desc: Verify rbd group commands
+      config:
+        rep_pool_config:
+          num_pools: 1
+          do_not_create_image: true
+        ec_pool_config:
+          num_pools: 1
+          do_not_create_image: true
+      module: test_rbd_group_commands_validation.py
+      name: RBD Group-related commands validation
+      polarion-id: CEPH-83594545

--- a/suites/squid/common/regression/rbd/tier-2_rbd_image_migration.yaml
+++ b/suites/squid/common/regression/rbd/tier-2_rbd_image_migration.yaml
@@ -1,0 +1,125 @@
+# Suite contains tier-2 RBD Image migration feature related tests
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+tests:
+  - test:
+      desc: Image migration from two different EC pools to EC pool
+      module: rbd_migration_2diff_ec_pool_ec.py
+      name: Test image migration on ecpool with different K_m values
+      polarion-id: CEPH-83573322
+
+  - test:
+      desc: Image migration from replication pools to replication pool
+      module: rbd_image_migration.py
+      config:
+        source:
+          rep-pool-only: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+            image: rbd_image
+            size: 10G
+        destination:
+          rep-pool-only: True
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+      name: Test image migration on replication pool
+      polarion-id: CEPH-83573293
+
+  - test:
+      desc: Image migration from EC pool to EC pool with default K_m value
+      module: rbd_image_migration.py
+      config:
+        source:
+          ec-pool-only: True
+          ec-pool-k-m: "2,2"
+          crush-failure-domain: osd
+          ec_pool_config:
+            pool: rbd_ECpool1
+            image: rbd_image_ec1
+            data_pool: data_pool_ec1
+            size: 10G
+        destination:
+          ec-pool-only: True
+          ec-pool-k-m: "2,2"
+          do_not_create_image: True
+          crush-failure-domain: osd
+          ec_pool_config:
+            pool: rbd_ECpool2
+            data_pool: data_pool_ec2
+      name: Test image migration on EC pool with default k_m value
+      polarion-id: CEPH-83573327
+
+  - test:
+      desc: Abort image migration from source to destination pool
+      module: rbd_abort_image_migration.py
+      config:
+        source:
+          ec-pool-k-m: "2,2"
+          crush-failure-domain: osd
+          rep_pool_config:
+            pool: rbd_RepPool1
+            image: rbd_image
+            size: 10G
+          ec_pool_config:
+            pool: rbd_ECpool1
+            image: rbd_image_ec1
+            data_pool: data_pool_ec1
+            size: 10G
+        destination:
+          ec-pool-k-m: "2,2"
+          do_not_create_image: True
+          crush-failure-domain: osd
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool2
+            data_pool: data_pool_ec2
+      name: Test abort image migration from source to destination pool
+      polarion-id: CEPH-83573324
+
+  - test:
+      desc: Setting up RGW user for s3 image migration test
+      module: exec.py
+      name: Setup rgw s3 user
+      config:
+        commands:
+          - "radosgw-admin user create --uid=test_rbd --display_name='test_rbd' --access-key test_rbd --secret test_rbd"
+
+  - test:
+      name: Image migration from s3 source
+      desc: Export an image to s3 source and reinstall as new image using migration
+      module: test_rbd_migration_image_s3_object.py
+      polarion-id: CEPH-83574092
+      config:
+        ec_pool_config:
+          pool: rbd_ec_pool
+          data_pool: rbd_data_pool
+          image: rbd_image
+          size: 100M
+        rep_pool_config:
+          pool: rbd_pool
+          image: rbd_rep_image
+          size: 100M
+
+  - test:
+      desc: Image migration pool namespace
+      module: readonly_namespace_image_migration.py
+      config:
+        source:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool1
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec1
+        destination:
+          do_not_create_image: True
+          rep_pool_config:
+            pool: rbd_RepPool2
+          ec_pool_config:
+            pool: rbd_ECpool1
+            data_pool: data_pool_ec2
+      name: Test image migration from pool namespace
+      polarion-id: CEPH-83573341

--- a/suites/squid/common/regression/rbd/tier-2_rbd_image_operation.yaml
+++ b/suites/squid/common/regression/rbd/tier-2_rbd_image_operation.yaml
@@ -1,0 +1,224 @@
+# Suite contains basic tier-2 RBD feature related tests
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+tests:
+  - test:
+      desc: Install rbd-nbd and remove any epel packages
+      module: exec.py
+      name: Install rbd-nbd
+      config:
+        sudo: true
+        commands:
+          - "rm -rf /etc/yum.repos.d/epel*"
+          - "dnf install rbd-nbd -y --nogpgcheck"
+
+  - test:
+      desc: snap and clone operations on imported image
+      destroy-cluster: false
+      module: rbd_snap_clone_imported_image.py
+      name: snap and clone on imported image
+      polarion-id: CEPH-9230
+
+  - test:
+      desc: Verify Delayed deletion with exclusive feature on RBD image
+      module: rbd_exclusive_lock_rm_image.py
+      config:
+        io-total: 5G
+      name: Verify exclusive lock feature
+      polarion-id: CEPH-11408
+
+  - test:
+      desc: verify for parent image deletion after flattening the clone and removing snap
+      config:
+        io-total: 5G
+      module: rbd_clone_delete_parent_image.py
+      name: Test for parent image deletion after flattening the clone and removing snap
+      polarion-id: CEPH-11409
+
+  - test:
+      desc: Verify that clones creation and deletion of parent image with V2 enabled
+      destroy-cluster: false
+      module: rbd_clonev2.py
+      name: clones creation with v2clone format
+      polarion-id: CEPH-83573309
+
+  - test:
+      desc: Verify parent snapshot deletion after flattening the clone
+      destroy-cluster: false
+      module: rbd_clone_delete_parent_snapshot.py
+      name: parent snap deletion after clone flattening
+      polarion-id: CEPH-83573650
+
+  - test:
+      desc: Rename image snapshots on an image on replicated and ecpools and its clones
+      module: rbd_snapshot_rename.py
+      name: Test Snapshot Rename functionality
+      polarion-id: CEPH-9833
+
+  - test:
+      desc: Rename image snapshot from which another image was cloned on a replicated and ecpool
+      module: rbd_rename_cloned_snapshot.py
+      name: Test Snapshot Rename for snapshot with clone
+      polarion-id: CEPH-9835
+
+  - test:
+      desc: Rename image snapshot when operations on clone/parent image is in progress
+      module: rbd_snapshot_rename_advanced.py
+      name: Test Snapshot Rename with clone operations in progress
+      polarion-id: CEPH-9836
+
+  - test:
+      desc: Trying to delete a protected snapshot should fail - negative
+      config:
+        do_not_create_image: True
+        operations:
+          map: true
+          io: true
+          nounmap: true
+      module: rbd_delete_protected_snapshot_krbd.py
+      name: krbd client - Test to Perform Deletion of protected snapshot
+      polarion-id: CEPH-9224
+
+  - test:
+      desc: Perform flatten operations while changing the image feature
+      config:
+        rbd_op_thread_timeout: 120
+      module: rbd_flatten_image_feature_disable.py
+      name: Test to disable image feature when flatten operation is performed
+      polarion-id: CEPH-9862
+
+  - test:
+      desc: Verify image feature disable on image having image meta set on it
+      config:
+        image_feature: deep-flatten
+      module: image_with_metadata_feature_disable.py
+      name: Test to verify image feature disable with image meta on it
+      polarion-id: CEPH-9864
+
+  - test:
+      desc: Verify image resize while changing image feature
+      config:
+        image_feature: fast-diff
+        size_increase: 11G
+        size_decrease: 5G
+        rep_pool_config:
+          size: 10G
+        ec_pool_config:
+          size: 10G
+      module: rbd_resize_image_with_image_feature.py
+      name: Test to verify image resize operation while changing image feature
+      polarion-id: CEPH-9861
+
+  - test:
+      desc: Verify RBD image with zero size
+      config:
+        resize_to: 0
+        rep_pool_config:
+          num_pools: 1
+          num_images: 2
+          images:
+            image_1024:
+              size: 1024
+            image_zero:
+              size: 0
+        ec_pool_config:
+          num_pools: 1
+          num_images: 2
+          images_ec:
+            data_pool: rbd_ec_data_pool
+            image_1024:
+              size: 1024
+            image_zero:
+              size: 0
+      module: test_rbd_image_zero_size.py
+      name: Test to verify RBD image with zero size
+      polarion-id: CEPH-83597243
+
+  - test:
+      desc: Verify rbd_compression_hint config settings
+      config:
+        compression_algorithm: snappy
+        compression_mode: passive
+        compression_ratio: 0.7
+        io_total: 1G
+      module: test_rbd_compression.py
+      name: Test to verify data compression on global, pool and image level
+      polarion-id: CEPH-83574644
+
+  - test:
+      desc: Verify python rbd module
+      config:
+        do_not_create_image: true
+        rep_pool_config:
+          num_pools: 1
+          num_images: 1
+        ec_pool_config:
+          num_pools: 1
+          num_images: 1
+      module: test_rbd_python_module.py
+      polarion-id: CEPH-83574791
+      name: Test image creation, write and read data using python rbd module
+
+  - test:
+      abort-on-fail: true
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          pool: test_pool
+          image1: immutable_image
+          size: 10G
+        fio:
+          runtime: 120
+      desc: Configure and validate immutable object cache feature
+      destroy-cluster: false
+      module: test_rbd_immutable_cache.py
+      name: Immutable object cache creation
+      polarion-id: CEPH-83574134
+
+  - test:
+      abort-on-fail: true
+      config:
+        rep_pool_config:
+          num_pools: 1
+          num_images: 1
+          size: 4G
+        ec_pool_config:
+          num_pools: 1
+          num_images: 1
+          size: 4G
+        fio:
+          size: 100M
+      desc: validate immutable object cache feature with cluster operation parallel
+      destroy-cluster: false
+      module: test_rbd_immutable_cache_cluster_operations.py
+      name: Immutable object cache creation with cluster operation
+      polarion-id: CEPH-83574132
+
+  - test:
+      desc: Encrypt & decrypt file using same keys and different keys
+      config:
+        encryption_type: #parent,clone
+          - luks1,luks1
+      destroy-cluster: false
+      module: test_rbd_encryption.py
+      name: encrypt image and clone using different keys
+      polarion-id: CEPH-83575263
+
+  - test:
+      desc: Apply different combinations of encryption to parent and clone
+      config:
+        encryption_type: #parent,clone
+           - luks1,luks1
+           - luks1,NA
+           - luks2,luks1
+           - luks2,luks2
+           - luks2,NA
+           - NA,luks1
+           - NA,luks2
+           - luks1,luks2
+      destroy-cluster: false
+      module: test_rbd_encryption.py
+      name: Encrypt image and clone using combinations of encryption type
+      polarion-id: CEPH-83575251
+

--- a/suites/squid/common/regression/rbd/tier-2_rbd_namespace.yaml
+++ b/suites/squid/common/regression/rbd/tier-2_rbd_namespace.yaml
@@ -1,0 +1,75 @@
+# Suite contains tier-2 RBD Namespace feature related tests
+# Conf: conf/squid/common/13node-4client-single-site-regression.yaml
+# Deployment: suites/squid/common/regression/single-site-deploy-and-configure.yaml
+
+tests:
+  - test:
+      desc: Run namespace creation in default pool
+      module: test_rbd_namespace_default_pool.py
+      name: RBD namespace creation in default pool
+      polarion-id: CEPH-83582474
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace creation in custom pool
+      module: test_rbd_namespace_custom_pool.py
+      name: RBD namespace creation in custom pool
+      polarion-id: CEPH-83582475
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd03: {}
+
+  - test:
+      desc: Run image creation in the namespace
+      module: test_rbd_namespace_image_pool.py
+      name: RBD image creation in the namespace
+      polarion-id: CEPH-83582476
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace creation with the same name in diff pool
+      module: test_rbd_namespace_same_ns_diff_pool.py
+      name: RBD namespace creation with the same name in diff pool
+      polarion-id: CEPH-83582478
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd05: {}
+          rbd06: {}
+
+  - test:
+      desc: Run img creation with the same name in diff ns
+      module: test_rbd_namespace_same_img_diff_ns.py
+      name: RBD img creation with the same name in diff ns
+      polarion-id: CEPH-83582479
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace deletion positive flow
+      module: test_rbd_namespace_remove_pos.py
+      name: RBD namespace deletion positive flow
+      polarion-id: CEPH-83583642
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}
+
+  - test:
+      desc: Run namespace deletion negative flow
+      module: test_rbd_namespace_remove_neg.py
+      name: RBD namespace deletion negative flow
+      polarion-id: CEPH-83582477
+      config:
+        rep-pool-only: True
+        rep_pool_config:
+          rbd: {}


### PR DESCRIPTION
# Description
Added RBD-related test suites for serial execution using new pipeline regression in common deployment.

- suites/squid/common/regression/rbd/tier-2_rbd_group.yaml
- suites/squid/common/regression/rbd/tier-2_rbd_image_migration.yaml
- suites/squid/common/regression/rbd/tier-2_rbd_image_operation.yaml
- suites/squid/common/regression/rbd/tier-2_rbd_namespace.yaml

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
