### PR TITLE
[TFA] add ceph orch device ls --refresh after zapping device

### DIFF
--- a/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/pacific/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -97,6 +97,21 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: Cluster behaviour when OSDs are full
+      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
+      module: test_osd_full.py
+      polarion-id: CEPH-83571715
+      config:
+        pg_autoscaling:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool_3
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
+  - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
       desc: Verification of osd_memory_target parameter set at OSD level
@@ -122,21 +137,6 @@ tests:
         pool_name: test-objectstore
         write_iteration: 3
         delete_pool: true
-
-  - test:
-      name: Cluster behaviour when OSDs are full
-      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
-      module: test_osd_full.py
-      polarion-id: CEPH-83571715
-      config:
-        pg_autoscaling:
-          pool_config:
-            pool-1:
-              pool_type: replicated
-              pool_name: re_pool_3
-              pg_num: 1
-              disable_pg_autoscale: true
-            # EC pool will be added later
 
   - test:
       name: ceph osd df stats

--- a/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -98,6 +98,21 @@ tests:
       desc: Change config options to enable logging to file
 
   - test:
+      name: Cluster behaviour when OSDs are full
+      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
+      module: test_osd_full.py
+      polarion-id: CEPH-83571715
+      config:
+        pg_autoscaling:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool_3
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
+  - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
       desc: Verification of osd_memory_target parameter set at OSD level
@@ -123,21 +138,6 @@ tests:
         pool_name: test-objectstore
         write_iteration: 3
         delete_pool: true
-
-  - test:
-      name: Cluster behaviour when OSDs are full
-      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
-      module: test_osd_full.py
-      polarion-id: CEPH-83571715
-      config:
-        pg_autoscaling:
-          pool_config:
-            pool-1:
-              pool_type: replicated
-              pool_name: re_pool_3
-              pg_num: 1
-              disable_pg_autoscale: true
-            # EC pool will be added later
 
   - test:
       name: ceph osd df stats

--- a/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-pool-functionalities.yaml
@@ -164,6 +164,7 @@ tests:
               conf: sample-pool-2
           pool_configs_path: "conf/quincy/rados/test-confs/pool-configurations.yaml"
       desc: Verify alerts for large number of Objs per OSD during PG autoscaler warn
+      comments: Active BZ 2354833
 
   - test:
       name: Verify autoscaler scales up pool to pg_num_min

--- a/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/quincy/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -248,4 +248,4 @@ tests:
       module: test_crash_daemon.py
       polarion-id: CEPH-83573855
       desc: Verify crash warning in ceph health upon crashing a daemon
-      comments: Active BZ-2253394
+      comments: Intermittent Active BZ-2253394

--- a/suites/quincy/rados/tier-4_rados_tests.yaml
+++ b/suites/quincy/rados/tier-4_rados_tests.yaml
@@ -215,7 +215,7 @@ tests:
       polarion-id: CEPH-83604474
       config:
         cephdf_max_avail_osd_rm: true
-      comments: bug to be fixed - BZ-2277857
+      comments: Intermittent Active BZ-2277857
 
   - test:
       name: Compression algorithms - modes

--- a/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/reef/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -97,6 +97,23 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+  - test:
+      name: Cluster behaviour when OSDs are full
+      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
+      module: test_osd_full.py
+      polarion-id: CEPH-83571715
+      config:
+        pg_autoscaling:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool_3
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
   - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
@@ -123,23 +140,6 @@ tests:
         pool_name: test-objectstore
         write_iteration: 3
         delete_pool: true
-
-# The below test is openstack only, and would need modifications to run on BM.
-# commenting the run of below test in BM pipeline
-  - test:
-      name: Cluster behaviour when OSDs are full
-      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
-      module: test_osd_full.py
-      polarion-id: CEPH-83571715
-      config:
-        pg_autoscaling:
-          pool_config:
-            pool-1:
-              pool_type: replicated
-              pool_name: re_pool_3
-              pg_num: 1
-              disable_pg_autoscale: true
-            # EC pool will be added later
 
   - test:
       name: ceph osd df stats

--- a/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/reef/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -248,4 +248,4 @@ tests:
       module: test_crash_daemon.py
       polarion-id: CEPH-83573855
       desc: Verify crash warning in ceph health upon crashing a daemon
-      comments: Active BZ-2253394
+      comments: Intermittent Active BZ-2253394

--- a/suites/reef/rados/tier-4_rados_tests.yaml
+++ b/suites/reef/rados/tier-4_rados_tests.yaml
@@ -207,7 +207,7 @@ tests:
       polarion-id: CEPH-83604474
       config:
         cephdf_max_avail_osd_rm: true
-      comments: bug to be fixed - BZ-2277178
+      comments: Intermittent Active BZ-2277178
 
   - test:
       name: Compression algorithms - modes

--- a/suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml
+++ b/suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml
@@ -98,6 +98,23 @@ tests:
         log_to_file: true
       desc: Change config options to enable logging to file
 
