### PR TITLE
Skip Orch service updation if 'placement' key is missing

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -4910,6 +4910,12 @@ EOF"""
         cmd_export = f"ceph orch ls {service_type} --export"
         out = self.run_ceph_command(cmd=cmd_export, client_exec=True)
         for _service in out:
+            if not _service.get("placement", False):
+                log.info(
+                    "Service %s does not have placement entry, skipping"
+                    % _service["service_name"]
+                )
+                continue
             if unmanaged:
                 log.debug(
                     f"Setting the {_service} service as unmanaged by cephadm. current status : {out}"

--- a/tests/rados/mute_alerts.py
+++ b/tests/rados/mute_alerts.py
@@ -139,6 +139,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/pool_tests.py
+++ b/tests/rados/pool_tests.py
@@ -117,6 +117,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -232,6 +234,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -347,6 +351,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.debug(f"Removing the pool created : {pool_name}")
@@ -458,6 +464,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -485,6 +493,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -535,6 +545,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -593,6 +605,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -907,6 +921,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -965,6 +981,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -1199,6 +1217,8 @@ def run(ceph_cluster, **kw):
             except Exception as e:
                 log.error(f"Exception hit in test flow: {e}")
                 log.exception(e)
+                # log cluster health
+                rados_obj.log_cluster_health()
                 return 1
             finally:
                 log.info("\n\n\n\n ====== IN FINALLY BLOCK ====== \n\n\n\n")
@@ -1304,6 +1324,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -1519,6 +1541,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Test failed with exception: {e}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
 
         finally:
@@ -1678,6 +1702,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error("Failed with exception:" + e.__doc__)
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/rados_prep.py
+++ b/tests/rados/rados_prep.py
@@ -267,6 +267,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_add_new_osd.py
+++ b/tests/rados/test_add_new_osd.py
@@ -43,6 +43,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_bilog_trim.py
+++ b/tests/rados/test_bilog_trim.py
@@ -108,6 +108,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Execution failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_bluefs_space.py
+++ b/tests/rados/test_bluefs_space.py
@@ -165,6 +165,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Execution failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_bluestore_data_compression.py
+++ b/tests/rados/test_bluestore_data_compression.py
@@ -1468,6 +1468,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_bluestore_min_alloc_size.py
+++ b/tests/rados/test_bluestore_min_alloc_size.py
@@ -389,6 +389,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Execution failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_bluestore_superblock.py
+++ b/tests/rados/test_bluestore_superblock.py
@@ -168,6 +168,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Execution failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -685,19 +685,33 @@ def run(ceph_cluster, **kw):
             )
             out = bluestore_obj.show_bluefs_stats(osd_id=osd_id)
             log.info(out)
+            if rhbuild.startswith("6"):
+                log.info(
+                    "Check if the chosen OSD has a dedicated DB device. Fetching metadata..."
+                )
+                osd_metadata = ceph_cluster.get_osd_metadata(
+                    osd_id=int(osd_id), client=client
+                )
+                # 1 if dedicated DB device is present, 0 otherwise
+                dedicated_db = int(osd_metadata["bluefs_dedicated_db"])
 
-            pattern_list = [
-                "device size",
-                "DEV/LEV",
-                "LOG",
-                "WAL",
-                "DB",
-                "SLOW",
-                "MAXIMUMS",
-                "TOTAL",
-            ]
-            if rhbuild.split(".")[0] < "6":
-                pattern_list = ["device size", "wal_total", "db_total", "slow_total"]
+            # default bluefs-stats for releases older than Reef
+            pattern_list = ["device size", "wal_total", "db_total", "slow_total"]
+
+            # verbose updated stats for Reef and above
+            if rhbuild.split(".")[0] > "6" or (
+                rhbuild.startswith("6") and dedicated_db
+            ):
+                pattern_list = [
+                    "device size",
+                    "DEV/LEV",
+                    "LOG",
+                    "WAL",
+                    "DB",
+                    "SLOW",
+                    "MAXIMUMS",
+                    "TOTAL",
+                ]
             for pattern in pattern_list:
                 assert (
                     pattern in out

--- a/tests/rados/test_bluestoretool_workflows.py
+++ b/tests/rados/test_bluestoretool_workflows.py
@@ -712,6 +712,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_brownfield.py
+++ b/tests/rados/test_brownfield.py
@@ -101,6 +101,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_bug_fixes.py
+++ b/tests/rados/test_bug_fixes.py
@@ -121,6 +121,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -206,6 +208,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -291,6 +295,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -441,6 +447,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_cephadm_ansible.py
+++ b/tests/rados/test_cephadm_ansible.py
@@ -189,6 +189,8 @@ EOF"""
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_cephdf.py
+++ b/tests/rados/test_cephdf.py
@@ -150,6 +150,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -524,6 +526,8 @@ def run(ceph_cluster, **kw):
         except AssertionError as AE:
             log.error(f"Failed with exception: {AE.__doc__}")
             log.exception(AE)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info("\n ************* Executing finally block **********\n")
