### PR TITLE
[Baremetal] Add osd nodes to mero multisite cluster

### DIFF
--- a/conf/baremetal/mero_multisite_1admin_3node_along_client.yaml
+++ b/conf/baremetal/mero_multisite_1admin_3node_along_client.yaml
@@ -88,6 +88,42 @@ globals:
             - /dev/sdj
             - /dev/sdk
             - /dev/sdl
+        - hostname: mero006
+          ip: 10.8.129.226
+          root_password: passwd
+          role:
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+        - hostname: mero008
+          ip: 10.8.129.228
+          root_password: passwd
+          role:
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
 
   - ceph-cluster:
       name: ceph-sec
@@ -178,3 +214,39 @@ globals:
             - /dev/sdk
             - /dev/sdl
             - /dev/sdm
+        - hostname: mero010
+          ip: 10.8.129.230
+          root_password: passwd
+          role:
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl
+        - hostname: mero012
+          ip: 10.8.129.232
+          root_password: passwd
+          role:
+            - osd
+          volumes:
+            - /dev/sda
+            - /dev/sdb
+            - /dev/sdc
+            - /dev/sdd
+            - /dev/sde
+            - /dev/sdf
+            - /dev/sdg
+            - /dev/sdh
+            - /dev/sdi
+            - /dev/sdj
+            - /dev/sdk
+            - /dev/sdl

--- a/suites/squid/baremetal/deploy/rh/mero_multisite_1admin_3node_along_client.yaml
+++ b/suites/squid/baremetal/deploy/rh/mero_multisite_1admin_3node_along_client.yaml
@@ -396,7 +396,7 @@ tests:
             controllers:
               - mero011
             drivers:
-              count: 2
+              count: 3
               hosts:
                 - mero011
                 - mero013


### PR DESCRIPTION
# Description
Adding the following mero nodes to rgw multisite conf [mero_multisite_1admin_3node_along_client](https://github.com/red-hat-storage/cephci/blob/main/conf/baremetal/mero_multisite_1admin_3node_along_client.yaml) , as OSDs 2 on each sites.

Mero 6,8,10,12

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
