### PR TITLE
Added EC pool for RGW bucket data

### DIFF
--- a/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ms_upgrade_61GA_to_8x_latest.yaml
@@ -57,6 +57,21 @@ tests:
                   args:
                     all-available-devices: true
               - config:
+                  args:
+                    - "ceph osd erasure-code-profile set rgwec22_4 k=2 m=2"
+                    - "crush-failure-domain=host crush-device-class=hdd"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool create primary.rgw.buckets.data 32 32"
+                    - "erasure rgwec22_4"
+                  command: shell
+              - config:
+                  args:
+                    - "ceph osd pool application enable"
+                    - "primary.rgw.buckets.data rgw"
+                  command: shell
+              - config:
                   command: apply
                   service: rgw
                   pos_args:


### PR DESCRIPTION
Configured an Erasure-Coded (EC) pool in the Ceph cluster for efficient storage of RGW bucket data.

pass log
http://magna002.ceph.redhat.com/ceph-qe-logs/mreddem/cephci-run-1B4KK6/

issue: https://issues.redhat.com/browse/RHCEPHQE-18825