### PR TITLE
Adding retries and optimised path check for validate initiator

### DIFF
--- a/tests/nvmeof/workflows/ha.py
+++ b/tests/nvmeof/workflows/ha.py
@@ -727,7 +727,6 @@ class HighAvailability:
                     LOG.info(
                         f"{list(active[0])} is new and only Active GW for failed {hostname}"
                     )
-                    active_gw = list(active[0])
                     break
 
                 if len(active) > 1:
@@ -749,7 +748,6 @@ class HighAvailability:
             "failover-end-time": end_time,
             "failover-start-counter-time": start_counter,
             "failover-end-counter-time": end_counter,
-            "active-gw": active_gw[0],
             "failed-gw": gateway,
         }
 
@@ -817,6 +815,7 @@ class HighAvailability:
             "failback-end-time": end_time,
             "failback-start-counter-time": start_counter,
             "failback-end-counter-time": end_counter,
+            "failed-gw": gateway,
         }
 
     @retry(IOError, tries=3, delay=3)
@@ -875,11 +874,13 @@ class HighAvailability:
             if failed_ana_grp_ids:
                 for ns in nspaces:
                     if ns["load_balancing_group"] in failed_ana_grp_ids:
+                        # <subsystem>|<nsid>|<pool_name>|<image>
+                        ns_info = f"nsid-{ns['nsid']}|{ns['rbd_pool_name']}|{ns['rbd_image_name']}"
                         if get_list:
-                            namespaces.append(ns)
+                            namespaces.append(
+                                {"list": ns, "info": f"{sub_name}|{ns_info}"}
+                            )
                         else:
-                            # <subsystem>|<nsid>|<pool_name>|<image>
-                            ns_info = f"nsid-{ns['nsid']}|{ns['rbd_pool_name']}|{ns['rbd_image_name']}"
                             namespaces.append(f"{sub_name}|{ns_info}")
         if not failed_ana_grp_ids:
             LOG.info(f"All namespaces : {log_json_dump(all_ns)}")
@@ -940,26 +941,46 @@ class HighAvailability:
 
         LOG.info("IO Validation is Successfull on all RBD images..")
 
-    def validate_initiator(self, gateway, ana_id, failed_gw=None):
+    @retry((IOError, TimeoutError, CommandFailed), tries=7, delay=2)
+    def fetch_gw_paths(self, gateway, client, ns_device):
+        """
+        Fetch the optimized and inaccessible paths for the namespaces
+        serviced by a particular gateway.
+
+        Args:
+            gateway: gateway object
+            ana_id: ana group id of the namespaces
+        """
+        gw_paths = client.fetch_anastate(ns_device)
+        LOG.info(f"Gateway paths : {log_json_dump(gw_paths)}")
+
+        if not gw_paths.get("optimized"):
+            raise IOError(
+                f"Namespace is not optimized for {gateway.daemon_name} at {client} initiator"
+            )
+
+        return gw_paths
+
+    def validate_initiator(self, gateway, namespaces_gw, failed_gw=None):
         """Check whether all namespaces serviced by a particular gateway are optimized
         for that gateway at the initiator and also during failover, check if the failed
         gateway is inaccessible at the initiator.
 
         Args:
             gateway: gateway object
-            namespaces: dict of namespaces for a gateway
-            ana_id: ana group id of the namespaces
+            namespaces_gw: namespaces related to the gateway
             failed_gw: failed gateway object
         """
         for client in self.clients:
-            namespaces_gw = self.fetch_namespaces(gateway, [ana_id], get_list=True)
             for ns in namespaces_gw:
                 ns_device = client.fetch_device_for_namespace(ns.get("uuid"))
                 if not ns_device:
                     raise Exception(
                         f"Namespace {ns.get('uuid')} is not available at {client} initiator"
                     )
