### PR TITLE
Rados test suite optimizations - Update bench duration->max_obj

### DIFF
--- a/suites/quincy/rados/mero_4_node_rados_db_wal_conf.yaml
+++ b/suites/quincy/rados/mero_4_node_rados_db_wal_conf.yaml
@@ -170,8 +170,8 @@ tests:
                  pool_name: blustore_pinned
                  pg_num: 64
                  pg_num_min: 32
-                 rados_write_duration: 300
-                 rados_read_duration: 150
+                 max_objs: 300
+                 rados_read_duration: 10
                  byte_size: 64MB
                pool-2:
                  pool_name: bluestore_ec_pool
@@ -180,6 +180,6 @@ tests:
                  k: 8
                  m: 4
                  plugin: jerasure
-                 rados_write_duration: 50
-                 rados_read_duration: 50
+                 max_objs: 300
+                 rados_read_duration: 10
           desc: Verification of the bluestore pinned tests

--- a/suites/quincy/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/rados/tier-2-rados-basic-regression.yaml
@@ -243,8 +243,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -266,12 +266,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -327,8 +327,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -400,7 +400,7 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: host
       desc: Verify the behaviour of EC profiles in ceph

--- a/suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/quincy/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -134,8 +134,8 @@ tests:
           m: 2
           pg_num: 32
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -154,8 +154,8 @@ tests:
           m: 2
           plugin: jerasure
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_ec_pool
           configurations:
@@ -182,8 +182,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool

--- a/suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -110,8 +110,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: host
       desc: Verify the behaviour of EC profiles in ceph
 
@@ -167,7 +167,7 @@ tests:
           - create_pool:
               pool_name: pool_p1
               pg_num: 64
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -236,7 +236,7 @@ tests:
           - create_pool:
               pool_name: rpool_1
               pg_num: 32
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -247,14 +247,14 @@ tests:
               pool_type: replicated
               size: 2
               min_size: 2
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               osd_max_backfills: 16
               osd_recovery_max_active: 16
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -268,8 +268,8 @@ tests:
               k: 4
               m: 2
               plugin: jerasure
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               create: true
               pool_name: ecpool_2
@@ -279,8 +279,8 @@ tests:
               m: 2
               l: 3
               plugin: lrc
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
         delete_pools:
           - rpool_1
           - rpool_2

--- a/suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -197,8 +197,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -224,13 +224,13 @@ tests:
           byte_size: 200KB
           m: 3
           plugin: jerasure
-          rados_write_duration: 200
-          rados_read_duration: 100
+          max_objs: 300
+          rados_read_duration: 10
         replicated_pool:
           pool_name: delete_pool
           pg_num: 32
           byte_size: 1024
-          rados_write_duration: 300
+          max_objs: 300
           rados_read_duration: 10
 
   - test:
@@ -259,7 +259,7 @@ tests:
           pool_config:
             pool-1: test_compression_ecpool-1
             pool-2: test_compression_ecpool-2
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2

--- a/suites/quincy/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -178,8 +178,8 @@ tests:
           pool_name: test_re_pool-1
           pg_num: 16
           size: 3
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool-1
           configurations:

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -134,8 +134,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -218,16 +218,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_1
               pg_num: 32
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -274,16 +274,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_2
               pg_num: 64
               pg_num_min: 32
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
@@ -396,7 +396,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 400KB
             pg_num: 32
           compression_config:

--- a/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-scrubbing.yaml
@@ -86,8 +86,8 @@ tests:
               pg_num: 32
               pg_num_min: 32
               pool_type: replicated
-              rados_write_duration: 120
-              rados_read_duration: 120
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 1KB
         delete_pools:
           - scheduled_scrub

--- a/suites/quincy/rados/tier-2_rados_test-slow-op-requests.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-slow-op-requests.yaml
@@ -96,7 +96,7 @@ tests:
           - create_pool:
               pool_name: pool1
               pg_num: 64
-              rados_write_duration: 1000
+              rmax_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -104,7 +104,7 @@ tests:
           - create_pool:
               pool_name: pool2
               pg_num: 64
-              rados_write_duration: 1000
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -112,7 +112,7 @@ tests:
           - create_pool:
               pool_name: pool3
               pg_num: 64
-              rados_write_duration: 1000
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -226,7 +226,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:

