### PR TITLE
CephFS 8.1 - Adding 1 last scenario to ref-inode link ops and fixed f-strings

### DIFF
--- a/tests/cephfs/lib/cephfs_refinode_utils.py
+++ b/tests/cephfs/lib/cephfs_refinode_utils.py
@@ -55,7 +55,15 @@ class RefInodeUtils(object):
         fs_util.auth_list(clients)
         return fs_util, clients, erasure
 
-    def create_subvolumes(self, client, fs_util, default_fs, subvol_group_name):
+    def create_subvolumes(
+        self,
+        client,
+        fs_util,
+        default_fs,
+        subvol_group_name,
+        num_grouped=3,
+        num_ungrouped=3,
+    ):
         """
         Creates a subvolume group and multiple subvolumes, both within and outside the group.
 
@@ -64,6 +72,8 @@ class RefInodeUtils(object):
             fs_util (FsUtils): CephFS utility instance.
             default_fs (str): Default Ceph filesystem name.
             subvol_group_name (str): Subvolume group name.
+            num_grouped (int): Number of subvolumes to create within the group.
+            num_ungrouped (int): Number of subvolumes to create outside the group.
 
         Returns:
             list: Created subvolume names.
@@ -72,8 +82,10 @@ class RefInodeUtils(object):
         fs_util.create_subvolumegroup(client, **subvolumegroup)
 
         subvolume_names = []
-        for i in range(1, 4):
-            subvolume_name = f"subvolume_ref_inode_{i}"
+
+        # Create subvolumes within the group
+        for i in range(1, num_grouped + 1):
+            subvolume_name = "subvolume_ref_inode_grp_%s" % i
             subvolume_with_group = {
                 "vol_name": default_fs,
                 "subvol_name": subvolume_name,
@@ -83,8 +95,9 @@ class RefInodeUtils(object):
             fs_util.create_subvolume(client, **subvolume_with_group)
             subvolume_names.append(subvolume_name)
 
-        for i in range(4, 7):
-            subvolume_name = f"subvolume_name_{i}"
+        # Create subvolumes outside the group
+        for i in range(1, num_ungrouped + 1):
+            subvolume_name = "subvolume_ref_inode_nongrp_%s" % (i + num_grouped)
             subvolume_without_group = {
                 "vol_name": default_fs,
                 "subvol_name": subvolume_name,
@@ -93,7 +106,7 @@ class RefInodeUtils(object):
             fs_util.create_subvolume(client, **subvolume_without_group)
             subvolume_names.append(subvolume_name)
 
-        log.info(f"Captured Subvolume Names: {subvolume_names}")
+        log.info("Captured Subvolume Names: %s", subvolume_names)
         return subvolume_names
 
     def mount_subvolumes(
@@ -107,54 +120,99 @@ class RefInodeUtils(object):
         nfs_name,
     ):
         """
-        Mounts CephFS subvolumes using different mount types (Fuse, Kernel, NFS).
-
-        Args:
-            client: The Ceph client node.
-            fs_util: The Ceph filesystem utility object.
-            default_fs: The default CephFS volume name.
-            subvolume_names: List of subvolume names to be mounted.
-            subvol_group_name: The subvolume group name (if applicable).
-            nfs_server: The NFS server hostname.
-            nfs_name: The NFS cluster name.
+        Mounts CephFS subvolumes dynamically using Fuse, Kernel, or NFS.
 
         Returns:
-            int: 0 if all mounts are successful, 1 if any NFS mount fails.
+            tuple: (fuse_mount_dirs, kernel_mount_dirs, nfs_mount_dirs)
         """
+        mount_types = ["fuse", "kernel", "nfs"]
         export_created = 0
+        total_subvols = len(subvolume_names)
 
-        for idx, mount_type in enumerate(
-            ["fuse", "kernel", "nfs", "fuse", "kernel", "nfs"]
-        ):
-            subvol_path, _ = client.exec_command(
-                sudo=True,
-                cmd=f"ceph fs subvolume getpath {default_fs} {subvolume_names[idx]} "
-                f"{subvol_group_name if idx in [0, 1, 2] else ''}",
-            )
+        # Separate lists for different mount types
+        fuse_mount_dirs = []
+        kernel_mount_dirs = []
+        nfs_mount_dirs = []
+
+        for idx, subvol in enumerate(subvolume_names):
+            mount_type = mount_types[idx % len(mount_types)]  # Rotate mount types
+
+            # Get subvolume path
+            if subvol_group_name and idx < total_subvols // 2:
+                cmd = "ceph fs subvolume getpath %s %s %s" % (
+                    default_fs,
+                    subvol,
+                    subvol_group_name,
+                )
+            else:
+                cmd = "ceph fs subvolume getpath %s %s" % (default_fs, subvol)
+
+            try:
+                subvol_path, _ = client.exec_command(sudo=True, cmd=cmd)
+                subvol_path = subvol_path.strip()
+                log.info("Subvolume %s path: %s", subvol, subvol_path)
+            except Exception as e:
+                log.error("Failed to get path for subvolume %s: %s", subvol, e)
+                continue  # Skip this subvolume instead of returning
+
             mount_params = {
                 "client": client,
                 "fs_util": fs_util,
                 "fs_name": default_fs,
-                "mnt_path": subvol_path.strip(),
+                "mnt_path": subvol_path,
+                "export_created": export_created,
+                "subvol_name": subvol,  # Adding subvolume name for mount suffix
             }
 
             if mount_type == "nfs":
+                export_name = "/nfs_export_%s_%s" % (
+                    subvol,
+                    "".join(secrets.choice(string.digits) for _ in range(3)),
+                )
+
+                log.info("Creating NFS export for %s: %s", subvol, export_name)
+                try:
+                    fs_util.create_nfs_export(
+                        client,
+                        nfs_name,
+                        export_name,
+                        default_fs,
+                        validate=True,
+                        path=subvol_path,
+                    )
+                except Exception as e:
+                    log.error("Failed creating NFS export for %s: %s", subvol, e)
+                    return None, None, None  # Return failure
+
                 mount_params.update(
                     {
                         "nfs_server": nfs_server,
                         "nfs_name": nfs_name,
-                        "nfs_export_name": f"/nfs_export_{''.join(secrets.choice(string.digits) for _ in range(3))}",
-                        "export_created": export_created,
+                        "nfs_export_name": export_name,
                     }
                 )
 
-            mounting_path, export_created = fs_util.mount_ceph(mount_type, mount_params)
+            mount_path, new_export_created = fs_util.mount_ceph(
+                mount_type, mount_params
+            )
+            if not mount_path:
+                log.error("Failed to mount %s using %s", subvol, mount_type)
+                return None, None, None  # Return failure
 
-            if mount_type == "nfs" and not mounting_path:
-                log.error("CephFS NFS export mount failed")
-                return 1
+            export_created = export_created or bool(
+                new_export_created
+            )  # Ensure boolean value
+            mounting_path = "%s/" % mount_path.rstrip("/")
 
-        return 0
+            # Store the mount path in the respective list
+            if mount_type == "fuse":
+                fuse_mount_dirs.append(mounting_path)
+            elif mount_type == "kernel":
+                kernel_mount_dirs.append(mounting_path)
+            elif mount_type == "nfs":
+                nfs_mount_dirs.append(mounting_path)
+
+        return fuse_mount_dirs, kernel_mount_dirs, nfs_mount_dirs
 
     def mount_rootfs(self, client, fs_util, default_fs, nfs_server, nfs_name):
         """
@@ -181,26 +239,31 @@ class RefInodeUtils(object):
         Raises:
             Exception: If the NFS export mount fails, the function logs an error and returns 1.
         """
+        fuse_mount_dirs = []
+        kernel_mount_dirs = []
+        nfs_mount_dirs = []
         mounting_dir = "".join(
             random.choice(string.ascii_lowercase + string.digits)
             for _ in list(range(10))
         )
 
         # Fuse mount
-        fuse_mount_dir = f"/mnt/cephfs_root_fuse{mounting_dir}_1/"
+        fuse_mount_dir = "/mnt/cephfs_root_fuse%s_1/" % mounting_dir
         fs_util.fuse_mount(
-            [client], fuse_mount_dir, extra_params=f"--client_fs {default_fs}"
+            [client], fuse_mount_dir, extra_params="--client_fs %s" % default_fs
         )
+        fuse_mount_dirs.append(fuse_mount_dir)
 
         # Kernel mount
-        kernel_mount_dir = f"/mnt/cephfs_root_kernel{mounting_dir}_1/"
+        kernel_mount_dir = "/mnt/cephfs_root_kernel%s_1/" % mounting_dir
         mon_node_ips = fs_util.get_mon_node_ips()
         fs_util.kernel_mount(
             [client],
             kernel_mount_dir,
             ",".join(mon_node_ips),
-            extra_params=f",fs={default_fs}",
+            extra_params=",fs=%s" % default_fs,
         )
+        kernel_mount_dirs.append(kernel_mount_dir)
 
         # NFS export creation and mount
         nfs_export_name = "/nfs_export_" + "".join(
@@ -211,199 +274,185 @@ class RefInodeUtils(object):
                 client, nfs_name, nfs_export_name, default_fs, path="/"
             )
         except Exception as e:
-            log.error(f"Failed to create NFS export: {str(e)}")
+            log.error("Failed to create NFS export: %s" % str(e))
             return 1
 
-        nfs_mounting_dir = f"/mnt/cephfs_root_nfs_{mounting_dir}_1/"
+        nfs_mounting_dir = "/mnt/cephfs_root_nfs_%s_1/" % mounting_dir
         if not fs_util.cephfs_nfs_mount(
             client, nfs_server, nfs_export_name, nfs_mounting_dir
         ):
             log.error("cephfs nfs export mount failed")
             return 1
+        nfs_mount_dirs.append(nfs_mounting_dir)
 
-        return fuse_mount_dir, kernel_mount_dir, nfs_mounting_dir
+        return fuse_mount_dirs, kernel_mount_dirs, nfs_mount_dirs
 
     def create_directories(self, client, base_path, dirs):
+        """
+        Creates multiple directories at the specified base path.
+
+        Args:
+            client: The Ceph client node used to execute commands.
+            base_path (str): The base directory path where new directories will be created.
+            dirs (list): List of directory names to create.
+        """
         for directory in dirs:
-            dir_path = f"{base_path}/{directory}"
-            client.exec_command(sudo=True, cmd=f"mkdir -p {dir_path}")
-            log.info(f"Created directory: {dir_path}")
+            dir_path = "%s/%s" % (base_path, directory)
+            client.exec_command(sudo=True, cmd="mkdir -p %s" % dir_path)
+            log.info("Created directory: %s", dir_path)
 
     def create_file_with_content(self, client, file_path, content):
-        client.exec_command(sudo=True, cmd=f'echo "{content}" > {file_path}')
-        log.info(f"Created file with content: {file_path}")
+        """
+        Creates a file at the specified path and writes content into it.
+
+        Args:
+            client: The Ceph client node used to execute commands.
+            file_path (str): The full path of the file to be created.
+            content (str): The content to write into the file.
+        """
+        client.exec_command(sudo=True, cmd='echo "%s" > %s' % (content, file_path))
+        log.info("Created file with content: %s", file_path)
 
     def append_to_file(self, client, file_path, content):
-        client.exec_command(sudo=True, cmd=f'echo "{content}" >> {file_path}')
-        log.info(f"Appended content to file: {file_path}")
+        """
+        Appends content to an existing file.
+
+        Args:
+            client: The Ceph client node used to execute commands.
+            file_path (str): The full path of the file to be modified.
+            content (str): The content to append to the file.
+        """
+        client.exec_command(sudo=True, cmd='echo "%s" >> %s' % (content, file_path))
+        log.info("Appended content to file: %s", file_path)
 
     def rename_file(self, client, old_path, new_path):
-        client.exec_command(sudo=True, cmd=f"mv {old_path} {new_path}")
-        log.info(f"Renamed file from {old_path} to {new_path}")
+        """
+        Renames or moves a file from old_path to new_path.
+
+        Args:
+            client: The Ceph client node used to execute commands.
+            old_path (str): The current file path.
+            new_path (str): The new file path.
+        """
+        client.exec_command(sudo=True, cmd="mv %s %s" % (old_path, new_path))
+        log.info("Renamed file from %s to %s", old_path, new_path)
 
     def create_snapshot_on_dir(self, client, dir_path, snapshot_name):
-        snap_path = f"{dir_path}/.snap/{snapshot_name}"
-        client.exec_command(sudo=True, cmd=f"mkdir -p {snap_path}")
-        log.info(f"Created snapshot: {snap_path}")
+        """
+        Creates a snapshot of a given directory.
+
+        Args:
+            client: The Ceph client node used to execute commands.
+            dir_path (str): The directory path where the snapshot will be created.
+            snapshot_name (str): The name of the snapshot.
+        """
+        snap_path = "%s/.snap/%s" % (dir_path, snapshot_name)
+        client.exec_command(sudo=True, cmd="mkdir -p %s" % snap_path)
+        log.info("Created snapshot: %s", snap_path)
 
     def get_rados_object_for_dir(self, client, meta_pool_name, dir_path):
         """
