### PR TITLE
RHCEPHQE-18767: Case Sensitivity NFS, SMB logic and refactor

### DIFF
--- a/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_functional.py
+++ b/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_functional.py
@@ -5,979 +5,1162 @@ import traceback
 
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.lib.cephfs_attributes_lib import CephFSAttributeUtilities
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(ceph_cluster, **kw):
-    try:
-        test_data = kw.get("test_data")
-        fs_util = FsUtils(ceph_cluster, test_data=test_data)
-        attr_util = CephFSAttributeUtilities(ceph_cluster)
-        config = kw.get("config")
-        clients = ceph_cluster.get_ceph_objects("client")
-        build = config.get("build", config.get("rhbuild"))
-        fs_util.prepare_clients(clients, build)
-        fs_util.auth_list(clients)
-        log.info("checking Pre-requisites")
-        if len(clients) < 1:
-            log.error(
-                "This test requires minimum 1 client nodes. This has only {} clients".format(
-                    len(clients)
-                )
-            )
-            return 1
-        client1 = clients[0]
+def test_case_sensitivity():
+    """Tests setting and verifying case sensitivity for a directory."""
+    global dir_path
+    dir_path = os.path.join(fuse_mounting_dir, "step-1")
+    attr_util.create_directory(client1, dir_path)
 
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------"
-            "\n  Pre-Requisite : Create file system, volumes, subvolumes and mount using FUSE  "
-            "\n---------------***************-----------------------------"
+    # Set case sensitivity to sensitive and verify
+    attr_util.set_attributes(client1, dir_path, casesensitive=1)
+    assert attr_util.get_charmap(client1, dir_path).get("casesensitive") is True
+    log.info("Passed: casesensitivity set to sensitive")
+
+    # Set case sensitivity to insensitive and verify
+    attr_util.set_attributes(client1, dir_path, casesensitive=0)
+    assert attr_util.get_charmap(client1, dir_path).get("casesensitive") is False
+    log.info("Passed: casesensitivity set to insensitive")
+
+
+def conflicting_directories():
+    """Tests creating directories with conflicting names in case-sensitive mode."""
+    attr_util.set_attributes(client1, dir_path, casesensitive=1)
+    attr_util.create_directory(client1, os.path.join(dir_path, "Dir1"))
+    attr_util.create_directory(client1, os.path.join(dir_path, "dir1"))
+    log.info("Passed: Conflicting directories created successfully")
+
+
+def check_default_value():
+    """Tests the default values for normalization and encoding attributes."""
+    default_dir = os.path.join(fuse_mounting_dir, "step-3")
+    attr_util.create_directory(client1, default_dir)
+    attr_util.set_attributes(client1, default_dir, casesensitive=1)
+
+    charmap = attr_util.get_charmap(client1, default_dir)
+    assert (
+        charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+        and charmap.get("casesensitive") is True
+    )
+    attr_util.delete_directory(client1, default_dir, recursive=True)
+
+    attr_util.create_directory(client1, default_dir)
+    attr_util.set_attributes(client1, default_dir, normalization="nfc")
+
+    charmap = attr_util.get_charmap(client1, default_dir)
+    assert (
+        charmap.get("normalization") == "nfc"
+        and charmap.get("encoding") == "utf8"
+        and charmap.get("casesensitive") is True
+    )
+
+    log.info("Passed: Default values are validated")
+
+
+def sub_directory_inheritance_case_True():
+    """Tests subdirectory inheritance of attributes when case sensitivity is True."""
+    normalization_types = ["nfkd", "nfkc", "nfd", "nfc"]
+    for norm_type in normalization_types:
+        parent_dir = attr_util.create_special_character_directories(
+            client1, fuse_mounting_dir
+        )
+        rel_parent_dir = os.path.relpath(parent_dir, fuse_mounting_dir)
+
+        attr_util.set_attributes(
+            client1, parent_dir, casesensitive=1, normalization=norm_type
         )
 
