### PR TITLE
Fix haproxy issue for the config: test_Mbuckets_with_Nobjects_etag.yaml

### DIFF
--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -311,7 +311,6 @@ tests:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_multipart_upload_with_tagging.yaml
 
-
   # test customer RFE: Public access block
 
   - test:

--- a/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_upgrade_61GA_to_8x_latest.yaml
@@ -76,6 +76,17 @@ tests:
       polarion-id: CEPH-83573758
 
   - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
       desc: test etag verification
       module: sanity_rgw.py
@@ -83,6 +94,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -197,6 +209,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests post upgrade

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -95,6 +95,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       desc: test to create "M" no of buckets and "N" no of objects with download


### PR DESCRIPTION
# Description
Fix haproxy issue for the config: test_Mbuckets_with_Nobjects_etag.yaml for the squid branch.
note: ssl-haproxy is not supported yet, that scenario is not handled here.


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
