### PR TITLE
[TFA] Update the upgrade module from test_cephadm_upgrade to test_upgrade_warn

### DIFF
--- a/suites/quincy/rados/tier-2_rados_test_parameters.yaml
+++ b/suites/quincy/rados/tier-2_rados_test_parameters.yaml
@@ -100,8 +100,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 6.1 ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade

--- a/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
+++ b/suites/reef/rados/tier-2_rados_ec-pool_recovery.yaml
@@ -116,8 +116,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
       config:
         command: start
         service: upgrade

--- a/suites/reef/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/reef/rados/tier-2_rados_test-brownfield.yaml
@@ -196,8 +196,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade

--- a/suites/reef/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/reef/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -134,8 +134,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 7.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
       abort-on-fail: true
       config:
         command: start

--- a/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
+++ b/suites/squid/common/regression/rados/rados_4-node-ecpools.yaml
@@ -131,8 +131,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
       config:
         command: start
         service: upgrade

--- a/suites/squid/rados/tier-2_rados_test-brownfield.yaml
+++ b/suites/squid/rados/tier-2_rados_test-brownfield.yaml
@@ -198,8 +198,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934
       config:
         command: start
         service: upgrade

--- a/suites/squid/rados/tier-2_rados_test-drain-customer-issue.yaml
+++ b/suites/squid/rados/tier-2_rados_test-drain-customer-issue.yaml
@@ -135,8 +135,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
       config:
         command: start
         service: upgrade

--- a/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
+++ b/suites/squid/rados/tier-3_rados_test-4-node-8+6-msr-ecpools.yaml
@@ -214,8 +214,8 @@ tests:
   - test:
       name: Upgrade cluster to latest 8.x ceph version
       desc: Upgrade cluster to latest version
-      module: test_cephadm_upgrade.py
-      polarion-id: CEPH-83573791,CEPH-83573790
+      module: test_upgrade_warn.py
+      polarion-id: CEPH-83574934,CEPH-83573790
       config:
         command: start
         service: upgrade

--- a/tests/rados/test_online_reads_balancer.py
+++ b/tests/rados/test_online_reads_balancer.py
@@ -66,7 +66,7 @@ def run(ceph_cluster, **kw):
                 log.debug("Creating replicated pool : %s", cr_pool["pool_name"])
                 method_should_succeed(rados_obj.create_pool, **cr_pool)
 
-            method_should_succeed(rados_obj.bench_write, max_objs=200, **cr_pool)
+            method_should_succeed(rados_obj.bench_write, **cr_pool)
         log.info(
             "Completed creating pools and writing test data into the pools\n Pools : %s",
             pool_names,
@@ -222,7 +222,6 @@ def run(ceph_cluster, **kw):
                     "Not failing the test"
                 )
         log.debug("Completed verifying reads balancer scores on all the pools")
-        rados_obj.rados_pool_cleanup()
         rados_obj.configure_pg_autoscaler(**{"default_mode": "on"})
         time.sleep(20)
 
@@ -314,6 +313,7 @@ def run(ceph_cluster, **kw):
         )
 
         for pool in pool_names:
+            pool_id = rados_obj.get_pool_id(pool_name=pool)
             if not rados_obj.delete_pool(pool=pool):
                 log.error("Could not delete pool : %s", pool)
                 raise Exception("Pool not deleted error")
@@ -322,7 +322,6 @@ def run(ceph_cluster, **kw):
                 pool,
             )
             time.sleep(5)
-            pool_id = rados_obj.get_pool_id(pool_name=pool)
             out = rados_obj.run_ceph_command(cmd="ceph osd dump")
             for item in out["pg_upmap_primaries"]:
                 if int(pool_id) == int(item["pgid"].split(".")[0]):

--- a/tests/rados/test_reads_balancer.py
+++ b/tests/rados/test_reads_balancer.py
@@ -64,7 +64,7 @@ def run(ceph_cluster, **kw):
                 )
             else:
                 method_should_succeed(rados_obj.create_pool, **cr_pool)
-            method_should_succeed(rados_obj.bench_write, max_objs=500, **cr_pool)
+            method_should_succeed(rados_obj.bench_write, **cr_pool)
         log.info("Completed creating pools and writing test data into the pools")
 
         existing_pools = rados_obj.list_pools()


### PR DESCRIPTION
PR includes below fixes:- 

(1) Update the Upgrade modules from test_cephadm_upgrade to test_upgrade_warn. 
Pass logs:- http://magna002.ceph.redhat.com/ceph-qe-logs/vips/upgrade_logs_pr/logs_pr_upgrade_test_fixes_25_04_16_12_12_39/ 
**After cluster deployment: ceph version 18.2.1-229.el9cp (ef652b206f2487adfc86613646a4cac946f6b4e0) reef (stable) 
After Upgrade cluster to 7.1z2 ceph version ceph Version 18.2.1-262.el9cp 
After Upgrade cluster to latest 8.x ceph version 19.2.1-137.el9cp** 

Pass logs:- http://magna002.ceph.redhat.com/ceph-qe-logs/vips/upgrade_logs_pr/logs_pr_upgrade_test_fixes_25_04_16_04_34_33/ 

(2) Test Online Reads Balancer Upmap-read 
Pass logs:- http://magna002.ceph.redhat.com/ceph-qe-logs/vips/upgrade_logs_pr/logs_pr_upgrade_test_fixes_25_04_16_11_48_50/


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
