### PR TITLE
[cephci] sanity suite for IBM build execution

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_ibm.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm.yaml
@@ -1,0 +1,152 @@
+# RGW build evaluation
+#
+# This test suite is auto triggered via the Jenkins pipeline to determine if the
+# newly available binary of IBM 8.x meets the minimum acceptance criteria set forth by
+# the Object QE FG team.
+#
+# The following evaluations are carried out
+# - Build can be deployed using CephADM
+# - The cluster health is good
+# - End users can perform object operations.
+
+# IBM 8.x sanity test suite for RGW daemon.
+# conf : conf/squid/rgw/tier-0_rgw.yaml
+tests:
+
+  # Cluster deployment stage
+
+  - test:
+      abort-on-fail: true
+      desc: Install software pre-requisites for cluster deployment.
+      module: install_prereq.py
+      name: setup pre-requisites
+
+  - test:
+      abort-on-fail: true
+      config:
+        verify_cluster_health: true
+        steps:
+          - config:
+              command: bootstrap
+              service: cephadm
+              args:
+                registry-url: registry.redhat.io
+                mon-ip: node1
+                initial-dashboard-password: admin@123
+                dashboard-password-noupdate: true
+                orphan-initial-daemons: true
+                skip-monitoring-stack: true
+          - config:
+              command: add_hosts
+              service: host
+              args:
+                attach_ip_address: true
+                labels: apply-all-labels
+          - config:
+              command: apply
+              service: osd
+              args:
+                all-available-devices: true
+          - config:
+              command: apply
+              service: rgw
+              pos_args:
+                - rgw.1
+              args:
+                placement:
+                  label: rgw
+      desc: bootstrap with registry-url option and deployment services.
+      destroy-cluster: false
+      polarion-id: CEPH-83573713
+      module: test_cephadm.py
+      name: deploy cluster using cephadm
+
+  - test:
+      abort-on-fail: true
+      config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+        git_clone: true
+        git_node_role: rgw
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node3:80
+          - node4:80
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  # Testing stage
+
+  - test:
+      name: Parallel run
+      desc: RGW tier-1 parallelly.
+      module: test_parallel.py
+      parallel:
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+              install_common: false
+            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+            module: sanity_rgw.py
+            name: Test multipart upload of M buckets with N objects
+            polarion-id: CEPH-9801
+        - test:
+            config:
+              script-name: test_Mbuckets_with_Nobjects.py
+              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+              run-on-haproxy: true
+            desc: test to create "M" no of buckets and "N" no of objects with download
+            module: sanity_rgw.py
+            name: Test download with M buckets with N objects
+            polarion-id: CEPH-14237
+
+  - test:
+      name: enable bucket versioning
+      desc: Basic versioning test, also called as test to enable bucket versioning
+      polarion-id: CEPH-14261 # also applies to CEPH-9222 and CEPH-10652
+      module: sanity_rgw.py
+      config:
+        script-name: test_versioning_with_objects.py
+        config-file-name: test_versioning_objects_enable.yaml
+  - test:
+      name: S3CMD small and multipart object download
+      desc: S3CMD small and multipart object download or GET
+      polarion-id: CEPH-83575477
+      module: sanity_rgw.py
+      config:
+        script-name: ../s3cmd/test_s3cmd.py
+        config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
+  - test:
+      name: Test GetObjectAttributes with checksum sha256
+      desc: Test GetObjectAttributes with checksum sha256
+      polarion-id: CEPH-83595849
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_get_object_attributes_checksum_sha256.yaml
+  - test:
+      name: Test GetObjectAttributes with multipart objects
+      desc: Test GetObjectAttributes with multipart objects
+      polarion-id: CEPH-83595849
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_get_object_attributes_multipart.yaml


### PR DESCRIPTION
# Description
 Initiative RGW on reducing the number of resources while pipeline is for IBM build and reduce execution for overall RGW execution.

IBM pipeline execution
1. Include only single suite for sanity, regression, weekly as most of the scenarios are executing in RH pipeline
2. As of now sanity suite has up to 19 testcase including deployment, we will raise separate suite for IBM execution


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