--- a/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-stretch-mode.yaml
@@ -226,5 +226,5 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster

--- a/suites/quincy/rados/tier-3_rados_ssd-tests.yaml
+++ b/suites/quincy/rados/tier-3_rados_ssd-tests.yaml
@@ -120,8 +120,8 @@ tests:
               pool_type: replicated
               size: 2
               min_size: 2
-              rados_write_duration: 30
-              rados_read_duration: 15
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               create: true
@@ -132,8 +132,8 @@ tests:
               k: 4
               m: 2
               plugin: jerasure
-              rados_write_duration: 30
-              rados_read_duration: 15
+              max_objs: 300
+              rados_read_duration: 10
               crush-failure-domain: osd
         delete_pools:
           - ecpool_1
@@ -181,8 +181,8 @@ tests:
           - create_pool:
               pool_name: rpool_01
               pg_num: 16
-              rados_write_duration: 60
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
         delete_pools:
@@ -213,7 +213,7 @@ tests:
           k: 4
           m: 2
           plugin: jerasure
-          rados_write_duration: 60
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: osd
       desc: Create pools and run IO

--- a/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -187,8 +187,8 @@ tests:
           pg_num: 32
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -208,8 +208,8 @@ tests:
 #          plugin: jerasure
 #          crush-failure-domain: host
 #          disable_pg_autoscale: true
-#          rados_write_duration: 50
-#          rados_read_duration: 30
+#          max_objs: 300
+#          rados_read_duration: 10
 #        set_pool_configs:
 #          pool_name: test_ec_pool
 #          configurations:
@@ -237,8 +237,8 @@ tests:
           m: 2
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool
@@ -279,7 +279,7 @@ tests:
             profile_name: ec86_5
             pool-1: ec86_pool5
             pool-2: ec86_pool6
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2
@@ -311,8 +311,8 @@ tests:
 #              plugin: jerasure
 #              crush-failure-domain: host
 #              target_size_ratio: 0.8
-#              rados_write_duration: 50
-#              rados_read_duration: 50
+#              max_objs: 300
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -403,8 +403,8 @@ tests:
 #              crush-failure-domain: host
 #              plugin: jerasure
 #              target_size_ratio: 0.8
-#              rados_write_duration: 50
-#              rados_read_duration: 50
+#              max_objs: 300
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -424,8 +424,8 @@ tests:
 #              plugin: jerasure
 #              crush-failure-domain: host
 #              pg_num_min: 16
-#              rados_write_duration: 50
-#              rados_read_duration: 50
+#              max_objs: 300
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
@@ -534,7 +534,7 @@ tests:
 #              plugin: jerasure
 #              crush-failure-domain: host
 #              pg_num: 64
-#              rados_write_duration: 1000
+#              max_objs: 300
 #              byte_size: 1024
 #              osd_max_backfills: 16
 #              osd_recovery_max_active: 16

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -218,7 +218,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:

--- a/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -199,7 +199,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
@@ -213,7 +213,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 100KB
             pg_num: 32
           compression_config:
@@ -233,12 +233,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -282,8 +282,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -226,12 +226,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -262,12 +262,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force

--- a/suites/quincy/upstream/tier-2-rados-basic-regression.yaml
+++ b/suites/quincy/upstream/tier-2-rados-basic-regression.yaml
@@ -215,8 +215,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -236,12 +236,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -270,8 +270,8 @@ tests:
       config:
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -300,8 +300,8 @@ tests:
       config:
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -361,8 +361,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -413,7 +413,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 400KB
             pg_num: 32
           compression_config:

--- a/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
+++ b/suites/quincy/upstream/tier-2_rados_test-stretch-mode.yaml
@@ -216,5 +216,5 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster

--- a/suites/reef/rados/mero_4_node_rados_db_wal_conf.yaml
+++ b/suites/reef/rados/mero_4_node_rados_db_wal_conf.yaml
@@ -170,8 +170,8 @@ tests:
                  pool_name: blustore_pinned
                  pg_num: 64
                  pg_num_min: 32
-                 rados_write_duration: 300
-                 rados_read_duration: 150
+                 max_objs: 300
+                 rados_read_duration: 10
                  byte_size: 64MB
                pool-2:
                  pool_name: bluestore_ec_pool
@@ -180,6 +180,6 @@ tests:
                  k: 8
                  m: 4
                  plugin: jerasure
