### PR TITLE
Fix haproxy endpoint issue seen with suite [DMFG][tier2-rgw-with-warn…

### DIFF
--- a/suites/squid/cephadm/tier2-rgw-with-warn-state.yaml
+++ b/suites/squid/cephadm/tier2-rgw-with-warn-state.yaml
@@ -78,6 +78,19 @@ tests:
       destroy-cluster: false
 
   - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node5
+        rgw_endpoints:
+          - node2:80
+          - node3:80
+          - node4:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
       name: Test M buckets with N objects
       desc: test to create "M" no of buckets and "N" no of objects
       polarion-id: CEPH-9789
@@ -110,6 +123,7 @@ tests:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
         timeout: 300
+        run-on-haproxy: true
       abort-on-fail: false
       destroy-cluster: false
 


### PR DESCRIPTION
…-state]

# Description

Fix haproxy endpoint issue seen with suite : cephci/suites/squid/cephadm/tier2-rgw-with-warn-state.yaml

Issue was due to missing required changes from ceph ci suite level.
Recently from RGW, we have added changes from ceph-qe-script to execute IO's using ha-proxy endpoints.
As part of this PR.
Added required changes i.e,
1. Configuration of haproxy on client node with port 5000
2. Add run_on_haproxy at the testcase level.

Fail log without changes: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/8.1/rhel-9/Regression/19.2.1-57/dmfg/93/tier2-rgw-with-warn-state/

Pass log with changes: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-0KL0MZ/


Note: We need these changes in other suites as well where particular config used.
that effort will be tracked in : https://issues.redhat.com/browse/RHCEPHQE-18671
draft PR: https://github.com/red-hat-storage/cephci/compare/main...ckulal:cephci:fix_haproxy_download?expand=1


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
