### PR TITLE
[TFA] Set run-on-haproxy: true for tests failing with HAProxy issue

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-omap-datalog-on-primary.yaml
@@ -360,6 +360,7 @@ tests:
           config:
             script-name: ../s3cmd/test_s3cmd.py
             config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+            run-on-haproxy: true
             # verify-io-on-site: ["ceph-sec"] as there is an io file issue, once its fixed need to uncomment
 
   # - test:

--- a/suites/pacific/rgw/tier-1_rgw_multisite_multirealm_upgrade-5-to-latest.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_multisite_multirealm_upgrade-5-to-latest.yaml
@@ -385,7 +385,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
             verify-io-on-site: ["ceph-sec"]
-            run-on-haproxy: true
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects pre upgrade
@@ -483,7 +482,6 @@ tests:
             set-env: true
             script-name: test_Mbuckets_with_Nobjects.py
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            run-on-haproxy: true
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw_multisite.py
       name: download objects post upgrade

--- a/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-lc-prefix.yaml
@@ -159,6 +159,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_rules.yaml
+        run-on-haproxy: true
   - test:
       name: Bucket Lifecycle Object_transition_tests multiple pool transition
       desc: Bucket Lifecycle Object_transition_tests multiple pool transition

--- a/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_test-using-s3cmd.yaml
@@ -193,6 +193,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Test deletlifecycle rule via s3cmd

--- a/suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_upgrade_5-3_to_6x_latest.yaml
@@ -105,6 +105,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
@@ -124,6 +125,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -133,6 +135,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -142,11 +145,13 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -272,6 +277,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
@@ -291,6 +297,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -300,6 +307,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -309,11 +317,13 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets post upgrade

--- a/suites/quincy/rgw/tier-1_rgw_upgrade_6-0GA_to_6x_latest.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_upgrade_6-0GA_to_6x_latest.yaml
@@ -154,6 +154,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -163,6 +164,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -172,11 +174,13 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -271,6 +275,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -280,6 +285,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -289,11 +295,13 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets post upgrade

--- a/suites/quincy/rgw/tier-2_rgw_regression.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_regression.yaml
@@ -166,6 +166,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_zstd.yaml
+        run-on-haproxy: true
 
   - test:
       name: compresstion_with_snappy_type
@@ -175,6 +176,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_compression_snappy.yaml
+        run-on-haproxy: true
 
   # REST API test
   - test:

--- a/suites/reef/rgw/tier-1_rgw.yaml
+++ b/suites/reef/rgw/tier-1_rgw.yaml
@@ -77,6 +77,16 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   # Testing stage
 
@@ -112,7 +122,7 @@ tests:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
               install_common: false
-              run-on-rgw: true
+              run-on-haproxy: true
             desc: test to create "M" no of buckets and "N" no of objects with download
             module: sanity_rgw.py
             name: Test download with M buckets with N objects
@@ -170,6 +180,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
   - test:
       name: Header validation of Bucket Lifecycle expiration with date
       desc: Test header validation bucket lifecycle expiration with date

--- a/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_5_3GA_to_7x_latest.yaml
@@ -74,6 +74,16 @@ tests:
       module: test_client.py
       name: configure client
       polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
@@ -83,6 +93,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -92,6 +103,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -101,11 +113,13 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -119,6 +133,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       config:
@@ -185,6 +200,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -198,6 +214,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification post upgrade
@@ -207,6 +224,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests post upgrade
@@ -216,6 +234,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -225,6 +244,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -234,6 +254,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:

--- a/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_6_1GA_to_7x_latest.yaml
@@ -76,6 +76,17 @@ tests:
       module: test_client.py
       name: configure client
       polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
 
   - test:
       abort-on-fail: true
@@ -106,6 +117,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -115,6 +127,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -124,6 +137,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -132,12 +146,14 @@ tests:
       module: sanity_rgw.py
       config:
         script-name: test_dynamic_bucket_resharding.py
+        run-on-haproxy: true
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -151,6 +167,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   # upgrade cluster
 
@@ -183,6 +200,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
       desc: test to create "M" no of buckets and "N" no of objects with download
       module: sanity_rgw.py
       name: download objects post upgrade
@@ -196,6 +214,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -205,6 +224,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -214,6 +234,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:

--- a/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_7_0GA_to_7x_latest.yaml
@@ -75,6 +75,16 @@ tests:
       module: test_client.py
       name: configure client
       polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   # Pre Upgrade tests
   - test:
@@ -100,6 +110,7 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+              run-on-haproxy: true
         - test:
             name: Upgrade cluster to latest 7.x ceph version
             desc: Upgrade cluster to latest version

--- a/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
+++ b/suites/reef/rgw/tier-1_rgw_upgrade_ssl_71GA_to_71x_latest.yaml
@@ -80,6 +80,16 @@ tests:
       module: test_client.py
       name: Configure client
       polarion-id: CEPH-83573758
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   - test:
       name: Mbuckets_with_Nobjects with etag verification pre upgrade
@@ -89,6 +99,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_etag.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests pre upgrade
@@ -98,6 +109,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests pre upgrade
@@ -107,6 +119,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version pre upgrade
@@ -116,11 +129,13 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:
         script-name: test_bucket_listing.py
         config-file-name: test_bucket_listing_flat_ordered.yaml
+        run-on-haproxy: true
       desc: test duration for ordered listing of bucket with top level objects
       module: sanity_rgw.py
       name: ordered listing of buckets pre upgrade
@@ -134,6 +149,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   # upgrade cluster
   - test:
@@ -149,6 +165,7 @@ tests:
             config:
               script-name: test_Mbuckets_with_Nobjects.py
               config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+              run-on-haproxy: true
         - test:
             name: Upgrade cluster to latest 7.1.x ceph version
             desc: Upgrade cluster to latest version
@@ -191,6 +208,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Manual Resharding tests post upgrade
@@ -200,6 +218,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_manual_resharding_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       name: Dynamic Resharding tests with version post upgrade
@@ -209,6 +228,7 @@ tests:
       config:
         script-name: test_dynamic_bucket_resharding.py
         config-file-name: test_dynamic_resharding_with_version_without_bucket_delete.yaml
+        run-on-haproxy: true
 
   - test:
       config:

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -69,6 +69,16 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node6
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   - test:
       name: Test BucketNotification with users in same tenant and different tenant
@@ -119,6 +129,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   - test:
       name: Swift user with read access

--- a/suites/squid/rgw/tier-1_rgw.yaml
+++ b/suites/squid/rgw/tier-1_rgw.yaml
@@ -187,6 +187,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
   - test:
       name: Test GetObjectAttributes with normal objects
       desc: Test GetObjectAttributes with normal objects


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

Added run-on-haproxy: true to test cases that were failing due to HAProxy endpoint issues in the Squid sanity suites, Reef sanity, upgrade regression suites, and Quincy upgrade suites.