-        Retrieves the RADOS object ID corresponding to a given directory in CephFS.
-
-        This function:
-        1. Retrieves the inode number of the specified directory using the `stat` command.
-        2. Converts the inode number to a hexadecimal representation.
-        3. Lists the objects in the specified metadata pool.
-        4. Checks if the expected RADOS object ID is present in the pool.
-
+        Get the RADOS object ID for a given directory in CephFS.
         Args:
-            client (CephClient): The Ceph client node used to execute commands.
-            meta_pool_name (str): The name of the metadata pool where directory metadata is stored.
-            dir_path (str): The absolute path of the directory in CephFS.
-
+            client (CephClient): Ceph client node.
+            meta_pool_name (str): Metadata pool name.
+            dir_path (str): Directory path in CephFS.
         Returns:
-            str: The RADOS object ID if found in the metadata pool.
-            None: If the corresponding RADOS object is not found.
-
-        Raises:
-            Exception: If any command execution fails, logs the error and returns None.
+            str: RADOS object ID if found, else None.
         """
         try:
-            # Step 1: Stat the directory to get the inode number
             stdout, stderr = client.exec_command(
-                sudo=True, cmd=f"stat -c %i {dir_path}"
+                sudo=True, cmd="stat -c %i %s" % dir_path
             )
             inode_number = stdout.strip()
-            log.info(f"Inode number for {dir_path}: {inode_number}")
+            log.info("Inode number for %s: %s" % (dir_path, inode_number))
 
-            # Step 2: Convert inode number to hexadecimal
             inode_hex = format(int(inode_number), "x").zfill(8)
-            rados_object_id = f"{inode_hex}.00000000"
-            log.info(f"Expected RADOS object ID for {dir_path}: {rados_object_id}")
+            rados_object_id = "%s.00000000" % inode_hex
+            log.info(
+                "Expected RADOS object ID for %s: %s" % (dir_path, rados_object_id)
+            )
 
-            # Step 3: List RADOS objects in the specified pool
             stdout, stderr = client.exec_command(
                 sudo=True,
-                cmd=f"rados -p {meta_pool_name} ls | egrep '([0-9]|[a-f]){{11}}'",
+                cmd="rados -p %s ls | egrep '([0-9]|[a-f]){11}'" % meta_pool_name,
             )
             rados_objects = stdout.splitlines()
-            log.info(f"Objects in pool {meta_pool_name}: {rados_objects}")
+            log.info("Objects in pool %s: %s" % (meta_pool_name, rados_objects))
 
-            # Step 4: Check if the expected RADOS object is present
             if rados_object_id in rados_objects:
-                log.info(f"RADOS object for {dir_path} found: {rados_object_id}")
+                log.info("RADOS object for %s found: %s" % (dir_path, rados_object_id))
                 return rados_object_id
             else:
-                log.error(f"RADOS object for {dir_path} not found!")
+                log.error("RADOS object for %s not found!" % dir_path)
                 return None
         except Exception as e:
-            raise Exception(f"Failed tretrieve RADOS object for {dir_path}: {e}")
+            raise Exception(
+                "Failed to retrieve RADOS object for %s: %s" % (dir_path, e)
+            )
 
     def get_rados_object_from_datapool(self, client, data_pool_name):
         """