@@ -672,6 +676,8 @@ def run(ceph_cluster, **kw):
         except Exception as AE:
             log.error(f"Failed with exception: {AE.__doc__}")
             log.exception(AE)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info("\n ************* Executing finally block **********\n")

--- a/tests/rados/test_cephvolume_workflows.py
+++ b/tests/rados/test_cephvolume_workflows.py
@@ -328,6 +328,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_clay_ecpool.py
+++ b/tests/rados/test_clay_ecpool.py
@@ -207,6 +207,8 @@ def run(ceph_cluster, **kw) -> int:
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_client_pg_access.py
+++ b/tests/rados/test_client_pg_access.py
@@ -93,6 +93,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_config_assimilation.py
+++ b/tests/rados/test_config_assimilation.py
@@ -76,6 +76,8 @@ def run(ceph_cluster, **kw) -> int:
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         # removing the additional configurations set in the mon database

--- a/tests/rados/test_config_parameter_chk.py
+++ b/tests/rados/test_config_parameter_chk.py
@@ -101,6 +101,8 @@ def run(ceph_cluster, **kw):
             except Exception as e:
                 log.error(f"Failed with exception: {e.__doc__}")
                 log.exception(e)
+                # log cluster health
+                rados_object.log_cluster_health()
                 return 1
             finally:
                 log.info(
@@ -248,6 +250,8 @@ def run(ceph_cluster, **kw):
                         except Exception as e:
                             log.error(f"Failed with exception: {e.__doc__}")
                             log.exception(e)
+                            # log cluster health
+                            rados_object.log_cluster_health()
                             return 1
                         finally:
                             log.info(

--- a/tests/rados/test_data_migration_bw_pools.py
+++ b/tests/rados/test_data_migration_bw_pools.py
@@ -135,6 +135,8 @@ def run(ceph_cluster, **kw) -> int:
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_ec_86.py
+++ b/tests/rados/test_ec_86.py
@@ -354,6 +354,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_election_strategies.py
+++ b/tests/rados/test_election_strategies.py
@@ -91,6 +91,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(
@@ -261,6 +263,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_fragmentation_warnings.py
+++ b/tests/rados/test_fragmentation_warnings.py
@@ -355,6 +355,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_libcephsqlite.py
+++ b/tests/rados/test_libcephsqlite.py
@@ -187,6 +187,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_mon_addition_removal.py
+++ b/tests/rados/test_mon_addition_removal.py
@@ -93,6 +93,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         # Adding the mon back to the cluster
         if not mon_obj.add_mon_service(host=mon_host):
             log.error("Could not add mon service")

--- a/tests/rados/test_mon_config_history.py
+++ b/tests/rados/test_mon_config_history.py
@@ -67,6 +67,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_mon_config_reset.py
+++ b/tests/rados/test_mon_config_reset.py
@@ -53,6 +53,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_mon_connection_scores.py
+++ b/tests/rados/test_mon_connection_scores.py
@@ -206,6 +206,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_mon_mgr_weight.py
+++ b/tests/rados/test_mon_mgr_weight.py
@@ -137,6 +137,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_mon_pg_warn.py
+++ b/tests/rados/test_mon_pg_warn.py
@@ -130,6 +130,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_mon_system_operations.py
+++ b/tests/rados/test_mon_system_operations.py
@@ -349,6 +349,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_object_ops.py
+++ b/tests/rados/test_object_ops.py
@@ -100,6 +100,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_objectstore_block.py
+++ b/tests/rados/test_objectstore_block.py
@@ -104,6 +104,8 @@ def run(ceph_cluster, **kw):
             )
             log.error(f"{e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
 
         log.debug(f"Object dump for {object_name} after initial write operation")
         log.debug(obj_dump)
@@ -139,6 +141,8 @@ def run(ceph_cluster, **kw):
             log.info("^FAIL")
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             raise
 
         method_should_succeed(
@@ -201,10 +205,14 @@ def run(ceph_cluster, **kw):
             log.info("^FAIL")
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             raise
     except Exception as e:
         log.error(f"Execution failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_objectstoretool_workflows.py
+++ b/tests/rados/test_objectstoretool_workflows.py
@@ -559,6 +559,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info("\n\n\n*********** Execution of finally block starts ***********\n\n")

--- a/tests/rados/test_omap_entries.py
+++ b/tests/rados/test_omap_entries.py
@@ -130,6 +130,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_osd_compaction.py
+++ b/tests/rados/test_osd_compaction.py
@@ -240,6 +240,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_osd_crashes.py
+++ b/tests/rados/test_osd_crashes.py
@@ -282,6 +282,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info(

--- a/tests/rados/test_osd_df.py
+++ b/tests/rados/test_osd_df.py
@@ -199,6 +199,8 @@ def run_test(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         # Mark the 'out' OSD as 'in'

--- a/tests/rados/test_osd_full.py
+++ b/tests/rados/test_osd_full.py
@@ -351,6 +351,8 @@ def run(ceph_cluster, **kw):
             except Exception as e:
                 log.error(f"Failed with exception: {e.__doc__}")
                 log.exception(e)
+                # log cluster health
+                rados_obj.log_cluster_health()
                 return 1
             finally:
                 log.info(
@@ -616,6 +618,8 @@ def run(ceph_cluster, **kw):
             except Exception as e:
                 log.error(f"Failed with exception: {e.__doc__}")
                 log.exception(e)
+                # log cluster health
+                rados_obj.log_cluster_health()
                 return 1
             finally:
                 log.info(
@@ -865,6 +869,8 @@ def run(ceph_cluster, **kw):
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             # deleting the created pool

--- a/tests/rados/test_osd_rebalance.py
+++ b/tests/rados/test_osd_rebalance.py
@@ -135,6 +135,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_osd_replacement.py
+++ b/tests/rados/test_osd_replacement.py
@@ -106,6 +106,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_osd_superblock.py
+++ b/tests/rados/test_osd_superblock.py
@@ -142,6 +142,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Execution failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_osdmap_trim.py
+++ b/tests/rados/test_osdmap_trim.py
@@ -164,6 +164,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info("*********** Execution of finally block starts ***********")

--- a/tests/rados/test_pg_autoscale_flag.py
+++ b/tests/rados/test_pg_autoscale_flag.py
@@ -158,6 +158,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_pg_log_limit.py
+++ b/tests/rados/test_pg_log_limit.py
@@ -148,6 +148,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_pool_osd_recovery.py
+++ b/tests/rados/test_pool_osd_recovery.py
@@ -326,6 +326,8 @@ def run(ceph_cluster, **kw) -> int:
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info("*********** Execution of finally block starts ***********")
@@ -386,6 +388,8 @@ def run(ceph_cluster, **kw) -> int:
         except Exception as e:
             log.error(f"Failed with exception: {e.__doc__}")
             log.exception(e)
+            # log cluster health
+            rados_obj.log_cluster_health()
             return 1
         finally:
             log.info("*********** Execution of finally block starts ***********")

--- a/tests/rados/test_pool_snap.py
+++ b/tests/rados/test_pool_snap.py
@@ -246,6 +246,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info("*********** Execution of finally block starts ***********")

--- a/tests/rados/test_rados_perf.py
+++ b/tests/rados/test_rados_perf.py
@@ -110,6 +110,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_replica1.py
+++ b/tests/rados/test_replica1.py
@@ -347,6 +347,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info("************* Execution of finally block starts ***********")

--- a/tests/rados/test_scrub_chunk_max.py
+++ b/tests/rados/test_scrub_chunk_max.py
@@ -178,6 +178,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info("*********** Execution of finally block starts ***********")

--- a/tests/rados/test_scrub_omap.py
+++ b/tests/rados/test_scrub_omap.py
@@ -82,6 +82,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_stretch_deployment_with_placement.py
+++ b/tests/rados/test_stretch_deployment_with_placement.py
@@ -425,6 +425,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_stretch_mon_replacements.py
+++ b/tests/rados/test_stretch_mon_replacements.py
@@ -299,6 +299,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_stretch_n_az_negative_scenarios.py
+++ b/tests/rados/test_stretch_n_az_negative_scenarios.py
@@ -273,6 +273,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_stretch_negative_scenarios.py
+++ b/tests/rados/test_stretch_negative_scenarios.py
@@ -254,6 +254,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_stretch_osd_serviceability_scenarios.py
+++ b/tests/rados/test_stretch_osd_serviceability_scenarios.py
@@ -926,6 +926,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_stretch_site_down.py
+++ b/tests/rados/test_stretch_site_down.py
@@ -241,6 +241,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_stretch_site_maintenance_modes.py
+++ b/tests/rados/test_stretch_site_maintenance_modes.py
@@ -291,6 +291,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(

--- a/tests/rados/test_stretch_site_reboot.py
+++ b/tests/rados/test_stretch_site_reboot.py
@@ -193,6 +193,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
 
     finally:

--- a/tests/rados/test_v1client.py
+++ b/tests/rados/test_v1client.py
@@ -110,6 +110,8 @@ def run(ceph_cluster, **kw):
     except Exception as e:
         log.error(f"Failed with exception: {e.__doc__}")
         log.exception(e)
+        # log cluster health
+        rados_obj.log_cluster_health()
         return 1
     finally:
         log.info(


### PR DESCRIPTION
Commit: [Skip Orch service updation if 'placement' key is missing](https://github.com/red-hat-storage/cephci/commit/b7fe4ab97e360b49138435783981443dc4bc183b)
Jira tracker: [RHCEPHQE-19052](https://issues.redhat.com/browse/RHCEPHQE-19052)
Recently it was found that the Orch service created for OSDs deployed manually using `ceph orch daemon add osd` method did not have any placement entry in their service spec file.

Due to the unavailability of `placement` key, modifying the 'unmanaged' status for such services is not feasible. Addition of custom `placement` key also does not help the cause as `placement` key can either take label or host/host pattern and what is required is individual daemon location. Consequently, it was decided to skip modification of such Orch services present on the cluster.

Test modules modified:
- `set_service_managed_type` in `ceph/rados/core_workflows.py`

Commit: 
Jira tracker: [RHCEPHQE-19103](https://issues.redhat.com/browse/RHCEPHQE-19103)
The changes ensure that cluster health detail and cluster status is logged immediately after a test fails or exception is encountered. It was found that the cluster health detail and cluster status logged in finally block was being recorded after considerable delay and sometimes after several other operations.


Signed-off-by: Harsh Kumar <hakumar@redhat.com>