### PR TITLE
[TFA] remove parallel run from suite part of sanity

### DIFF
--- a/suites/quincy/rgw/test-basic-object-operations.yaml
+++ b/suites/quincy/rgw/test-basic-object-operations.yaml
@@ -91,61 +91,47 @@ tests:
   # Testing stage
 
   - test:
-      name: Parallel run
-      desc: RGW tier-0 parallelly.
-      module: test_parallel.py
-      parallel:
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects
-            module: sanity_rgw.py
-            name: Test M buckets with N objects
-            polarion-id: CEPH-9789
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects.yaml
+      desc: test to create "M" no of buckets and "N" no of objects
+      module: sanity_rgw.py
+      name: Test M buckets with N objects
+      polarion-id: CEPH-9789
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects with delete
-            module: sanity_rgw.py
-            name: Test delete using M buckets with N objects
-            polarion-id: CEPH-14237
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with delete
+      module: sanity_rgw.py
+      name: Test delete using M buckets with N objects
+      polarion-id: CEPH-14237
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              install_common: false
-              run-on-haproxy: true
-            desc: test to create "M" no of buckets and "N" no of objects with download
-            module: sanity_rgw.py
-            name: Test download with M buckets with N objects
-            polarion-id: CEPH-14237
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      module: sanity_rgw.py
+      name: Test download with M buckets with N objects
+      polarion-id: CEPH-14237
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
-            module: sanity_rgw.py
-            name: Test multipart upload of M buckets with N objects
-            polarion-id: CEPH-9801
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+      module: sanity_rgw.py
+      name: Test multipart upload of M buckets with N objects
+      polarion-id: CEPH-9801
 
-        - test:
-            config:
-              script-name: test_swift_basic_ops.py
-              config-file-name: test_swift_basic_ops.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: Test object operations with swift
-            module: sanity_rgw.py
-            name: Swift based tests
-            polarion-id: CEPH-11019
+  - test:
+      config:
+        script-name: test_swift_basic_ops.py
+        config-file-name: test_swift_basic_ops.yaml
+      desc: Test object operations with swift
+      module: sanity_rgw.py
+      name: Swift based tests
+      polarion-id: CEPH-11019

--- a/suites/reef/rgw/tier-1_rgw.yaml
+++ b/suites/reef/rgw/tier-1_rgw.yaml
@@ -89,55 +89,42 @@ tests:
       name: "Configure HAproxy"
 
   # Testing stage
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects.yaml
+      desc: test to create "M" no of buckets and "N" no of objects
+      module: sanity_rgw.py
+      name: Test M buckets with N objects
+      polarion-id: CEPH-9789
 
   - test:
-      name: Parallel run
-      desc: RGW tier-1 parallelly.
-      module: test_parallel.py
-      parallel:
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects
-            module: sanity_rgw.py
-            name: Test M buckets with N objects
-            polarion-id: CEPH-9789
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with delete
+      module: sanity_rgw.py
+      name: Test delete using M buckets with N objects
+      polarion-id: CEPH-14237
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects with delete
-            module: sanity_rgw.py
-            name: Test delete using M buckets with N objects
-            polarion-id: CEPH-14237
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      module: sanity_rgw.py
+      name: Test download with M buckets with N objects
+      polarion-id: CEPH-14237
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              install_common: false
-              run-on-haproxy: true
-            desc: test to create "M" no of buckets and "N" no of objects with download
-            module: sanity_rgw.py
-            name: Test download with M buckets with N objects
-            polarion-id: CEPH-14237
-
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
-            module: sanity_rgw.py
-            name: Test multipart upload of M buckets with N objects
-            polarion-id: CEPH-9801
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+      module: sanity_rgw.py
+      name: Test multipart upload of M buckets with N objects
+      polarion-id: CEPH-9801
 
   - test:
       name: enable bucket versioning
@@ -188,12 +175,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_days_expire_header.yaml
-  - test:
-      name: Indexless buckets
-      desc: Indexless (blind) buckets
-      polarion-id: CEPH-10354 # also applies to CEPH-10357
-      module: sanity_rgw.py
-      config:
-        test-version: v2
-        script-name: test_indexless_buckets.py
-        config-file-name: test_indexless_buckets_s3.yaml

--- a/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
+++ b/suites/reef/rgw/tier-2_rgw_regression_extended.yaml
@@ -375,3 +375,12 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_bi_purge.yaml
+  - test:
+      name: Indexless buckets
+      desc: Indexless (blind) buckets
+      polarion-id: CEPH-10354 # also applies to CEPH-10357
+      module: sanity_rgw.py
+      config:
+        test-version: v2
+        script-name: test_indexless_buckets.py
+        config-file-name: test_indexless_buckets_s3.yaml

--- a/suites/squid/rgw/tier-1_rgw.yaml
+++ b/suites/squid/rgw/tier-1_rgw.yaml
@@ -96,64 +96,42 @@ tests:
       name: "Configure HAproxy"
 
   # Testing stage
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects.yaml
+      desc: test to create "M" no of buckets and "N" no of objects
+      module: sanity_rgw.py
+      name: Test M buckets with N objects
+      polarion-id: CEPH-9789
 
   - test:
-      name: Parallel run
-      desc: RGW tier-1 parallelly.
-      module: test_parallel.py
-      parallel:
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects
-            module: sanity_rgw.py
-            name: Test M buckets with N objects
-            polarion-id: CEPH-9789
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with delete
+      module: sanity_rgw.py
+      name: Test delete using M buckets with N objects
+      polarion-id: CEPH-14237
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_delete.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects with delete
-            module: sanity_rgw.py
-            name: Test delete using M buckets with N objects
-            polarion-id: CEPH-14237
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      module: sanity_rgw.py
+      name: Test download with M buckets with N objects
+      polarion-id: CEPH-14237
 
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              install_common: false
-              run-on-haproxy: true
-            desc: test to create "M" no of buckets and "N" no of objects with download
-            module: sanity_rgw.py
-            name: Test download with M buckets with N objects
-            polarion-id: CEPH-14237
-
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              install_common: false
-              run-on-rgw: true
-            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
-            module: sanity_rgw.py
-            name: Test multipart upload of M buckets with N objects
-            polarion-id: CEPH-9801
-        - test:
-            name: test_bi_purge for a bucket
-            desc: test bi_purge should not error
-            module: sanity_rgw.py
-            polarion-id: CEPH-83575234
-            config:
-              install_common: false
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_bi_purge.yaml
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+      desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+      module: sanity_rgw.py
+      name: Test multipart upload of M buckets with N objects
+      polarion-id: CEPH-9801
 
   - test:
       name: enable bucket versioning
@@ -228,12 +206,3 @@ tests:
       config:
         script-name: test_bucket_lifecycle_object_expiration_transition.py
         config-file-name: test_lc_days_expire_header.yaml
-  - test:
-      name: Indexless buckets
-      desc: Indexless (blind) buckets
-      polarion-id: CEPH-10354 # also applies to CEPH-10357
-      module: sanity_rgw.py
-      config:
-        test-version: v2
-        script-name: test_indexless_buckets.py
-        config-file-name: test_indexless_buckets_s3.yaml

--- a/suites/squid/rgw/tier-1_rgw_ibm.yaml
+++ b/suites/squid/rgw/tier-1_rgw_ibm.yaml
@@ -92,30 +92,25 @@ tests:
       name: "Configure HAproxy"
 
   # Testing stage
+  - test:
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
+        install_common: false
+      desc: test to create "M" no of buckets and "N" no of objects with multipart upload
+      module: sanity_rgw.py
+      name: Test multipart upload of M buckets with N objects
+      polarion-id: CEPH-9801
 
   - test:
-      name: Parallel run
-      desc: RGW tier-1 parallelly.
-      module: test_parallel.py
-      parallel:
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_multipart.yaml
-              install_common: false
-            desc: test to create "M" no of buckets and "N" no of objects with multipart upload
-            module: sanity_rgw.py
-            name: Test multipart upload of M buckets with N objects
-            polarion-id: CEPH-9801
-        - test:
-            config:
-              script-name: test_Mbuckets_with_Nobjects.py
-              config-file-name: test_Mbuckets_with_Nobjects_download.yaml
-              run-on-haproxy: true
-            desc: test to create "M" no of buckets and "N" no of objects with download
-            module: sanity_rgw.py
-            name: Test download with M buckets with N objects
-            polarion-id: CEPH-14237
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
+      desc: test to create "M" no of buckets and "N" no of objects with download
+      module: sanity_rgw.py
+      name: Test download with M buckets with N objects
+      polarion-id: CEPH-14237
 
   - test:
       name: enable bucket versioning

--- a/suites/squid/rgw/tier-2_rgw_regression_test.yaml
+++ b/suites/squid/rgw/tier-2_rgw_regression_test.yaml
@@ -636,3 +636,22 @@ tests:
       config:
         script-name: ../s3_swift/test_swift_acl_with_keystone.py
         config-file-name: ../../s3_swift/configs/test_swift_acl_with_keystone.yaml
+
+  - test:
+      name: test_bi_purge for a bucket
+      desc: test bi_purge should not error
+      module: sanity_rgw.py
+      polarion-id: CEPH-83575234
+      config:
+        script-name: test_Mbuckets_with_Nobjects.py
+        config-file-name: test_bi_purge.yaml
+
+  - test:
+      name: Indexless buckets
+      desc: Indexless (blind) buckets
+      polarion-id: CEPH-10354 # also applies to CEPH-10357
+      module: sanity_rgw.py
+      config:
+        test-version: v2
+        script-name: test_indexless_buckets.py
+        config-file-name: test_indexless_buckets_s3.yaml


### PR DESCRIPTION
# Description
remove parallel run from suite part of sanity , seeing issue with error: sudo mkdir rgw-tests returned mkdir: cannot create directory â€˜rgw-testsâ€™: File exists

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