-        Retrieves the list of RADOS objects stored in the specified data pool.
-        This function executes a `rados ls` command to list all objects in the given
-        data pool and returns them as a list.
+        List RADOS objects in the given data pool.
         Args:
-            client (CephClient): The Ceph client node used to execute commands.
-            data_pool_name (str): The name of the Ceph data pool to query.
+            client (CephClient): Ceph client node.
+            data_pool_name (str): Data pool name.
         Returns:
-            list: A list of RADOS object names present in the specified data pool.
-        Raises:
-            Exception: If the command execution fails, logs the error.
+            list: RADOS object names in the pool.
         """
-        #  List RADOS objects in the specified pool
         stdout, stderr = client.exec_command(
-            sudo=True, cmd=f"rados -p {data_pool_name} ls"
+            sudo=True, cmd="rados -p %s ls" % data_pool_name
         )
-        log.info(f"List Rados Objects : {stdout}")
+        log.info("List Rados Objects : %s" % stdout)
         rados_objects = stdout.splitlines()
-        log.info(f"Objects in pool {data_pool_name}: {rados_objects}")
+        log.info("Objects in pool %s: %s" % (data_pool_name, rados_objects))
         return rados_objects
 
     def list_snapshots_for_object(self, client, data_pool_name, rados_object):
         """
-        Fetches and validates snapshot details for a given RADOS object in a specified data pool.
-
-        This function executes a `rados listsnaps` command to retrieve snapshot information
-        for the given RADOS object in JSON format. It then parses the output and counts
-        the number of snapshots, returning a summary.
-
+        Get snapshots for a given RADOS object.
         Args:
-            client (CephClient): The Ceph client node used to execute commands.
-            data_pool_name (str): The name of the Ceph data pool where the object resides.
-            rados_object (str): The RADOS object for which snapshots need to be listed.
-
+            client (CephClient): Ceph client node.
+            data_pool_name (str): Data pool name.
+            rados_object (str): RADOS object name.
         Returns:
-            str: A formatted message indicating the number of snapshots created for the object,
-                along with the JSON output.
-
-        Raises:
-            Exception: If the command execution fails, logs the error.
+            str: Snapshot count with JSON output.
         """
-        # Run rados command to fetch snapshot details in JSON format
-        cmd = f"rados -p {data_pool_name} listsnaps {rados_object} -f json"
+        cmd = "rados -p %s listsnaps %s -f json" % (data_pool_name, rados_object)
         stdout, stderr = client.exec_command(sudo=True, cmd=cmd)
 
-        # Parse JSON output
         data = json.loads(stdout)
         clones = data.get("clones", [])
 
-        # Check if only "head" exists and no snapshots are present
         if (
             len(clones) == 1
             and clones[0].get("id") == "head"
             and not clones[0].get("snapshots")
         ):
-            return f"No new snapshots created.\nOutput:\n{json.dumps(data, indent=4)}"
+            return "No new snapshots created.\nOutput:\n%s" % json.dumps(data, indent=4)
 
-        # Count the number of snapshots
         snapshot_count = sum(
             len(clone.get("snapshots", []))
             for clone in clones
             if clone.get("id") != "head"
         )
 
-        return f"{snapshot_count} snapshot(s) created.\nOutput:\n{json.dumps(data, indent=4)}"
+        return "%d snapshot(s) created.\nOutput:\n%s" % (
+            snapshot_count,
+            json.dumps(data, indent=4),
+        )
 
     def create_hardlink_and_validate(
         self, client, fs_util, file1_path, hl_file_path, data_pool_name, fs_name
     ):
         """
