### PR TITLE
Removed parallel execution due to test failures during parallel run

### DIFF
--- a/suites/squid/common/sanity/rgw.yaml
+++ b/suites/squid/common/sanity/rgw.yaml
@@ -68,6 +68,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Test GetObjectAttributes with normal objects

--- a/suites/squid/common/sanity/rgw.yaml
+++ b/suites/squid/common/sanity/rgw.yaml
@@ -24,63 +24,26 @@ tests:
         config-file-name: test_versioning_objects_enable.yaml
 
   - test:
-      name: Parallel run
-      desc: RGW tier-1 parallelly.
-      module: test_parallel.py
-      parallel:
-        - test:
-            name: Test M buckets with N objects
-            desc: test to create "M" no of buckets and "N" no of objects
-            polarion-id: CEPH-9789
-            module: sanity_rgw.py
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              install_common: false
-              run-on-rgw: true
+      name: Test download with M buckets with N objects
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      polarion-id: CEPH-14237
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        install_common: false
+        run-on-haproxy: true
 
-        - test:
-            name: Test delete using M buckets with N objects
-            desc: test to create "M" no of buckets and "N" no of objects with delete
-            polarion-id: CEPH-14237
-            module: sanity_rgw.py
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              install_common: false
-              run-on-rgw: true
-
-        - test:
-            name: Test download with M buckets with N objects
-            desc: test to create "M" no of buckets and "N" no of objects with download
-            polarion-id: CEPH-14237
-            module: sanity_rgw.py
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              install_common: false
-              run-on-haproxy: true
-
-        - test:
-            name: Test multipart upload of M buckets with N objects
-            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
-            polarion-id: CEPH-9801
-            module: sanity_rgw.py
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              install_common: false
-              run-on-rgw: true
-
-        - test:
-            name: test_bi_purge for a bucket
-            desc: test bi_purge should not error
-            polarion-id: CEPH-83575234
-            module: sanity_rgw.py
-            config:
-              install_common: false
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_bi_purge.yaml
+  - test:
+      name: Test multipart upload of M buckets with N objects
+      desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+      polarion-id: CEPH-9801
+      module: sanity_rgw.py
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+        install_common: false
+        run-on-rgw: true
 
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration

--- a/suites/squid/common/sanity/rgw.yaml
+++ b/suites/squid/common/sanity/rgw.yaml
@@ -31,7 +31,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-        install_common: false
         run-on-haproxy: true
 
   - test:
@@ -42,8 +41,6 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-        install_common: false
-        run-on-rgw: true
 
   - test:
       name: Bucket Lifecycle Object_expiration_tests for non current version expiration


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
Removed parallel run as multiple test cases intermittently fail with 'mkdir: cannot create directory: File exists' error, commonly seen during parallel execution.

Failed log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Sanity/19.2.1-107/43/rgw/Parallel_run_0.log 

Pass log: http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/logsanityparallel4/ 