### PR TITLE
TFA Fix - Inconsistent object pg check using pool snapshot for RE pools failing with "not scrubbed in time error" 

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -3961,7 +3961,7 @@ EOF"""
             log.error(f"Unable to start the OSD : {target_osd}")
             return None
         log.info(f"Performing the deep-scrub on the pg-{pg_id}")
-        if not self.start_check_deep_scrub_complete(pg_id=pg_id, wait_time=1000):
+        if not self.start_check_deep_scrub_complete(pg_id=pg_id, wait_time=3600):
             log.debug(f"deep-scrubbing could not be completed on PG : {pg_id}")
             raise Exception("PG not deep-scrubbed error")
         log.debug(f"Completed deep-scrubbing the pg : {pg_id}")

--- a/tests/rados/test_osd_replicated_inconsistency_scenario.py
+++ b/tests/rados/test_osd_replicated_inconsistency_scenario.py
@@ -25,7 +25,7 @@ import traceback
 
 from test_osd_ecpool_inconsistency_scenario import (
     get_inconsistent_count,
-    set_default_param_value,
+    set_ecpool_inconsistent_default_param_value,
     verify_pg_state,
 )
 
@@ -244,7 +244,8 @@ def run(ceph_cluster, **kw):
         if config.get("delete_pool"):
             method_should_succeed(rados_obj.delete_pool, replicated_pool_name)
             log.info("deleted the pool successfully")
-        set_default_param_value(mon_obj)
+        # The values used for the  replicated and ec pool are same.Using the same method to set the default values
+        set_ecpool_inconsistent_default_param_value(mon_obj, scrub_object)
         rados_obj.log_cluster_health()
         # check for crashes after test execution
         if rados_obj.check_crash_status():


### PR DESCRIPTION
# Description

Following TFA fixes provided -
1. Inconsistent object pg check using pool snapshot for RE pools failing with "not scrubbed in time error"
2. Import failure at test_osd_replicated_inconsistency_scenario.py file

Jira - https://issues.redhat.com/browse/RHCEPHQE-18555

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