-                gw_paths = client.fetch_anastate(ns_device)
+
+                gw_paths = self.fetch_gw_paths(gateway, client, ns_device)
+
                 if len(gw_paths.get("optimized")) > 1:
                     raise Exception(
                         f"Namespace {ns.get('uuid')} has more than one at optimized paths {client} initiator"
@@ -977,8 +998,7 @@ class HighAvailability:
                         at {client} initiator"
                     )
         LOG.info(
-            f"All namespaces for the ana-group-id {ana_id} are optimized for all \
-            initiators for gateway {gateway.daemon_name}"
+            f"All namespaces are optimized for all initiators for gateway {gateway.daemon_name}"
         )
 
     def validate_init_namespace_masking(
@@ -1226,13 +1246,17 @@ class HighAvailability:
                     fail_gws, _ = self.catogorize(nodes)
                     fail_gw_ana_ids = []
                     namespaces = []
-                    namespaces_gw = {}
+                    all_failed_ns = {}
                     for gw in fail_gws:
                         fail_gw_ana_ids.append(gw.ana_group_id)
-                        ns = self.fetch_namespaces(gw, [gw.ana_group_id])
-                        namespaces.extend(ns)
-                        namespaces_gw[gw.ana_group_id] = ns
-                        self.validate_initiator(gw, gw.ana_group_id)
+                        namespaces_gw = self.fetch_namespaces(
+                            gw, [gw.ana_group_id], get_list=True
+                        )
+                        ns_list = [ns.get("list") for ns in namespaces_gw]
+                        ns_info = [ns.get("info") for ns in namespaces_gw]
+                        namespaces.extend(ns_info)
+                        all_failed_ns.update({gw.ana_group_id: ns_list})
+                        self.validate_initiator(gw, ns_list)
 
                     self.validate_io(namespaces)
 
@@ -1244,16 +1268,21 @@ class HighAvailability:
                             else:
                                 p.spawn(self.failover, gw, fail_tool)
                         for result in p:
-                            active_gw = result.pop("active-gw")
-                            failed_gw = result.pop("failed-gw")
+                            if not isinstance(result, dict):
+                                raise Exception("Failover failed")
+                            failed_gw = result.pop("failed-gw", None)
+                            if not failed_gw:
+                                raise Exception("Faileover failed")
+                            active = self.get_optimized_state(failed_gw.ana_group_id)
+                            active_gw = list(active[0])[0]
                             LOG.info(log_json_dump(result))
-                            ns = namespaces_gw[gw.ana_group_id]
-                            new_gw = [
+                            active_gw_obj = [
                                 gw
                                 for gw in self.gateways
                                 if gw.daemon_name in active_gw
                             ][0]
-                            self.validate_initiator(new_gw, gw.ana_group_id, failed_gw)
+                            ns_list = all_failed_ns.get(failed_gw.ana_group_id)
+                            self.validate_initiator(active_gw_obj, ns_list, failed_gw)
                         self.validate_io(namespaces)
 
                     # Fail Back
@@ -1262,9 +1291,14 @@ class HighAvailability:
                             for gw in fail_gws:
                                 p.spawn(self.failback, gw, fail_tool)
                             for result in p:
+                                if not isinstance(result, dict):
+                                    raise Exception("Failback failed")
+                                failed_gw = result.pop("failed-gw", None)
                                 LOG.info(log_json_dump(result))
-                                ns = namespaces_gw[gw.ana_group_id]
-                                self.validate_initiator(gw, gw.ana_group_id)
+                                if not failed_gw:
+                                    raise Exception("Failback failed")
+                                ns_list = all_failed_ns.get(failed_gw.ana_group_id)
+                                self.validate_initiator(failed_gw, ns_list)
                             self.validate_io(namespaces)
 
                         time.sleep(20)


### PR DESCRIPTION
Changes done as part of this PR for validate initiator method of NVMe HA.

1. Added retries and also check whether any optimised path was found to validate initiator method.
2. Fetch active gateway right before executing the validate initiator method, so we will have the current active gateway for validation
3. Passing namespaces as an object to validate initiator instead of fetching them inside the method to reduce the time take for fetching namespaces, this will ensure that that active gateway object has not changed in the time taken for fetching namespaces

Logs 

1. tier-1_nvmeof_ha_sanity.yaml - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-J3TTN1/
5. NVMeoF 4-GW HA test with mTLS configuration - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-99JVU2/
6. Switch NVMeoF with mTLS to Non-mTLS configuration - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-O0EEUZ/
7. NVMeoF 4-GW HA test Single failure - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N6O08A/
8. NVMeoF 4-GW HA test Single failure with daemon failure - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-9MUB3J/
9. NVMeoF 4-GW Test HA multinode fail parallel via orchestrator - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-FLXO26/
10. Test NVMeoF 4-GW HA multi node sequential failure - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-W1K7L2/
11. Test NVMeoF 4-GW HA 2-sub multinode fail parallel - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-N4P89O/
12. Test NVMeoF 4-GW HA 4-sub multinode fail parallel - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-YWZ3OR/Test_NVMeoF_4-GW_HA_4-sub_multinode_fail_parallel_0.log
13. Test NVMeoF 4-GW HA 4-sub n-1 node fail parallel - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1ZQ48Y/Test_NVMeoF_4-GW_HA_4-sub_n-1_node_fail_parallel_0.log
14. Test NVMeoF 4-GW HA 4-sub fail using node maintanence_mode - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-V0GYTC/Test_NVMeoF_4-GW_HA_4-sub_fail_using_node_maintanence_mode_0.log
15. Test NVMeoF 4-GW HA 4-sub fail using node power on off - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1ZQ48Y/Test_NVMeoF_4-GW_HA_4-sub_fail_using_node_power_on_off_0.log - Failback failed because the nodes remained offline even after failing back. some issue with environment is what I suspect. Need to investigate this as part of a different task. Not related to validate initiator.
16. Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail parallel - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-ERF14I/Test_NVMeoF_8-GW_1GWgroup_HA_4-sub_n-1_node_fail_parallel_0.log 
17. Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail using poweronoff - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-6V1H22/Test_NVMeoF_8-GW_1GWgroup_HA_4-sub_n-1_node_fail_using_poweronoff_0.log - Failback failed because the nodes remained offline even after failing back. some issue with environment is what I suspect. Need to investigate this as part of a different task. Not related to validate initiator.
18. Test NVMeoF 8-GW 1GWgroup HA 4-sub n-1 node fail using redeploy - http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-1B9QQQ/Test_NVMeoF_8-GW_1GWgroup_HA_4-sub_n-1_node_fail_using_redeploy_0.log - Failover failed
