### PR TITLE
Increasing the timeout for smallfile ops

### DIFF
--- a/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
+++ b/tests/cephfs/cephfs_upgrade/cephfs_post_upgrade_validation.py
@@ -80,7 +80,7 @@ def nfs_test(nfs_req_params):
         f"--operation create --threads 1 --file-size 1024 "
         f"--files 10 --top {dir_path}",
         long_running=True,
-        timeout=20,
+        timeout=600,
     )
     log.info("Verify exports are active by mounting and running IO")
     nfs_mounting_dir = f"{existing_nfs_mount}_new"
@@ -248,7 +248,7 @@ def snap_sched_test(snap_req_params):
             f"--operation create --threads 1 --file-size 1024 "
             f"--files 10 --top {dir_path}",
             long_running=True,
-            timeout=20,
+            timeout=600,
         )
 
     log.info(
@@ -466,7 +466,7 @@ def clone_test(clone_req_params):
             f"--operation create --threads 1 --file-size 1024 "
             f"--files 10 --top {dir_path}",
             long_running=True,
-            timeout=20,
+            timeout=600,
         )
 
     log.info("Mount existing clones, verify IO suceeds")


### PR DESCRIPTION
# Description
Increasing the timeout for smallfile ops

This PR increases the timeout for smallfile operations from 20 seconds to 600 seconds.
During the 8.1 upgrade, we observed NFS mount issues where even a basic ls -l on /mnt/nfs was unresponsive.
[8.1 log](http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Upgrade/19.2.1-147/94/tier-0_cephfs_upgrade_7x_to_8x/Validates_NFS_after_upgrade_0.log)

In the 8.0 upgrade, the smallfile command frequently timed out due to delays in NFS readiness post-upgrade.
[8.0 log](http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Upgrade/19.2.0-124/88/tier-0_cephfs_upgrade_7x_to_8x/Validates_NFS_after_upgrade_0.log)


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