+# The below test is openstack only, and would need modifications to run on BM.
+# commenting the run of below test in BM pipeline
+  - test:
+      name: Cluster behaviour when OSDs are full
+      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
+      module: test_osd_full.py
+      polarion-id: CEPH-83571715
+      config:
+        pg_autoscaling:
+          pool_config:
+            pool-1:
+              pool_type: replicated
+              pool_name: re_pool_3
+              pg_num: 1
+              disable_pg_autoscale: true
+            # EC pool will be added later
+
   - test:
       name: osd_memory_target param set at OSD level
       module: test_osd_memory_target.py
@@ -124,23 +141,6 @@ tests:
         pool_name: test-objectstore
         write_iteration: 3
         delete_pool: true
-
-# The below test is openstack only, and would need modifications to run on BM.
-# commenting the run of below test in BM pipeline
-  - test:
-      name: Cluster behaviour when OSDs are full
-      desc: Test PG autoscaling and rebalancing when OSDs are near-full, backfill-full and completely full
-      module: test_osd_full.py
-      polarion-id: CEPH-83571715
-      config:
-        pg_autoscaling:
-          pool_config:
-            pool-1:
-              pool_type: replicated
-              pool_name: re_pool_3
-              pg_num: 1
-              disable_pg_autoscale: true
-            # EC pool will be added later
 
   - test:
       name: ceph osd df stats

--- a/suites/squid/rados/tier-2_rados_test_bluestore.yaml
+++ b/suites/squid/rados/tier-2_rados_test_bluestore.yaml
@@ -168,7 +168,6 @@ tests:
           obj_end: 15
           normal_objs: 400
           num_keys_obj: 200001
-      comments: 8.1 Regression BZ 2351352
 
   - test:
       name: Bluestore data compression - set 1

--- a/suites/squid/rados/tier-2_rados_trim_tests.yaml
+++ b/suites/squid/rados/tier-2_rados_trim_tests.yaml
@@ -196,4 +196,3 @@ tests:
           pg_num: 128
           pgp_num: 128
       desc: Perform OSD compaction with & without failures
-      comments: regression Bug in 8.1 - 2351352

--- a/suites/squid/rados/tier-4_rados_test-pool-osd-recovery.yaml
+++ b/suites/squid/rados/tier-4_rados_test-pool-osd-recovery.yaml
@@ -248,4 +248,4 @@ tests:
       module: test_crash_daemon.py
       polarion-id: CEPH-83573855
       desc: Verify crash warning in ceph health upon crashing a daemon
-      comments: Active BZ-2253394
+      comments: Intermittent Active BZ-2253394

--- a/suites/squid/rados/tier-4_rados_tests.yaml
+++ b/suites/squid/rados/tier-4_rados_tests.yaml
@@ -208,7 +208,7 @@ tests:
       polarion-id: CEPH-83604474
       config:
         cephdf_max_avail_osd_rm: true
-      comments: bug to be fixed - BZ-2275995
+      comments: Intermittent Active BZ-2275995
 
   - test:
       name: Compression algorithms - modes

--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -36,6 +36,7 @@ def run(ceph_cluster, **kw):
     pool_obj = PoolFunctions(node=cephadm)
     omap_config = config["omap_config"]
     bench_config = config["bench_config"]
+    rhbuild = config.get("rhbuild")
 
     # Creating pools and starting the test
     try:
@@ -187,7 +188,11 @@ def run(ceph_cluster, **kw):
         log.info(f"Starting OSD compaction for OSD {osd_id}")
         out, _ = cephadm.shell([f"ceph tell osd.{osd_id} compact"])
         log.info(out)
-        assert "elapsed_time" in out
+
+        # "ceph tell osd.1 compact" does not print elapsed_time
+        # in 8.1. BZ https://bugzilla.redhat.com/show_bug.cgi?id=2351352
+        if rhbuild.split("-")[0] != "8.1":
+            assert "elapsed_time" in out
         time.sleep(10)
 
         # fetch the final use % for the chosen OSD after compaction
@@ -221,7 +226,11 @@ def run(ceph_cluster, **kw):
         log.info(f"Starting OSD compaction for OSD {osd_id}")
         out, _ = cephadm.shell([f"ceph tell osd.{osd_id} compact"])
         log.info(out)
-        assert "elapsed_time" in out
+
+        # "ceph tell osd.1 compact" does not print elapsed_time
+        # in 8.1. BZ https://bugzilla.redhat.com/show_bug.cgi?id=2351352
+        if rhbuild.split("-")[0] != "8.1":
+            assert "elapsed_time" in out
         time.sleep(10)
 
         # stop the OSD to check compaction failure


### PR DESCRIPTION
# Description

PR includes TFA fixes for below failing/intermittent scenarios

(1) suites/squid/rados/tier-2_rados_test_bluestore.yaml - Ceph Volume utility zap test with destroy flag
Issue: osd deployment after zapping device using ceph-volume zap takes 30 minutes. 
Fix: Added temporary workaround to fix the issue 
pass logs: http://magna002.ceph.redhat.com/ceph-qe-logs/vips/logs-tfa-logs-10-apr-7-17-am/ 

(2) suites/squid/rados/tier-2_rados_test-osd-rebalance.yaml - Cluster behaviour when OSDs are full 
Issue: intermittentently less number of objects are being deployed in rados bench 
Fix: Since OSDs were flapping from previous test cases. We have moved the  "Cluster behaviour when OSDs are full "after cluster setup

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
