### PR TITLE
Fix issue seen with haproxy endpoint w.r.t config: test_Mbuckets_with…

### DIFF
--- a/suites/squid/common/sanity/rgw.yaml
+++ b/suites/squid/common/sanity/rgw.yaml
@@ -2,6 +2,17 @@
 tests:
 
 # Tests from - suites/squid/rgw/tier-1_rgw.yaml
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node2:80
+          - node3:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   - test:
       name: enable bucket versioning
@@ -48,7 +59,7 @@ tests:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
               install_common: false
-              run-on-rgw: true
+              run-on-haproxy: true
 
         - test:
             name: Test multipart upload of M buckets with N objects

--- a/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
+++ b/suites/squid/rgw/baremetal/scale_rgw_single_site.yaml
@@ -45,7 +45,7 @@ tests:
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
               timeout: 300
               install_common: false
-              run-on-rgw: true
+              run-on-haproxy: true
             desc: test to create "M" no of buckets and "N" no of objects with download
             module: sanity_rgw.py
             name: Test download with M buckets with N objects

--- a/suites/squid/rgw/tier-1_rgw.yaml
+++ b/suites/squid/rgw/tier-1_rgw.yaml
@@ -78,6 +78,17 @@ tests:
       module: test_client.py
       name: configure client
 
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   # Testing stage
 
   - test:
@@ -112,7 +123,7 @@ tests:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
               install_common: false
-              run-on-rgw: true
+              run-on-haproxy: true
             desc: test to create "M" no of buckets and "N" no of objects with download
             module: sanity_rgw.py
             name: Test download with M buckets with N objects

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_71GA_to_8x_latest.yaml
@@ -203,6 +203,26 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+# configuring HAproxy on the client node 'node6' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   - test:
       abort-on-fail: true
       clusters:
@@ -425,6 +445,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            run-on-haproxy: true
 
   - test:
       clusters:

--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_multirealm_71GA_to_8x_latest.yaml
@@ -217,6 +217,26 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+# configuring HAproxy on the client node 'node6' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   - test:
       abort-on-fail: true
       clusters:
@@ -415,6 +435,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            run-on-haproxy: true
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects post upgrade

--- a/suites/squid/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/squid/rgw/tier-1_rgw_multisite.yaml
@@ -202,6 +202,26 @@ tests:
       module: test_client.py
       name: configure client
 
+# configuring HAproxy on the client node 'node6' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   - test:
       abort-on-fail: true
       clusters:
@@ -317,6 +337,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            run-on-haproxy: true
   - test:
       name: multipart upload on primary
       desc: test_Mbuckets_with_Nobjects_multipart on primary

--- a/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_71GA_to_8x_latest.yaml
@@ -78,6 +78,17 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
       desc: test etag verification
       module: sanity_rgw.py
@@ -146,6 +157,7 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+              run-on-haproxy: true
         - test:
             name: Upgrade cluster to latest 8.x ceph version
             desc: Upgrade cluster to latest version

--- a/suites/squid/rgw/tier-2_rgw_3_way_ms_failover.yaml
+++ b/suites/squid/rgw/tier-2_rgw_3_way_ms_failover.yaml
@@ -336,6 +336,7 @@ tests:
           config:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+            run-on-haproxy: true
 
   - test:
       abort-on-fail: true

--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -203,6 +203,26 @@ tests:
       name: configure client
       polarion-id: CEPH-83573758
 
+# configuring HAproxy on the client node 'node6' and port '5000'
+  - test:
+      abort-on-fail: true
+      clusters:
+        ceph-pri:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+        ceph-sec:
+          config:
+            haproxy_clients:
+              - node6
+            rgw_endpoints:
+              - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   - test:
       abort-on-fail: true
       clusters:
@@ -332,6 +352,7 @@ tests:
                 config:
                   script-name: test_Mbuckets_with_Nobjects.py
                   config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+                  run-on-haproxy: true
             desc: test to create "M" no of buckets and "N" no of objects with download
             module: sanity_rgw_multisite.py
             name: download objects post upgrade

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -77,6 +77,17 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
       desc: test etag verification
       module: sanity_rgw.py
@@ -93,6 +104,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
 
   # upgrade cluster
   - test:

--- a/suites/squid/upstream/tier-1_rgw_upstream.yaml
+++ b/suites/squid/upstream/tier-1_rgw_upstream.yaml
@@ -78,6 +78,17 @@ tests:
       module: test_client.py
       name: configure client
 
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
   # Testing stage
 
   - test:
@@ -112,7 +123,7 @@ tests:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
               install_common: false
-              run-on-rgw: true
+              run-on-haproxy: true
             desc: test to create "M" no of buckets and "N" no of objects with download
             module: sanity_rgw.py
             name: Test download with M buckets with N objects


### PR DESCRIPTION
…_Nobjects_download

Phase-1:

Fix issue seen with haproxy endpoint w.r.t config: test_Mbuckets_with_Nobjects_download
Issue was due to missing required changes from ceph ci suite level.
Recently from RGW, we have added changes from ceph-qe-script to execute IO's using ha-proxy endpoints.
As part of this PR.
Added required changes i.e,

Configuration of haproxy on client node with port 5000
Add run_on_haproxy at the testcase level.



# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