-        Creates a hard link for a given file, fetches file statistics, validates inode numbers,
-        and checks for the presence of a newly created RADOS object.
-
-        This function performs the following steps:
-        1. Captures the initial list of RADOS objects in the specified data pool.
-        2. Creates a hard link to the given file.
-        3. Flushes the journal on the active MDS nodes to ensure changes are recorded.
-        4. Validates that both the original file and the hard link have the same inode number.
-        5. Captures the list of RADOS objects again and identifies any new objects created.
-        6. Determines whether a new referent inode was created.
-
-        Args:
-            client (CephClient): The Ceph client node used to execute commands.
-            fs_util (FSUtil): The filesystem utility instance to manage CephFS operations.
-            file1_path (str): Path to the original file.
-            hl_file_path (str): Path where the hard link will be created.
-            data_pool_name (str): Name of the Ceph data pool to monitor RADOS objects.
-            fs_name (str): Name of the Ceph filesystem.
-
-        Returns:
-            tuple:
-                - (bool): `True` if the validation succeeds, `False` otherwise.
-                - (str): "yes" if a new RADOS object is created, "no" otherwise.
-                - (set): Set of newly created RADOS objects, if any.
-
-        Raises:
-            Exception: If any command execution fails.
-
+        Creates a hard link, validates inode numbers, and checks for new RADOS objects.
         """
 
         def exec_stat(file_path):
             """Executes stat command and extracts inode number."""
-            stdout, stderr = client.exec_command(sudo=True, cmd=f"stat {file_path}")
-            log.info(f"File statistics for {file_path}:\n{stdout}")
+            stdout, stderr = client.exec_command(sudo=True, cmd="stat %s" % file_path)
+            log.info("File statistics for %s:\n%s" % (file_path, stdout))
             match = re.search(r"Inode:\s+(\d+)", stdout)
             return match.group(1) if match else None
 
@@ -411,119 +460,57 @@ class RefInodeUtils(object):
         initial_rados_objects = set(
             self.get_rados_object_from_datapool(client, data_pool_name)
         )
-        log.info(f"Initial RADOS objects: {initial_rados_objects}")
+        log.info("Initial RADOS objects: %s" % initial_rados_objects)
 
         # Step 2: Create hard link
-        client.exec_command(sudo=True, cmd=f"ln {file1_path} {hl_file_path}")
-        log.info(f"Created hardlink: {hl_file_path}")
+        client.exec_command(sudo=True, cmd="ln %s %s" % (file1_path, hl_file_path))
+        log.info("Created hardlink: %s" % hl_file_path)
 
-        # Step 3: Flush journal to ensure changes are recorded
+        # Step 3: Flush journal
         self.flush_journal_on_active_mdss(fs_util, client, fs_name)
 
         # Step 4: Compare Inode to validate hardlinks
         inode1, inode2 = exec_stat(file1_path), exec_stat(hl_file_path)
         if inode1 and inode2 and inode1 == inode2:
-            log.info(f"Validation Passed: Inodes match ({inode1})")
+            log.info("Validation Passed: Inodes match (%s)" % inode1)
         else:
-            log.error(f"Validation Failed: Inodes do not match ({inode1} != {inode2})")
+            log.error(
+                "Validation Failed: Inodes do not match (%s != %s)" % (inode1, inode2)
+            )
             return False, "no", None
 
         # Step 5: Capture RADOS objects after creating hardlink
         post_rados_objects = set(
             self.get_rados_object_from_datapool(client, data_pool_name)
         )
-        log.info(f"RADOS objects after creating hardlink: {post_rados_objects}")
+        log.info("RADOS objects after creating hardlink: %s" % post_rados_objects)
 
         # Step 6: Identify the newly created RADOS object
         new_rados_objects = post_rados_objects - initial_rados_objects
-        log.info(f"Newly created RADOS objects: {new_rados_objects}")
+        log.info("Newly created RADOS objects: %s" % new_rados_objects)
 
         # Step 7: Validate referent inode
         referent_inode = "yes" if len(new_rados_objects) > 0 else "no"
-        log.info(f"Referent Inode: {referent_inode}")
+        log.info("Referent Inode: %s" % referent_inode)
 
         return True, referent_inode, new_rados_objects
 
     def flush_journal_on_active_mdss(self, fs_util, client, fs_name):
         """
-        Flushes the journal on all active MDS nodes for a given Ceph filesystem.
-
-        This function retrieves the list of active Metadata Server (MDS) nodes for the specified
-        filesystem and issues the `ceph tell mds.<mds> flush journal` command on each active MDS.
-        Flushing the journal ensures that all pending metadata changes are committed to the backing
-        storage, improving metadata consistency.
-
-        Args:
-            fs_util (FSUtil): The filesystem utility instance used to fetch active MDS nodes.
-            client (CephClient): The Ceph client node used to execute commands.
-            fs_name (str): Name of the Ceph filesystem.
-
-        Returns:
-            None
-
-        Logs:
-            - The list of active MDS nodes retrieved.
-            - Confirmation messages when journals are flushed on each active MDS.
-
-        Notes:
-            - Redirects command output to `/dev/null 2>&1` to suppress standard output and errors.
-
-        Raises:
-            Exception: If the execution of any command fails.
-
+        Flushes the journal on active MDS nodes.
         """
-        # Retrieve the list of active MDS nodes
         active_mdss = fs_util.get_active_mdss(client, fs_name)
-        # Issue flush journal command to each active MDS
         for mds in active_mdss:
             client.exec_command(
-                sudo=True, cmd=f"ceph tell mds.{mds} flush journal > /dev/null 2>&1"
+                sudo=True, cmd="ceph tell mds.%s flush journal > /dev/null 2>&1" % mds
             )
-            log.info(f"Journal flushed on MDS: mds.{mds}")
+            log.info("Journal flushed on MDS: mds.%s" % mds)
 
-    def validate_referent_inode(
-        self,
-        fs_util,
-        client,
-        mount_path,
-        data_pool,
-        fs_name,
-    ):
+    def validate_referent_inode(self, fs_util, client, mount_path, data_pool, fs_name):
         """