-        # Common Pre-Req
-        fs_name = "case-sensitivity-functional-1"
+        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+        if not attr_util.validate_alternate_name(
+            alter_dict, rel_parent_dir, norm_type.upper(), empty_name=True
+        ):
+            log.error("Validation failed for alternate name")
+            return 1
+
+        log.info("Validating for Normalization: {}".format(norm_type))
+        child_dir = attr_util.create_special_character_directories(client1, parent_dir)
+        rel_child_dir = os.path.relpath(child_dir, fuse_mounting_dir)
+        actual_child_dir_root = rel_child_dir.split("/")[0]
+        actual_child_dir_name = rel_child_dir.split("/")[1]
+
+        charmap = attr_util.get_charmap(client1, child_dir)
+        assert (
+            charmap.get("normalization") == norm_type
+            and charmap.get("encoding") == "utf8"
+            and charmap.get("casesensitive") is True
+        )
+
+        assert attr_util.validate_normalization(
+            client1,
+            fs_name,
+            actual_child_dir_root,
+            actual_child_dir_name,
+            norm_type.upper(),
+        )
+
+        log.info("Validating alternate name for %s", rel_child_dir)
+        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+        if not attr_util.validate_alternate_name(
+            alter_dict, rel_child_dir, norm_type.upper()
+        ):
+            log.error("Validation failed for alternate name")
+            return 1
+
+        log.info("** Cleanup ** ")
+        attr_util.delete_directory(client1, parent_dir, recursive=True)
+
+    log.info("Passed: Subdirectory inherited attribute")
+
+
+def test_empty_normalization_and_encoding_inheritance():
+    """Tests the inheritance of empty normalization and encoding attributes."""
+    dir_step_5 = os.path.join(fuse_mounting_dir, "step-5")
+
+    for attribute in ["normalization", "encoding"]:
+        log.info("Setting empty {} and validating the default values".format(attribute))
+        attr_util.create_directory(client1, dir_step_5)
+
+        try:
+            attr_util.get_charmap(client1, dir_step_5)
+            log.error(
+                "Charmap expected to fail for new directory when it's parent directory does not have charmap"
+            )
+        except ValueError:
+            log.info(
+                "Get Charmap expected to fail when there it's a new folder and "
+                " parent directory does not have charmap set"
+            )
+
+        attr_util.set_attributes(client1, dir_step_5, **{attribute: '""'})
+
+        charmap = attr_util.get_charmap(client1, dir_step_5)
+        assert (
+            charmap.get("normalization") == "nfd"
+            and charmap.get("encoding") == "utf8"
+            and charmap.get("casesensitive") is True
+        )
+
+        dir_step_5a = os.path.join(dir_step_5, "step-5a")
+        attr_util.create_directory(client1, dir_step_5a)
+
+        charmap = attr_util.get_charmap(client1, dir_step_5a)
+        assert (
+            charmap.get("normalization") == "nfd"
+            and charmap.get("encoding") == "utf8"
+            and charmap.get("casesensitive") is True
+        )
+
+        attr_util.delete_directory(client1, dir_step_5a, recursive=True)
+        attr_util.delete_directory(client1, dir_step_5, recursive=True)
+
+    log.info("Passed: Empty normalization and encoding")
+
+
+def test_directory_normalization():
+    """Tests setting and validating normalization for a new directory."""
+    dir_path_6 = os.path.join(fuse_mounting_dir, "step-6")
+    attr_util.create_directory(client1, dir_path_6)
+    attr_util.set_attributes(client1, dir_path_6, normalization="''")
+    log.info(attr_util.get_charmap(client1, dir_path_6).get("normalization"))
+
+    normalize_supported = ["nfc", "nfd", "nfkd", "nfkc"]
+
+    for supported_value in normalize_supported:
+        log.info("Test for Normalization: {}".format(supported_value))
+        uni_names = attr_util.generate_random_unicode_names()
+        dir_path_6_child = os.path.join(dir_path_6, uni_names[0])
+        rel_dir_path_6_child = os.path.relpath(dir_path_6_child, fuse_mounting_dir)
+        attr_util.create_directory(client1, dir_path_6_child)
+
+        attr_util.set_attributes(
+            client1, dir_path_6_child, normalization=supported_value
+        )
+
+        assert (
+            attr_util.get_charmap(client1, dir_path_6_child).get("normalization")
+            == supported_value
+        )
+
+        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+        if not attr_util.validate_alternate_name(
+            alter_dict,
+            rel_dir_path_6_child,
+            supported_value.upper(),
+        ):
+            log.error("Validation failed for alternate name")
+            return 1
+
+        log.info("Passed: Normalization set to {}".format(supported_value))
+
+    log.info("Passed: Set normalization for a new directory")
+
+
+def test_subdirectory_inheritance_special_chars():
+    """Tests subdirectory inheritance of attributes when case sensitivity is False."""
+    normalization_types = ["nfkd", "nfkc", "nfd", "nfc"]
+    for norm_type in normalization_types:
+        parent_dir = attr_util.create_special_character_directories(
+            client1, fuse_mounting_dir
+        )
+        rel_parent_dir = os.path.relpath(parent_dir, fuse_mounting_dir)
+        attr_util.set_attributes(
+            client1, parent_dir, casesensitive=0, normalization=norm_type
+        )
+
+        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+        if not attr_util.validate_alternate_name(
+            alter_dict,
+            rel_parent_dir,
+            norm_type.upper(),
+            empty_name=True,
+            casesensitive=False,
+        ):
+            log.error("Validation failed for alternate name")
+            return 1
+
+        log.info("Validating for Normalization: {}".format(norm_type))
+        child_dir = attr_util.create_special_character_directories(client1, parent_dir)
+        rel_child_dir = os.path.relpath(child_dir, fuse_mounting_dir)
+        actual_child_dir_root = rel_child_dir.split("/")[0]
+        actual_child_dir_name = rel_child_dir.split("/")[1]
+
+        charmap = attr_util.get_charmap(client1, child_dir)
+        assert (
+            charmap.get("normalization") == norm_type
+            and charmap.get("encoding") == "utf8"
+            and charmap.get("casesensitive") is False
+        )
+
+        assert attr_util.validate_normalization(
+            client1,
+            fs_name,
+            actual_child_dir_root,
+            actual_child_dir_name,
+            norm_type.upper(),
+            casesensitive=False,
+        )
+
+        log.info("Validating alternate name for %s", rel_child_dir)
+        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+        if not attr_util.validate_alternate_name(
+            alter_dict, rel_child_dir, norm_type.upper(), casesensitive=False
+        ):
+            log.error("Validation failed for alternate name")
+            return 1
+
+        log.info("** Cleanup ** ")
+        attr_util.delete_directory(client1, parent_dir, recursive=True)
+
+    log.info("Passed: Subdirectory inherited attribute")
+
+
+def test_snapshot_functionality_with_attributes():
+    """Tests the functionality of snapshots with attributes set on a subvolume."""
+    sv_group = "sv_group"
+    sv_name = "subvol1"
+    snap_name = "snap_1"
+    fs_util.create_subvolumegroup(client1, fs_name, sv_group)
+    fs_util.create_subvolume(client1, fs_name, sv_name, group_name=sv_group)
+
+    log.info("Get the path of sub volume")
+    subvol_path_test_snap, rc = client1.exec_command(
+        sudo=True,
+        cmd="ceph fs subvolume getpath {} {} {}".format(fs_name, sv_name, sv_group),
+    )
+
+    mounting_dir = "".join(
+        random.choice(string.ascii_lowercase + string.digits) for _ in list(range(10))
+    )
+    snap_fuse_mounting_dir = "/mnt/cephfs_fuse_snap_{}/".format(mounting_dir)
+    attr_util.create_directory(client1, snap_fuse_mounting_dir)
+
+    fs_util.fuse_mount(
+        [client1],
+        snap_fuse_mounting_dir,
+        extra_params=" -r {} --client_fs {}".format(
+            subvol_path_test_snap.strip(), fs_name
+        ),
+    )
+
+    attr_util.set_attributes(
+        client1, snap_fuse_mounting_dir, casesensitive=0, normalization="nfkc"
+    )
+    fs_util.create_file_data(
+        client1, {snap_fuse_mounting_dir}, 3, snap_name, "snap_1_data "
+    )
+    fs_util.create_snapshot(client1, fs_name, sv_name, snap_name, group_name=sv_group)
+
+    assert attr_util.validate_snapshot_from_mount(
+        client1, snap_fuse_mounting_dir, [snap_name]
+    )
+
+    charmap = attr_util.get_charmap(client1, snap_fuse_mounting_dir)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfkc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    try:
+        attr_util.set_attributes(
+            client1, snap_fuse_mounting_dir, casesensitive=1, normalization="nfd"
+        )
+        log.error("Expected to fail when snapshot exists")
+        return 1
+    except Exception:
+        log.info(
+            "Passed: Failed as Expected. Attributes should not be set on a snapshot directory"
+        )
+
+    log.info("Removing the snapshot directory")
+    attr_util.delete_snapshots_from_mount(client1, snap_fuse_mounting_dir)
+
+    attr_util.set_attributes(
+        client1, snap_fuse_mounting_dir, casesensitive=1, normalization="nfd"
+    )
+    charmap = attr_util.get_charmap(client1, snap_fuse_mounting_dir)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info("Passed: Validated snapshot functionality")
+
+
+def test_directory_rename_attribute_validation():
+    """Tests renaming a directory and validating the attributes after the rename."""
+    dir_9_root = os.path.join(fuse_mounting_dir, "step-9")
+    child_1 = os.path.join(dir_9_root, "child-1")
+    child_1_renamed = os.path.join(dir_9_root, "gá")
+    child_2 = os.path.join(child_1_renamed, "child-2")
+    attr_util.create_directory(client1, dir_9_root, force=True)
+
+    attr_util.set_attributes(client1, dir_9_root, normalization="nfkc")
+    attr_util.create_directory(client1, child_1)
+
+    charmap = attr_util.get_charmap(client1, child_1)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfkc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    assert attr_util.rename_directory(client1, child_1, child_1_renamed)
+
+    log.info("Validating the attributes after renaming the directory")
+    charmap = attr_util.get_charmap(client1, child_1_renamed)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfkc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    assert attr_util.validate_normalization(
+        client1,
+        fs_name,
+        os.path.relpath(child_1_renamed, fuse_mounting_dir).split("/")[0],
+        os.path.relpath(child_1_renamed, fuse_mounting_dir).split("/")[-1],
+        "NFKC",
+    )
+
+    log.info(
+        "Validating alternate name for %s",
+        os.path.relpath(child_1_renamed, fuse_mounting_dir),
+    )
+    alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+    if not attr_util.validate_alternate_name(
+        alter_dict, os.path.relpath(child_1_renamed, fuse_mounting_dir), "NFKC"
+    ):
+        log.error("Validation failed for alternate name")
+        return 1
+    log.info(
+        "Validating the attributes after creating the directory followed by rename"
+    )
+
+    attr_util.create_directory(client1, child_2)
+    charmap = attr_util.get_charmap(client1, child_2)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfkc"
+        and charmap.get("encoding") == "utf8"
+    )
+    log.info("Passed: Renaming the directory and validate the attribute")
+
+
+def test_softlink_attribute_validation():
+    """Tests the creation of soft links and validates the attributes of the source directory and the links."""
+    global dir_10_child, soft_link_1, soft_link_2
+
+    dir_10_parent = os.path.join(fuse_mounting_dir, "step-10-parent-dir")
+    dir_10_child = os.path.join(dir_10_parent, "step-10-child-dir")
+    dir_10_link_charmap = os.path.join(fuse_mounting_dir, "step-10-link-charmap")
+
+    attr_util.create_directory(client1, dir_10_parent)
+    attr_util.create_directory(client1, dir_10_link_charmap)
+
+    attr_util.set_attributes(
+        client1, dir_10_parent, casesensitive=0, normalization="nfc"
+    )
+    attr_util.create_directory(client1, dir_10_child)
+
+    charmap = attr_util.get_charmap(client1, dir_10_child)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info(
+        "** Creating soft links in the root folder where charmap does not exist **"
+    )
+    soft_link_1 = os.path.join(fuse_mounting_dir, "link-1")
+    attr_util.create_links(client1, dir_10_child, soft_link_1, "soft")
+
+    charmap = attr_util.get_charmap(client1, soft_link_1)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info(
+        "** Creating soft links in different folder where different charmap exist **"
+    )
+    soft_link_2 = os.path.join(dir_10_link_charmap, "link-2")
+    attr_util.set_attributes(
+        client1, dir_10_link_charmap, casesensitive=1, normalization="nfkd"
+    )
+
+    charmap = attr_util.get_charmap(client1, dir_10_link_charmap)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfkd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    attr_util.create_links(client1, dir_10_child, soft_link_2, "soft")
+
+    charmap = attr_util.get_charmap(client1, dir_10_child)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info("Passed: Creation of softlink for dir and validation of the attribute")
+
+
+def test_softlink_modification_attribute_validation():
+    """Tests modifying the attributes of the source directory and validating the soft links."""
+    log.info("Making changes to the source dir and validating the soft link 1 & 2")
+    for attribute in ["casesensitive", "normalization", "encoding"]:
+        attr_util.remove_attributes(client1, dir_10_child, attribute)
+
+    charmap = attr_util.get_charmap(client1, dir_10_child)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    charmap = attr_util.get_charmap(client1, soft_link_1)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    charmap = attr_util.get_charmap(client1, soft_link_2)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    # Validation
+    try:
+        assert attr_util.check_ls_case_sensitivity(client1, soft_link_1)
+        log.error("Failed: Expected to fail since Case sensitive is True")
+        return 1
+    except Exception:
+        log.info("Passed: Expected to fail since Case sensitive is True")
+
+    log.info(
+        "Making changes to the soft link 2 and validating the source dir & soft link 1"
+    )
+    attr_util.set_attributes(
+        client1, soft_link_2, casesensitive=0, normalization="nfkd"
+    )
+
+    charmap = attr_util.get_charmap(client1, soft_link_2)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfkd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    charmap = attr_util.get_charmap(client1, dir_10_child)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfkd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    charmap = attr_util.get_charmap(client1, soft_link_1)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfkd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info("Passed: Making changes to the softlink and validating the attribute")
+
+
+def test_softlink_file_attribute_validation():
+    """Tests the creation of a file in the source directory and validating the soft links."""
+    log.info("Creating a file in the source dir and validating the soft link 1 & 2")
+
+    file_name = "step-12-file.txt"
+    file_path_soft_link = attr_util.create_file(
+        client1, os.path.join(dir_10_child, file_name)
+    )
+
+    assert attr_util.check_if_file_exists(client1, file_path_soft_link)
+    assert attr_util.check_if_file_exists(client1, os.path.join(soft_link_1, file_name))
+    assert attr_util.check_if_file_exists(client1, os.path.join(soft_link_2, file_name))
+
+    assert attr_util.check_ls_case_sensitivity(client1, file_path_soft_link)
+    assert attr_util.check_ls_case_sensitivity(
+        client1, os.path.join(soft_link_1, file_name)
+    )
+    assert attr_util.check_ls_case_sensitivity(
+        client1, os.path.join(soft_link_2, file_name)
+    )
+
+    log.info(
+        "Creating a file in the soft link 2 and validating the source directory & soft link 1"
+    )
+
+    file_name_2 = "step-12-file-2.txt"
+    file_path_soft_link_2 = attr_util.create_file(
+        client1, os.path.join(soft_link_2, file_name_2)
+    )
+
+    assert attr_util.check_if_file_exists(client1, file_path_soft_link_2)
+    assert attr_util.check_if_file_exists(client1, os.path.join(soft_link_1, file_name))
+    assert attr_util.check_if_file_exists(client1, os.path.join(soft_link_2, file_name))
+
+    assert attr_util.check_ls_case_sensitivity(client1, file_path_soft_link_2)
+    assert attr_util.check_ls_case_sensitivity(
+        client1, os.path.join(soft_link_1, file_name)
+    )
+    assert attr_util.check_ls_case_sensitivity(
+        client1, os.path.join(soft_link_2, file_name)
+    )
+
+    log.info("** Cleanup of Link ** ")
+    assert attr_util.delete_links(client1, soft_link_1)
+    assert attr_util.delete_links(client1, soft_link_2)
+
+    log.info("Passed: Creation of softlink for File and validation of the attribute")
+
+
+def test_hardlink_file_attribute_validation():
+    """Tests the creation of a file in the source directory and validating the hard links."""
+    log.info("Creating a file in the source dir and validating the hard link 1")
+
+    dir_13_parent = os.path.join(fuse_mounting_dir, "step-13-parent-dir")
+    file_name_1 = "File-1.log"
+    dir_13_child_file = os.path.join(dir_13_parent, file_name_1)
+    dir_13_link_same_config = os.path.join(
+        fuse_mounting_dir, "step_13_link_same_config"
+    )
+    dir_13_link_diff_config = os.path.join(
+        fuse_mounting_dir, "step_13_link_diff_config"
+    )
+
+    attr_util.create_directory(client1, dir_13_parent)
+    attr_util.create_directory(client1, dir_13_link_same_config)
+    attr_util.create_directory(client1, dir_13_link_diff_config)
+
+    attr_util.set_attributes(
+        client1, dir_13_parent, casesensitive=0, normalization="nfc"
+    )
+
+    attr_util.create_file(client1, dir_13_child_file)
+
+    charmap = attr_util.get_charmap(client1, dir_13_parent)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info(
+        "** Creating hard link in the folder where charmap exist with the same config **"
+    )
+
+    attr_util.set_attributes(
+        client1, dir_13_link_same_config, casesensitive=0, normalization="nfc"
+    )
+
+    charmap = attr_util.get_charmap(client1, dir_13_link_same_config)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfc"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    hard_link_1 = os.path.join(dir_13_link_same_config, file_name_1)
+    attr_util.create_links(client1, dir_13_child_file, hard_link_1, "hard")
+
+    # Validation
+    assert attr_util.check_ls_case_sensitivity(client1, hard_link_1)
+
+    log.info(
+        "** Creating hard link in the folder where charmap exist with different config **"
+    )
+
+    attr_util.set_attributes(
+        client1, dir_13_link_diff_config, casesensitive=1, normalization="nfd"
+    )
+
+    charmap = attr_util.get_charmap(client1, dir_13_link_diff_config)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    hard_link_2 = os.path.join(dir_13_link_diff_config, file_name_1)
+    attr_util.create_links(client1, dir_13_child_file, hard_link_2, "hard")
+
+    # Validation
+    try:
+        assert attr_util.check_ls_case_sensitivity(client1, hard_link_2)
+        log.error("Failed: Expected to fail when case sensitivity is set to True")
+        return 1
+    except Exception:
+        log.info("Passed: Failed as expected when case sensitivity is set to True")
+
+    log.info("Passed: Creation of hardlink for File and validation of the attribute")
+
+
+def test_subvolume_non_default_group_fuse_mount():
+    """Tests the creation of a subvolume with a non-default group and validates the attributes using FUSE mount."""
+    dir_path = os.path.join(fuse_mounting_dir_14, "step-14")
+    attr_util.create_directory(client1, dir_path)
+
+    norm_type = "nfkd"
+    attr_util.set_attributes(
+        client1, dir_path, casesensitive=0, normalization=norm_type
+    )
+
+    charmap = attr_util.get_charmap(client1, dir_path)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == norm_type
+        and charmap.get("encoding") == "utf8"
+    )
+
+    unicode_name = attr_util.generate_random_unicode_names()[0]
+    log.info("Unicode Dir Name: %s", unicode_name)
+
+    child_dir_path = os.path.join(dir_path, unicode_name)
+    rel_child_dir = os.path.relpath(child_dir_path, fuse_mounting_dir_14)
+
+    # Removing the first slash for the subvolumes. Need to check
+    actual_child_dir_root = os.path.join(
+        subvol_path.strip().lstrip("/"), rel_child_dir.split("/")[0]
+    )
+
+    attr_util.create_directory(client1, child_dir_path)
+    charmap = attr_util.get_charmap(client1, child_dir_path)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == norm_type
+        and charmap.get("encoding") == "utf8"
+    )
+
+    assert attr_util.validate_normalization(
+        client1,
+        fs_name,
+        actual_child_dir_root,
+        unicode_name,
+        norm_type.upper(),
+        casesensitive=False,
+    )
+
+    log.info(
+        "Validating alternate name for %s",
+        os.path.join(actual_child_dir_root, unicode_name),
+    )
+    alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+    if not attr_util.validate_alternate_name(
+        alter_dict,
+        os.path.join(actual_child_dir_root, unicode_name),
+        norm_type.upper(),
+        casesensitive=False,
+    ):
+        log.error("Validation failed for alternate name")
+        return 1
+
+    assert attr_util.check_ls_case_sensitivity(client1, child_dir_path)
+
+    log.info(
+        "Passed: Validated subvolume with non-default sub volume group and mount using FUSE"
+    )
+
+
+def test_subvolume_default_group_fuse_mount():
+    dir_path = os.path.join(fuse_mounting_dir_15, "step-15")
+    attr_util.create_directory(client1, dir_path)
+
+    for attribute in ["casesensitive", "normalization", "encoding"]:
+        attr_util.remove_attributes(client1, dir_path, attribute)
+
+    charmap = attr_util.get_charmap(client1, dir_path)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    unicode_name = attr_util.generate_random_unicode_names()[0]
+    log.info("Unicode Dir Name: %s", unicode_name)
+
+    child_dir_path = os.path.join(dir_path, unicode_name)
+    rel_child_dir = os.path.relpath(child_dir_path, fuse_mounting_dir_15)
+
+    # Removing the first slash for the subvolumes. Need to check
+    actual_child_dir_root = os.path.join(
+        subvol_path_2.strip().lstrip("/"), rel_child_dir.split("/")[0]
+    )
+
+    attr_util.create_directory(client1, child_dir_path)
+    charmap = attr_util.get_charmap(client1, child_dir_path)
+    assert (
+        charmap.get("casesensitive") is True
+        and charmap.get("normalization") == "nfd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    assert attr_util.validate_normalization(
+        client1,
+        fs_name,
+        actual_child_dir_root,
+        unicode_name,
+        charmap.get("normalization").upper(),
+    )
+
+    log.info(
+        "Validating alternate name for %s",
+        os.path.join(actual_child_dir_root, unicode_name),
+    )
+    alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
+    if not attr_util.validate_alternate_name(
+        alter_dict,
+        os.path.join(actual_child_dir_root, unicode_name),
+        charmap.get("normalization").upper(),
+    ):
+        log.error("Validation failed for alternate name")
+        return 1
+
+    try:
+        assert attr_util.check_ls_case_sensitivity(client1, child_dir_path)
+        log.error("Failed: Expected to fail if case sensitivity is True")
+        return 1
+    except Exception as e:
+        log.info(
+            "Passed: Expected to fail if case sensitivity is True: {}".format(str(e))
+        )
+
+    log.info("Passed: Validated subvolume in default group and mount using FUSE")
+
+    log.info("*** Case Sensitivity: Functional Workflow completed ***")
+
+
+def mount_fuse_nfs(client1, mount_type):
+    global subvol_path
+    global subvol_path_2
+    global nfs_params
+
+    mds = fs_util.get_active_mdss(client1, fs_name)
+    active_mds_hostnames = [i.split(".")[1] for i in mds]
+    nfs_server_name = active_mds_hostnames[0]
+
+    nfs_params = {
+        "nfs_cluster_name": "nfs-1",
+        "nfs_server_name": nfs_server_name,
+        "binding": "/export_binding1",
+        "binding_uc_14": "/export_binding_uc14",
+        "binding_uc_15": "/export_binding_uc15",
+    }
+
+    log.info("*** Mounting Base File System via {} ***".format(mount_type))
+    fuse_mounting_dir = common_util.setup_cephfs_mount(
+        client1,
+        fs_name,
+        mount_type,
+        nfs_server_name=nfs_params.get("nfs_server_name"),
+        nfs_cluster_name=nfs_params.get("nfs_cluster_name"),
+        binding=nfs_params.get("binding"),
+    )
+    log.info("Mounting dir: {}".format(fuse_mounting_dir))
+
+    # Usecase 14
+    log.info("*** Pre-Req for Usecase 14 {} ***".format(mount_type))
+    subvolume_name = "subvolume-1"
+    subvolume_group = "subvolumegroup-1"
+
+    fuse_mounting_dir_14 = common_util.setup_cephfs_mount(
+        client1,
+        fs_name,
+        mount_type,
+        subvolume_name=subvolume_name,
+        subvolume_group=subvolume_group,
+        nfs_server_name=nfs_params.get("nfs_server_name"),
+        nfs_cluster_name=nfs_params.get("nfs_cluster_name"),
+        binding=nfs_params.get("binding_uc_14"),
+    )
+    log.info("Mounting dir: {}".format(fuse_mounting_dir_14))
+    log.info("Get the path of sub volume")
+    subvol_path, _ = client1.exec_command(
+        sudo=True,
+        cmd="ceph fs subvolume getpath {} {} {}".format(
+            fs_name, subvolume_name, subvolume_group
+        ),
+    )
+
+    # Usecase 15
+    log.info("*** Pre-Req for Usecase 15 {} ***".format(mount_type))
+    subvolume_name = "subvolume-2"
+    fuse_mounting_dir_15 = common_util.setup_cephfs_mount(
+        client1,
+        fs_name,
+        mount_type,
+        subvolume_name=subvolume_name,
+        nfs_server_name=nfs_params.get("nfs_server_name"),
+        nfs_cluster_name=nfs_params.get("nfs_cluster_name"),
+        binding=nfs_params.get("binding_uc_15"),
+    )
+    log.info("Mounting dir: {}".format(fuse_mounting_dir_15))
+    log.info("Get the path of sub volume")
+    subvol_path_2, _ = client1.exec_command(
+        sudo=True,
+        cmd="ceph fs subvolume getpath {} {}".format(fs_name, subvolume_name),
+    )
+    return fuse_mounting_dir, fuse_mounting_dir_14, fuse_mounting_dir_15
+
+
+def mount_smb(client1, fs_name, mount_type):
+    global smb_params
+
+    log.info("*** Mounting via SMB ***")
+    smb_params = {
+        "smb_cluster_id": "smb-1",
+        "smb_shares": ["share-1"],
+        # "installer": inst_node,
+    }
+
+    fuse_mounting_dir = common_util.setup_cephfs_mount(
+        client1,
+        fs_util,
+        fs_name,
+        mount_type,
+        smb_cluster_id=smb_params.get("smb_cluster_id"),
+        smb_shares=smb_params.get("smb_shares"),
+        installer=smb_params.get("installer"),
+    )
+    log.info("Mounting dir: {}".format(fuse_mounting_dir))
+
+    # Usecase 14 (smb)
+    log.info("*** Pre-Req for Usecase 14 (SMB) ***")
+    fuse_mounting_dir_14 = common_util.setup_cephfs_mount(
+        client1,
+        fs_util,
+        fs_name,
+        mount_type,
+        subvolume_name="subvolume-1",
+        subvolume_group="subvolumegroup-1",
+        smb_cluster_id=smb_params.get("smb_cluster_id"),
+        smb_shares=smb_params.get("smb_shares"),
+        # installer=smb_params.get("installer"),
+    )
+    log.info("Mounting dir: {}".format(fuse_mounting_dir_14))
+
+    # Usecase 15 (smb)
+    log.info("*** Pre-Req for Usecase 15 (SMB) ***")
+    fuse_mounting_dir_15 = common_util.setup_cephfs_mount(
+        client1,
+        fs_util,
+        fs_name,
+        mount_type,
+        subvolume_name="subvolume-2",
+        smb_cluster_id=smb_params.get("smb_cluster_id"),
+        smb_shares=smb_params.get("smb_shares"),
+        installer=smb_params.get("installer"),
+    )
+    log.info("Mounting dir: {}".format(fuse_mounting_dir_15))
+
+
+def run(ceph_cluster, **kw):
+    test_data = kw.get("test_data")
+
+    global fs_util
+    global attr_util
+    global common_util
+    global client1
+    # global inst_node
+
+    fs_util = FsUtils(ceph_cluster, test_data=test_data)
+    attr_util = CephFSAttributeUtilities(ceph_cluster)
+    common_util = CephFSCommonUtils(ceph_cluster)
+    config = kw.get("config")
+    log.info("Config Debug: {}".format(config))
+    clients = ceph_cluster.get_ceph_objects("client")
+    # inst_node = ceph_cluster.get_nodes(role="installer")[0]
+    build = config.get("build", config.get("rhbuild"))
+    ibm_build = config.get("ibm_build", False)
+    fs_util.prepare_clients(clients, build)
+    fs_util.auth_list(clients)
+    log.info("checking Pre-requisites")
+    if len(clients) < 1:
+        log.error(
+            "This test requires minimum 1 client nodes. This has only {} clients".format(
+                len(clients)
+            )
+        )
+        return 1
+    client1 = clients[0]
+
+    log.info(
+        "\n"
+        "\n---------------***************-----------------------------"
+        "\n  Pre-Requisite : Create file system, volumes, subvolumes and mount using FUSE, SMB  "
+        "\n---------------***************-----------------------------"
+    )
+
+    # mount_type_list = ["fuse", "nfs", "smb"]
+    mount_type_list = ["fuse", "smb"]
+    for mount_type in mount_type_list:
+        global fuse_mounting_dir, fuse_mounting_dir_14, fuse_mounting_dir_15
+        global fs_name
+
+        # Create File System
+        fs_name = "case-sensitivity-functional-{}".format(mount_type)
         fs_util.create_fs(client1, fs_name)
         fs_util.wait_for_mds_process(client1, fs_name)
 
