### PR TITLE
[TFA Fix]: RHCEPHQE-19096: Mirror failure during dbench installation

### DIFF
--- a/tests/cephfs/cephfs_IO_lib.py
+++ b/tests/cephfs/cephfs_IO_lib.py
@@ -254,6 +254,24 @@ class FSIO(object):
             )
 
         def dbench():
+            log.info("Installing dbench if not already installed")
+            out, _ = client.node.exec_command(
+                sudo=True, cmd="rpm -qa | grep -w 'dbench'", check_ec=False
+            )
+            if "dbench" not in out:
+                log.info("Installing dbench")
+                client.node.exec_command(
+                    sudo=True,
+                    cmd=(
+                        "rhel_version=$(rpm -E %rhel) && "
+                        "dnf config-manager --add-repo="
+                        "https://dl.fedoraproject.org/pub/epel/${rhel_version}/Everything/x86_64/"
+                    ),
+                )
+                client.node.exec_command(
+                    sudo=True,
+                    cmd="dnf install dbench -y --nogpgcheck",
+                )
             log.info("IO tool scheduled : dbench")
             io_params = {
                 "clients": random.choice(

--- a/tests/cephfs/cephfs_utilsV1.py
+++ b/tests/cephfs/cephfs_utilsV1.py
@@ -137,23 +137,6 @@ class FsUtils(object):
                 ]
                 for cmd in cmd_list:
                     client.node.exec_command(cmd=cmd)
-            out, rc = client.node.exec_command(
-                sudo=True, cmd="rpm -qa | grep -w 'dbench'", check_ec=False
-            )
-            if "dbench" not in out:
-                log.info("Installing dbench")
-                client.node.exec_command(
-                    sudo=True,
-                    cmd=(
-                        "rhel_version=$(rpm -E %rhel) && "
-                        "dnf config-manager --add-repo="
-                        "https://download.fedoraproject.org/pub/epel/${rhel_version}/Everything/x86_64/"
-                    ),
-                )
-                client.node.exec_command(
-                    sudo=True,
-                    cmd="dnf install dbench -y --nogpgcheck",
-                )
         if (
             hasattr(clients[0].node, "vm_node")
             and clients[0].node.vm_node.node_type == "baremetal"


### PR DESCRIPTION
# Description

## Issue:
- Mirror failure during dbench installation intermittenly (http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Regression/19.2.1-109/cephfs/98/tier-1_fs/cephfs_snapshot_management_0.log)

## Fix:
- Use direct or stable mirror. Update the endpoint
- Run the installation only when dbench function is invoked and remove it from prepare clients function

## Automation Changes:

- tests/cephfs/cephfs_utilsV1.py (Remove the installation logic from the prepare_clients)
- tests/cephfs/cephfs_IO_lib.py (Moved logic inside dbench function)

## Logs
- http://magna002.ceph.redhat.com/ceph-qe-logs/manim/logs/RHCEPHQE-19096/

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
