### PR TITLE
[TFA]Include haproxy for the rgw testcase of download

### DIFF
--- a/suites/quincy/cephadm/tier-2-rgw-with-warn-state.yaml
+++ b/suites/quincy/cephadm/tier-2-rgw-with-warn-state.yaml
@@ -78,6 +78,19 @@ tests:
       destroy-cluster: false
 
   - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node5
+        rgw_endpoints:
+          - node2:80
+          - node3:80
+          - node4:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
       name: Test M buckets with N objects
       desc: test to create "M" no of buckets and "N" no of objects
       polarion-id: CEPH-9789
@@ -109,6 +122,7 @@ tests:
       config:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
+        run-on-haproxy: true
         timeout: 300
       abort-on-fail: false
       destroy-cluster: false

--- a/suites/reef/cephadm/tier2-rgw-with-warn-state.yaml
+++ b/suites/reef/cephadm/tier2-rgw-with-warn-state.yaml
@@ -78,6 +78,19 @@ tests:
       destroy-cluster: false
 
   - test:
+      abort-on-fail: true
+      config:
+        haproxy_clients:
+          - node5
+        rgw_endpoints:
+          - node2:80
+          - node3:80
+          - node4:80
+      desc: "Configure HAproxy"
+      module: haproxy.py
+      name: "Configure HAproxy"
+
+  - test:
       name: Test M buckets with N objects
       desc: test to create "M" no of buckets and "N" no of objects
       polarion-id: CEPH-9789
@@ -110,6 +123,7 @@ tests:
         script-name: test_Mbuckets_with_Nobjects.py
         config-file-name: test_Mbuckets_with_Nobjects_download.yaml
         timeout: 300
+        run-on-haproxy: true
       abort-on-fail: false
       destroy-cluster: false
 


### PR DESCRIPTION
# Description
issue : http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/6.1/rhel-9/Regression/17.2.6-277/dmfg/82/tier-2-rgw-with-warn-state/
also seen in 7.1

with fix pass log :
6.1: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-VSRRSQ/
7.1: http://magna002.ceph.redhat.com/cephci-jenkins/Anuchaithra/cephci-run-OJNVA0/ 

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
