### PR TITLE
[TFA]Create flag for disable/enable modify profile with --force flag

### DIFF
--- a/ceph/rados/core_workflows.py
+++ b/ceph/rados/core_workflows.py
@@ -4918,12 +4918,12 @@ EOF"""
                 continue
             if unmanaged:
                 log.debug(
-                    f"Setting the {_service} service as unmanaged by cephadm. current status : {out}"
+                    f"Setting the {_service['service_name']} service as unmanaged by cephadm. current status : {out}"
                 )
                 _service["unmanaged"] = True
             else:
                 log.debug(
-                    f"Setting the {_service} service as managed by cephadm. current status : {out}"
+                    f"Setting the {_service['service_name']} service as managed by cephadm. current status : {out}"
                 )
                 _service.pop("unmanaged", "key not found")
             json_out = json.dumps(_service)
@@ -4937,15 +4937,21 @@ EOF"""
             time.sleep(10)
         out = self.list_orch_services(service_type=service_type, export=True)
         for _service in out:
+            if not _service.get("placement", False):
+                log.info(
+                    "Service %s does not have placement entry, skipping"
+                    % _service["service_name"]
+                )
+                continue
             status = _service.get("unmanaged", False)
-            if status == "false":
+            if status is False:
                 unmanaged_check = False
             else:
                 unmanaged_check = True
 
             if unmanaged_check != unmanaged:
                 log.error(
-                    f"{service_type} Service with {_service['service_id']}not unmanaged={unmanaged} state. Fail"
+                    f"{service_type} Service with {_service['service_name']} not unmanaged={unmanaged} state. Fail"
                 )
                 return False
         log.info(f" All {service_type} Service in unmanaged={unmanaged} state. Pass")

--- a/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
+++ b/conf/quincy/rados/stretch-mode-host-location-attrs.yaml
@@ -22,7 +22,6 @@ globals:
           - mgr
           - _admin
           - osd
-          - osd-bak
         no-of-volumes: 4
         disk-size: 25
       node3:
@@ -31,7 +30,6 @@ globals:
           - mgr
           - nfs
           - osd
-          - osd-bak
         no-of-volumes: 4
         disk-size: 25
       node4:
@@ -39,7 +37,6 @@ globals:
           - rgw
           - osd
           - mds
-          - osd-bak
         no-of-volumes: 4
         disk-size: 25
       node5:
@@ -48,7 +45,6 @@ globals:
           - _admin
           - mgr
           - osd
-          - osd-bak
         no-of-volumes: 4
         disk-size: 25
       node6:
@@ -56,14 +52,12 @@ globals:
           - mon
           - mgr
           - osd
-          - osd-bak
           - nfs
         no-of-volumes: 4
         disk-size: 25
       node7:
         role:
           - osd
-          - osd-bak
           - rgw
           - mds
         no-of-volumes: 4

--- a/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/quincy/rados/tier-2_rados_test-bugfixes.yaml
@@ -161,23 +161,26 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
-      comments: Active bug 2277111
-  - test:
-      name: Inconsistent objects in replicated pool functionality check
-      desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
-      module: test_osd_replicated_inconsistency_scenario.py
-      polarion-id: CEPH-83586175
-      config:
-        replicated_pool:
-          create: true
-          pool_name: replicated_pool
-          pg_num: 1
-          disable_pg_autoscale: true
-        inconsistent_obj_count: 4
-        debug_enable: False
-        delete_pool:
-          - replicated_pool
-      comments: Active bug 2316244
+      comments:  Intermittent active bug 2277111
+
+  # commenting Test case BZ 2316244 to be fixed in later release
+  # - test:
+  #     name: Inconsistent objects in replicated pool functionality check
+  #     desc: Scub and deep-scrub on  inconsistent objects in Replicated pool
+  #     module: test_osd_replicated_inconsistency_scenario.py
+  #     polarion-id: CEPH-83586175
+  #     config:
+  #       replicated_pool:
+  #         create: true
+  #         pool_name: replicated_pool
+  #         pg_num: 1
+  #         disable_pg_autoscale: true
+  #       inconsistent_obj_count: 4
+  #       debug_enable: False
+  #       delete_pool:
+  #         - replicated_pool
+  #     comments: Active bug 2316244
+
   - test:
       name: Verification of ceph config show & get
       module: test_bug_fixes.py

--- a/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/quincy/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -368,4 +368,48 @@ tests:
         stretch_bucket: datacenter
         tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
       desc: Test stretch Cluster osd and Host replacement
+
+  - test:
+      name: OSD replacement enhancement - 1
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-3
+          - scenario-4
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD replacement enhancement - 2
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-5
+          - scenario-6
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD Host replacement enhancement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-7
+      desc: Test stretch Cluster Host replacement

--- a/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/reef/rados/tier-2_rados_test-bugfixes.yaml
@@ -161,7 +161,7 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
-      comments:  Active bug 2277111
+      comments:  Intermittent active bug 2277111
 
   - test:
       name: Inconsistent objects in replicated pool functionality check
@@ -178,7 +178,7 @@ tests:
         debug_enable: False
         delete_pool:
           - replicated_pool
-      comments: Active bug 2316244
+      comments: Active bug 2362650
 
   - test:
       name: Verification of ceph config show & get

--- a/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/reef/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -383,4 +383,48 @@ tests:
         stretch_bucket: datacenter
         tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
       desc: Test stretch Cluster osd and Host replacement
+
+  - test:
+      name: OSD replacement enhancement - 1
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-3
+          - scenario-4
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD replacement enhancement - 2
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-5
+          - scenario-6
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD Host replacement enhancement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-7
+      desc: Test stretch Cluster Host replacement

--- a/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
+++ b/suites/squid/rados/tier-2_rados_test-bugfixes.yaml
@@ -176,6 +176,7 @@ tests:
         debug_enable: False
         delete_pool:
           - ecpool
+      comments:  Intermittent active bug 2277111
 
   - test:
       name: Inconsistent objects in replicated pool functionality check

--- a/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
+++ b/suites/squid/rados/tier-3_rados_test-location-stretch-mode.yaml
@@ -382,4 +382,48 @@ tests:
         stretch_bucket: datacenter
         tiebreaker_mon_site_name: tiebreaker
         delete_pool: true
+        scenarios_to_run:
+          - scenario-1
+          - scenario-2
       desc: Test stretch Cluster osd and Host replacement
+
+  - test:
+      name: OSD replacement enhancement - 1
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-3
+          - scenario-4
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD replacement enhancement - 2
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-5
+          - scenario-6
+      desc: Test stretch Cluster osd replacement
+
+  - test:
+      name: OSD Host replacement enhancement
+      module: test_stretch_osd_serviceability_scenarios.py
+      polarion-id: CEPH-83575474
+      config:
+        pool_name: test_stretch_pool7
+        stretch_bucket: datacenter
+        tiebreaker_mon_site_name: tiebreaker
+        delete_pool: true
+        scenarios_to_run:
+          - scenario-7
+      desc: Test stretch Cluster Host replacement


### PR DESCRIPTION
PR addressed below TFA and stabilisation fixes:

(1) Splits OSD and Host replacement scenarios in stretch mode into multiple scenarios
(2) Resolves OSD and host replacement scenario in stretch mode quincy.
(3) Comment the test case  "Inconsistent objects in replicated pool functionality check" in quincy
(4) Adds "modify_ec_profile_with_force" flag to execute test case "Modifying the profile with the --force flag"


# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