-                 rados_write_duration: 50
-                 rados_read_duration: 50
+                 max_objs: 300
+                 rados_read_duration: 10
           desc: Verification of the bluestore pinned tests

--- a/suites/reef/rados/test_rados_all_generic_features.yaml
+++ b/suites/reef/rados/test_rados_all_generic_features.yaml
@@ -342,8 +342,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -365,12 +365,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -402,8 +402,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -438,8 +438,8 @@ tests:
           pool_name: test_re_pool-1
           pg_num: 16
           size: 3
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool-1
           configurations:
@@ -459,7 +459,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 400KB
             pg_num: 32
           compression_config:
@@ -565,8 +565,8 @@ tests:
           m: 2
           pg_num: 32
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -585,8 +585,8 @@ tests:
           m: 2
           plugin: jerasure
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_ec_pool
           configurations:
@@ -613,8 +613,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool
@@ -740,7 +740,7 @@ tests:
           pool_config:
             pool-1: test_compression_ecpool-1
             pool-2: test_compression_ecpool-2
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2
@@ -821,20 +821,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -844,8 +844,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1
@@ -866,20 +866,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -889,8 +889,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1
@@ -1099,16 +1099,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_2
               pg_num: 64
               pg_num_min: 32
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
@@ -1187,16 +1187,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_1
               pg_num: 32
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -1394,7 +1394,7 @@ tests:
           - create_pool:
               pool_name: pool1
               pg_num: 64
-              rados_write_duration: 1000
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -1402,7 +1402,7 @@ tests:
           - create_pool:
               pool_name: pool2
               pg_num: 64
-              rados_write_duration: 1000
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -1410,7 +1410,7 @@ tests:
           - create_pool:
               pool_name: pool3
               pg_num: 64
-              rados_write_duration: 1000
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -1677,8 +1677,8 @@ tests:
               pg_num: 32
               pg_num_min: 32
               pool_type: replicated
-              rados_write_duration: 120
-              rados_read_duration: 120
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 1KB
         delete_pools:
           - scheduled_scrub

--- a/suites/reef/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/reef/rados/tier-2-rados-basic-regression.yaml
@@ -245,8 +245,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -268,12 +268,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -329,8 +329,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -402,8 +402,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: host
       desc: Verify the behaviour of EC profiles in ceph
 

--- a/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -139,8 +139,8 @@ tests:
           m: 2
           pg_num: 32
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -159,8 +159,8 @@ tests:
           m: 2
           plugin: jerasure
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_ec_pool
           configurations:
@@ -187,8 +187,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool

--- a/suites/reef/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -110,8 +110,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: host
       desc: Verify the behaviour of EC profiles in ceph
 
@@ -167,7 +167,7 @@ tests:
           - create_pool:
               pool_name: pool_p1
               pg_num: 64
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -236,7 +236,7 @@ tests:
           - create_pool:
               pool_name: rpool_1
               pg_num: 32
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -247,14 +247,14 @@ tests:
               pool_type: replicated
               size: 2
               min_size: 2
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               osd_max_backfills: 16
               osd_recovery_max_active: 16
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -268,8 +268,8 @@ tests:
               k: 4
               m: 2
               plugin: jerasure
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               create: true
               pool_name: ecpool_2
@@ -279,8 +279,8 @@ tests:
               m: 2
               l: 3
               plugin: lrc
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
         delete_pools:
           - rpool_1
           - rpool_2

--- a/suites/reef/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/reef/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -197,8 +197,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -224,13 +224,13 @@ tests:
           byte_size: 200KB
           m: 3
           plugin: jerasure
-          rados_write_duration: 200
-          rados_read_duration: 100
+          max_objs: 300
+          rados_read_duration: 10
         replicated_pool:
           pool_name: delete_pool
           pg_num: 32
           byte_size: 1024
-          rados_write_duration: 300
+          max_objs: 300
           rados_read_duration: 10
 
   - test:
@@ -259,7 +259,7 @@ tests:
           pool_config:
             pool-1: test_compression_ecpool-1
             pool-2: test_compression_ecpool-2
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2

--- a/suites/reef/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -178,8 +178,8 @@ tests:
           pool_name: test_re_pool-1
           pg_num: 16
           size: 3
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool-1
           configurations:

--- a/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -108,20 +108,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -131,8 +131,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1
@@ -153,20 +153,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -176,8 +176,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1

--- a/suites/reef/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/reef/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -134,8 +134,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -218,16 +218,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_1
               pg_num: 32
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -274,16 +274,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_2
               pg_num: 64
               pg_num_min: 32
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
@@ -396,7 +396,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 400KB
             pg_num: 32
           compression_config:

--- a/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/reef/rados/tier-2_rados_test-scrubbing.yaml
@@ -100,8 +100,8 @@ tests:
               pg_num: 32
               pg_num_min: 32
               pool_type: replicated
-              rados_write_duration: 120
-              rados_read_duration: 120
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 1KB
         delete_pools:
           - scheduled_scrub

--- a/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/reef/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -229,7 +229,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:

--- a/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/reef/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -207,7 +207,7 @@ tests:
           - create_pool:
               pool_name: pool1
               pg_num: 64
-              rados_write_duration: 500
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -216,7 +216,7 @@ tests:
           - create_pool:
               pool_name: pool2
               pg_num: 128
-              rados_write_duration: 500
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -225,7 +225,7 @@ tests:
           - create_pool:
               pool_name: pool3
               pg_num: 256
-              rados_write_duration: 500
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16

--- a/suites/reef/rados/tier-3_rados_ssd-tests.yaml
+++ b/suites/reef/rados/tier-3_rados_ssd-tests.yaml
@@ -120,8 +120,8 @@ tests:
               pool_type: replicated
               size: 2
               min_size: 2
-              rados_write_duration: 30
-              rados_read_duration: 15
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               create: true
@@ -132,8 +132,8 @@ tests:
               k: 4
               m: 2
               plugin: jerasure
-              rados_write_duration: 30
-              rados_read_duration: 15
+              max_objs: 300
+              rados_read_duration: 10
               crush-failure-domain: osd
         delete_pools:
           - ecpool_1
@@ -181,8 +181,8 @@ tests:
           - create_pool:
               pool_name: rpool_01
               pg_num: 16
-              rados_write_duration: 60
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
         delete_pools:
@@ -213,7 +213,7 @@ tests:
           k: 4
           m: 2
           plugin: jerasure
-          rados_write_duration: 60
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: osd
       desc: Create pools and run IO

--- a/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/reef/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -216,8 +216,8 @@ tests:
           pg_num: 32
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -238,7 +238,7 @@ tests:
 #          crush-failure-domain: host
 #          disable_pg_autoscale: true
 #          rados_write_duration: 50
-#          rados_read_duration: 30
+#          rados_read_duration: 10
 #        set_pool_configs:
 #          pool_name: test_ec_pool
 #          configurations:
@@ -266,8 +266,8 @@ tests:
           m: 2
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool
@@ -308,7 +308,7 @@ tests:
           pool_config:
             pool-1: ec86_pool5
             pool-2: ec86_pool6
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2
@@ -341,7 +341,7 @@ tests:
 #              crush-failure-domain: host
 #              target_size_ratio: 0.8
 #              rados_write_duration: 50
-#              rados_read_duration: 50
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -433,7 +433,7 @@ tests:
 #              plugin: jerasure
 #              target_size_ratio: 0.8
 #              rados_write_duration: 50
-#              rados_read_duration: 50
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -454,7 +454,7 @@ tests:
 #              crush-failure-domain: host
 #              pg_num_min: 16
 #              rados_write_duration: 50
-#              rados_read_duration: 50
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -234,7 +234,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:

--- a/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/reef/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -199,7 +199,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
@@ -213,7 +213,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 100KB
             pg_num: 32
           compression_config:
@@ -233,12 +233,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -282,8 +282,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -218,12 +218,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -254,12 +254,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force

--- a/suites/squid/rados/mero_4_node_rados_db_wal_conf.yaml
+++ b/suites/squid/rados/mero_4_node_rados_db_wal_conf.yaml
@@ -170,8 +170,8 @@ tests:
                  pool_name: blustore_pinned
                  pg_num: 64
                  pg_num_min: 32
-                 rados_write_duration: 300
-                 rados_read_duration: 150
+                 max_objs: 300
+                 rados_read_duration: 10
                  byte_size: 64MB
                pool-2:
                  pool_name: bluestore_ec_pool