-        mounting_dir = "".join(
-            random.choice(string.ascii_lowercase + string.digits)
-            for _ in list(range(10))
-        )
-        fuse_mounting_dir = "/mnt/cephfs_fuse_{}/".format(mounting_dir)
-        fs_util.fuse_mount(
-            [client1], fuse_mounting_dir, extra_params=" --client_fs {}".format(fs_name)
-        )
-
-        # Pre-Req for Usecase 14
-        log.info("*** Pre-Req for Usecase 14 ***")
-
-        subvolume_name = "subvolume-1"
-        subvolume_group = "subvolumegroup-1"
-
-        fs_util.create_subvolumegroup(
-            client1,
-            fs_name,
-            subvolume_group,
-        )
-        fs_util.create_subvolume(
-            client1, fs_name, subvolume_name, group_name=subvolume_group
-        )
-
-        mounting_dir = "".join(
-            random.choice(string.ascii_lowercase + string.digits)
-            for _ in list(range(10))
-        )
-        fuse_mounting_dir_14 = "/mnt/cephfs_fuse_{}/".format(mounting_dir)
-
-        subvol_path, rc = client1.exec_command(
-            sudo=True,
-            cmd="ceph fs subvolume getpath {} {} {}".format(
-                fs_name, subvolume_name, subvolume_group
-            ),
-        )
-        log.info("Sub volume path for usecase 14: {}".format(subvol_path))
-
-        fs_util.fuse_mount(
-            [client1],
-            fuse_mounting_dir_14,
-            extra_params=" --client_fs {} -r {}".format(fs_name, subvol_path.strip()),
-        )
-
-        # Pre-Req for Usecase 15
-        log.info("*** Pre-Req for Usecase 15 ***")
-
-        subvolume_name_2 = "subvolume-2"
-
-        fs_util.create_subvolume(client1, fs_name, subvolume_name_2)
-
-        mounting_dir = "".join(
-            random.choice(string.ascii_lowercase + string.digits)
-            for _ in list(range(10))
-        )
-        fuse_mounting_dir_15 = "/mnt/cephfs_fuse_{}/".format(mounting_dir)
-
-        subvol_path_2, rc = client1.exec_command(
-            sudo=True,
-            cmd="ceph fs subvolume getpath {} {}".format(fs_name, subvolume_name_2),
-        )
-
-        log.info("Sub volume path for usecase 15: {}".format(subvol_path_2))
-
-        fs_util.fuse_mount(
-            [client1],
-            fuse_mounting_dir_15,
-            extra_params=" --client_fs {} -r {}".format(fs_name, subvol_path_2.strip()),
-        )
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------"
-            "\nUsecase 1: Set casesensitivity for a new directory "
-            "\n---------------***************---------------------"
-        )
-        dir_path = os.path.join(fuse_mounting_dir, "step-1")
-
-        attr_util.create_directory(client1, dir_path)
-        attr_util.set_attributes(client1, dir_path, casesensitive=1)
-        assert attr_util.get_charmap(client1, dir_path).get("casesensitive") is True
-        log.info("Passed: casesensitivity set to sensitive")
-
-        attr_util.set_attributes(client1, dir_path, casesensitive=0)
-        assert attr_util.get_charmap(client1, dir_path).get("casesensitive") is False
-        log.info("Passed: casesensitivity set to insensitive")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\n     Usecase 2: Allow conflicting names in sensitive mode        "
-            "\n---------------***************-----------------------------------"
-        )
-        attr_util.set_attributes(client1, dir_path, casesensitive=1)
-        attr_util.create_directory(client1, os.path.join(dir_path, "Dir1"))
-        attr_util.create_directory(client1, os.path.join(dir_path, "dir1"))
-        log.info("Passed: Conflicting directories created successfully")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\n       Usecase 3: Check the default value                        "
-            "\n---------------***************-----------------------------------"
-        )
-        # Note: Default value cannot be checked until we set value for atleast one of the attirbute
-        default_dir = os.path.join(fuse_mounting_dir, "step-3")
-        attr_util.create_directory(client1, default_dir)
-        attr_util.set_attributes(client1, default_dir, casesensitive=1)
-        assert attr_util.get_charmap(client1, default_dir).get("normalization") == "nfd"
-        assert attr_util.get_charmap(client1, default_dir).get("encoding") == "utf8"
-        attr_util.delete_directory(client1, default_dir, recursive=True)
-
-        attr_util.create_directory(client1, default_dir)
-        attr_util.set_attributes(client1, default_dir, normalization="nfc")
-        assert attr_util.get_charmap(client1, default_dir).get("casesensitive") is True
-
-        log.info("Passed: Default values are validated")
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------------"
-            "\n   Usecase 4: Validate subdirectory inheritance, special character dir     "
-            "\n              and validate normalization with case sensitive True          "
-            "\n---------------***************---------------------------------------------"
-        )
-        normalization_types = ["nfkd", "nfkc", "nfd", "nfc"]
-        for norm_type in normalization_types:
-            parent_dir = attr_util.create_special_character_directories(
-                client1, fuse_mounting_dir
-            )
-            rel_parent_dir = os.path.relpath(parent_dir, fuse_mounting_dir)
-
-            attr_util.set_attributes(client1, parent_dir, casesensitive=1)
-            attr_util.set_attributes(client1, parent_dir, normalization=norm_type)
-
-            alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-            if not attr_util.validate_alternate_name(
-                alter_dict, rel_parent_dir, norm_type.upper(), empty_name=True
-            ):
-                log.error("Validation failed for alternate name")
-                return 1
-
-            log.info("Validating for Normalization: {}".format(norm_type))
-            child_dir = attr_util.create_special_character_directories(
-                client1, parent_dir
-            )
-            rel_child_dir = os.path.relpath(child_dir, fuse_mounting_dir)
-            actual_child_dir_root = rel_child_dir.split("/")[0]
-            actual_child_dir_name = rel_child_dir.split("/")[1]
-
-            assert (
-                attr_util.get_charmap(client1, child_dir).get("casesensitive") is True
-            )
-            assert (
-                attr_util.get_charmap(client1, child_dir).get("normalization")
-                == norm_type
-            )
-            assert attr_util.get_charmap(client1, child_dir).get("encoding") == "utf8"
-
-            assert attr_util.validate_normalization(
-                client1,
-                fs_name,
-                actual_child_dir_root,
-                actual_child_dir_name,
-                norm_type.upper(),
+        if mount_type == "fuse" or mount_type == "nfs":
+            # common_util.test_mount(client1, )
+            fuse_mounting_dir, fuse_mounting_dir_14, fuse_mounting_dir_15 = (
+                mount_fuse_nfs(client1, mount_type)
             )
 
-            log.info("Validating alternate name for %s", rel_child_dir)
-            alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-            if not attr_util.validate_alternate_name(
-                alter_dict, rel_child_dir, norm_type.upper()
-            ):
-                log.error("Validation failed for alternate name")
-                return 1
-
-            log.info("** Cleanup ** ")
-            attr_util.delete_directory(client1, parent_dir, recursive=True)
-
-        log.info("Passed: Subdirectory inherited attribute")
-
-        log.info(
-            "\n"
-            "\n---------------***************----------------------------------------"
-            "\n    Usecase 5: Set empty normalisation and encoding                   "
-            "\n               and ensure it fetches default value and gets inherited "
-            "\n---------------***************----------------------------------------"
-        )
-        dir_step_5 = os.path.join(fuse_mounting_dir, "step-5")
-
-        for attribute in ["normalization", "encoding"]:
-            log.info(
-                "Setting empty {} and validating the default values".format(attribute)
-            )
-            attr_util.create_directory(client1, dir_step_5)
-
-            try:
-                attr_util.get_charmap(client1, dir_step_5)
-                log.error(
-                    "Charmap expected to fail for new directory when it's parent directory does not have charmap"
+        elif mount_type == "smb":
+            if ibm_build:
+                fuse_mounting_dir, fuse_mounting_dir_14, fuse_mounting_dir_15 = (
+                    mount_smb(client1, mount_type)
                 )
-            except ValueError:
+            else:
                 log.info(
-                    "Get Charmap expected to fail when there it's a new folder and "
-                    " parent directory does not have charmap set"
+                    "\n---------------***************-----------------------------"
+                    "\n  Current build is not IBM build, skipping SMB mount test."
+                    "\n---------------***************-----------------------------"
                 )
-
-            attr_util.set_attributes(client1, dir_step_5, **{attribute: '""'})
-
-            assert (
-                attr_util.get_charmap(client1, dir_step_5).get("casesensitive") is True
-            )
-            assert (
-                attr_util.get_charmap(client1, dir_step_5).get("normalization") == "nfd"
-            )
-            assert attr_util.get_charmap(client1, dir_step_5).get("encoding") == "utf8"
-
-            dir_step_5a = os.path.join(dir_step_5, "step-5a")
-            attr_util.create_directory(client1, dir_step_5a)
-
-            assert (
-                attr_util.get_charmap(client1, dir_step_5a).get("casesensitive") is True
-            )
-            assert (
-                attr_util.get_charmap(client1, dir_step_5a).get("normalization")
-                == "nfd"
-            )
-            assert attr_util.get_charmap(client1, dir_step_5a).get("encoding") == "utf8"
-
-            attr_util.delete_directory(client1, dir_step_5a, recursive=True)
-            attr_util.delete_directory(client1, dir_step_5, recursive=True)
-
-        log.info("Passed: Empty normalization and encoding")
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------"
-            "\nUsecase 6: Set normalization for a new directory   "
-            "\n---------------***************---------------------"
-        )
-        dir_path_6 = os.path.join(fuse_mounting_dir, "step-6")
-        attr_util.create_directory(client1, dir_path_6)
-        attr_util.set_attributes(client1, dir_path_6, normalization="''")
-        log.info(attr_util.get_charmap(client1, dir_path_6).get("normalization"))
-
-        normalize_supported = ["nfc", "nfd", "nfkd", "nfkc"]
-
-        for supported_value in normalize_supported:
-            log.info("Test for Normalization: {}".format(supported_value))
-            uni_names = attr_util.generate_random_unicode_names()
-            dir_path_6_child = os.path.join(dir_path_6, uni_names[0])
-            rel_dir_path_6_child = os.path.relpath(dir_path_6_child, fuse_mounting_dir)
-            attr_util.create_directory(client1, dir_path_6_child)
-
-            attr_util.set_attributes(
-                client1, dir_path_6_child, normalization=supported_value
-            )
-
-            assert (
-                attr_util.get_charmap(client1, dir_path_6_child).get("normalization")
-                == supported_value
-            )
-
-            alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-            if not attr_util.validate_alternate_name(
-                alter_dict,
-                rel_dir_path_6_child,
-                supported_value.upper(),
-            ):
-                log.error("Validation failed for alternate name")
-                return 1
-
-            log.info("Passed: Normalization set to {}".format(supported_value))
-
-        log.info("Passed: Set normalization for a new directory")
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------------"
-            "\n   Usecase 7: Validate subdirectory inheritance, special character dir     "
-            "\n              and validate normalization with case sensitive False         "
-            "\n---------------***************---------------------------------------------"
-        )
-        normalization_types = ["nfkd", "nfkc", "nfd", "nfc"]
-        for norm_type in normalization_types:
-            parent_dir = attr_util.create_special_character_directories(
-                client1, fuse_mounting_dir
-            )
-            rel_parent_dir = os.path.relpath(parent_dir, fuse_mounting_dir)
-            attr_util.set_attributes(client1, parent_dir, casesensitive=0)
-            attr_util.set_attributes(client1, parent_dir, normalization=norm_type)
-
-            alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-            if not attr_util.validate_alternate_name(
-                alter_dict,
-                rel_parent_dir,
-                norm_type.upper(),
-                empty_name=True,
-                casesensitive=False,
-            ):
-                log.error("Validation failed for alternate name")
-                return 1
-
-            log.info("Validating for Normalization: {}".format(norm_type))
-            child_dir = attr_util.create_special_character_directories(
-                client1, parent_dir
-            )
-            rel_child_dir = os.path.relpath(child_dir, fuse_mounting_dir)
-            actual_child_dir_root = rel_child_dir.split("/")[0]
-            actual_child_dir_name = rel_child_dir.split("/")[1]
-
-            assert (
-                attr_util.get_charmap(client1, child_dir).get("casesensitive") is False
-            )
-            assert (
-                attr_util.get_charmap(client1, child_dir).get("normalization")
-                == norm_type
-            )
-            assert attr_util.get_charmap(client1, child_dir).get("encoding") == "utf8"
-
-            assert attr_util.validate_normalization(
-                client1,
-                fs_name,
-                actual_child_dir_root,
-                actual_child_dir_name,
-                norm_type.upper(),
-                casesensitive=False,
-            )
-
-            log.info("Validating alternate name for %s", rel_child_dir)
-            alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-            if not attr_util.validate_alternate_name(
-                alter_dict, rel_child_dir, norm_type.upper(), casesensitive=False
-            ):
-                log.error("Validation failed for alternate name")
-                return 1
-
-            log.info("** Cleanup ** ")
-            attr_util.delete_directory(client1, parent_dir, recursive=True)
-
-        log.info("Passed: Subdirectory inherited attribute")
-
-        # # Able to set the charmap attribute when the snap folder exists
-        # # Discussing with Dev. Will map the BZ accordingly
-        # # Commenting for now since this is failing
-        # log.info(
-        #     "\n"
-        #     "\n---------------***************---------------------------------------------"
-        #     "\n   Usecase 8: Validate snapshot functionality after setting the attribute  "
-        #     "\n---------------***************---------------------------------------------"
-        # )
-        # sv_group = "sv_group"
-        # sv_name = "subvol1"
-        # snap_name = "snap_1"
-        # fs_util.create_subvolumegroup(client1, fs_name, sv_group)
-        # fs_util.create_subvolume(client1, fs_name, sv_name, group_name=sv_group)
-
-        # log.info("Get the path of sub volume")
-        # subvol_path, rc = client1.exec_command(
-        #     sudo=True,
-        #     cmd="ceph fs subvolume getpath {} {} {}".format(fs_name, sv_name, sv_group),
-        # )
-
-        # mounting_dir = "".join(
-        #     random.choice(string.ascii_lowercase + string.digits)
-        #     for _ in list(range(10))
-        # )
-        # snap_fuse_mounting_dir = "/mnt/cephfs_fuse_snap_{}/".format(mounting_dir)
-        # attr_util.create_directory(client1, snap_fuse_mounting_dir)
-
-        # fs_util.fuse_mount(
-        #     [client1],
-        #     snap_fuse_mounting_dir,
-        #     extra_params=" -r {} --client_fs {}".format(subvol_path.strip(), fs_name),
-        # )
-
-        # attr_util.set_attributes(
-        #     client1, snap_fuse_mounting_dir, casesensitive=0, normalization="nfkc"
-        # )
-        # fs_util.create_file_data(
-        #     client1, {snap_fuse_mounting_dir}, 3, snap_name, "snap_1_data "
-        # )
-        # fs_util.create_snapshot(
-        #     client1, fs_name, sv_name, snap_name, group_name=sv_group
-        # )
-
-        # assert attr_util.validate_snapshot_from_mount(
-        #     client1, snap_fuse_mounting_dir, [snap_name]
-        # )
-
-        # charmap = attr_util.get_charmap(client1, snap_fuse_mounting_dir)
-        # assert (
-        #     charmap.get("casesensitive") is False
-        #     and charmap.get("normalization") == "nfkc"
-        #     and charmap.get("encoding") == "utf8"
-        # )
-
-        # try:
-        #     attr_util.set_attributes(
-        #         client1, snap_fuse_mounting_dir, casesensitive=1, normalization="nfd"
-        #     )
-        #     log.error("Expected to fail when snapshot exists")
-        #     return 1
-        # except Exception:
-        #     log.info(
-        #         "Passed: Failed as Expected. Attributes should not be set on a snapshot directory"
-        #     )
-
-        # log.info("Removing the snapshot directory")
-        # attr_util.delete_snapshots_from_mount(client1, snap_fuse_mounting_dir)
-
-        # attr_util.set_attributes(
-        #     client1, snap_fuse_mounting_dir, casesensitive=1, normalization="nfd"
-        # )
-        # charmap = attr_util.get_charmap(client1, snap_fuse_mounting_dir)
-        # assert (
-        #     charmap.get("casesensitive") is True
-        #     and charmap.get("normalization") == "nfd"
-        #     and charmap.get("encoding") == "utf8"
-        # )
-
-        # log.info("Passed: Validated snapshot functionality")
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------------"
-            "\n   Usecase 9: Renaming the directory and validate the attribute            "
-            "\n---------------***************---------------------------------------------"
-        )
-
-        dir_9_root = os.path.join(fuse_mounting_dir, "step-9")
-        child_1 = os.path.join(dir_9_root, "child-1")
-        child_1_renamed = os.path.join(dir_9_root, "gá")
-        child_2 = os.path.join(child_1_renamed, "child-2")
-        attr_util.create_directory(client1, dir_9_root, force=True)
-
-        attr_util.set_attributes(client1, dir_9_root, normalization="nfkc")
-        attr_util.create_directory(client1, child_1)
-
-        charmap = attr_util.get_charmap(client1, child_1)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfkc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        assert attr_util.rename_directory(client1, child_1, child_1_renamed)
-
-        log.info("Validating the attributes after renaming the directory")
-        charmap = attr_util.get_charmap(client1, child_1_renamed)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfkc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        assert attr_util.validate_normalization(
-            client1,
-            fs_name,
-            os.path.relpath(child_1_renamed, fuse_mounting_dir).split("/")[0],
-            os.path.relpath(child_1_renamed, fuse_mounting_dir).split("/")[-1],
-            "NFKC",
-        )
-
-        log.info(
-            "Validating alternate name for %s",
-            os.path.relpath(child_1_renamed, fuse_mounting_dir),
-        )
-        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-        if not attr_util.validate_alternate_name(
-            alter_dict, os.path.relpath(child_1_renamed, fuse_mounting_dir), "NFKC"
-        ):
-            log.error("Validation failed for alternate name")
-            return 1
-        log.info(
-            "Validating the attributes after creating the directory followed by rename"
-        )
-
-        attr_util.create_directory(client1, child_2)
-        charmap = attr_util.get_charmap(client1, child_2)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfkc"
-            and charmap.get("encoding") == "utf8"
-        )
-        log.info("Passed: Renaming the directory and validate the attribute")
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------------"
-            "\n   Usecase 10: Create softlink for dir and validate the attribute          "
-            "\n---------------***************---------------------------------------------"
-        )
-
-        dir_10_parent = os.path.join(fuse_mounting_dir, "step-10-parent-dir")
-        dir_10_child = os.path.join(dir_10_parent, "step-10-child-dir")
-        dir_10_link_charmap = os.path.join(fuse_mounting_dir, "step-10-link-charmap")
-
-        attr_util.create_directory(client1, dir_10_parent)
-        attr_util.create_directory(client1, dir_10_link_charmap)
-
-        attr_util.set_attributes(
-            client1, dir_10_parent, casesensitive=0, normalization="nfc"
-        )
-        attr_util.create_directory(client1, dir_10_child)
-
-        charmap = attr_util.get_charmap(client1, dir_10_child)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        log.info(
-            "** Creating soft links in the root folder where charmap does not exist **"
-        )
-        soft_link_1 = os.path.join(fuse_mounting_dir, "link-1")
-        attr_util.create_links(client1, dir_10_child, soft_link_1, "soft")
-
-        charmap = attr_util.get_charmap(client1, soft_link_1)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        log.info(
-            "** Creating soft links in different folder where different charmap exist **"
-        )
-        soft_link_2 = os.path.join(dir_10_link_charmap, "link-2")
-        attr_util.set_attributes(
-            client1, dir_10_link_charmap, casesensitive=1, normalization="nfkd"
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_10_link_charmap)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfkd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        attr_util.create_links(client1, dir_10_child, soft_link_2, "soft")
-
-        charmap = attr_util.get_charmap(client1, dir_10_child)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        log.info("Passed: Creation of softlink for dir and validation of the attribute")
-
-        log.info(
-            "\n"
-            "\n---------------***************--------------------------------------------------"
-            "\nUsecase 11:Create softlink for dir, make modification and validate the attribute"
-            "\n---------------***************--------------------------------------------------"
-        )
-
-        log.info("Making changes to the source dir and validating the soft link 1 & 2")
-        for attribute in ["casesensitive", "normalization", "encoding"]:
-            attr_util.remove_attributes(client1, dir_10_child, attribute)
-
-        charmap = attr_util.get_charmap(client1, dir_10_child)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        charmap = attr_util.get_charmap(client1, soft_link_1)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        charmap = attr_util.get_charmap(client1, soft_link_2)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        # Validation
-        try:
-            assert attr_util.check_ls_case_sensitivity(client1, soft_link_1)
-            log.error("Failed: Expected to fail since Case sensitive is True")
-            return 1
-        except Exception:
-            log.info("Passed: Expected to fail since Case sensitive is True")
-
-        log.info(
-            "Making changes to the soft link 2 and validating the source dir & soft link 1"
-        )
-        attr_util.set_attributes(
-            client1, soft_link_2, casesensitive=0, normalization="nfkd"
-        )
-
-        charmap = attr_util.get_charmap(client1, soft_link_2)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfkd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_10_child)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfkd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        charmap = attr_util.get_charmap(client1, soft_link_1)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfkd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        log.info("Passed: Making changes to the softlink and validating the attribute")
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------------------"
-            "\nUsecase 12:Create softlink for File  and validate the attribute                  "
-            "\n---------------***************---------------------------------------------------"
-        )
-
-        log.info("Creating a file in the source dir and validating the soft link 1 & 2")
-
-        file_name = "step-12-file.txt"
-        file_path_soft_link = attr_util.create_file(
-            client1, os.path.join(dir_10_child, file_name)
-        )
-
-        assert attr_util.check_if_file_exists(client1, file_path_soft_link)
-        assert attr_util.check_if_file_exists(
-            client1, os.path.join(soft_link_1, file_name)
-        )
-        assert attr_util.check_if_file_exists(
-            client1, os.path.join(soft_link_2, file_name)
-        )
-
-        assert attr_util.check_ls_case_sensitivity(client1, file_path_soft_link)
-        assert attr_util.check_ls_case_sensitivity(
-            client1, os.path.join(soft_link_1, file_name)
-        )
-        assert attr_util.check_ls_case_sensitivity(
-            client1, os.path.join(soft_link_2, file_name)
-        )
-
-        log.info(
-            "Creating a file in the soft link 2 and validating the source directory & soft link 1"
-        )
-
-        file_name_2 = "step-12-file-2.txt"
-        file_path_soft_link_2 = attr_util.create_file(
-            client1, os.path.join(soft_link_2, file_name_2)
-        )
-
-        assert attr_util.check_if_file_exists(client1, file_path_soft_link_2)
-        assert attr_util.check_if_file_exists(
-            client1, os.path.join(soft_link_1, file_name)
-        )
-        assert attr_util.check_if_file_exists(
-            client1, os.path.join(soft_link_2, file_name)
-        )
-
-        assert attr_util.check_ls_case_sensitivity(client1, file_path_soft_link_2)
-        assert attr_util.check_ls_case_sensitivity(
-            client1, os.path.join(soft_link_1, file_name)
-        )
-        assert attr_util.check_ls_case_sensitivity(
-            client1, os.path.join(soft_link_2, file_name)
-        )
-
-        log.info("** Cleanup of Link ** ")
-        assert attr_util.delete_links(client1, soft_link_1)
-        assert attr_util.delete_links(client1, soft_link_2)
-
-        log.info(
-            "Passed: Creation of softlink for File and validation of the attribute"
-        )
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------------------"
-            "\n   Usecase 13:Create hard link for File and validate the attribute               "
-            "\n---------------***************---------------------------------------------------"
-        )
-
-        log.info("Creating a file in the source dir and validating the hard link 1")
-
-        dir_13_parent = os.path.join(fuse_mounting_dir, "step-13-parent-dir")
-        file_name_1 = "File-1.log"
-        dir_13_child_file = os.path.join(dir_13_parent, file_name_1)
-        dir_13_link_same_config = os.path.join(
-            fuse_mounting_dir, "step_13_link_same_config"
-        )
-        dir_13_link_diff_config = os.path.join(
-            fuse_mounting_dir, "step_13_link_diff_config"
-        )
-
-        attr_util.create_directory(client1, dir_13_parent)
-        attr_util.create_directory(client1, dir_13_link_same_config)
-        attr_util.create_directory(client1, dir_13_link_diff_config)
-
-        attr_util.set_attributes(
-            client1, dir_13_parent, casesensitive=0, normalization="nfc"
-        )
-
-        attr_util.create_file(client1, dir_13_child_file)
-
-        charmap = attr_util.get_charmap(client1, dir_13_parent)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        log.info(
-            "** Creating hard link in the folder where charmap exist with the same config **"
-        )
-
-        attr_util.set_attributes(
-            client1, dir_13_link_same_config, casesensitive=0, normalization="nfc"
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_13_link_same_config)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfc"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        hard_link_1 = os.path.join(dir_13_link_same_config, file_name_1)
-        attr_util.create_links(client1, dir_13_child_file, hard_link_1, "hard")
-
-        # Validation
-        assert attr_util.check_ls_case_sensitivity(client1, hard_link_1)
-
-        log.info(
-            "** Creating hard link in the folder where charmap exist with different config **"
-        )
-
-        attr_util.set_attributes(
-            client1, dir_13_link_diff_config, casesensitive=1, normalization="nfd"
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_13_link_diff_config)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        hard_link_2 = os.path.join(dir_13_link_diff_config, file_name_1)
-        attr_util.create_links(client1, dir_13_child_file, hard_link_2, "hard")
-
-        # Validation
-        try:
-            assert attr_util.check_ls_case_sensitivity(client1, hard_link_2)
-            log.error("Failed: Expected to fail when case sensitivity is set to True")
-            return 1
-        except Exception:
-            log.info("Passed: Failed as expected when case sensitivity is set to True")
-
-        log.info(
-            "Passed: Creation of hardlink for File and validation of the attribute"
-        )
-
-        log.info(
-            "\n"
-            "\n---------------***************------------------------------------------------------"
-            "\n  Usecase 14 : Create subvolume with non-default subvolume group and mount using FUSE"
-            "\n---------------***************------------------------------------------------------"
-        )
-
-        dir_path = os.path.join(fuse_mounting_dir_14, "step-14")
-        attr_util.create_directory(client1, dir_path)
-
-        norm_type = "nfkd"
-        attr_util.set_attributes(
-            client1, dir_path, casesensitive=0, normalization=norm_type
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_path)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == norm_type
-            and charmap.get("encoding") == "utf8"
-        )
-
-        unicode_name = attr_util.generate_random_unicode_names()[0]
-        log.info("Unicode Dir Name: %s", unicode_name)
-
-        child_dir_path = os.path.join(dir_path, unicode_name)
-        rel_child_dir = os.path.relpath(child_dir_path, fuse_mounting_dir_14)
-
-        # Removing the first slash for the subvolumes. Need to check
-        actual_child_dir_root = os.path.join(
-            subvol_path.strip().lstrip("/"), rel_child_dir.split("/")[0]
-        )
-
-        attr_util.create_directory(client1, child_dir_path)
-        charmap = attr_util.get_charmap(client1, child_dir_path)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == norm_type
-            and charmap.get("encoding") == "utf8"
-        )
-
-        assert attr_util.validate_normalization(
-            client1,
-            fs_name,
-            actual_child_dir_root,
-            unicode_name,
-            norm_type.upper(),
-            casesensitive=False,
-        )
-
-        log.info(
-            "Validating alternate name for %s",
-            os.path.join(actual_child_dir_root, unicode_name),
-        )
-        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-        if not attr_util.validate_alternate_name(
-            alter_dict,
-            os.path.join(actual_child_dir_root, unicode_name),
-            norm_type.upper(),
-            casesensitive=False,
-        ):
-            log.error("Validation failed for alternate name")
-            return 1
-
-        assert attr_util.check_ls_case_sensitivity(client1, child_dir_path)
-
-        log.info(
-            "Passed: Validated subvolume with non-default sub volume group and mount using FUSE"
-        )
-
-        log.info(
-            "\n"
-            "\n---------------***************---------------------------------------"
-            "\n  Usecase 15 : Create subvolume in default group and mount using FUSE"
-            "\n---------------***************---------------------------------------"
-        )
-
-        dir_path = os.path.join(fuse_mounting_dir_15, "step-15")
-        attr_util.create_directory(client1, dir_path)
-
-        for attribute in ["casesensitive", "normalization", "encoding"]:
-            attr_util.remove_attributes(client1, dir_path, attribute)
-
-        charmap = attr_util.get_charmap(client1, dir_path)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        unicode_name = attr_util.generate_random_unicode_names()[0]
-        log.info("Unicode Dir Name: %s", unicode_name)
-
-        child_dir_path = os.path.join(dir_path, unicode_name)
-        rel_child_dir = os.path.relpath(child_dir_path, fuse_mounting_dir_15)
-
-        # Removing the first slash for the subvolumes. Need to check
-        actual_child_dir_root = os.path.join(
-            subvol_path_2.strip().lstrip("/"), rel_child_dir.split("/")[0]
-        )
-
-        attr_util.create_directory(client1, child_dir_path)
-        charmap = attr_util.get_charmap(client1, child_dir_path)
-        assert (
-            charmap.get("casesensitive") is True
-            and charmap.get("normalization") == "nfd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        assert attr_util.validate_normalization(
-            client1,
-            fs_name,
-            actual_child_dir_root,
-            unicode_name,
-            charmap.get("normalization").upper(),
-        )
-
-        log.info(
-            "Validating alternate name for %s",
-            os.path.join(actual_child_dir_root, unicode_name),
-        )
-        alter_dict = attr_util.fetch_alternate_name(client1, fs_name, "/")
-        if not attr_util.validate_alternate_name(
-            alter_dict,
-            os.path.join(actual_child_dir_root, unicode_name),
-            charmap.get("normalization").upper(),
-        ):
-            log.error("Validation failed for alternate name")
-            return 1
+                continue
 
         try:
-            assert attr_util.check_ls_case_sensitivity(client1, child_dir_path)
-            log.error("Failed: Expected to fail if case sensitivity is True")
-            return 1
-        except Exception as e:
             log.info(
-                "Passed: Expected to fail if case sensitivity is True: {}".format(
-                    str(e)
-                )
+                "\n"
+                "\n---------------***************---------------------"
+                "\nUsecase 1: Set casesensitivity for a new directory "
+                "\n---------------***************---------------------"
+            )
+            test_case_sensitivity()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\n     Usecase 2: Allow conflicting names in sensitive mode        "
+                "\n---------------***************-----------------------------------"
+            )
+            conflicting_directories()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\n       Usecase 3: Check the default value                        "
+                "\n---------------***************-----------------------------------"
             )
 
-        log.info("Passed: Validated subvolume in default group and mount using FUSE")
+            check_default_value()
 
-        log.info("*** Case Sensitivity: Functional Workflow completed ***")
-        return 0
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------------"
+                "\n   Usecase 4: Validate subdirectory inheritance, special character dir     "
+                "\n              and validate normalization with case sensitive True          "
+                "\n---------------***************---------------------------------------------"
+            )
+            sub_directory_inheritance_case_True()
 
-    except Exception as e:
-        log.error("Test execution failed: {}".format(str(e)))
-        log.error(traceback.format_exc())
-        return 1
-
-    finally:
-        log.info(
-            "\n"
-            "\n---------------***************----------------------------------------"
-            "\n                 Cleanup                                              "
-            "\n---------------***************----------------------------------------"
-        )
-        for mount_dir in [
-            fuse_mounting_dir,
-            fuse_mounting_dir_14,
-            fuse_mounting_dir_15,
-        ]:
-            fs_util.client_clean_up(
-                "umount", fuse_clients=[client1], mounting_dir=mount_dir
+            log.info(
+                "\n"
+                "\n---------------***************----------------------------------------"
+                "\n    Usecase 5: Set empty normalisation and encoding                   "
+                "\n               and ensure it fetches default value and gets inherited "
+                "\n---------------***************----------------------------------------"
             )
 
-        fs_util.remove_fs(client1, fs_name)
+            test_empty_normalization_and_encoding_inheritance()
+
+            log.info(
+                "\n"
+                "\n---------------***************---------------------"
+                "\nUsecase 6: Set normalization for a new directory   "
+                "\n---------------***************---------------------"
+            )
+            test_directory_normalization()
+
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------------"
+                "\n   Usecase 7: Validate subdirectory inheritance, special character dir     "
+                "\n              and validate normalization with case sensitive False         "
+                "\n---------------***************---------------------------------------------"
+            )
+            test_subdirectory_inheritance_special_chars()
+
+            # # Able to set the charmap attribute when the snap folder exists
+            # # Discussing with Dev. Will map the BZ accordingly
+            # # Commenting for now since this is failing
+            # log.info(
+            #     "\n"
+            #     "\n---------------***************---------------------------------------------"
+            #     "\n   Usecase 8: Validate snapshot functionality after setting the attribute  "
+            #     "\n---------------***************---------------------------------------------"
+            # )
+            # test_snapshot_functionality_with_attributes()
+
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------------"
+                "\n   Usecase 9: Renaming the directory and validate the attribute            "
+                "\n---------------***************---------------------------------------------"
+            )
+            test_directory_rename_attribute_validation()
+
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------------"
+                "\n   Usecase 10: Create softlink for dir and validate the attribute          "
+                "\n---------------***************---------------------------------------------"
+            )
+            test_softlink_attribute_validation()
+
+            log.info(
+                "\n"
+                "\n---------------***************--------------------------------------------------"
+                "\nUsecase 11:Create softlink for dir, make modification and validate the attribute"
+                "\n---------------***************--------------------------------------------------"
+            )
+            test_softlink_modification_attribute_validation()
+
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------------------"
+                "\nUsecase 12:Create softlink for File  and validate the attribute                  "
+                "\n---------------***************---------------------------------------------------"
+            )
+            test_softlink_file_attribute_validation()
+
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------------------"
+                "\n   Usecase 13:Create hard link for File and validate the attribute               "
+                "\n---------------***************---------------------------------------------------"
+            )
+            test_hardlink_file_attribute_validation()
+
+            log.info(
+                "\n"
+                "\n---------------***************------------------------------------------------------"
+                "\n  Usecase 14 : Create subvolume with non-default subvolume group and mount using FUSE"
+                "\n---------------***************------------------------------------------------------"
+            )
+            test_subvolume_non_default_group_fuse_mount()
+            log.info(
+                "\n"
+                "\n---------------***************---------------------------------------"
+                "\n  Usecase 15 : Create subvolume in default group and mount using FUSE"
+                "\n---------------***************---------------------------------------"
+            )
+            test_subvolume_default_group_fuse_mount()
+
+        except Exception as e:
+            log.error("Test execution failed: {}".format(str(e)))
+            log.error(traceback.format_exc())
+            return 1
+
+        finally:
+            log.info(
+                "\n"
+                "\n---------------***************----------------------------------------"
+                "\n                 Cleanup                                              "
+                "\n---------------***************----------------------------------------"
+            )
+
+            for mount_dir in [
+                fuse_mounting_dir,
+                fuse_mounting_dir_14,
+                fuse_mounting_dir_15,
+            ]:
+                if mount_type == "fuse":
+                    fs_util.client_clean_up(
+                        "umount", fuse_clients=[client1], mounting_dir=mount_dir
+                    )
+                elif mount_type == "nfs":
+                    fs_util.client_clean_up(
+                        "umount", kernel_clients=[client1], mounting_dir=mount_dir
+                    )
+
+                    cleanup_nfs_params = {
+                        fuse_mounting_dir: "binding",
+                        fuse_mounting_dir_14: "binding_uc_14",
+                        fuse_mounting_dir_15: "binding_uc_15",
+                    }
+
+                    fs_util.remove_nfs_export(
+                        client1,
+                        nfs_params.get("nfs_cluster_name"),
+                        nfs_params.get(cleanup_nfs_params[mount_dir]),
+                    )
+
+                elif mount_type == "smb":
+                    client1.exec_command(
+                        sudo=True,
+                        cmd=f"rm -rf {mount_dir}",
+                    )
+                    client1.exec_command(
+                        sudo=True,
+                        cmd=f"umount {mount_dir}",
+                    )
+                    common_util.smb_cleanup(
+                        smb_params.get("installer"),
+                        smb_params.get("smb_shares"),
+                        smb_params.get("smb_cluster_id"),
+                    )
+
+            fs_util.remove_nfs_cluster(client1, nfs_params.get("nfs_cluster_name"))
+            fs_util.remove_fs(client1, fs_name)
+
+    return 0

