### PR TITLE
[TFA] update RHEL versions in mix OS conf files

### DIFF
--- a/conf/quincy/cephadm/1admin_4node_1client_mix_os.yaml
+++ b/conf/quincy/cephadm/1admin_4node_1client_mix_os.yaml
@@ -7,7 +7,7 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.2.0-x86_64-ga-latest
+          openstack: RHEL-9.5.0-x86_64-ga-latest
         role:
           - _admin
           - installer
@@ -24,7 +24,7 @@ globals:
         disk-size: 15
       node2:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - osd
           - mon
@@ -36,7 +36,7 @@ globals:
         disk-size: 15
       node3:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - mon
           - mgr
@@ -47,12 +47,12 @@ globals:
         disk-size: 15
       node4:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - mds
           - rgw
       node5:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - client

--- a/conf/reef/cephadm/1admin_4node_1client_mix_os.yaml
+++ b/conf/reef/cephadm/1admin_4node_1client_mix_os.yaml
@@ -7,7 +7,7 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.2.0-x86_64-ga-latest
+          openstack: RHEL-9.5.0-x86_64-ga-latest
         role:
           - _admin
           - installer
@@ -24,7 +24,7 @@ globals:
         disk-size: 15
       node2:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - osd
           - mon
@@ -36,7 +36,7 @@ globals:
         disk-size: 15
       node3:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - mon
           - mgr
@@ -47,12 +47,12 @@ globals:
         disk-size: 15
       node4:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - mds
           - rgw
       node5:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - client

--- a/conf/squid/cephadm/1admin-4node-1client-mix-os.yaml
+++ b/conf/squid/cephadm/1admin-4node-1client-mix-os.yaml
@@ -7,7 +7,7 @@ globals:
       name: ceph
       node1:
         image-name:
-          openstack: RHEL-9.2.0-x86_64-ga-latest
+          openstack: RHEL-9.5.0-x86_64-ga-latest
         role:
           - _admin
           - installer
@@ -24,7 +24,7 @@ globals:
         disk-size: 15
       node2:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - osd
           - mon
@@ -36,7 +36,7 @@ globals:
         disk-size: 15
       node3:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - mon
           - mgr
@@ -47,12 +47,12 @@ globals:
         disk-size: 15
       node4:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - mds
           - rgw
       node5:
         image-name:
-          openstack: RHEL-8.7.0-x86_64-ga-latest
+          openstack: RHEL-8.10.0-x86_64-ga-latest
         role:
           - client


### PR DESCRIPTION
# Description

The test suite `tier1-mix-os-deployment.yaml` had old RHEL 9 and RHEL 8 versions in the conf files.
Updated the RHEL versions to the latest available ones.