### PR TITLE
[TFA][Baremetal] REmove testcase of IO from deployment as it already part of IO

### DIFF
--- a/suites/squid/baremetal/deploy/rh/mero1_1admin_4node_4client.yaml
+++ b/suites/squid/baremetal/deploy/rh/mero1_1admin_4node_4client.yaml
@@ -149,21 +149,6 @@ tests:
       module: test_client.py
       name: "configure client"
   - test:
-      abort-on-fail: false
-      desc: "Fill the cluster with specific percentage"
-      name: "Fill Cluster"
-      module: test_io.py
-      config:
-        wait_for_io: True
-        cephfs:
-          "fill_data": 10
-          "num_of_clients": 4
-          "io_tool": "smallfile"
-          "mount": "fuse"
-          "batch_size": 30
-          "filesystem": "cephfs_io_1"
-          "mount_dir": ""
-  - test:
       name: EC pool LC
       module: rados_prep.py
       polarion-id: CEPH-83571632

--- a/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml
+++ b/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml
@@ -149,21 +149,6 @@ tests:
       module: test_client.py
       name: "configure client"
   - test:
-      abort-on-fail: false
-      desc: "Fill the cluster with specific percentage"
-      name: "Fill Cluster"
-      module: test_io.py
-      config:
-        wait_for_io: True
-        cephfs:
-          "fill_data": 10
-          "num_of_clients": 4
-          "io_tool": "smallfile"
-          "mount": "fuse"
-          "batch_size": 30
-          "filesystem": "cephfs_io_1"
-          "mount_dir": ""
-  - test:
       name: EC pool LC
       module: rados_prep.py
       polarion-id: CEPH-83571632


### PR DESCRIPTION
# Description
In Single site, we have fill workload testcase of cephfs (which take more than 12 hr to execute) which is also part of IO. 
https://github.com/red-hat-storage/cephci/blob/main/suites/squid/baremetal/deploy/rh/mero2_1admin_4node_4client.yaml#L151
https://github.com/red-hat-storage/cephci/blob/main/suites/squid/baremetal/deploy/rh/mero1_1admin_4node_4client.yaml#L151

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
