### PR TITLE
[TFA-Fix] added skip-monitoring-stack: true 

### DIFF
--- a/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary.yaml
@@ -202,25 +202,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            haproxy_clients:
-              - node8
-            rgw_endpoints:
-              - node7:80
-        ceph-sec:
-          config:
-            haproxy_clients:
-              - node8
-            rgw_endpoints:
-              - node7:80
-      desc: "Configure HAproxy"
-      module: haproxy.py
-      name: "Configure HAproxy"
-
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
             cephadm: true
             commands:
               - "radosgw-admin realm create --rgw-realm india --default"
@@ -354,7 +335,6 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-sec"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            run-on-haproxy: true
   - test:
       name: test encryption on primary
       desc: test_Mbuckets_with_Nobjects_enc on primary

--- a/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
+++ b/suites/pacific/rgw/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary.yaml
@@ -147,24 +147,6 @@ tests:
       clusters:
         ceph-pri:
           config:
-            haproxy_clients:
-              - node6
-            rgw_endpoints:
-              - node5:80
-        ceph-sec:
-          config:
-            haproxy_clients:
-              - node6
-            rgw_endpoints:
-              - node5:80
-      desc: "Configure HAproxy"
-      module: haproxy.py
-      name: "Configure HAproxy"
-  - test:
-      abort-on-fail: true
-      clusters:
-        ceph-pri:
-          config:
             cephadm: true
             commands:
               - "radosgw-admin realm create --rgw-realm india --default"
@@ -314,7 +296,7 @@ tests:
             script-name: test_Mbuckets_with_Nobjects.py
             verify-io-on-site: ["ceph-pri"]
             config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-            run-on-haproxy: true
+
   - test:
       name: test encryption on secondary
       desc: test_Mbuckets_with_Nobjects_enc on secondary

--- a/suites/pacific/rgw/tier-2_rgw_ms_failover_failback.yaml
+++ b/suites/pacific/rgw/tier-2_rgw_ms_failover_failback.yaml
@@ -31,6 +31,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,6 +77,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/quincy/rgw/tier-1_rgw_multisite.yaml
+++ b/suites/quincy/rgw/tier-1_rgw_multisite.yaml
@@ -31,6 +31,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,6 +77,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/quincy/rgw/tier-2_rgw_multisite.yaml
+++ b/suites/quincy/rgw/tier-2_rgw_multisite.yaml
@@ -31,6 +31,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host
@@ -76,6 +77,7 @@ tests:
                     orphan-initial-daemons: true
                     initial-dashboard-password: admin@123
                     dashboard-password-noupdate: true
+                    skip-monitoring-stack: true
               - config:
                   command: add_hosts
                   service: host

--- a/suites/reef/rgw/tier-2_rgw_test_lifecycle.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_lifecycle.yaml
@@ -104,6 +104,16 @@ tests:
       destroy-cluster: false
       module: test_client.py
       name: configure client
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node5
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   # Testing stage with lifecycle configuration set
 
@@ -161,6 +171,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_transition_multiple_rules.yaml
+        run-on-haproxy: true
   - test:
       name: Bucket Lifecycle Object_transition_tests multiple pool transition
       desc: Bucket Lifecycle Object_transition_tests multiple pool transition

--- a/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
+++ b/suites/reef/rgw/tier-2_rgw_test_using_s3cmd.yaml
@@ -98,7 +98,16 @@ tests:
       destroy-cluster: false
       module: test_cephadm.py
       name: deploy cluster
-
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node5
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 #   S3CMD tests
   - test:
       name: S3CMD basic  operations
@@ -173,6 +182,7 @@ tests:
       config:
         script-name: ../s3cmd/test_s3cmd.py
         config-file-name: ../../s3cmd/configs/test_get_s3cmd.yaml
+        run-on-haproxy: true
 
   # - test:
   #    name: Test Ratelimit at global scope

