### PR TITLE
[TFA]: Remove NFS Scenario from Sanity suite

### DIFF
--- a/suites/quincy/cephfs/tier-0_fs.yaml
+++ b/suites/quincy/cephfs/tier-0_fs.yaml
@@ -8,7 +8,6 @@
 #	CEPH-83573777: Execute the cluster deployment workflow with label placement.
 #   CEPH-83574284: Deploy MDS with default values using cephadm.
 #   CEPH-11293: Perform cephfs basic operations.
-#   CEPH-83574439: Configure nfs-ganesha on NFS server, do mount on any client, and perform IOs.
 #   CEPH-83574286: Deploy MDS using cephadm and increase & decrease the number of MDS.
 #=======================================================================================================================
 tests:
@@ -124,13 +123,6 @@ tests:
       module: cephfs_basic_tests.py
       name: cephfs-basics
       polarion-id: "CEPH-11293"
-  -
-    test:
-      name: nfs-ganesha_with_cephfs
-      module: nfs-ganesha_basics.py
-      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
-      polarion-id: CEPH-83574439
-      abort-on-fail: false
   - test:
       name: Increase and Decrease of MDS
       module: mds_inc_dec.py

--- a/suites/reef/cephfs/tier-0_fs.yaml
+++ b/suites/reef/cephfs/tier-0_fs.yaml
@@ -112,13 +112,6 @@ tests:
       module: cephfs_basic_tests.py
       name: cephfs-basics
       polarion-id: "CEPH-11293"
-  -
-    test:
-      name: nfs-ganesha_with_cephfs
-      module: nfs-ganesha_basics.py
-      desc: Configure nfs-ganesha on nfs server,do mount on any client and do IOs
-      polarion-id: CEPH-83574439
-      abort-on-fail: false
   - test:
       name: Increase and Decrease of MDS
       module: mds_inc_dec.py

--- a/suites/squid/common/sanity/cephfs.yaml
+++ b/suites/squid/common/sanity/cephfs.yaml
@@ -12,12 +12,6 @@ tests:
       module: cephfs_basic_tests.py
 
   - test:
-      name: Test NFS Ganesha with cephfs
-      desc: Configure nfs-ganesha on nfs server and IOs operations
-      polarion-id: CEPH-83574439
-      module: nfs-ganesha_basics.py
-
-  - test:
       name: Test Increase and Decrease of MDs
       desc: MDs deployment using CephAdm and increase/decrease number of MDs
       polarion-id: CEPH-83574286


### PR DESCRIPTION
# Description

Removing the NFS Scenario from CEPHFS sanity test as this is already covered as part of other NFS suites.
Also, currently the script is failing since the nfs mount name is common across both cephfs and NFS suite

Hence removing the TC from suite.

Got the mail confirmation from our NFS Team (Manishaa)

Failure Run for Ref: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Sanity/19.2.0-122/34

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