--- a/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_negative.py
+++ b/tests/cephfs/cephfs_case_sensitivity/case_sensitivity_negative.py
@@ -6,446 +6,540 @@ import traceback
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.lib.cephfs_attributes_lib import CephFSAttributeUtilities
+from tests.cephfs.lib.cephfs_common_lib import CephFSCommonUtils
 from utility.log import Log
 
 log = Log(__name__)
 
 
-def run(ceph_cluster, **kw):
-    try:
-        test_data = kw.get("test_data")
-        fs_util = FsUtils(ceph_cluster, test_data=test_data)
-        attr_util = CephFSAttributeUtilities(ceph_cluster)
-        config = kw.get("config")
-        clients = ceph_cluster.get_ceph_objects("client")
-        build = config.get("build", config.get("rhbuild"))
-        fs_util.prepare_clients(clients, build)
-        fs_util.auth_list(clients)
-        log.info("checking Pre-requisites")
-        if len(clients) < 1:
-            log.error(
-                "This test requires minimum 1 client nodes. This has only {} clients".format(
-                    len(clients)
-                )
-            )
-            return 1
-        client1 = clients[0]
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------"
-            "\n  Pre-Requisite : Create file system and mount using FUSE  "
-            "\n---------------***************-----------------------------"
-        )
-
-        fs_name = "case-sensitivity-negative-fs-1"
-        fs_util.create_fs(client1, fs_name)
-        fs_util.wait_for_mds_process(client1, fs_name)
-
-        mounting_dir = "".join(
-            random.choice(string.ascii_lowercase + string.digits)
-            for _ in list(range(10))
-        )
-        fuse_mounting_dir = "/mnt/cephfs_fuse_{}/".format(mounting_dir)
-        fs_util.fuse_mount(
-            [client1], fuse_mounting_dir, extra_params=" --client_fs {}".format(fs_name)
-        )
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\nUsecase 1: Fail to set casesensitivity on a directory with files "
-            "\n---------------***************-----------------------------------"
-        )
-        dir_with_files = os.path.join(fuse_mounting_dir, "step-1")
-        attr_util.create_directory(client1, dir_with_files)
-        list_filenames = ["file.txt", ".tmp"]
-        for fnames in list_filenames:
-            file_name = attr_util.create_file(
-                client1, os.path.join(dir_with_files, fnames)
-            )
-            try:
-                attr_util.set_attributes(client1, dir_with_files, casesensitive=1)
-                log.error("Failed: Attribute was set despite files present")
-                return 1
-            except CommandFailed:
-                log.info("Passed: Failed to set attribute as expected")
-                log.info("Deleting the file {}".format(file_name))
-                attr_util.delete_file(client1, file_name)
-                attr_util.set_attributes(client1, dir_with_files, casesensitive=0)
-                assert (
-                    attr_util.get_charmap(client1, dir_with_files).get("casesensitive")
-                    is False
-                )
-                log.info(
-                    "Passed: Attribute set successfully on emptied directory for {}".format(
-                        dir_with_files
-                    )
-                )
-            finally:
-                attr_util.delete_file(client1, os.path.join(dir_with_files, fnames))
-
-        log.info("Passed: Setting casesensitivity on a directory with files")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\nUsecase 2: Fail to create conflicting names in insensitive mode  "
-            "\n---------------***************-----------------------------------"
-        )
-        attr_util.create_directory(client1, os.path.join(dir_with_files, "Dir1"))
-        try:
-            attr_util.create_directory(client1, os.path.join(dir_with_files, "dir1"))
-            log.error("Failed: Allowed conflicting directory names")
-            return 1
-        except CommandFailed:
-            log.info("Passed: Conflict prevented as expected")
-            attr_util.delete_directory(
-                client1, os.path.join(dir_with_files, "Dir1"), recursive=True
-            )
-
-        log.info("Passed: Creating conflicting names in insensitive mode")
-
-        log.info(
-            "\n"
-            "\n---------------***************----------------------------------------"
-            "\n    Usecase 3 : Remove casesensitive, normalisation and encoding      "
-            "\n              and ensure it fetches default value and gets inherited  "
-            "\n---------------***************----------------------------------------"
-        )
-        dir_step_3 = os.path.join(fuse_mounting_dir, "step-3")
-
-        for attribute in ["casesensitive", "normalization", "encoding"]:
-            log.info("Removing {} and validating the default values".format(attribute))
-            attr_util.create_directory(client1, dir_step_3)
-
-            try:
-                attr_util.get_charmap(client1, dir_step_3)
-                log.error(
-                    "Charmap expected to fail for new directory when it's parent directory does not have charmap"
-                )
-            except ValueError:
-                log.info(
-                    "Get Charmap expected to fail when there it's a new folder and "
-                    "parent directory does not have charmap set"
-                )
-
-            attr_util.remove_attributes(client1, dir_step_3, attribute)
-
-            assert (
-                attr_util.get_charmap(client1, dir_step_3).get("casesensitive") is True
-            )
-            assert (
-                attr_util.get_charmap(client1, dir_step_3).get("normalization") == "nfd"
-            )
-            assert attr_util.get_charmap(client1, dir_step_3).get("encoding") == "utf8"
-
-            dir_step_3a = os.path.join(dir_step_3, "step-3a")
-            attr_util.create_directory(client1, dir_step_3a)
-
-            assert (
-                attr_util.get_charmap(client1, dir_step_3a).get("casesensitive") is True
-            )
-            assert (
-                attr_util.get_charmap(client1, dir_step_3a).get("normalization")
-                == "nfd"
-            )
-            assert attr_util.get_charmap(client1, dir_step_3a).get("encoding") == "utf8"
-
-            attr_util.delete_directory(client1, dir_step_3a, recursive=True)
-            attr_util.delete_directory(client1, dir_step_3, recursive=True)
-
-        log.info("Passed: Removed casesensitive, normalisation and encoding")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\nUsecase 4: Fail to set normalization on a directory with files   "
-            "\n---------------***************-----------------------------------"
-        )
-        dir_with_files = os.path.join(fuse_mounting_dir, "step-4")
-        attr_util.create_directory(client1, dir_with_files)
-        list_filenames = ["file.txt", ".tmp"]
-        for fnames in list_filenames:
-            file_name = attr_util.create_file(
-                client1, os.path.join(dir_with_files, fnames)
-            )
-            try:
-                attr_util.set_attributes(client1, dir_with_files, normalization="nfkc")
-                log.error("Failed: Attribute was set despite files present")
-                return 1
-            except CommandFailed:
-                log.info("Passed: Failed to set attribute as expected")
-                log.info("Deleting the file {}".format(file_name))
-                attr_util.delete_file(client1, file_name)
-                attr_util.set_attributes(client1, dir_with_files, normalization="nfkc")
-                assert (
-                    attr_util.get_charmap(client1, dir_with_files).get("normalization")
-                    == "nfkc"
-                )
-                log.info(
-                    "Passed: Attribute set successfully on emptied directory for {}".format(
-                        dir_with_files
-                    )
-                )
-            finally:
-                attr_util.delete_file(client1, os.path.join(dir_with_files, fnames))
-
-        log.info("Passed: Setting normalization on a directory with files")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\nUsecase 5: Fail to create file with unsupported encoding type    "
-            "\n---------------***************-----------------------------------"
-        )
-        dir_with_files = os.path.join(fuse_mounting_dir, "step-5")
-        attr_util.create_directory(client1, dir_with_files)
-        fnames = "file.log"
-        encoding_value = random.choice(["ASCII", "utf16", "utf32"])
+def test_fail_set_casesensitivity_with_files():
+    global dir_with_files
+    dir_with_files = os.path.join(fuse_mounting_dir, "step-1")
+    attr_util.create_directory(client1, dir_with_files)
+    list_filenames = ["file.txt", ".tmp"]
+    for fnames in list_filenames:
         file_name = attr_util.create_file(client1, os.path.join(dir_with_files, fnames))
         try:
-            attr_util.set_attributes(client1, dir_with_files, encoding=encoding_value)
+            attr_util.set_attributes(client1, dir_with_files, casesensitive=1)
             log.error("Failed: Attribute was set despite files present")
             return 1
         except CommandFailed:
             log.info("Passed: Failed to set attribute as expected")
             log.info("Deleting the file {}".format(file_name))
             attr_util.delete_file(client1, file_name)
-            attr_util.set_attributes(client1, dir_with_files, encoding=encoding_value)
+            attr_util.set_attributes(client1, dir_with_files, casesensitive=0)
             assert (
-                attr_util.get_charmap(client1, dir_with_files).get("encoding")
-                == encoding_value
+                attr_util.get_charmap(client1, dir_with_files).get("casesensitive")
+                is False
             )
-            try:
-                file_name = attr_util.create_file(
-                    client1, os.path.join(dir_with_files, fnames)
-                )
-                log.error("Failed: Attribute was set despite unsupported value")
-                return 1
-            except CommandFailed:
-                log.info(
-                    "Passed: Failed to create file under unsupported encoding type"
-                )
-
-        log.info("Passed: Creating file with unsupported encoding type")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\n     Usecase 6: Setting invalid value for normalization          "
-            "\n---------------***************-----------------------------------"
-        )
-        dir_6 = os.path.join(fuse_mounting_dir, "step-6")
-        attr_util.create_directory(client1, dir_6)
-        norm_invalid_name = "".join(
-            random.choices(string.ascii_letters, k=random.choice([3, 4]))
-        )
-
-        attr_util.set_attributes(client1, dir_6, normalization=norm_invalid_name)
-        assert (
-            attr_util.get_charmap(client1, dir_6).get("normalization")
-            == norm_invalid_name
-        )
-        try:
-            attr_util.create_special_character_directories(client1, dir_6)
-            log.error("Expected to fail creating directories but successful")
-            return 1
-        except CommandFailed:
-            log.info("Passed: Failed as Expected")
-
-        log.info("Passed: Setting invalid value for normalization")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\nUsecase 7: Fail to remove charmap on a directory with files      "
-            "\n---------------***************-----------------------------------"
-        )
-        dir_with_files = os.path.join(fuse_mounting_dir, "step-7")
-        attr_util.create_directory(client1, dir_with_files)
-        attr_util.set_attributes(
-            client1, dir_with_files, casesensitive=0, normalization="nfkc"
-        )
-        assert (
-            attr_util.get_charmap(client1, dir_with_files).get("casesensitive") is False
-        )
-        assert (
-            attr_util.get_charmap(client1, dir_with_files).get("normalization")
-            == "nfkc"
-        )
-        assert attr_util.get_charmap(client1, dir_with_files).get("encoding") == "utf8"
-
-        supported_attributes = ["casesensitive", "normalization", "encoding", "charmap"]
-        for attribute in supported_attributes:
             log.info(
-                "Trying to remove attribute {} for the directory {}".format(
-                    attribute, dir_with_files
+                "Passed: Attribute set successfully on emptied directory for {}".format(
+                    dir_with_files
                 )
             )
-            file_name = attr_util.create_file(
-                client1, os.path.join(dir_with_files, "file1.log")
-            )
-            try:
-                attr_util.remove_attributes(client1, dir_with_files, attribute)
-                log.error("Failed: Attribute was removed despite files present")
-                return 1
-            except CommandFailed:
-                log.info("Passed: Failed to remove attribute as expected")
-                log.info("Deleting the file {}".format(file_name))
-                attr_util.delete_file(client1, file_name)
+        finally:
+            attr_util.delete_file(client1, os.path.join(dir_with_files, fnames))
 
-        log.info("Passed: Removing charmap on a directory with files")
+    log.info("Passed: Setting casesensitivity on a directory with files")
 
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\n  Usecase 8: Kernel mount should fail setting the attributes     "
-            "\n---------------***************-----------------------------------"
+
+def test_fail_create_conflicting_names_insensitive_mode():
+    attr_util.create_directory(client1, os.path.join(dir_with_files, "Dir1"))
+    try:
+        attr_util.create_directory(client1, os.path.join(dir_with_files, "dir1"))
+        log.error("Failed: Allowed conflicting directory names")
+        return 1
+    except CommandFailed:
+        log.info("Passed: Conflict prevented as expected")
+        attr_util.delete_directory(
+            client1, os.path.join(dir_with_files, "Dir1"), recursive=True
         )
 
-        log.info("Mount file system on Kernel Client")
-        kernel_mount_dir = "/mnt/cephfs_kernel_{}_1/".format(mounting_dir)
-        mon_node_ips = fs_util.get_mon_node_ips()
+    log.info("Passed: Creating conflicting names in insensitive mode")
 
-        fs_util.kernel_mount(
-            [client1],
-            kernel_mount_dir,
-            ",".join(mon_node_ips),
-            extra_params=",fs={}".format(fs_name),
-        )
 
-        dir_path = os.path.join(kernel_mount_dir, "step-8")
-        attr_util.create_directory(client1, dir_path)
+def test_remove_attributes_and_inherit_defaults():
+    dir_step_3 = os.path.join(fuse_mounting_dir, "step-3")
 
-        attr_util.set_attributes(
-            client1, dir_path, casesensitive=0, normalization="nfkd"
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_path)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfkd"
-            and charmap.get("encoding") == "utf8"
-        )
+    for attribute in ["casesensitive", "normalization", "encoding"]:
+        log.info("Removing {} and validating the default values".format(attribute))
+        attr_util.create_directory(client1, dir_step_3)
 
         try:
-            child_dir_path = os.path.join(dir_path, "step-8-child")
-            attr_util.create_directory(client1, child_dir_path)
-            log.error("Failed: Created child directory under kernel mount")
-            return 1
-        except CommandFailed:
-            log.info("Passed: Failed to create child directory as expected")
-
-        log.info("Cleaning up kernel mount")
-
-        fs_util.client_clean_up(
-            "umount",
-            kernel_clients=[client1],
-            mounting_dir=kernel_mount_dir,
-            retain_keyring=True,
-        )
-
-        log.info("Passed: Kernel mount should fail setting the attributes")
-
-        log.info(
-            "\n"
-            "\n---------------***************-----------------------------------"
-            "\n  Usecase 9: Create client users without p flag and validate     "
-            "\n---------------***************-----------------------------------"
-        )
-
-        log.info("Create directories and set attributes")
-        dir_path = os.path.join(fuse_mounting_dir, "step-9")
-        attr_util.create_directory(client1, dir_path)
-
-        attr_util.set_attributes(
-            client1, dir_path, casesensitive=0, normalization="nfkd"
-        )
-
-        charmap = attr_util.get_charmap(client1, dir_path)
-        assert (
-            charmap.get("casesensitive") is False
-            and charmap.get("normalization") == "nfkd"
-            and charmap.get("encoding") == "utf8"
-        )
-
-        log.info("Create client user without p flag and validate attributes")
-
-        new_client1_name = client1.node.hostname + "_"
-        new_mount_dir = "/mnt/{}new/".format(new_client1_name)
-        attr_util.create_directory(client1, new_mount_dir, force=True)
-
-        rc1 = fs_util.auth_list(
-            [client1],
-            path="",
-            permission="rw",
-            mds=True,
-        )
-        if rc1 != 0:
-            log.error("auth list failed")
-            return 1
-
-        fs_util.fuse_mount(
-            [client1],
-            new_mount_dir,
-            new_client_hostname=new_client1_name,
-            extra_params=" --client_fs {}".format(fs_name),
-        )
-
-        new_dir_path = os.path.join(new_mount_dir, "step-9")
-
-        try:
-            charmap = attr_util.get_charmap(client1, new_dir_path)
-            assert (
-                charmap.get("casesensitive") is False
-                and charmap.get("normalization") == "nfkd"
-                and charmap.get("encoding") == "utf8"
-            )
-            log.info("Validated attributes for client user without p flag")
-        except AssertionError:
+            attr_util.get_charmap(client1, dir_step_3)
             log.error(
-                "Failed: Attributes validation failed for client user without p flag"
+                "Charmap expected to fail for new directory when it's parent directory does not have charmap"
             )
-            return 1
+        except ValueError:
+            log.info(
+                "Get Charmap expected to fail when there it's a new folder and "
+                "parent directory does not have charmap set"
+            )
 
+        attr_util.remove_attributes(client1, dir_step_3, attribute)
+
+        assert attr_util.get_charmap(client1, dir_step_3).get("casesensitive") is True
+        assert attr_util.get_charmap(client1, dir_step_3).get("normalization") == "nfd"
+        assert attr_util.get_charmap(client1, dir_step_3).get("encoding") == "utf8"
+
+        dir_step_3a = os.path.join(dir_step_3, "step-3a")
+        attr_util.create_directory(client1, dir_step_3a)
+
+        assert attr_util.get_charmap(client1, dir_step_3a).get("casesensitive") is True
+        assert attr_util.get_charmap(client1, dir_step_3a).get("normalization") == "nfd"
+        assert attr_util.get_charmap(client1, dir_step_3a).get("encoding") == "utf8"
+
+        attr_util.delete_directory(client1, dir_step_3a, recursive=True)
+        attr_util.delete_directory(client1, dir_step_3, recursive=True)
+
+    log.info("Passed: Removed casesensitive, normalisation and encoding")
+
+
+def test_fail_to_set_normalization_with_existing_files():
+    dir_with_files = os.path.join(fuse_mounting_dir, "step-4")
+    attr_util.create_directory(client1, dir_with_files)
+    list_filenames = ["file.txt", ".tmp"]
+    for fnames in list_filenames:
+        file_name = attr_util.create_file(client1, os.path.join(dir_with_files, fnames))
         try:
-            attr_util.set_attributes(
-                client1, new_dir_path, casesensitive=1, normalization="nfc"
-            )
-            log.error("Failed: Attribute was set when the user doesn't have p flag")
+            attr_util.set_attributes(client1, dir_with_files, normalization="nfkc")
+            log.error("Failed: Attribute was set despite files present")
             return 1
         except CommandFailed:
-            log.info(
-                "Passed: Failed to set attribute as expected for user without p flag"
+            log.info("Passed: Failed to set attribute as expected")
+            log.info("Deleting the file {}".format(file_name))
+            attr_util.delete_file(client1, file_name)
+            attr_util.set_attributes(client1, dir_with_files, normalization="nfkc")
+            assert (
+                attr_util.get_charmap(client1, dir_with_files).get("normalization")
+                == "nfkc"
             )
+            log.info(
+                "Passed: Attribute set successfully on emptied directory for {}".format(
+                    dir_with_files
+                )
+            )
+        finally:
+            attr_util.delete_file(client1, os.path.join(dir_with_files, fnames))
 
-        log.info("** Cleanup **")
-        fs_util.client_clean_up(
-            "umount", fuse_clients=[client1], mounting_dir=new_mount_dir
+    log.info("Passed: Setting normalization on a directory with files")
+
+
+def test_fail_to_create_file_with_unsupported_encoding():
+    dir_with_files = os.path.join(fuse_mounting_dir, "step-5")
+    attr_util.create_directory(client1, dir_with_files)
+    fnames = "file.log"
+    encoding_value = random.choice(["ASCII", "utf16", "utf32"])
+    file_name = attr_util.create_file(client1, os.path.join(dir_with_files, fnames))
+    try:
+        attr_util.set_attributes(client1, dir_with_files, encoding=encoding_value)
+        log.error("Failed: Attribute was set despite files present")
+        return 1
+    except CommandFailed:
+        log.info("Passed: Failed to set attribute as expected")
+        log.info("Deleting the file {}".format(file_name))
+        attr_util.delete_file(client1, file_name)
+        attr_util.set_attributes(client1, dir_with_files, encoding=encoding_value)
+        assert (
+            attr_util.get_charmap(client1, dir_with_files).get("encoding")
+            == encoding_value
         )
-        fs_util.auth_list([client1])
+        try:
+            file_name = attr_util.create_file(
+                client1, os.path.join(dir_with_files, fnames)
+            )
+            log.error("Failed: Attribute was set despite unsupported value")
+            return 1
+        except CommandFailed:
+            log.info("Passed: Failed to create file under unsupported encoding type")
 
+    log.info("Passed: Creating file with unsupported encoding type")
+
+
+def test_set_invalid_normalization_value():
+    dir_6 = os.path.join(fuse_mounting_dir, "step-6")
+    attr_util.create_directory(client1, dir_6)
+    norm_invalid_name = "".join(
+        random.choices(string.ascii_letters, k=random.choice([3, 4]))
+    )
+
+    attr_util.set_attributes(client1, dir_6, normalization=norm_invalid_name)
+    assert (
+        attr_util.get_charmap(client1, dir_6).get("normalization") == norm_invalid_name
+    )
+    try:
+        attr_util.create_special_character_directories(client1, dir_6)
+        log.error("Expected to fail creating directories but successful")
+        return 1
+    except CommandFailed:
+        log.info("Passed: Failed as Expected")
+
+    log.info("Passed: Setting invalid value for normalization")
+
+
+def test_fail_remove_charmap_with_files():
+    dir_with_files = os.path.join(fuse_mounting_dir, "step-7")
+    attr_util.create_directory(client1, dir_with_files)
+    attr_util.set_attributes(
+        client1, dir_with_files, casesensitive=0, normalization="nfkc"
+    )
+    assert attr_util.get_charmap(client1, dir_with_files).get("casesensitive") is False
+    assert attr_util.get_charmap(client1, dir_with_files).get("normalization") == "nfkc"
+    assert attr_util.get_charmap(client1, dir_with_files).get("encoding") == "utf8"
+
+    supported_attributes = ["casesensitive", "normalization", "encoding", "charmap"]
+    for attribute in supported_attributes:
         log.info(
-            "Passed: Creating client users without p flag and validating attributes"
+            "Trying to remove attribute {} for the directory {}".format(
+                attribute, dir_with_files
+            )
         )
+        file_name = attr_util.create_file(
+            client1, os.path.join(dir_with_files, "file1.log")
+        )
+        try:
+            attr_util.remove_attributes(client1, dir_with_files, attribute)
+            log.error("Failed: Attribute was removed despite files present")
+            return 1
+        except CommandFailed:
+            log.info("Passed: Failed to remove attribute as expected")
+            log.info("Deleting the file {}".format(file_name))
+            attr_util.delete_file(client1, file_name)
 
-        log.info("*** Case Sensitivity: Negative Workflow completed ***")
-        return 0
+    log.info("Passed: Removing charmap on a directory with files")
 
-    except Exception as e:
-        log.error("Test execution failed: {}".format(str(e)))
-        log.error(traceback.format_exc())
+
+def test_kernel_mount_fail_set_attributes():
+    log.info("Mount file system on Kernel Client")
+    kernel_mount_dir = "/mnt/cephfs_kernel_{}_1/".format(mounting_dir)
+    mon_node_ips = fs_util.get_mon_node_ips()
+
+    fs_util.kernel_mount(
+        [client1],
+        kernel_mount_dir,
+        ",".join(mon_node_ips),
+        extra_params=",fs={}".format(fs_name),
+    )
+
+    dir_path = os.path.join(kernel_mount_dir, "step-8")
+    attr_util.create_directory(client1, dir_path)
+
+    attr_util.set_attributes(client1, dir_path, casesensitive=0, normalization="nfkd")
+
+    charmap = attr_util.get_charmap(client1, dir_path)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfkd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    try:
+        child_dir_path = os.path.join(dir_path, "step-8-child")
+        attr_util.create_directory(client1, child_dir_path)
+        log.error("Failed: Created child directory under kernel mount")
+        return 1
+    except CommandFailed:
+        log.info("Passed: Failed to create child directory as expected")
+
+    log.info("Cleaning up kernel mount")
+
+    fs_util.client_clean_up(
+        "umount",
+        kernel_clients=[client1],
+        mounting_dir=kernel_mount_dir,
+        retain_keyring=True,
+    )
+
+    log.info("Passed: Kernel mount should fail setting the attributes")
+
+
+def test_create_client_users_without_p_flag():
+    log.info("Create directories and set attributes")
+    dir_path = os.path.join(fuse_mounting_dir, "step-9")
+    attr_util.create_directory(client1, dir_path)
+
+    attr_util.set_attributes(client1, dir_path, casesensitive=0, normalization="nfkd")
+
+    charmap = attr_util.get_charmap(client1, dir_path)
+    assert (
+        charmap.get("casesensitive") is False
+        and charmap.get("normalization") == "nfkd"
+        and charmap.get("encoding") == "utf8"
+    )
+
+    log.info("Create client user without p flag and validate attributes")
+
+    new_client1_name = client1.node.hostname + "_"
+    new_mount_dir = "/mnt/{}new/".format(new_client1_name)
+    attr_util.create_directory(client1, new_mount_dir, force=True)
+
+    rc1 = fs_util.auth_list(
+        [client1],
+        path="",
+        permission="rw",
+        mds=True,
+    )
+    if rc1 != 0:
+        log.error("auth list failed")
         return 1
 
-    finally:
-        log.info(
-            "\n"
-            "\n---------------***************----------------------------------------"
-            "\n                 Cleanup                                              "
-            "\n---------------***************----------------------------------------"
+    fs_util.fuse_mount(
+        [client1],
+        new_mount_dir,
+        new_client_hostname=new_client1_name,
+        extra_params=" --client_fs {}".format(fs_name),
+    )
+
+    new_dir_path = os.path.join(new_mount_dir, "step-9")
+
+    try:
+        charmap = attr_util.get_charmap(client1, new_dir_path)
+        assert (
+            charmap.get("casesensitive") is False
+            and charmap.get("normalization") == "nfkd"
+            and charmap.get("encoding") == "utf8"
         )
-        fs_util.client_clean_up(
-            "umount", fuse_clients=[client1], mounting_dir=fuse_mounting_dir
+        log.info("Validated attributes for client user without p flag")
+    except AssertionError:
+        log.error("Failed: Attributes validation failed for client user without p flag")
+        return 1
+
+    try:
+        attr_util.set_attributes(
+            client1, new_dir_path, casesensitive=1, normalization="nfc"
         )
-        fs_util.remove_fs(client1, fs_name)
+        log.error("Failed: Attribute was set when the user doesn't have p flag")
+        return 1
+    except CommandFailed:
+        log.info("Passed: Failed to set attribute as expected for user without p flag")
+
+    log.info("** Cleanup **")
+    fs_util.client_clean_up(
+        "umount", fuse_clients=[client1], mounting_dir=new_mount_dir
+    )
+    fs_util.auth_list([client1])
+
+    log.info("Passed: Creating client users without p flag and validating attributes")
+
+
+def run(ceph_cluster, **kw):
+    global fs_util, attr_util, client1, mounting_dir, fuse_mounting_dir, fs_name
+    test_data = kw.get("test_data")
+    fs_util = FsUtils(ceph_cluster, test_data=test_data)
+    common_util = CephFSCommonUtils(ceph_cluster)
+    attr_util = CephFSAttributeUtilities(ceph_cluster)
+    config = kw.get("config")
+    clients = ceph_cluster.get_ceph_objects("client")
+    build = config.get("build", config.get("rhbuild"))
+    ibm_build = config.get("ibm_build", False)
+    fs_util.prepare_clients(clients, build)
+    fs_util.auth_list(clients)
+    log.info("checking Pre-requisites")
+    if len(clients) < 1:
+        log.error(
+            "This test requires minimum 1 client nodes. This has only {} clients".format(
+                len(clients)
+            )
+        )
+        return 1
+    client1 = clients[0]
+
+    mount_type_list = ["fuse", "smb"]
+    for mount_type in mount_type_list:
+        try:
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------"
+                "\n  Pre-Requisite : Create file system and mount using {}    ".format(
+                    mount_type
+                )
+                + "\n---------------***************-----------------------------"
+            )
+
+            fs_name = "case-sensitivity-negative-fs-1"
+            fs_util.create_fs(client1, fs_name)
+            fs_util.wait_for_mds_process(client1, fs_name)
+
+            mounting_dir = "".join(
+                random.choice(string.ascii_lowercase + string.digits)
+                for _ in list(range(10))
+            )
+
+            fuse_mounting_dir = "/mnt/cephfs_fuse_{}/".format(mounting_dir)
+            if mount_type == "fuse":
+                log.info("*** Mounting via FUSE ***")
+                fs_util.fuse_mount(
+                    [client1],
+                    fuse_mounting_dir,
+                    extra_params=" --client_fs {}".format(fs_name),
+                )
+            elif mount_type == "nfs":
+                log.info("*** Mounting via nfs ***")
+                mds = fs_util.get_active_mdss(client1, fs_name)
+                active_mds_hostnames = [i.split(".")[1] for i in mds]
+                nfs_server_name = active_mds_hostnames[0]
+                nfs_params = {
+                    "nfs_cluster_name": "nfs-1",
+                    "nfs_server_name": nfs_server_name,
+                    "binding": "/export_binding1",
+                }
+
+                log.info("*** Mounting Base File System via {} ***".format(mount_type))
+                fuse_mounting_dir = common_util.setup_cephfs_mount(
+                    client1,
+                    fs_name,
+                    mount_type,
+                    nfs_server_name=nfs_params.get("nfs_server_name"),
+                    nfs_cluster_name=nfs_params.get("nfs_cluster_name"),
+                    binding=nfs_params.get("binding"),
+                )
+            elif mount_type == "smb":
+                if ibm_build:
+                    global smb_params
+                    log.info("*** Mounting via SMB ***")
+                    smb_params = {
+                        "smb_cluster_id": "smb-1",
+                        "smb_shares": ["share-1"],
+                    }
+
+                    fuse_mounting_dir = common_util.setup_cephfs_mount(
+                        client1,
+                        fs_util,
+                        fs_name,
+                        mount_type,
+                        smb_cluster_id=smb_params.get("smb_cluster_id"),
+                        smb_shares=smb_params.get("smb_shares"),
+                    )
+                    log.info("Mounting dir: {}".format(fuse_mounting_dir))
+                    common_util.setup_cephfs_mount(client1, fs_name, "smb")
+                else:
+                    log.info(
+                        "\n---------------***************-----------------------------"
+                        "\n  Current build is not IBM build, skipping SMB mount test."
+                        "\n---------------***************-----------------------------"
+                    )
+                    continue
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\nUsecase 1: Fail to set casesensitivity on a directory with files "
+                "\n---------------***************-----------------------------------"
+            )
+            test_fail_set_casesensitivity_with_files()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\nUsecase 2: Fail to create conflicting names in insensitive mode  "
+                "\n---------------***************-----------------------------------"
+            )
+            test_fail_create_conflicting_names_insensitive_mode()
+
+            log.info(
+                "\n"
+                "\n---------------***************----------------------------------------"
+                "\n    Usecase 3 : Remove casesensitive, normalisation and encoding      "
+                "\n              and ensure it fetches default value and gets inherited  "
+                "\n---------------***************----------------------------------------"
+            )
+            test_remove_attributes_and_inherit_defaults()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\nUsecase 4: Fail to set normalization on a directory with files   "
+                "\n---------------***************-----------------------------------"
+            )
+            test_fail_to_set_normalization_with_existing_files()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\nUsecase 5: Fail to create file with unsupported encoding type    "
+                "\n---------------***************-----------------------------------"
+            )
+            test_fail_to_create_file_with_unsupported_encoding()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\n     Usecase 6: Setting invalid value for normalization          "
+                "\n---------------***************-----------------------------------"
+            )
+            test_set_invalid_normalization_value()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\nUsecase 7: Fail to remove charmap on a directory with files      "
+                "\n---------------***************-----------------------------------"
+            )
+            test_fail_remove_charmap_with_files()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\n  Usecase 8: Kernel mount should fail setting the attributes     "
+                "\n---------------***************-----------------------------------"
+            )
+            test_kernel_mount_fail_set_attributes()
+
+            log.info(
+                "\n"
+                "\n---------------***************-----------------------------------"
+                "\n  Usecase 9: Create client users without p flag and validate     "
+                "\n---------------***************-----------------------------------"
+            )
+            test_create_client_users_without_p_flag()
+
+            log.info("*** Case Sensitivity: Negative Workflow completed ***")
+
+        except Exception as e:
+            log.error("Test execution failed: {}".format(str(e)))
+            log.error(traceback.format_exc())
+            return 1
+
+        finally:
+            log.info(
+                "\n"
+                "\n---------------***************----------------------------------------"
+                "\n                 Cleanup                                              "
+                "\n---------------***************----------------------------------------"
+            )
+            if mount_type == "fuse":
+                fs_util.client_clean_up(
+                    "umount", fuse_clients=[client1], mounting_dir=fuse_mounting_dir
+                )
+            elif mount_type == "nfs":
+                fs_util.client_clean_up(
+                    "umount", kernel_clients=[client1], mounting_dir=fuse_mounting_dir
+                )
+
+                fs_util.remove_nfs_export(
+                    client1,
+                    nfs_params.get("nfs_cluster_name"),
+                    nfs_params.get("binding"),
+                )
+
+                fs_util.remove_nfs_cluster(client1, nfs_params.get("nfs_cluster_name"))
+
+            elif mount_type == "smb":
+                if ibm_build:
+                    client1.exec_command(
+                        sudo=True,
+                        cmd=f"rm -rf {fuse_mounting_dir}",
+                    )
+                    client1.exec_command(
+                        sudo=True,
+                        cmd=f"umount {fuse_mounting_dir}",
+                    )
+                    common_util.smb_cleanup(
+                        smb_params.get("installer"),
+                        smb_params.get("smb_shares"),
+                        smb_params.get("smb_cluster_id"),
+                    )
+
+            fs_util.remove_fs(client1, fs_name)
+
+    return 0

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -1216,6 +1216,8 @@ class FsUtils(object):
             tuple: A tuple containing the Ceph command output and command return code.
         """
         nfs_cmd = f"ceph nfs cluster create {nfs_cluster_name}"
+        if kwargs.get("nfs_server_name"):
+            nfs_cmd += f" {kwargs.get('nfs_server_name')}"
         if kwargs.get("placement"):
             nfs_cmd += f" --placement '{kwargs.get('placement')}'"
 

--- a/tests/cephfs/lib/cephfs_common_lib.py
+++ b/tests/cephfs/lib/cephfs_common_lib.py
@@ -5,12 +5,18 @@ This is cephfs utilsV1 extension to include further common reusable methods for 
 
 import datetime
 import random
+import secrets
 import string
 import time
 
 from ceph.ceph import CommandFailed
 from tests.cephfs.cephfs_utilsV1 import FsUtils
 from tests.cephfs.cephfs_volume_management import wait_for_process
+from tests.smb.smb_operations import (
+    deploy_smb_service_imperative,
+    smb_cifs_mount,
+    smbclient_check_shares,
+)
 from utility.log import Log
 
 log = Log(__name__)
@@ -250,3 +256,175 @@ class CephFSCommonUtils(FsUtils):
             log.error("Cleanup failed with error : %s", ex)
             return 1
         return 0
+
+    def generate_mount_dir(self):
+        """Generate a random mounting directory name."""
+        return "".join(
+            random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
+        )
+
+    def setup_cephfs_mount(self, client, fs_name, mount_type, **kwargs):
+        """
+        Set up a CephFS mount using the specified mount type.
+
+        Args:
+            client: The client node where the CephFS will be mounted.
+            fs_name (str): The name of the Ceph file system.
+            mount_type (str): The type of mount. Options:
+                - "fuse": Mount using FUSE.
+                - "smb": Mount using SMB.
+                - "nfs": Mount using NFS.
+            **kwargs: Additional optional parameters based on mount type:
+
+                For "fuse":
+                    - subvolume_name (str, optional): Name of the subvolume.
+                    - subvolume_group (str, optional): Name of the subvolume group.
+
+                For "smb":
+                    - smb_subvolume_group (str, optional): SMB subvolume group. Default is "smb".
+                    - smb_subvolumes (list, optional): List of SMB subvolumes. Default is ["sv1"].
+                    - smb_subvolume_mode (str, optional): Subvolume mode. Default is "0777".
+                    - smb_cluster_id (str, optional): SMB cluster ID. Default is "smb1".
+                    - auth_mode (str, optional): Authentication mode. Default is "user".
+                    - domain_realm (str, optional): Kerberos domain realm (if applicable).
+                    - custom_dns (str, optional): Custom DNS for SMB.
+                    - smb_user_name (str, optional): SMB username. Default is "user1".
+                    - smb_user_password (str, optional): SMB user password. Default is "passwd".
+                    - smb_shares (list, optional): SMB shares to mount. Default is ["share1", "share2"].
+                    - path (str, optional): Path to mount the SMB share. Default is "/".
+                    - cifs_mount_point (str, optional): CIFS mount point. Default is "/mnt/smb".
+
+                For "nfs":
+                    - nfs_cluster_name (str, optional): NFS cluster name. Default is "nfs-cluster-1".
+                    - nfs_server_name (str, optional): NFS server name.
+                    - binding (str, optional): NFS export binding. Default is dynamically generated.
+
+        Returns:
+            str: The mount path if successful.
+            int: Returns 1 in case of a failure.
+
+        Raises:
+            ValueError: If an invalid mount type is provided.
+        """
+
+        mounting_dir = self.generate_mount_dir()
+        mount_path = f"/mnt/cephfs_{mount_type}_{mounting_dir}/"
+
+        subvolume_name = kwargs.get("subvolume_name")
+        subvolume_group = kwargs.get("subvolume_group")
+
+        if subvolume_name:
+            if subvolume_group:
+                self.create_subvolumegroup(client, fs_name, subvolume_group)
+            self.create_subvolume(
+                client, fs_name, subvolume_name, group_name=subvolume_group
+            )
+
+            subvol_path, _ = client.exec_command(
+                sudo=True,
+                cmd="ceph fs subvolume getpath {} {} {}".format(
+                    fs_name, subvolume_name, subvolume_group or ""
+                ).strip(),
+            )
+            log.info(f"Sub volume path: {subvol_path.strip()}")
+
+        if mount_type == "fuse":
+            if subvolume_name:
+                self.fuse_mount(
+                    [client],
+                    mount_path,
+                    extra_params=f" --client_fs {fs_name} -r {subvol_path.strip()}",
+                )
+            else:
+                self.fuse_mount(
+                    [client], mount_path, extra_params=f" --client_fs {fs_name}"
+                )
+
+        elif mount_type == "smb":
+            smb_subvol_group = kwargs.get("smb_subvolume_group", "smb")
+            smb_subvols = kwargs.get("smb_subvolumes", ["sv1"])
+            smb_subvolume_mode = kwargs.get("smb_subvolume_mode", "0777")
+            smb_cluster_id = kwargs.get("smb_cluster_id", "smb1")
+            auth_mode = kwargs.get("auth_mode", "user")
+            domain_realm = kwargs.get("domain_realm", None)
+            custom_dns = kwargs.get("custom_dns", None)
+            smb_user_name = kwargs.get("smb_user_name", "user1")
+            smb_user_password = kwargs.get("smb_user_password", "passwd")
+            smb_shares = kwargs.get("smb_shares", ["share1", "share2"])
+            path = kwargs.get("path", "/")
+            installer = self.ceph_cluster.get_nodes(role="installer")[0]
+            smb_nodes = self.ceph_cluster.get_nodes("smb")
+            client = self.ceph_cluster.get_nodes(role="client")[0]
+            mount_path = kwargs.get("cifs_mount_point", "/mnt/smb")
+
+            try:
+                # deploy smb services
+                deploy_smb_service_imperative(
+                    installer,
+                    fs_name,
+                    smb_subvol_group,
+                    smb_subvols,
+                    smb_subvolume_mode,
+                    smb_cluster_id,
+                    auth_mode,
+                    smb_user_name,
+                    smb_user_password,
+                    smb_shares,
+                    path,
+                    domain_realm,
+                    custom_dns,
+                )
+
+                # Check smb share using smbclient
+                smbclient_check_shares(
+                    smb_nodes,
+                    client,
+                    smb_shares,
+                    smb_user_name,
+                    smb_user_password,
+                    auth_mode,
+                    domain_realm,
+                )
+
+                # Mount smb share with cifs
+                smb_cifs_mount(
+                    smb_nodes[0],
+                    client,
+                    smb_shares[0],
+                    smb_user_name,
+                    smb_user_password,
+                    auth_mode,
+                    domain_realm,
+                    mount_path,
+                )
+
+            except Exception as e:
+                log.error("failed to setup smb with error: {}".format(e))
+                return 1
+
+        elif mount_type == "nfs":
+            nfs_cluster_name = kwargs.get("nfs_cluster_name", "nfs-cluster-1")
+            nfs_server_name = kwargs.get("nfs_server_name", None)
+            binding = kwargs.get(
+                "binding",
+                "/export_" + "".join(secrets.choice(string.digits) for i in range(3)),
+            )
+
+            self.create_nfs(client, nfs_cluster_name, nfs_server_name=nfs_server_name)
+
+            if subvolume_name:
+                export_path = f"{subvol_path}"
+                self.create_nfs_export(
+                    client, nfs_cluster_name, binding, fs_name, path=export_path
+                )
+            else:
+                self.create_nfs_export(client, nfs_cluster_name, binding, fs_name)
+            rc = self.cephfs_nfs_mount(client, nfs_server_name, binding, mount_path)
+            if not rc:
+                log.error("cephfs nfs export mount failed")
+                return 1
+
+        else:
+            raise ValueError("Invalid mount type. Choose from 'fuse', 'smb', or 'nfs'.")
+
+        return mount_path


### PR DESCRIPTION
# Description

Covering the below scenarios as part of this PR

- Include NFS and SMB logic in the existing scenario
- Refactor code

## Changes

- tests/cephfs/cephfs_case_sensitivity/case_sensitivity_functional.py
   - Handle Pre-Requisite and Cleanup for NFS and SMB 
   - Refactor the code for better readability
- tests/cephfs/cephfs_case_sensitivity/case_sensitivity_negative.py
   - Handle Pre-Requisite and Cleanup for NFS and SMB 
   - Refactor the code for better readability
- tests/cephfs/cephfs_utilsV1.py
   -  Enable nfs_server_name params in function create_nfs
- tests/cephfs/lib/cephfs_common_lib.py
   -  New function setup_cephfs_mount
       - Performs Subvolume/subvolume group creation
       - Supports to mount the FUSE, SMB and NFS
 
## Logs

- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-18767/functional/
- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-18767/negative/

## Polarion TC

- Negative: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83611927
- Fucntional: https://polarion.engineering.redhat.com/polarion/#/project/CEPH/workitem?id=CEPH-83606639 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