--- a/suites/reef/rgw/tier-4-rgw.yaml
+++ b/suites/reef/rgw/tier-4-rgw.yaml
@@ -88,6 +88,16 @@ tests:
                 - service_type: crash
                   placement:
                     host_pattern: "*"
+  - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node5
+        rgw_endpoints:
+          - node5:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
 
   # Bucket policy tests
 
@@ -99,6 +109,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_action.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket policy with invalid conditional in condition blocks
@@ -108,6 +119,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_condition_key.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket policy with invalid effect
@@ -117,6 +129,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_effect.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket policy with invalid key
@@ -126,6 +139,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_key.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket policy with invalid principal
@@ -135,6 +149,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_principal.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket policy with invalid resource
@@ -144,6 +159,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_resource.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket policy with invalid version
@@ -153,6 +169,7 @@ tests:
       config:
         script-name: test_bucket_policy_ops.py
         config-file-name: test_bucket_policy_invalid_version.yaml
+        run-on-haproxy: true
 
   # Bucket lifecycle tests
 
@@ -164,6 +181,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_btw_exp_transition.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket lc rule conflict between expiration days
@@ -173,6 +191,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_exp_days.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket lc rule conflict between transition actions
@@ -182,6 +201,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_conflict_transition_actions.yaml
+        run-on-haproxy: true
 
   - test:
       name: test bucket lc rules with same ruleid but different rules
@@ -191,6 +211,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_same_rule_id_diff_rules.yaml
+        run-on-haproxy: true
 
   - test:
       name: Test bucket lc reverse transition
@@ -200,6 +221,7 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_rule_reverse_transition.yaml
+        run-on-haproxy: true
 
   # swift container operation
   - test:
@@ -233,6 +255,7 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth1.yaml
+        run-on-haproxy: true
 
   - test:
       name: test s3select with depth2 queries on csv objects
@@ -242,6 +265,7 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_csv_depth2.yaml
+        run-on-haproxy: true
 
   - test:
       name: test s3select with depth1 queries on parquet objects
@@ -251,6 +275,7 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth1.yaml
+        run-on-haproxy: true
 
   - test:
       name: test s3select with depth2 queries on parquet objects
@@ -260,6 +285,7 @@ tests:
       config:
         script-name: test_s3select.py
         config-file-name: test_s3select_query_gen_parquet_depth2.yaml
+        run-on-haproxy: true
 
   # test MOD hotfix bz: complete and abort multipart upload race causes obj download failure after gc kicks in
 


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
Issue:
Node exporter deployment fails during monitoring service setup in IBM 6.1 builds [multisite]. Logs  that only 4 out of 5 node-exporters are running, the deployment of node-exporter is failing on the installer node.
like this :

INFO - 4/5 node-exporter up... retrying  
ERROR - node-exporter service deployment failed!!! 
 
Failed log: http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/IBM/6.1/rhel-9/Regression/17.2.6-268/rgw/74/tier-1_rgw_multisite/ 

Root Cause:
Its seen only in IBM ceph node-exporter  fails to deploy on the installer node when using service specs for the monitoring stack. This issue is not observed in RH builds.

Solution:
I added skip-monitoring-stack: true during the bootstrap to prevent the node-exporter from being deployed automatically, and deploying it with spec .

pass log:http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/log6.1Tfa2/
JIRA: https://issues.redhat.com/browse/RHCEPHQE-19043


Also fixed Haproxy issue:

In 6.1 weekly seen endpoint issue which with port 80 where the testcase should run on rgw there is run-on-haproxy added which  ia clearly not needed so along with run-on-haproxy removed the haproxy config also

Without Haproxy: [pass logs]
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-264/rgw/36/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-264/rgw/36/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary


With Haproxy: [failed]
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-276/rgw/38/tier-1_rgw_ecpool_ms-bucket-object-gc-policy-on-primary
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Weekly/17.2.6-276/rgw/38/tier-1_rgw_ms-bucket-object-gc-policy-on-secondary/

