### PR TITLE
[TFA] Baremetal logging error in lc

### DIFF
--- a/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml
+++ b/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml
@@ -189,6 +189,8 @@ tests:
         haproxy_clients:
           - node5
           - node6
+          - node7
+          - node8
         rgw_endpoints:
           - "node1:80"
           - "node2:80"

--- a/suites/squid/rgw/tier-4-rgw.yaml
+++ b/suites/squid/rgw/tier-4-rgw.yaml
@@ -165,6 +165,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_btw_exp_transition.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket lc rule conflict between expiration days
@@ -174,6 +175,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_exp_days.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket lc rule conflict between transition actions
@@ -183,6 +185,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_transition_actions.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket lc rules with same ruleid but different rules
@@ -192,6 +195,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
+        run-on-haproxy: true
 
   - test:
       name: Test bucket lc reverse transition
@@ -201,6 +205,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_reverse_transition.yaml
+        run-on-haproxy: true
 
   # swift container operation
   - test:


### PR DESCRIPTION
# Description
all client nodes had 2 repos of ceph-qe-scripts was not from branch master
so observed issue : http://magna002.ceph.redhat.com/cephci-jenkins/results/baremetal/RH/8.1/rhel-9/19.2.1-59/rgw/63/tier-4-rgw/Test_bucket_lc_reverse_transition_0.log

with proper repo in place observed issue of haproxy which is resolved in this pr :http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-4R2QXF/

for issue seen (which is lc validation) created ticket : https://issues.redhat.com/browse/RHCEPHQE-18689 


<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
