### PR TITLE
[rbd] bvt fix with downstream test

### DIFF
--- a/suites/pacific/integrations/cvp.yaml
+++ b/suites/pacific/integrations/cvp.yaml
@@ -100,14 +100,39 @@ tests:
       desc: "Run object, block and filesystem basic operations in parallel"
       parallel:
         - test:
-            desc: "Testing rbd CLI Generic scenarios using unit-tests."
+            name: Run RBD tier-0 operations
+            desc: Run RBD tier-0 operations
+            polarion-id: CEPH-83575401
+            module: rbd_tier0.py
             config:
-              branch: pacific
-              script_path: qa/workunits/rbd
-              script: cli_generic.sh
-            module: test_rbd.py
-            name: "test rbd generic cli commands"
-            polarion-id: CEPH-83574241
+              ec-pool-k-m: 2,1
+              ec-pool-only: False
+              ec_pool_config:
+                pool: rbd_pool
+                data_pool: rbd_ec_pool
+                ec_profile: rbd_ec_profile
+                image: rbd_image
+                image_thick_provision: rbd_thick_image
+                snap_thick_provision: rbd_thick_snap
+                clone_thick_provision: rbd_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_ec_pool_snap
+                clone: rbd_ec_pool_clone
+              rep_pool_config:
+                pool: rbd_rep_pool
+                image: rbd_rep_image
+                image_thick_provision: rbd_rep_thick_image
+                snap_thick_provision: rbd_rep_thick_snap
+                clone_thick_provision: rbd_rep_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_rep_pool_snap
+                clone: rbd_rep_pool_clone
+              operations:
+                map: true
+                io: true
+                nounmap: false
 
         - test:
             desc: "Test M buckets having N objects"

--- a/suites/pacific/interop/test-ceph-sanity.yaml
+++ b/suites/pacific/interop/test-ceph-sanity.yaml
@@ -108,14 +108,39 @@ tests:
             name: Test M buckets with N objects
             polarion-id: CEPH-9789
         - test:
+            name: Run RBD tier-0 operations
+            desc: Run RBD tier-0 operations
+            polarion-id: CEPH-83575401
+            module: rbd_tier0.py
             config:
-              branch: pacific
-              script: cli_generic.sh
-              script_path: qa/workunits/rbd
-            desc: "Executing upstream RBD CLI Generic scenarios"
-            module: test_rbd.py
-            name: 1_rbd_cli_generic
-            polarion-id: CEPH-83574241
+              ec-pool-k-m: 2,1
+              ec-pool-only: False
+              ec_pool_config:
+                pool: rbd_pool
+                data_pool: rbd_ec_pool
+                ec_profile: rbd_ec_profile
+                image: rbd_image
+                image_thick_provision: rbd_thick_image
+                snap_thick_provision: rbd_thick_snap
+                clone_thick_provision: rbd_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_ec_pool_snap
+                clone: rbd_ec_pool_clone
+              rep_pool_config:
+                pool: rbd_rep_pool
+                image: rbd_rep_image
+                image_thick_provision: rbd_rep_thick_image
+                snap_thick_provision: rbd_rep_thick_snap
+                clone_thick_provision: rbd_rep_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_rep_pool_snap
+                clone: rbd_rep_pool_clone
+              operations:
+                map: true
+                io: true
+                nounmap: false
         - test:
             abort-on-fail: false
             desc: "cephfs basic operations"

--- a/suites/quincy/integrations/cvp.yaml
+++ b/suites/quincy/integrations/cvp.yaml
@@ -100,14 +100,39 @@ tests:
       desc: "Run object, block and filesystem basic operations in parallel"
       parallel:
         - test:
-            desc: "Testing rbd CLI Generic scenarios using unit-tests."
+            name: Run RBD tier-0 operations
+            desc: Run RBD tier-0 operations
+            polarion-id: CEPH-83575401
+            module: rbd_tier0.py
             config:
-              branch: quincy
-              script_path: qa/workunits/rbd
-              script: cli_generic.sh
-            module: test_rbd.py
-            name: "test rbd generic cli commands"
-            polarion-id: CEPH-83574241
+              ec-pool-k-m: 2,1
+              ec-pool-only: False
+              ec_pool_config:
+                pool: rbd_pool
+                data_pool: rbd_ec_pool
+                ec_profile: rbd_ec_profile
+                image: rbd_image
+                image_thick_provision: rbd_thick_image
+                snap_thick_provision: rbd_thick_snap
+                clone_thick_provision: rbd_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_ec_pool_snap
+                clone: rbd_ec_pool_clone
+              rep_pool_config:
+                pool: rbd_rep_pool
+                image: rbd_rep_image
+                image_thick_provision: rbd_rep_thick_image
+                snap_thick_provision: rbd_rep_thick_snap
+                clone_thick_provision: rbd_rep_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_rep_pool_snap
+                clone: rbd_rep_pool_clone
+              operations:
+                map: true
+                io: true
+                nounmap: false
 
         - test:
             desc: "Test M buckets having N objects"

--- a/suites/quincy/interop/test-ceph-sanity.yaml
+++ b/suites/quincy/interop/test-ceph-sanity.yaml
@@ -108,14 +108,39 @@ tests:
             name: Test M buckets with N objects
             polarion-id: CEPH-9789
         - test:
+            name: Run RBD tier-0 operations
+            desc: Run RBD tier-0 operations
+            polarion-id: CEPH-83575401
+            module: rbd_tier0.py
             config:
-              branch: quincy
-              script: cli_generic.sh
-              script_path: qa/workunits/rbd
-            desc: "Executing upstream RBD CLI Generic scenarios"
-            module: test_rbd.py
-            name: 1_rbd_cli_generic
-            polarion-id: CEPH-83574241
+              ec-pool-k-m: 2,1
+              ec-pool-only: False
+              ec_pool_config:
+                pool: rbd_pool
+                data_pool: rbd_ec_pool
+                ec_profile: rbd_ec_profile
+                image: rbd_image
+                image_thick_provision: rbd_thick_image
+                snap_thick_provision: rbd_thick_snap
+                clone_thick_provision: rbd_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_ec_pool_snap
+                clone: rbd_ec_pool_clone
+              rep_pool_config:
+                pool: rbd_rep_pool
+                image: rbd_rep_image
+                image_thick_provision: rbd_rep_thick_image
+                snap_thick_provision: rbd_rep_thick_snap
+                clone_thick_provision: rbd_rep_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_rep_pool_snap
+                clone: rbd_rep_pool_clone
+              operations:
+                map: true
+                io: true
+                nounmap: false
         - test:
             abort-on-fail: false
             desc: "cephfs basic operations"

--- a/suites/reef/interop/test-ceph-sanity.yaml
+++ b/suites/reef/interop/test-ceph-sanity.yaml
@@ -108,14 +108,39 @@ tests:
             name: Test M buckets with N objects
             polarion-id: CEPH-9789
         - test:
+            name: Run RBD tier-0 operations
+            desc: Run RBD tier-0 operations
+            polarion-id: CEPH-83575401
+            module: rbd_tier0.py
             config:
-              branch: reef
-              script: cli_generic.sh
-              script_path: qa/workunits/rbd
-            desc: "Executing upstream RBD CLI Generic scenarios"
-            module: test_rbd.py
-            name: 1_rbd_cli_generic
-            polarion-id: CEPH-83574241
+              ec-pool-k-m: 2,1
+              ec-pool-only: False
+              ec_pool_config:
+                pool: rbd_pool
+                data_pool: rbd_ec_pool
+                ec_profile: rbd_ec_profile
+                image: rbd_image
+                image_thick_provision: rbd_thick_image
+                snap_thick_provision: rbd_thick_snap
+                clone_thick_provision: rbd_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_ec_pool_snap
+                clone: rbd_ec_pool_clone
+              rep_pool_config:
+                pool: rbd_rep_pool
+                image: rbd_rep_image
+                image_thick_provision: rbd_rep_thick_image
+                snap_thick_provision: rbd_rep_thick_snap
+                clone_thick_provision: rbd_rep_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_rep_pool_snap
+                clone: rbd_rep_pool_clone
+              operations:
+                map: true
+                io: true
+                nounmap: false
         - test:
             abort-on-fail: false
             desc: "cephfs basic operations"

--- a/suites/squid/interop/test-ceph-sanity.yaml
+++ b/suites/squid/interop/test-ceph-sanity.yaml
@@ -108,14 +108,39 @@ tests:
             name: Test M buckets with N objects
             polarion-id: CEPH-9789
         - test:
+            name: Run RBD tier-0 operations
+            desc: Run RBD tier-0 operations
+            polarion-id: CEPH-83575401
+            module: rbd_tier0.py
             config:
-              branch: squid
-              script: cli_generic.sh
-              script_path: qa/workunits/rbd
-            desc: "Executing upstream RBD CLI Generic scenarios"
-            module: test_rbd.py
-            name: 1_rbd_cli_generic
-            polarion-id: CEPH-83574241
+              ec-pool-k-m: 2,1
+              ec-pool-only: False
+              ec_pool_config:
+                pool: rbd_pool
+                data_pool: rbd_ec_pool
+                ec_profile: rbd_ec_profile
+                image: rbd_image
+                image_thick_provision: rbd_thick_image
+                snap_thick_provision: rbd_thick_snap
+                clone_thick_provision: rbd_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_ec_pool_snap
+                clone: rbd_ec_pool_clone
+              rep_pool_config:
+                pool: rbd_rep_pool
+                image: rbd_rep_image
+                image_thick_provision: rbd_rep_thick_image
+                snap_thick_provision: rbd_rep_thick_snap
+                clone_thick_provision: rbd_rep_thick_clone
+                thick_size: 2G
+                size: 10G
+                snap: rbd_rep_pool_snap
+                clone: rbd_rep_pool_clone
+              operations:
+                map: true
+                io: true
+                nounmap: false
         - test:
             abort-on-fail: false
             desc: "cephfs basic operations"


### PR DESCRIPTION
# Description
Due to some of the upstream commits not backported to downstream,
rbd upstream test `cli_generic.sh` script fails for those backport commits,
But the dev has not agreed to backport those commits to older releases
Hence replaced those test with downstream tests to keep the BVT and sanity tests green 

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