@@ -180,6 +180,6 @@ tests:
                  k: 8
                  m: 4
                  plugin: jerasure
-                 rados_write_duration: 50
-                 rados_read_duration: 50
+                 max_objs: 300
+                 rados_read_duration: 10
           desc: Verification of the bluestore pinned tests

--- a/suites/squid/rados/tier-2-rados-basic-regression.yaml
+++ b/suites/squid/rados/tier-2-rados-basic-regression.yaml
@@ -258,8 +258,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -283,12 +283,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -350,8 +350,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -432,8 +432,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: host
       desc: Verify the behaviour of EC profiles in ceph
 

--- a/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/squid/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -139,8 +139,8 @@ tests:
           m: 2
           pg_num: 32
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -159,8 +159,8 @@ tests:
           m: 2
           plugin: jerasure
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_ec_pool
           configurations:
@@ -187,8 +187,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool
@@ -283,20 +283,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -306,8 +306,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1
@@ -330,8 +330,8 @@ tests:
           m: 2
           plugin: isa
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_isa_ec_pool
           configurations:
@@ -358,8 +358,8 @@ tests:
           k: 2
           m: 2
           plugin: isa
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: isa_re_pool_overwrite
           image_name: image_ec_pool

--- a/suites/squid/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
+++ b/suites/squid/rados/tier-2_rados_test-ecpool-osd-rebalance.yaml
@@ -111,8 +111,8 @@ tests:
           k: 2
           m: 2
           plugin: jerasure
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: host
       desc: Verify the behaviour of EC profiles in ceph
 
@@ -168,7 +168,7 @@ tests:
           - create_pool:
               pool_name: pool_p1
               pg_num: 64
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -237,7 +237,7 @@ tests:
           - create_pool:
               pool_name: rpool_1
               pg_num: 32
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -248,14 +248,14 @@ tests:
               pool_type: replicated
               size: 2
               min_size: 2
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               osd_max_backfills: 16
               osd_recovery_max_active: 16
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -269,8 +269,8 @@ tests:
               k: 4
               m: 2
               plugin: jerasure
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               create: true
               pool_name: ecpool_2
@@ -280,8 +280,8 @@ tests:
               m: 2
               l: 3
               plugin: lrc
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
         delete_pools:
           - rpool_1
           - rpool_2

--- a/suites/squid/rados/tier-2_rados_test-mon-db-trimming.yaml
+++ b/suites/squid/rados/tier-2_rados_test-mon-db-trimming.yaml
@@ -198,8 +198,8 @@ tests:
           pg_num: 16
           size: 2
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool
           configurations:
@@ -225,13 +225,13 @@ tests:
           byte_size: 200KB
           m: 3
           plugin: jerasure
-          rados_write_duration: 200
-          rados_read_duration: 100
+          max_objs: 300
+          rados_read_duration: 10
         replicated_pool:
           pool_name: delete_pool
           pg_num: 32
           byte_size: 1024
-          rados_write_duration: 300
+          max_objs: 300
           rados_read_duration: 10
 
   - test:
@@ -260,7 +260,7 @@ tests:
           pool_config:
             pool-1: test_compression_ecpool-1
             pool-2: test_compression_ecpool-2
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2

--- a/suites/squid/rados/tier-2_rados_test-pg-dups-trimming.yaml
+++ b/suites/squid/rados/tier-2_rados_test-pg-dups-trimming.yaml
@@ -178,8 +178,8 @@ tests:
           pool_name: test_re_pool-1
           pg_num: 16
           size: 3
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: test_re_pool-1
           configurations:

--- a/suites/squid/rados/tier-2_rados_test-pg-split-merge.yaml
+++ b/suites/squid/rados/tier-2_rados_test-pg-split-merge.yaml
@@ -109,20 +109,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -132,8 +132,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1
@@ -154,20 +154,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -177,8 +177,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1

--- a/suites/squid/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/squid/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -135,8 +135,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn
@@ -190,16 +190,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_1
               pg_num: 32
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -246,16 +246,16 @@ tests:
               plugin: jerasure
               crush-failure-domain: osd
               pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
             pool-2:
               pool_type: replicated
               pool_name: re_pool_2
               pg_num: 64
               pg_num_min: 32
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
@@ -368,7 +368,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 400KB
             pg_num: 32
           compression_config:
