### PR TITLE
Fix deployment issue seen with upgrade path

### DIFF
--- a/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_ms_upgrade_8xsanity_to_8xlatest.yaml
@@ -25,7 +25,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 8.0
+                    rhcs-version: 8.1
                     release: sanity
                     registry-url: registry.redhat.io
                     mon-ip: node1
@@ -72,7 +72,7 @@ tests:
                   command: bootstrap
                   service: cephadm
                   args:
-                    rhcs-version: 8.0
+                    rhcs-version: 8.1
                     release: sanity
                     registry-url: registry.redhat.io
                     mon-ip: node1

--- a/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
+++ b/suites/squid/rgw/tier-2_rgw_upgrade_8xsanity_to_8xlatest.yaml
@@ -18,7 +18,7 @@ tests:
               command: bootstrap
               service: cephadm
               args:
-                rhcs-version: 8.0
+                rhcs-version: 8.1
                 release: sanity
                 registry-url: registry.redhat.io
                 mon-ip: node1


### PR DESCRIPTION
# Description

Fix deployment issue seen with upgrade path
http://magna002.ceph.redhat.com/cephci-jenkins/results/openstack/RH/8.1/rhel-9/Sanity/19.2.1-152/308/tier-2_rgw_upgrade_8xsanity_to_8xlatest/

This failure was due to unavailability of repo file,
suite is designed for upgrade from 8.0 sanity build to 8.x latest.
since we are not receiving any 8.0 builds now,
currently existing repo in recipe file is of pretty old,
i.e, http://download-01.beak-001.prod.iad2.dc.redhat.com/rhel-9/composes/auto/ceph-8.0-rhel-9/RHCEPH-8.0-RHEL-9-20250307.ci.0/
this image is not available now.

log: http://magna002.ceph.redhat.com/ceph-qe-logs/Chaithra/cephci-run-Z3KYHU/

Please include Automation development guidelines. Source of Test case - New Feature/Regression Test/Close loop of customer BZs
<details>

<summary>click to expand checklist</summary>

- [ ] Create a test case in Polarion reviewed and approved.
- [ ] Create a design/automation approach doc. Optional for tests with similar tests already automated.
- [ ] Review the automation design
- [ ] Implement the test script and perform test runs
- [ ] Submit PR for code review and approve
- [ ] Update Polarion Test with Automation script details and update automation fields
- [ ] If automation is part of Close loop, update BZ flag qe-test_coverage “+” and link Polarion test
</details>
