### PR TITLE
Add back compatibility with RSA SSH keys

### DIFF
--- a/ceph/ceph.py
+++ b/ceph/ceph.py
@@ -1298,9 +1298,22 @@ class SSHConnectionManager(object):
         """Get SSH key based on file type"""
         private_key = None
         with open(private_key_file_path, "rb") as key_file:
+            key_data = key_file.read()
+
+        try:
+            # Try loading as OpenSSH first
             private_key = (
                 cryptography.hazmat.primitives.serialization.load_ssh_private_key(
-                    key_file.read(),
+                    key_data,
+                    password=None,
+                    backend=cryptography.hazmat.backends.default_backend(),
+                )
+            )
+        except ValueError:
+            # Fall back to PEM format
+            private_key = (
+                cryptography.hazmat.primitives.serialization.load_pem_private_key(
+                    key_data,
                     password=None,
                     backend=cryptography.hazmat.backends.default_backend(),
                 )


### PR DESCRIPTION
This should fix issue with RSA .pem ssh keys which with recent change stopped working with this error:
```
2025-04-25 13:00:33    File "/home/jenkins/workspace/qe-standalone-ceph-deployment/cephci/.venv/lib64/python3.9/site-packages/cryptography/hazmat/primitives/serialization/ssh.py", line 676, in load_ssh_private_key
2025-04-25 13:00:33      raise ValueError("Not OpenSSH private key format")
```
