### PR TITLE
CEPH-83611097: NVMeoF Missing Listener warning alert

### DIFF
--- a/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
+++ b/suites/squid/nvmeof/tier-2_nvmeof-alerts_health-checks-events.yaml
@@ -121,3 +121,21 @@ tests:
       module: test_ceph_nvmeof_alerts_events.py
       name: Validate NVMeoFMultipleNamespacesOfRBDImage alert
       polarion-id: CEPH-83610950
+
+  - test:
+      abort-on-fail: true
+      config:
+        rbd_pool: rbd
+        test_case: CEPH-83611097
+        cleanup:
+          - pool
+          - gateway
+        gw_group: group1
+        gw_nodes:
+          - node5
+          - node6
+      desc: NVMeoF Missing Listener warning alert
+      destroy-cluster: false
+      module: test_ceph_nvmeof_alerts_events.py
+      name: Validate NVMeoFMissingListener alert
+      polarion-id: CEPH-83611097

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -7,6 +7,7 @@ Test suite that verifies the deployment of Ceph NVMeoF Gateway HA
 from copy import deepcopy
 
 from ceph.ceph import Ceph
+from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.helper import check_service_exists
 from ceph.nvmegw_cli import NVMeGWCLI
 from ceph.nvmeof.initiator import Initiator
@@ -26,8 +27,15 @@ from utility.utils import generate_unique_id
 LOG = Log(__name__)
 
 
-def configure_listeners(ha_obj, nodes, config):
-    """Configure Listeners on subsystem."""
+def configure_listeners(ha_obj, nodes, config, action="add"):
+    """Configure Listeners on subsystem.
+
+    Args:
+        ha_obj: HA object
+        nodes: List of GW nodes
+        config: listener config
+        action: listener add, del
+    """
     lb_group_ids = {}
     for node in nodes:
         nvmegwcli = ha_obj.check_gateway(node)
@@ -40,7 +48,8 @@ def configure_listeners(ha_obj, nodes, config):
                 "host-name": hostname,
             }
         }
-        nvmegwcli.listener.add(**listener_config)
+        method = fetch_method(nvmegwcli.listener, action)
+        method(**listener_config)
         lb_group_ids.update({hostname: nvmegwcli.ana_group_id})
     return lb_group_ids
 


### PR DESCRIPTION
# Description

8.1-Dashbaord-NVMe-alert: Prometheus alert for unbalanced number of Listeners per subsystem on each GW

NVMeoFMissingListener alert helps user to identify the missing listener which is important for HA. where initiators could get connected to multipath data paths, ensuring IO is uninterupted when GW(s) fails.

```
All test logs located here: /Users/sunilkumarn/logs/8_1_upstream-alerts-wait_until-02

TEST NAME                        TEST DESCRIPTION                                               DURATION                         STATUS                    COMMENTS
Validate GW unavailability hea   GW failure or unavailability alert via healthcheck warning     0:03:46.007197                   Pass
Validate NVMeoFMultipleNamespa   Multinamespace over single RBD image warning                   0:08:10.726989                   Pass
Validate NVMeoFMissingListener   NVMeoF Missing Listener warning alert                          0:36:00.792847                   Pass


```