### PR TITLE
[Conf] Set http timeout config for IBM VPC APIs

### DIFF
--- a/compute/ibm_vpc.py
+++ b/compute/ibm_vpc.py
@@ -37,6 +37,7 @@ def get_ibm_service(access_key: str, service_url: str):
 
     service = VpcV1(authenticator=authenticator)
     service.set_service_url(service_url=service_url)
+    service.set_http_config({"timeout": 130})  # Increase to 130s
 
     return service
 


### PR DESCRIPTION
Cluster deployments in IBM Cloud failing due to API timeouts with below error -
```
Traceb[2]ack (most recent call last):
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Sanity/19.2.1-112/6/cephci/.venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 534, in _make_request
    response = conn.getresponse()
  File "/home/jenkins/ceph-builds/ibmc/IBM/8.1/rhel-9/Sanity/19.2.1-112/6/cephci/.venv/lib/python3.10/site-packages/urllib3/connection.py", line 516, in getresponse
    httplib_response = super().getresponse()
  File "/usr/local/lib/python3.10/http/client.py", line 1374, in getresponse
    response.begin()
  File "/usr/local/lib/python3.10/http/client.py", line 318, in begin
    version, status, reason = self._read_status()
  File "/usr/local/lib/python3.10/http/client.py", line 279, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/usr/local/lib/python3.10/socket.py", line 705, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.10/ssl.py", line 1273, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/local/lib/python3.10/ssl.py", line 1129, in read
    return self._sslobj.read(len, buffer)
TimeoutError: The read operation timed out
```
Set below config to `VpcV1` api
```
set_http_config({"timeout": 130})
```