### PR TITLE
Fixing typo in method name

### DIFF
--- a/tests/cephfs/cephfs_mirror_upgrade/post_upgrade_validate.py
+++ b/tests/cephfs/cephfs_mirror_upgrade/post_upgrade_validate.py
@@ -77,10 +77,10 @@ def run(ceph_cluster, **kw):
             source_clients[0], source_fs
         )
         log.info("Add files into the path and create snapshot on each path")
-        retry_add_files_and_validatet = retry(CommandFailed, tries=3, delay=30)(
-            fs_mirroring_utils.add_files_and_validatet
+        retry_add_files_and_validate = retry(CommandFailed, tries=3, delay=30)(
+            fs_mirroring_utils.add_files_and_validate
         )
-        retry_add_files_and_validatet(
+        retry_add_files_and_validate(
             source_clients,
             kernel_mounting_dir_1,
             subvol1_path,


### PR DESCRIPTION
# Description
Fixing typo in method name

Failed log : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Upgrade/19.2.0-124/88/tier-0_cephfs_mirrror_upgrade_6x_to_8x/Validate_the_Synchronisation_is_successful_upon_upgrade._0.log


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
