### PR TITLE
Fix failure seen with suite pacific-rgw-tier-4-rgw.yaml

### DIFF
--- a/suites/pacific/rgw/tier-4-rgw.yaml
+++ b/suites/pacific/rgw/tier-4-rgw.yaml
@@ -91,8 +91,23 @@ tests:
   - test:
       abort-on-fail: true
       config:
+        command: add
+        id: client.1
+        node: node6
+        install_packages:
+          - ceph-common
+        copy_admin_keyring: true
+      desc: Configure the RGW client system
+      polarion-id: CEPH-83573758
+      destroy-cluster: false
+      module: test_client.py
+      name: configure client
+
+  - test:
+      abort-on-fail: true
+      config:
         haproxy_clients:
-          - node5
+          - node6
         rgw_endpoints:
           - node5:80
       desc: "Configure HAproxy"


### PR DESCRIPTION
# Description
Previously in this suite haproxy was configured on a same node where rgw service is deployed.
in that case we were seeing these failures.
Fail log: 
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Regression/17.2.6-269/rgw/75/tier-4-rgw/
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Regression/17.2.6-277/rgw/78/tier-4-rgw/

By moving haproxy configuration to the client node, we are seeing failures.

Pass log:
http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-QLYJND/


Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