@@ -448,20 +448,20 @@ tests:
               pg_num: 64
               byte_size: 256
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
           - create_pool:
               pool_name: rpool_2
               pg_num: 128
               pool_type: replicated
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               pool_name: rpool_3
               pg_num: 32
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
           - create_pool:
@@ -471,8 +471,8 @@ tests:
               pg_num: 32
               k: 2
               m: 2
-              rados_write_duration: 50
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
         delete_pools:
           - rpool_1

--- a/suites/squid/rados/tier-2_rados_test-scrubbing.yaml
+++ b/suites/squid/rados/tier-2_rados_test-scrubbing.yaml
@@ -104,8 +104,8 @@ tests:
               pg_num: 32
               pg_num_min: 32
               pool_type: replicated
-              rados_write_duration: 120
-              rados_read_duration: 120
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 1KB
         delete_pools:
           - scheduled_scrub

--- a/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
+++ b/suites/squid/rados/tier-2_rados_test-stretch-mode-upgrade.yaml
@@ -227,7 +227,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:

--- a/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
+++ b/suites/squid/rados/tier-3_rados_cidr_blocklisting.yaml
@@ -207,7 +207,7 @@ tests:
           - create_pool:
               pool_name: pool1
               pg_num: 64
-              rados_write_duration: 500
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -216,7 +216,7 @@ tests:
           - create_pool:
               pool_name: pool2
               pg_num: 128
-              rados_write_duration: 500
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16
@@ -225,7 +225,7 @@ tests:
           - create_pool:
               pool_name: pool3
               pg_num: 256
-              rados_write_duration: 500
+              max_objs: 300
               byte_size: 1024
               pool_type: replicated
               osd_max_backfills: 16

--- a/suites/squid/rados/tier-3_rados_ssd-tests.yaml
+++ b/suites/squid/rados/tier-3_rados_ssd-tests.yaml
@@ -120,8 +120,8 @@ tests:
               pool_type: replicated
               size: 2
               min_size: 2
-              rados_write_duration: 30
-              rados_read_duration: 15
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
           - create_pool:
               create: true
@@ -132,8 +132,8 @@ tests:
               k: 4
               m: 2
               plugin: jerasure
-              rados_write_duration: 30
-              rados_read_duration: 15
+              max_objs: 300
+              rados_read_duration: 10
               crush-failure-domain: osd
         delete_pools:
           - ecpool_1
@@ -181,8 +181,8 @@ tests:
           - create_pool:
               pool_name: rpool_01
               pg_num: 16
-              rados_write_duration: 60
-              rados_read_duration: 30
+              max_objs: 300
+              rados_read_duration: 10
               byte_size: 256
               pool_type: replicated
         delete_pools:
@@ -213,7 +213,7 @@ tests:
           k: 4
           m: 2
           plugin: jerasure
-          rados_write_duration: 60
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           crush-failure-domain: osd
       desc: Create pools and run IO

--- a/suites/squid/rados/tier-3_rados_test-3-AZ-Cluster.yaml
+++ b/suites/squid/rados/tier-3_rados_test-3-AZ-Cluster.yaml
@@ -279,7 +279,7 @@ tests:
   - test:
       name: Negative Scenarios
       module: test_stretch_n_az_negative_scenarios.py
-      polarion-id: CCEPH-83609872
+      polarion-id: CEPH-83609872
       config:
         stretch_bucket: datacenter
         rule_name: 3az_rule

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -241,8 +241,8 @@ tests:
           crush-osds-per-failure-domain: 4
           crush-num-failure-domains: 4
           crush-failure-domain: host
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -267,8 +267,8 @@ tests:
           plugin: jerasure
           crush-failure-domain: host
           disable_pg_autoscale: true
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
         set_pool_configs:
           pool_name: ec86_pool2
           configurations:
@@ -300,8 +300,8 @@ tests:
           crush-num-failure-domains: 4
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool
@@ -345,7 +345,7 @@ tests:
           pool_config:
             pool-1: ec86_pool5
             pool-2: ec86_pool6
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 8
@@ -383,8 +383,8 @@ tests:
               plugin: jerasure
               crush-failure-domain: host
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -485,8 +485,8 @@ tests:
               plugin: jerasure
               crush-failure-domain: host
               target_size_ratio: 0.8
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -509,8 +509,8 @@ tests:
               plugin: jerasure
               crush-failure-domain: host
               pg_num_min: 16