-        Automates the creation of directories, files, snapshots, and hardlinks to validate referent inodes.
-
-        This function performs the following steps:
-        1. Creates directories and flushes the journal to persist metadata.
-        2. Creates a file in one of the directories, captures its RADOS object, and lists snapshots.
-        3. Creates a snapshot directly on the directory, modifies the file, and checks snapshot details.
-        4. Creates a hardlink for the file in another directory and validates that the referent inode exists.
-
-        Args:
-            fs_util (FSUtil): The filesystem utility instance used to perform CephFS operations.
-            client (CephClient): The Ceph client node used to execute commands.
-            mount_path (str): The mount point of the Ceph filesystem.
-            data_pool (str): The name of the data pool where RADOS objects are stored.
-            fs_name (str): Name of the Ceph filesystem.
-
-        Returns:
-            None
-
-        Logs:
-            - Step-by-step execution of directory, file, and snapshot creation.
-            - Details of the initial and post-snapshot RADOS objects.
-            - Validation results of the referent inode presence after creating a hardlink.
-
-        Notes:
-            - This function assumes that the first RADOS object in `get_rados_object_from_datapool`
-                corresponds to `dir1`.
-            - The `flush_journal_on_active_mdss` function is called after critical
-                operations to ensure metadata persistence.
-
-        Raises:
-            Exception: If any command execution or validation step fails.
-
+        Validates referent inodes by creating directories, files, snapshots, and hardlinks.
         """
-        log.info("Starting validatiopn of the referent inode automation...")
+        log.info("Starting validation of the referent inode automation...")
 
         # Step 1: Create directories
         dirs = ["dir1", "dir2"]
@@ -531,193 +518,149 @@ class RefInodeUtils(object):
         self.flush_journal_on_active_mdss(fs_util, client, fs_name)
 
         # Step 2: Create files and snapshots in dir1
-        file1_path = f"{mount_path}/dir1/file1"
+        file1_path = "%s/dir1/file1" % mount_path
         self.create_file_with_content(client, file1_path, "first file")
         self.flush_journal_on_active_mdss(fs_util, client, fs_name)
         object_id = self.get_rados_object_from_datapool(client, data_pool)
-        object_id_dir1 = object_id[0]  # Assuming first object corresponds to dir1
+        object_id_dir1 = object_id[0]
         snapshot_details = self.list_snapshots_for_object(
             client, data_pool, object_id_dir1
         )
-        log.info(f"Snapshot Details : {snapshot_details}")
+        log.info("Snapshot Details : %s" % snapshot_details)
 
         # Step 3 : Create Snapshot directly on dir path
-        self.create_snapshot_on_dir(client, f"{mount_path}/dir1", "snap1")
+        self.create_snapshot_on_dir(client, "%s/dir1" % mount_path, "snap1")
         self.append_to_file(client, file1_path, "first file second line")
         self.flush_journal_on_active_mdss(fs_util, client, fs_name)
         snapshot_details = self.list_snapshots_for_object(
             client, data_pool, object_id_dir1
         )
-        log.info(f"Snapshot Details on Dir1 : {snapshot_details}")
+        log.info("Snapshot Details on Dir1 : %s" % snapshot_details)
 
         # Step 4: Create hardlink and validate
-        file1_path = f"{mount_path}/dir1/file1"
-        hl_file_path = f"{mount_path}/dir2/hl_file1"
-        (
-            validation_result,
-            referent_inode,
-            new_rados_objects,
-        ) = self.create_hardlink_and_validate(
-            client, fs_util, file1_path, hl_file_path, data_pool, fs_name
+        file1_path = "%s/dir1/file1" % mount_path
+        hl_file_path = "%s/dir2/hl_file1" % mount_path
+        validation_result, referent_inode, new_rados_objects = (
+            self.create_hardlink_and_validate(
+                client, fs_util, file1_path, hl_file_path, data_pool, fs_name
+            )
         )
         log.info(
-            f"Validation Result: {validation_result}, Referent Inode exists : {referent_inode} : {new_rados_objects}"
+            "Validation Result: %s, Referent Inode exists : %s : %s"
+            % (validation_result, referent_inode, new_rados_objects)
         )
         log.info("Validation of presence of Referent Inode completed successfully!")
 
     def cleanup_snap_directories(self, client, mount_path):
         """
