### PR TITLE
[TFA]Fix changed the cert generate command. 

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ssl_cephadm_gen_cert.yaml
@@ -171,7 +171,7 @@ tests:
               - "ceph config set client.rgw rgw_verify_ssl False"
               - "ceph config set client.rgw.{daemon_id:shared.pri} rgw_verify_ssl False"
               - "ceph orch restart {service_name:shared.pri}"
-              - "ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt"
+              - "ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt"
               - "sudo yum install -y sshpass"
               - "sleep 20"
               - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-sec#node5}:/etc/pki/ca-trust/source/anchors/"
@@ -193,7 +193,7 @@ tests:
               - "ceph orch restart {service_name:shared.sec}"
               - "sudo yum install -y sshpass"
               - "sleep 120"
-              - "ceph orch cert-store get cert cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt"
+              - "ceph orch certmgr cert get cephadm_root_ca_cert > /home/cephuser/cephadm-root-ca.crt"
               - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node5}:/etc/pki/ca-trust/source/anchors/"
               - "sshpass -p 'passwd' scp /home/cephuser/cephadm-root-ca.crt root@{node_ip:ceph-pri#node6}:/etc/pki/ca-trust/source/anchors/"
       desc: Setting up RGW multisite replication environment


### PR DESCRIPTION
# Description

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>

https://bugzilla.redhat.com/show_bug.cgi?id=2358993#c3
There’s an issue with the command where the certificate is not generated, so I raised a BZ and they provided a solution:

**The cert-store was never officially supported. In 8.1, we're introducing certmgr (as a tech preview) as the new official cephadm command to manage certificates. Please replace the failing command with:

ceph orch certmgr cert get cephadm_root_ca_cert**

It was working fine in 8.0:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.0/rhel-9/Weekly/19.2.0-124/rgw/23/tier-2_rgw_ssl_cephadm_gen_cert/

But failing in 8.1:
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Weekly/19.2.1-61/rgw/22/tier-2_rgw_ssl_cephadm_gen_cert/setup_multisite_0.log

I updated the command and tested it. Attaching the passing log here:
http://magna002.ceph.redhat.com/ceph-qe-logs/yuva/logtfacert-store2/