-              rados_write_duration: 50
-              rados_read_duration: 50
+              max_objs: 300
+              rados_read_duration: 10
               delete_pool: true
       desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 
@@ -627,7 +627,7 @@ tests:
               plugin: jerasure
               crush-failure-domain: host
               pg_num: 64
-              rados_write_duration: 1000
+              max_objs: 300
               byte_size: 1024
               osd_max_backfills: 16
               osd_recovery_max_active: 16

--- a/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-ecpools.yaml
@@ -216,8 +216,8 @@ tests:
           pg_num: 32
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 100
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           osd_max_backfills: 16
           osd_recovery_max_active: 16
           delete_pool: true
@@ -238,7 +238,7 @@ tests:
 #          crush-failure-domain: host
 #          disable_pg_autoscale: true
 #          rados_write_duration: 50
-#          rados_read_duration: 30
+#          rados_read_duration: 10
 #        set_pool_configs:
 #          pool_name: test_ec_pool
 #          configurations:
@@ -266,8 +266,8 @@ tests:
           m: 2
           plugin: jerasure
           crush-failure-domain: host
-          rados_write_duration: 50
-          rados_read_duration: 30
+          max_objs: 300
+          rados_read_duration: 10
           test_overwrites_pool: true
           metadata_pool: re_pool_overwrite
           image_name: image_ec_pool
@@ -308,7 +308,7 @@ tests:
           pool_config:
             pool-1: ec86_pool5
             pool-2: ec86_pool6
-            rados_write_duration: 300
+            max_objs: 300
             byte_size: 10KB
             pg_num: 32
             k: 2
@@ -341,7 +341,7 @@ tests:
 #              crush-failure-domain: host
 #              target_size_ratio: 0.8
 #              rados_write_duration: 50
-#              rados_read_duration: 50
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -434,7 +434,7 @@ tests:
 #              plugin: jerasure
 #              target_size_ratio: 0.8
 #              rados_write_duration: 50
-#              rados_read_duration: 50
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify target_size_ratio
 
@@ -455,7 +455,7 @@ tests:
 #              crush-failure-domain: host
 #              pg_num_min: 16
 #              rados_write_duration: 50
-#              rados_read_duration: 50
+#              rados_read_duration: 10
 #              delete_pool: true
 #      desc: Specifying pool bounds on pool Pgs - Verify pg_num_min
 

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -233,7 +233,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:

--- a/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
+++ b/suites/squid/rados/tier-3_rados_test-stretch-mode-baremetal.yaml
@@ -199,7 +199,7 @@ tests:
         verify_forced_recovery: true
         osd_max_backfills: 16
         osd_recovery_max_active: 16
-        rados_write_duration: 200
+        max_objs: 300
       desc: Verify forced recovery and healthy on a stretch configured cluster
 
   - test:
@@ -213,7 +213,7 @@ tests:
           pool_config:
             pool-1: test_compression_repool-1
             pool-2: test_compression_repool-2
-            rados_write_duration: 200
+            max_objs: 300
             byte_size: 100KB
             pg_num: 32
           compression_config:
@@ -233,12 +233,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -282,8 +282,8 @@ tests:
         replicated_pool:
           create: true
           pool_name: rep_test_pool
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           pg_num: 32
         configure_pg_autoscaler:
           default_mode: warn

--- a/suites/squid/rados/tier-4_rados_tests.yaml
+++ b/suites/squid/rados/tier-4_rados_tests.yaml
@@ -219,12 +219,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force
@@ -255,12 +255,12 @@ tests:
           create: true
           pool_name: re_pool_compress
           pg_num: 32
-          rados_write_duration: 10
+          max_objs: 300
           rados_read_duration: 10
         enable_compression:
           pool_name: re_pool_compress
-          rados_write_duration: 50
-          rados_read_duration: 50
+          max_objs: 300
+          rados_read_duration: 10
           configurations:
             - config-1:
                 compression_mode: force


### PR DESCRIPTION
Rados test suite optimizations - Update bench duration->max_obj & max read time to 10 sec.

This will help reduce the run time by :
1. Writing less objects via bench will complete faster.
2. the rebalancing time in the cluster will be fast due to less objects and will drastically reduce time for clean PGs on cluster. This should be fine as the intent is functional testing.