-        Cleans up snapshot directories and files within a specified mount path.
-
-        This function performs the following cleanup operations:
-        1. Removes all snapshot entries within the `.snap` directories for each subdirectory.
-        2. Deletes all files and directories within the given mount path.
-            - The function attempts to remove `.snap` directories first using `rmdir`,
-                which only works if they are empty.
-            - It then forcefully removes all remaining files and directories within the mount path.
-        Args:
-            client (CephClient): The Ceph client node used to execute commands.
-            mount_path (str): The mount point of the Ceph filesystem where snapshots and directories need to be cleaned.
-        Returns:
-            None
-        Raises:
-            Exception: If command execution fails, it logs the error and continues.
+        Cleans up snapshot directories and files within the mount path.
         """
-        log.info(f"Cleaning up snapshots within {mount_path}...")
+        log.info("Cleaning up snapshots within %s..." % mount_path)
         try:
-            client.exec_command(sudo=True, cmd=f"rmdir {mount_path}/*/.snap/*")
-            client.exec_command(sudo=True, cmd=f"rm -rf {mount_path}/*")
+            client.exec_command(sudo=True, cmd="rmdir %s/*/.snap/*" % mount_path)
+            client.exec_command(sudo=True, cmd="rm -rf %s/*" % mount_path)
         except Exception as e:
-            log.error(f"Failed to clean up .snap directories within {mount_path}: {e}")
+            log.error(
+                "Failed to clean up .snap directories within %s: %s" % (mount_path, e)
+            )
             return 1
         log.info("Cleanup of snap directories completed.")
 
     def get_inode_number(self, client, file_path):
-        cmd = f"stat -c %i {file_path}"
+        """Gets the inode number of a file."""
+        cmd = "stat -c %s %s" % ("%i", file_path)
         stdout, stderr = client.exec_command(sudo=True, cmd=cmd)
 
-        # Extract the output and validate
         inode_number = stdout.strip()
         if not inode_number.isdigit():
-            raise Exception(f"Failed to get inode number: {stdout} {stderr}")
+            raise Exception("Failed to get inode number: %s %s" % (stdout, stderr))
 
         return int(inode_number)
 
     def get_inode_details(self, client, fs_name, inode_number, mount_dir):
-        """
-        Retrieves inode details using 'ceph tell mds' and validates hard links.
-
-        :param client: The client object to execute commands.
-        :param fs_name: The CephFS name.
-        :param inode_number: The inode number to query.
-        :param mount_dir: The mount directory path to validate.
-        :return: Dictionary of inode details if present, otherwise None.
-        """
-        cmd = f"ceph tell mds.{fs_name}:0 dump inode {inode_number} -f json"
+        """Gets inode details and checks hard links."""
+        cmd = "ceph tell mds.%s:0 dump inode %s -f json" % (fs_name, inode_number)
         out, rc = client.exec_command(sudo=True, cmd=cmd)
 
         try:
-            inode_data = json.loads(out.strip())  # Correctly parse JSON
+            inode_data = json.loads(out.strip())
         except json.JSONDecodeError:
-            raise Exception(f"Failed to parse JSON output: {out}")
+            raise Exception("Failed to parse JSON output: %s" % out)
 
-        # Return file path for the given inode
         file_path = inode_data.get("path", "")
-        log.info(f"File path for inode {inode_number}: {file_path}")
+        log.info("File path for inode %s: %s" % (inode_number, file_path))
 
-        # Check for hard links
         nlink = inode_data.get("nlink", 1)
         if nlink == 1:
-            log.info(f"No hard links found for inode {inode_number}.")
+            log.info("No hard links found for inode %s." % inode_number)
         else:
             log.info(
-                f"Hard links found for inode {inode_number}. Total links: {nlink} (Includes original file)"
+                "Hard links found for inode %s. Total links: %s" % (inode_number, nlink)
             )
 
-        # Retrieve referent inodes
         referent_inodes = inode_data.get("referent_inodes", [])
         if referent_inodes:
-            log.info(f"Referent inodes for {inode_number}: {referent_inodes}")
+            log.info("Referent inodes for %s: %s" % (inode_number, referent_inodes))
 
-        return inode_data  # Returning full inode data instead of just referent inodes
+        return inode_data
 
     def get_referent_inode_details(
         self, client, fs_name, source_inode, source_referent_inode_number, mount_dir
     ):
-        """
-        Retrieves referent inode details and validates linkage to the original file.
-
-        :param client: The client object to execute commands.
-        :param fs_name: The CephFS name.
-        :param source_referent_inode_number: The inode number whose referent details need to be checked.
-        :param mount_dir: The mount directory path to validate.
-        :return: Dictionary containing inode details.
-        """
-        cmd = f"ceph tell mds.{fs_name}:0 dump inode {source_referent_inode_number} -f json"
+        """Gets referent inode details and validates linkage."""
+        cmd = "ceph tell mds.%s:0 dump inode %s -f json" % (
+            fs_name,
+            source_referent_inode_number,
+        )
         out, rc = client.exec_command(sudo=True, cmd=cmd)
 
         try:
-            inode_data = json.loads(out.strip())  # Correctly parse JSON
+            inode_data = json.loads(out.strip())
         except json.JSONDecodeError:
-            raise Exception(f"Failed to parse JSON output: {out}")
+            raise Exception("Failed to parse JSON output: %s" % out)
 
-        # Fetch file path for the given inode
         hl_file_path = inode_data.get("path", "")
-        log.info(f"File path for inode {source_referent_inode_number}: {hl_file_path}")
+        log.info(
+            "File path for inode %s: %s" % (source_referent_inode_number, hl_file_path)
+        )
 
-        # Validate that the referent inode is linked to the original file
         remote_ino = inode_data.get("remote_ino")
-
         if remote_ino:
             if remote_ino == source_inode:
                 log.info(
-                    f"Remote inode for {hl_file_path} matches the original file with inode: {source_inode}"
+                    "Remote inode for %s matches original inode %s"
+                    % (hl_file_path, source_inode)
                 )
             else:
                 log.error(
-                    f"Remote inode mismatch: Expected {source_referent_inode_number},\n"
-                    "Found {remote_ino} for {hl_file_path}"
+                    "Remote inode mismatch: Expected %s, Found %s for %s"
+                    % (source_referent_inode_number, remote_ino, hl_file_path)
                 )
                 return 1
 
-        return inode_data  # Returning the full inode details instead of just the inode number
+        return inode_data
 
     def create_hardlink(self, client, source_path, target_path):
         """
