### PR TITLE
CEPH-83575397: Adding negative testcase for radosgw-admin commands

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -291,7 +291,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec

--- a/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -268,6 +268,23 @@ tests:
       polarion-id: CEPH-83575227
       module: exec.py
       name: get shared realm info on secondary
+  
+  - test:
+      name: test radosgw-admin negative commands
+      desc: Test negative scenarios for radosgw-admin commands in RGW multisite setup.
+      polarion-id: CEPH-83575397
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: test_negative_radosgwadmin_commands.py
+            config-file-name: test_negative_radosgw_admin_primary.yaml
+        ceph-sec:
+          config:
+            set-env: true
+            script-name: test_negative_radosgwadmin_commands.py
+            config-file-name: test_negative_radosgw_admin_secondary.yaml
   # Test work flow
 
   - test:

--- a/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -268,7 +268,7 @@ tests:
       polarion-id: CEPH-83575227
       module: exec.py
       name: get shared realm info on secondary
-  
+
   - test:
       name: test radosgw-admin negative commands
       desc: Test negative scenarios for radosgw-admin commands in RGW multisite setup.

--- a/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -291,7 +291,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            set-env: true
             script-name: user_create.py
             config-file-name: non_tenanted_user.yaml
             copy-user-info-to-site: ceph-sec

--- a/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -268,6 +268,23 @@ tests:
       polarion-id: CEPH-83575227
       module: exec.py
       name: get shared realm info on secondary
+  
+  - test:
+      name: test radosgw-admin negative commands
+      desc: Test negative scenarios for radosgw-admin commands in RGW multisite setup.
+      polarion-id: CEPH-83575397
+      module: sanity_rgw_multisite.py
+      clusters:
+        ceph-pri:
+          config:
+            set-env: true
+            script-name: test_negative_radosgwadmin_commands.py
+            config-file-name: test_negative_radosgw_admin_primary.yaml
+        ceph-sec:
+          config:
+            set-env: true
+            script-name: test_negative_radosgwadmin_commands.py
+            config-file-name: test_negative_radosgw_admin_secondary.yaml
   # Test work flow
 
   - test:

--- a/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
+++ b/suites/squid/rgw/tier-2_rgw_multisite_regression_extended.yaml
@@ -268,7 +268,7 @@ tests:
       polarion-id: CEPH-83575227
       module: exec.py
       name: get shared realm info on secondary
-  
+
   - test:
       name: test radosgw-admin negative commands
       desc: Test negative scenarios for radosgw-admin commands in RGW multisite setup.


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
This is an  integration PR introduces tests for negative scenarios involving radosgw-admin commands in a Ceph RGW multisite setup. The tests validate the system’s behavior when invalid parameters, missing data, or incorrect credentials are provided.[negative and boundary scenarios]

Primary Cluster (ceph-pri): Runs tests using the configuration file test_negative_radosgw_admin_primary.yaml.

Secondary Cluster (ceph-sec): Runs tests using the configuration file test_negative_radosgw_admin_secondary.yaml.

polarian https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83575397
