### PR TITLE
TFA issue fix rados bench overwriting object

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -451,7 +451,7 @@ class RadosOrchestrator:
         log.info(f"check_ec: {check_ec}")
 
         try:
-            self.node.shell([cmd], check_status=check_ec, timeout=_timeout)
+            self.client.exec_command(sudo=True, cmd=cmd, timeout=_timeout)
             if max_objs and verify_stats:
                 exp_objs = org_objs + max_objs
                 assert self.verify_pool_stats(pool_name=pool_name, exp_objs=exp_objs)

--- a/ceph/rados/serviceability_workflows.py
+++ b/ceph/rados/serviceability_workflows.py
@@ -158,7 +158,9 @@ class ServiceabilityMethods:
             )
 
             # cursory check to ensure input node is actually offline
-            if self.rados_obj.check_host_status(hostname=rm_host.hostname):
+            if not self.rados_obj.check_host_status(
+                hostname=rm_host.hostname, status="offline"
+            ):
                 err_msg = (
                     f"Input host {rm_host.hostname} is not in Offline state. Exiting"
                 )

--- a/tests/rados/test_libcephsqlite.py
+++ b/tests/rados/test_libcephsqlite.py
@@ -192,7 +192,7 @@ def run(ceph_cluster, **kw):
         log.info(
             "\n \n ************** Execution of finally block begins here *************** \n \n"
         )
-        if rhbuild.split(".")[0] > 5:
+        if rhbuild.split(".")[0] > "5":
             mon_obj.remove_config(section="mgr", name="debug_mgr")
             mon_obj.remove_config(section="mgr", name="debug_cephsqlite")
             if "cephsqlite_addr" in locals() or "cephsqlite_addr" in globals():


### PR DESCRIPTION
# Description

PR includes Fix for below TFA issues: 

1) Task https://issues.redhat.com/browse/RHCEPHQE-18701 :- rados bench is writing to the same object multiple times which is causing below test cases to fail. Since we have checks in place 
`Objs in the re_pool_compress before IOPS: 104768 | Objs in the pool post IOPS: 104768 | Expected 104768 > 0 | Expected 104768 > 104768`

logs 1:http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/tier-4_rados_tests/Compression_algorithms_-_modes_0.log  

`2025-03-23 23:46:44,883 - cephci - ceph:1606 - INFO - Execution of ceph df -f json on 10.0.195.89 took 1.003504 seconds 2025-03-23 23:46:44,883 - cephci - core_workflows:464 - INFO - Objs in the re_pool_compress before IOPS: 104768 | Objs in the pool post IOPS: 104768 | Expected 104768 > 0 | Expected 104768 > 10476`8 

logs 2: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/tier-4_rados_tests/Compression_algorithm_tuneables_0.log 

Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-8YOJLI/ 

2) Task https://issues.redhat.com/browse/RHCEPHQE-18699:- 
Magna link:- http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/tier-3_rados_cidr_blocklisting/Database_reopening_by_libcephsqlite_0.log 

Failing in finally block:
```
2025-03-24 09:44:29,216 - cephci - run:854 - ERROR - '>' not supported between instances of 'str' and 'int'
Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/cephci/run.py", line 839, in run
    rc = test_mod.run(
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/cephci/tests/rados/test_libcephsqlite.py", line 195, in run
    if rhbuild.split(".")[0] > 5:
TypeError: '>' not supported between instances of 'str' and 'int' 
```

3) Task https://issues.redhat.com/browse/RHCEPHQE-18702 :    http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/tier-4_rados_tests/Replacement_of_a_failed_OSD_host_0.log 

Required args missing to the function:- 

```
Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/cephci/ceph/rados/serviceability_workflows.py", line 161, in remove_offline_host
    if self.rados_obj.check_host_status(hostname=rm_host.hostname):
TypeError: check_host_status() missing 1 required positional argument: 'status'
2025-03-23 23:59:57,227 - cephci - test_pool_osd_recovery:387 - ERROR - Failed with exception: Inappropriate argument type.
2025-03-23 23:59:57,227 - cephci - test_pool_osd_recovery:388 - ERROR - check_host_status() missing 1 required positional argument: 'status'
Traceback (most recent call last):
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/cephci/tests/rados/test_pool_osd_recovery.py", line 378, in run
    service_obj.remove_offline_host(host_node_name=osd_hosts[0])
  File "/home/jenkins/ceph-builds/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rados/24/cephci/ceph/rados/serviceability_workflows.py", line 161, in remove_offline_host
    if self.rados_obj.check_host_status(hostname=rm_host.hostname):
TypeError: check_host_status() missing 1 required positional argument: 'status' 
```
Pass logs:- http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-RDG03R/ 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