-        Creates a hard link for a given file.
-
-        Args:
-            client (CephClient): The Ceph client node used to execute commands.
-            file1_path (str): Path to the original file.
-            hl_file_path (str): Path where the hard link will be created.
-
-        Returns:
-            bool: True if the hard link is created successfully, False otherwise.
+        Creates a hard link.
         """
-
         try:
             client.exec_command(
-                sudo=True, cmd=f"ln {source_path} {target_path}", check_ec=True
+                sudo=True, cmd="ln %s %s" % (source_path, target_path), check_ec=True
             )
-            log.info(f"Successfully created hard link: {target_path}")
+            log.info("Successfully created hard link: %s" % target_path)
             return True
-
         except Exception as e:
-            log.error(f"Exception while creating hard link: {e}")
+            log.error("Exception while creating hard link: %s" % e)
             return False
 
     def allow_referent_inode_feature_enablement(self, clients, fs_name, enable=False):
         """
-        Validate if 'allow_referent_inodes' is enabled or disabled.
-        If disabled and enable=True, enable it and validate again.
-
-        :param clients: Ceph client object to execute commands
-        :param fs_name: Name of the Ceph filesystem
-        :param enable: Boolean flag to enable the feature if disabled
+        Checks if 'allow_referent_inodes' is enabled. Enables if needed.
         """
         out, _ = clients.exec_command(
             sudo=True,
-            cmd=f"ceph fs get {fs_name} -f json",
+            cmd="ceph fs get %s -f json" % fs_name,
             check_ec=False,
         )
 
@@ -728,22 +671,25 @@ class RefInodeUtils(object):
 
         if allow_referent_inodes:
             log.info(
-                f"'allow_referent_inodes' is already enabled for filesystem {fs_name}."
+                "'allow_referent_inodes' is already enabled for filesystem %s."
+                % fs_name
             )
         else:
-            log.info(f"'allow_referent_inodes' is disabled for filesystem {fs_name}.")
+            log.info("'allow_referent_inodes' is disabled for filesystem %s." % fs_name)
             if enable:
-                log.info(f"Enabling 'allow_referent_inodes' for filesystem {fs_name}.")
+                log.info(
+                    "Enabling 'allow_referent_inodes' for filesystem %s." % fs_name
+                )
                 clients.exec_command(
                     sudo=True,
-                    cmd=f"ceph fs set {fs_name} allow_referent_inodes true",
+                    cmd="ceph fs set %s allow_referent_inodes true" % fs_name,
                     check_ec=True,
                 )
 
                 # Revalidate after enabling
                 out, _ = clients.exec_command(
                     sudo=True,
-                    cmd=f"ceph fs get {fs_name} -f json",
+                    cmd="ceph fs get %s -f json" % fs_name,
                     check_ec=False,
                 )
 
@@ -752,10 +698,58 @@ class RefInodeUtils(object):
                     "allow_referent_inodes", False
                 ):
                     log.info(
-                        f"Successfully enabled 'allow_referent_inodes' for filesystem {fs_name}."
+                        "Successfully enabled 'allow_referent_inodes' for filesystem %s."
+                        % fs_name
                     )
                 else:
                     log.error(
-                        f"Failed to enable 'allow_referent_inodes' for filesystem {fs_name}."
+                        "Failed to enable 'allow_referent_inodes' for filesystem %s."
+                        % fs_name
                     )
                     return 1
+
+    def fetch_all_hardlinks(self, client, fs_name, path, mount_dir):
+        """
+        Fetch all hard links for a file.
+        """
+        try:
+            inode_number = self.get_inode_number(client, path)
+            inode_data = self.get_inode_details(
+                client, fs_name, inode_number, mount_dir
+            )
+            referent_inodes = inode_data.get("referent_inodes", [])
+
+            hardlinks = []
+            for ref_inode in referent_inodes:
+                ref_inode_data = self.get_inode_details(
+                    client, fs_name, ref_inode, mount_dir
+                )
+                if ref_inode_data and "path" in ref_inode_data:
+                    hardlinks.append(ref_inode_data["path"])
+
+            return hardlinks
+        except Exception as e:
+            log.error("Failed to fetch hard links: %s", e)
+            return []
+
+    def unlink_hardlinks(self, client, fs_name, file_path, mount_dir):
+        """
+        Unlink all hardlinks of a file.
+        """
+        log.info("Fetching hardlinks for file: %s", file_path)
+
+        hardlinks = self.fetch_all_hardlinks(client, fs_name, file_path, mount_dir)
+
+        if not hardlinks:
+            log.info("No hardlinks found for %s", file_path)
+            return
+
+        log.info("Found %d hardlinks for %s: %s", len(hardlinks), file_path, hardlinks)
+
+        for link in hardlinks:
+            full_path = "%s/%s" % (mount_dir.rstrip("/"), link.lstrip("/"))
+            cmd = "rm -f %s" % full_path
+            client.exec_command(sudo=True, cmd=cmd)
+            log.info("Unlinked hardlink: %s", full_path)
+
+        log.info("Successfully unlinked all hardlinks for %s.", file_path)


### PR DESCRIPTION
# Description
With this addition, all referent inode management tests with link ops on a cephfs volume completes, There is a failure where the referent inodes still exists when links are removed of a file which were renamed. Issue is reported in upstream tracker.

Replaced all f-strings as well. 

Logs :  http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-HE4XLE/ 

While replacing the f-string, I made a mistake that caused the unlink operation to be performed on the wrong path, leading to the failure. I have now fixed the issue, and the attached log confirms a successful test pass.

http://magna002.ceph.redhat.com/cephci-jenkins/cephci-run-Y985WS/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
