### PR TITLE
[TFA] [Fix] Automation issue and comment section

### DIFF
--- a/conf/reef/rados/13-node-cluster.yaml
+++ b/conf/reef/rados/13-node-cluster.yaml
@@ -41,6 +41,8 @@ globals:
           - mgr
           - mds
           - nfs
+        no-of-volumes: 4
+        disk-size: 15
       node7:
         role:
           - client
@@ -48,6 +50,8 @@ globals:
         role:
           - mon
           - rgw
+        no-of-volumes: 4
+        disk-size: 15
       node9:
         role:
           - osd

--- a/conf/squid/rados/13-node-cluster.yaml
+++ b/conf/squid/rados/13-node-cluster.yaml
@@ -20,20 +20,23 @@ globals:
           - mgr
           - mds
           - nfs
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
       node3:
         role:
           - osd
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15
       node4:
         role:
           - osd
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15
       node5:
         role:
           - osd
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15
       node6:
         role:
@@ -41,6 +44,9 @@ globals:
           - mgr
           - mds
           - nfs
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
       node7:
         role:
           - client
@@ -48,27 +54,33 @@ globals:
         role:
           - mon
           - rgw
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
       node9:
         role:
           - osd
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15
       node10:
         role:
           - osd
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15
       node11:
         role:
           - mon
           - rgw
+          - osd
+        no-of-volumes: 3
+        disk-size: 15
       node12:
         role:
           - osd-bak
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15
       node13:
         role:
           - osd-bak
-        no-of-volumes: 4
+        no-of-volumes: 3
         disk-size: 15

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -215,14 +215,12 @@ tests:
       polarion-id: CEPH-83594645
       desc: Ensure client connection over v1 port does not crash
 
-  # Below test is currently failing, BZ raised #2315596
-  # will be un-commented once fix is available
-  # - test:
-  #     name: Mon connection scores testing
-  #     desc: Verification of mon connection scores in different scenarios
-  #     module: test_mon_connection_scores.py
-  #     polarion-id: CEPH-83602911
-  #     comments: Active bug 2151501
+  - test:
+      name: Mon connection scores testing
+      desc: Verification of mon connection scores in different scenarios
+      module: test_mon_connection_scores.py
+      polarion-id: CEPH-83602911
+      comments: Intermittent bug 2151501
 
   - test:
       name: Verify config values via cephadm-ansible

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -176,7 +176,6 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
-      comments: Active bugs 2277111,2335727 and 2335762
 
   - test:
       name: Inconsistent objects in replicated pool functionality check
@@ -222,7 +221,7 @@ tests:
       desc: Verification of mon connection scores in different scenarios
       module: test_mon_connection_scores.py
       polarion-id: CEPH-83602911
-      comments: Active bug 2151501
+      comments: Active bug 2357894
 
   - test:
       name: Verify config values via cephadm-ansible

--- a/suites/squid/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/squid/rados/tier-2_rados_test_bluestore.yaml
@@ -168,22 +168,7 @@ tests:
           obj_end: 15
           normal_objs: 400
           num_keys_obj: 200001
-
-  - test:
-      name: Ceph Volume utility zap test with destroy flag
-      module: test_cephvolume_workflows.py
-      polarion-id:
-      desc: verify ceph-volume lvm zap functionality with destroy flag
-      config:
-        zap_with_destroy_flag: true
-
-  - test:
-      name: Ceph Volume utility zap test without destroy flag
-      module: test_cephvolume_workflows.py
-      polarion-id:
-      desc: verify ceph-volume lvm zap functionality without destroy flag
-      config:
-        zap_without_destroy_flag: true
+      comments: 8.1 Regression BZ 2351352
 
   - test:
       name: Bluestore data compression - set 1
@@ -217,3 +202,19 @@ tests:
         scenarios_to_run:
           - scenario-8
           - scenario-9
+
+  - test:
+      name: Ceph Volume utility zap test with destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id: CEPH-83603694
+      desc: verify ceph-volume lvm zap functionality with destroy flag
+      config:
+        zap_with_destroy_flag: true
+
+  - test:
+      name: Ceph Volume utility zap test without destroy flag
+      module: test_cephvolume_workflows.py
+      polarion-id: CEPH-83603694
+      desc: verify ceph-volume lvm zap functionality without destroy flag
+      config:
+        zap_without_destroy_flag: true

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -121,7 +121,7 @@ def run(ceph_cluster, **kw) -> int:
                 try:
                     for node in osd_nodes:
                         assert rados_obj.check_host_status(
-                            hostname=node.hostname, status="offline"
+                            hostname=node.hostname, status=""
                         )
                     log.info("Rebooted hosts are up")
                     break


### PR DESCRIPTION
# Description

PR includes TFA fixes and comment updates for
(1) tier-2_rados_test_bluestore - bluestore_superblock_redundency 
pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_bluestore_25_04_07_02_06_38/ 

(2) tier-4_rados_test-pool-osd-recovery - Failure recovery on Replicated & EC
Pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs_rados_osd_recovery_25_04_05_01_31_22/ 

(3) Issue fixed for Mon connection scores testing - hence uncommenting the test case

(4) Rearrange the tests due to test case failure in ceph volume test cases

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
